### PR TITLE
Updates And Partially Redesigns Free Miner Ship

### DIFF
--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,87 +2,35 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"af" = (
+"ac" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"al" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ag" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"ar" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"aD" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"aO" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_bridge"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"aS" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+"as" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"bk" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"bn" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"bu" = (
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"bx" = (
-/obj/effect/mob_spawn/human/free_miner/captain,
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"bA" = (
+"ay" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -97,157 +45,17 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"cj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"cx" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"cF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+"aD" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"cQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/equipment_vendor/free_miner,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"da" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 1;
-	name = "waste";
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"dh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"dA" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"dK" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/machinery/door/window/westright{
-	dir = 4
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"dT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"dW" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"ek" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"eu" = (
-/obj/effect/mob_spawn/human/free_miner/engi,
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"ex" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/template_noop)
-"eD" = (
-/turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"eS" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"eZ" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bathroom"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"fp" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fq" = (
-/obj/machinery/syndicatebomb/training{
-	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
-	name = "self-destruct device"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"fF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fM" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"gj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gv" = (
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gL" = (
+"aH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -259,7 +67,89 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"hl" = (
+"aQ" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"aU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"bk" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"bx" = (
+/obj/structure/closet/crate{
+	name = "emergency supplies crate"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight/flare{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/wrench,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"cs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"cx" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"ds" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"dG" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 8
+	},
+/turf/template_noop,
+/area/shuttle/abandoned)
+"dH" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"dO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"dZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ef" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -271,192 +161,31 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"hy" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"hD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"iD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"iK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"iU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"je" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"jk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ka" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"ku" = (
+"eq" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/optable,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"kJ" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"kP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"la" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 7
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"ls" = (
-/obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"lD" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/machinery/light/small{
+"eu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"lT" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 8
+"eA" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 2
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -8
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 1;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"lZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ne" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oe" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ol" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"pf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"ps" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"pB" = (
+"eC" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -475,166 +204,105 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"pW" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"eG" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"qc" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
+"eH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"qC" = (
+"eI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"fB" = (
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/stack/cable_coil,
+/obj/item/assembly/igniter,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fS" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"gl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"qN" = (
+"gQ" = (
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"hP" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"hQ" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
+/turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"qR" = (
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"rh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"rs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 8
+"hY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/turf/open/floor/carpet/black,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
 /area/shuttle/abandoned)
-"rv" = (
-/obj/structure/closet/crate/medical{
-	name = "medical crate"
+"ig" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/obj/item/healthanalyzer,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/donkpockets{
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"rO" = (
-/obj/machinery/vending/coffee{
-	pixel_x = -2
-	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sa" = (
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"sr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ss" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sw" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"th" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"tn" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ts" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"uj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"ux" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"uO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"uT" = (
+"ih" = (
 /obj/docking_port/mobile{
 	callTime = 250;
 	dheight = 0;
@@ -658,149 +326,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"vo" = (
-/obj/machinery/button/door{
-	id = "freeship_bridge";
-	name = "Bridge Blast Door Control";
-	pixel_x = -24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "freeship_windows";
-	name = "Windows Blast Door Control";
-	pixel_x = -24;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"vK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"vM" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"wg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+"iq" = (
+/obj/machinery/processor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"wj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wm" = (
-/obj/machinery/griddle,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"wp" = (
-/obj/structure/closet/crate{
-	name = "emergency supplies crate"
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight/flare{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/wrench,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wq" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"wG" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"wJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"xs" = (
-/obj/structure/ore_box,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xL" = (
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ym" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"yz" = (
+"jb" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "dormitory"
+	icon_state = "closed";
+	name = "medbay";
+	welded = 0
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -808,9 +342,19 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"yO" = (
+"jB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"jT" = (
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"kh" = (
 /obj/machinery/mecha_part_fabricator/maint{
 	req_access = list(71)
 	},
@@ -819,7 +363,7 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"zt" = (
+"kr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/window/shuttle,
 /obj/structure/grille,
@@ -828,41 +372,317 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"Ac" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"AG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+"ks" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Ba" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"BC" = (
-/obj/machinery/light,
+"kt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"kB" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"kN" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"kS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lg" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"lr" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"lx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lJ" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"lQ" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"md" = (
+/obj/machinery/vending/coffee{
+	pixel_x = -2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"mu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"mz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Ch" = (
+"mA" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"mK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"na" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"nn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"nD" = (
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nK" = (
+/obj/structure/table,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/chassis/clarke,
+/obj/item/circuitboard/mecha/clarke/peripherals,
+/obj/item/circuitboard/mecha/clarke/main,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"on" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ov" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oz" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oU" = (
+/obj/machinery/computer/shuttle/white_ship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"pd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"pU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"qJ" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"rB" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"sa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"su" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"sN" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"ta" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"te" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"th" = (
+/obj/structure/ore_box,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ti" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"tI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
@@ -877,17 +697,125 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Cp" = (
+"uq" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.7;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ut" = (
+/turf/template_noop,
+/area/shuttle/abandoned)
+"uH" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1;
+	name = "waste";
+	volume_rate = 200
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"uO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"CR" = (
+"uV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"CS" = (
+"vh" = (
+/obj/machinery/button/door{
+	id = "freeship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "freeship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -24;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"vJ" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"vP" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"wd" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"we" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"wi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"wH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wO" = (
+/obj/structure/mecha_wreckage/clarke,
+/turf/open/floor/plasteel/recharge_floor,
+/area/shuttle/abandoned)
+"wU" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = -2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"xd" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -28;
@@ -905,210 +833,61 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"DN" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "kitchen"
+"xg" = (
+/obj/structure/mirror{
+	pixel_x = 28
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"xn" = (
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"DX" = (
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = -32
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"DZ" = (
-/obj/structure/mecha_wreckage/clarke,
-/turf/open/floor/plasteel/recharge_floor,
-/area/shuttle/abandoned)
-"Ew" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 8
-	},
-/turf/template_noop,
-/area/shuttle/abandoned)
-"EZ" = (
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Fk" = (
+"xH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xQ" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plasteel/shuttle,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"Fn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/table,
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"FD" = (
-/obj/machinery/door/airlock/shuttle{
-	icon_state = "closed";
-	name = "medbay";
-	welded = 0
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Gm" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"GU" = (
-/obj/machinery/light{
+"xY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"GV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Hd" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 4;
-	name = "R&D Console";
-	req_access_txt = "71";
-	research_control = 0
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Hs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth{
+/obj/structure/chair/americandiner/booth/end_left{
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"Hu" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
+"yu" = (
+/obj/structure/table,
+/obj/item/storage/box/ids/free_miners{
+	pixel_x = 1;
+	pixel_y = 7
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"HX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"IC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"IG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Jt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"Jx" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"JG" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"JI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science{
-	categories = list("Exosuit Modules");
-	pixel_x = -2;
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -1;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Kt" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
-	dir = 8
-	},
+/obj/item/pen/fountain,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"KQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"KY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
+"yS" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Li" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Ls" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Mq" = (
+"yU" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
@@ -1117,98 +896,52 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"ME" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"MN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"MO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Nv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"Oo" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"ON" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"OS" = (
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"OV" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Pe" = (
+"zd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"Pm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"PB" = (
+"zk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/chair/americandiner/booth{
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"zJ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"PR" = (
+"Aa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Ao" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"AB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"AD" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"AE" = (
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
@@ -1223,118 +956,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Qx" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"QE" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Rd" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+"Bj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"Rj" = (
-/obj/machinery/computer/shuttle/white_ship/miner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"RK" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"RN" = (
-/obj/structure/toilet{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"RQ" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"Sk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"Sl" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"Ss" = (
+"CQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Su" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
+"CY" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/clothing/glasses/meson/sunglasses,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"Sw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"SF" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/soap,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"SJ" = (
+"De" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -1344,298 +986,85 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"SK" = (
+"Dl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"SR" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"SU" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"TH" = (
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/ore_redemption,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Uq" = (
+"DA" = (
+/obj/effect/mob_spawn/human/free_miner/captain,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Ej" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"EC" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"EY" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
 /obj/item/wrench,
 /obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"Uu" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/camera,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet/cyan,
+"Fz" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Uz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"UC" = (
-/obj/structure/table,
-/obj/item/storage/box/ids/free_miners{
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/pen/fountain,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"UD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
+"FF" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1
+	dir = 2
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"UL" = (
-/obj/structure/table,
-/obj/item/megaphone,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/item/storage/bag/ore,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/mining_scanner,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"UQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Vt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"VE" = (
-/turf/template_noop,
-/area/shuttle/abandoned)
-"VH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"VO" = (
-/obj/structure/sign/departments/minsky/engineering/engineering{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"FQ" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Wq" = (
-/obj/structure/table,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Wz" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = -2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"WB" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "engineering"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"WJ" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/clothing/glasses/meson/sunglasses,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"WX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XF" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/mecha_parts/mecha_equipment/mining_scanner,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
-/obj/item/mecha_parts/mecha_equipment/drill,
-/obj/item/mecha_parts/chassis/clarke,
-/obj/item/circuitboard/mecha/clarke/peripherals,
-/obj/item/circuitboard/mecha/clarke/main,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XG" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XX" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"YC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"YU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Zs" = (
-/obj/machinery/computer/mech_bay_power_console{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Zv" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Zw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Zx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ZB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"ZG" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice{
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"ZV" = (
+"Ga" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Gd" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Gj" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 6
@@ -1659,412 +1088,983 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"Gw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Hc" = (
+/obj/structure/closet/crate/medical{
+	name = "medical crate"
+	},
+/obj/item/healthanalyzer,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Hx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"HY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/table,
+/obj/item/storage/box/fancy/donut_box,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Ik" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/soap,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Iv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"IB" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"IL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"IX" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Jl" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"JQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Kv" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"KL" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"KZ" = (
+/obj/structure/table,
+/obj/item/megaphone,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/bag/ore,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/mining_scanner,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Lb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"LN" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"LZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Mt" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"MV" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/camera,
+/obj/item/storage/photo_album,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Nk" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/obj/machinery/door/window/westright{
+	dir = 4
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"Nl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Nu" = (
+/obj/machinery/syndicatebomb/training{
+	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
+	name = "self-destruct device"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"NN" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Oc" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ol" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ou" = (
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"OJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Pv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"QA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Rp" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"RS" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"RV" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"SX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"SZ" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"Tn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"TU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Uj" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Un" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"UF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"UN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"UW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Va" = (
+/obj/effect/mob_spawn/human/free_miner/engi,
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Vp" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Vv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"VA" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"VD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science{
+	categories = list("Exosuit Modules");
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"VV" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Ws" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"WW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Xn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"XK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XQ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"XR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XS" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_bridge"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Yd" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 4;
+	name = "R&D Console";
+	req_access_txt = "71";
+	research_control = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Yo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Yp" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Yx" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YJ" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YM" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"YS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"YT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/equipment_vendor/free_miner,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"ZL" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"ZO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
-VE
-VE
-Ew
+ut
+ut
+dG
 aa
 aa
-Sl
-ME
-Sl
+XQ
+pU
+XQ
 aa
 aa
-VE
-VE
-Ew
+ut
+ut
+dG
 aa
 "}
 (2,1,1) = {"
 aa
-VE
-VE
-VE
+ut
+ut
+ut
 aa
-ex
-Sl
-bA
-zt
-da
+xQ
+XQ
+ay
+kr
+uH
 aa
-VE
-VE
-VE
+ut
+ut
+ut
 aa
 "}
 (3,1,1) = {"
-Sl
-qR
-qR
-qR
-Sl
-YC
-Sl
-Rd
-Sl
-Sl
-Sl
-qR
-qR
-qR
+XQ
+lJ
+lJ
+lJ
+XQ
+SX
+XQ
+ZO
+XQ
+XQ
+XQ
+lJ
+lJ
+lJ
 bk
 "}
 (4,1,1) = {"
-Sl
-wq
+XQ
+VV
 aD
-wq
-Sl
-Wz
-rO
-Fk
-XX
-xL
-Sl
-bn
-bn
-bn
+VV
+XQ
+wU
+md
+cs
+rB
+lQ
+XQ
+sN
+sN
+sN
 bk
 "}
 (5,1,1) = {"
-Sl
-RN
+XQ
+gQ
 bk
-dK
-Sl
-xM
-ux
-hl
-ux
-pW
-Sl
-vM
-ts
-sw
+Nk
+XQ
+eq
+FF
+ef
+FF
+Oc
+XQ
+VA
+eA
+Pv
 bk
 "}
 (6,1,1) = {"
-QE
-lD
-eZ
-RQ
-eZ
-gv
-sa
-PB
-vK
-YU
-Sl
-fu
-Oo
-bu
-QE
+LN
+Kv
+su
+xg
+su
+yS
+Ou
+Nl
+kt
+Ol
+XQ
+eu
+zJ
+dH
+LN
 "}
 (7,1,1) = {"
-Sl
-Sl
-Sl
-Sl
-ps
-gv
-Fn
-AG
-MO
-SJ
-WB
-Uz
-cj
-RK
-QE
+XQ
+XQ
+XQ
+XQ
+SZ
+yS
+HY
+Ws
+xa
+De
+hP
+eH
+Aa
+vP
+LN
 "}
 (8,1,1) = {"
-QE
-ZG
-Cp
-pf
-yz
-Ss
-rs
-Hs
+LN
+Rp
 uO
-VO
+Tn
+ZL
+CQ
+sc
+Bj
+xY
+AD
 bk
-eu
-GV
-Uq
-Sl
+Va
+rR
+EY
+XQ
 "}
 (9,1,1) = {"
-Sl
-fM
-SR
-Gm
+XQ
+ac
+kB
+FQ
 bk
-XS
-gv
-iK
-lZ
-fp
+Hx
+yS
+ti
+WW
+wd
 cx
 bk
-Sl
-Sl
-Sl
+XQ
+XQ
+XQ
 "}
 (10,1,1) = {"
-Sl
-Sl
-Sl
-Sl
-Sl
-ZB
-gv
-qN
-UD
-cF
-DN
-HX
-PR
-Li
-Sl
+XQ
+XQ
+XQ
+XQ
+XQ
+YZ
+yS
+OJ
+pd
+sa
+Ej
+jB
+AE
+lr
+XQ
 "}
 (11,1,1) = {"
-Sl
-SF
-wJ
-ss
-Sl
-Nv
-Pe
-IG
-SK
-th
-Sl
-pB
-wg
-dW
-QE
+XQ
+Ik
+TU
+Uj
+XQ
+wi
+qT
+dZ
+hY
+vJ
+XQ
+eC
+AB
+iq
+LN
 "}
 (12,1,1) = {"
-QE
-gv
-iU
-gv
-Sl
-Sl
-Sl
-tn
-Sl
-Sl
-Sl
-wm
-wg
-Ch
-QE
+LN
+yS
+Dl
+yS
+XQ
+XQ
+XQ
+Jl
+XQ
+XQ
+XQ
+Mt
+AB
+tI
+LN
 "}
 (13,1,1) = {"
-QE
-sr
-Pm
-KY
-VH
-ne
-gL
-wj
-gv
-XG
-Sl
-wG
-uj
-ZV
-Sl
+LN
+QA
+ks
+wH
+Gd
+IL
+aH
+ov
+yS
+eG
+XQ
+ig
+UW
+Gj
+XQ
 "}
 (14,1,1) = {"
-Sl
-iD
-GU
-gv
-WX
-gv
-gv
-ag
-gv
-la
-Sl
-Sl
-Sl
-Sl
-Sl
+XQ
+XK
+UF
+yS
+XR
+yS
+yS
+uV
+yS
+YJ
+XQ
+XQ
+XQ
+XQ
+XQ
 "}
 (15,1,1) = {"
-Sl
-Sl
-Jt
-Sl
-af
-gv
-gv
-ag
-gv
-gv
-XF
-JI
-Hd
-yO
-Sl
+XQ
+XQ
+eI
+XQ
+mK
+yS
+yS
+uV
+yS
+yS
+nO
+VD
+Yd
+kh
+XQ
 "}
 (16,1,1) = {"
-uT
-qc
-dh
-wP
-KY
-KY
-Zw
-fq
-gj
-gj
-qC
-fF
-rh
-BC
-QE
+ih
+YM
+na
+as
+wH
+wH
+te
+Nu
+Yo
+Yo
+Ga
+mz
+zd
+aQ
+LN
 "}
 (17,1,1) = {"
-Sl
-Sl
-Sl
-Sl
-MN
-gv
-jk
-ym
-rh
-rh
-dA
-ol
-DZ
-Zs
-Sl
+XQ
+XQ
+XQ
+XQ
+al
+yS
+lx
+on
+zd
+zd
+gl
+KL
+wO
+qJ
+XQ
 "}
 (18,1,1) = {"
-Sl
-eS
-xs
-DX
-WX
-gv
-gv
-Zx
-UQ
-Wq
-Sl
-Sl
-Sl
-Sl
-Sl
+XQ
+Fz
+th
+nD
+XR
+yS
+yS
+zk
+kS
+nK
+XQ
+XQ
+XQ
+XQ
+XQ
 "}
 (19,1,1) = {"
-Sl
-gv
-CR
-gv
-WX
-gv
-gv
-Fk
-gv
-hy
-Sl
-Mq
-CS
-rv
-Sl
+XQ
+yS
+Lb
+yS
+XR
+yS
+yS
+cs
+yS
+Yx
+XQ
+yU
+xd
+Hc
+XQ
 "}
 (20,1,1) = {"
-Sl
-cQ
-Sw
-KY
-Zv
-KY
-KY
-oe
-gv
-EZ
+XQ
+YT
+mu
+wH
+oz
+wH
+wH
+JQ
+yS
+ds
 bk
-ek
-dT
-kJ
-Sl
+lg
+nn
+xn
+XQ
 "}
 (21,1,1) = {"
-QE
-TH
-xy
-Qx
-Sl
-ls
-gv
-Vt
-Ba
-Ba
-FD
-Su
-hD
-Ac
-QE
+LN
+fB
+xH
+Vp
+XQ
+uq
+yS
+Iv
+aU
+aU
+jb
+Vv
+Gw
+EC
+LN
 "}
 (22,1,1) = {"
-QE
-wp
-jk
-OS
-Sl
-Sl
-Sl
-aS
-Sl
-Sl
-Sl
-ku
-wg
-ka
-QE
+LN
+bx
+lx
+Ao
+XQ
+XQ
+XQ
+RV
+XQ
+XQ
+XQ
+UN
+AB
+Yp
+LN
 "}
 (23,1,1) = {"
-Ls
-JG
-gv
-OS
-Sl
-bx
-vo
-Sk
-eD
-ar
-Sl
-Jx
-Hu
-lT
+RS
+mA
+yS
+Ao
+XQ
+DA
+vh
+Un
+jT
+IX
+XQ
+kN
+NN
+ta
 bk
 "}
 (24,1,1) = {"
 bk
 bk
-QE
-Sl
-Sl
-OV
-kP
-KQ
-IC
-UL
-Sl
-Sl
-QE
+LN
+XQ
+XQ
+LZ
+YS
+Xn
+dO
+KZ
+XQ
+XQ
+LN
 bk
 bk
 "}
@@ -2073,13 +2073,13 @@ aa
 aa
 aa
 aa
-aO
-UC
-je
-je
-je
-ON
-aO
+XS
+yu
+hQ
+hQ
+hQ
+we
+XS
 aa
 aa
 aa
@@ -2090,13 +2090,13 @@ aa
 aa
 aa
 aa
-aO
-Uu
-SU
-Rj
-Kt
-WJ
-aO
+XS
+MV
+IB
+oU
+fS
+CY
+XS
 aa
 aa
 aa
@@ -2108,11 +2108,11 @@ aa
 aa
 aa
 bk
-aO
-aO
-aO
-aO
-aO
+XS
+XS
+XS
+XS
+XS
 bk
 aa
 aa

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,237 +2,27 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "cargo bay";
-	req_access_txt = "71"
-	},
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/border_only{
+"af" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ad" = (
-/obj/structure/closet/crate/medical{
-	name = "medical crate"
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/healthanalyzer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ae" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"af" = (
-/obj/structure/frame/machine,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "ag" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ah" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "recovery shuttle external airlock"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ai" = (
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aj" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ak" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "burst_s"
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"al" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/pen,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"am" = (
-/obj/structure/closet/crate{
-	name = "emergency supplies crate"
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight/flare{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/wrench,
-/obj/item/extinguisher,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/mining_scanner,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"an" = (
-/obj/structure/toilet{
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow{
-	desc = "Looks like something's sprung a leak"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ao" = (
-/obj/structure/ore_box,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ap" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "cargo bay"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aq" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ar" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"as" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"at" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"au" = (
-/obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"aw" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ax" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ay" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"az" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aA" = (
-/obj/structure/table,
-/obj/item/camera,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"aB" = (
-/obj/item/paper/crumpled{
-	info = "Card readers are expensive, so I only put access restrictions on the outer doors of the main airlock and the cargo bay. I doubt anyone would want to stow away on this hunk of junk anyway.<br><br>-E"
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ar" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
 "aD" = (
 /obj/structure/shuttle/engine/heater{
@@ -244,387 +34,123 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"aE" = (
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aG" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bathroom"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aH" = (
-/obj/structure/table,
-/obj/item/megaphone,
-/obj/item/clothing/glasses/meson{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"aI" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"aJ" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood/random{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/random,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"aL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aM" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "E.V.A. equipment"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"aN" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
 "aO" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -28;
-	req_access_txt = "0"
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_bridge"
 	},
-/obj/machinery/light{
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"aS" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bd" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bathroom"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bf" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "dormitory"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bg" = (
-/obj/machinery/vending/boozeomat{
-	icon_deny = "smartfridge";
-	icon_state = "smartfridge";
-	req_access_txt = "0"
-	},
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
 "bk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"bm" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/mineral/titanium/white,
+"bn" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"bv" = (
+"bu" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"bw" = (
-/obj/machinery/vending/coffee{
-	pixel_x = -2
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "bx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/mob_spawn/human/free_miner/captain,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"by" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bC" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "recovery shuttle interior airlock"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bD" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bE" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bG" = (
-/obj/structure/table,
-/obj/item/storage/box/fancy/donut_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bH" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bI" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bP" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bridge"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"bT" = (
-/obj/machinery/vending/cola{
-	pixel_x = -1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bU" = (
-/obj/structure/chair{
+"bA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"bZ" = (
-/obj/machinery/vending/snack{
-	pixel_x = -1
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ce" = (
-/obj/structure/sign/departments/botany,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"cf" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "hydroponics"
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"cg" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "kitchen"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ci" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "cj" = (
-/obj/machinery/door/airlock/shuttle{
-	icon_state = "closed";
-	name = "medbay";
-	welded = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"cl" = (
-/obj/item/storage/bag/plants/portaseeder,
-/obj/structure/table,
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/rh{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"cm" = (
-/obj/machinery/biogenerator{
-	idle_power_usage = 0
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"cn" = (
-/obj/machinery/vending/hydroseeds{
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"cw" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "cx" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"cy" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+"cF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"cz" = (
-/obj/effect/decal/cleanable/food/egg_smudge,
-/obj/effect/decal/cleanable/food/flour,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium,
+"cQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/equipment_vendor/free_miner,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"cH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+"da" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1;
+	name = "waste";
+	volume_rate = 200
+	},
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"cI" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/seeds/glowshroom,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+"dh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"cJ" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
+"dA" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"cL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -5
-	},
-/obj/item/stock_parts/cell/high{
-	pixel_x = -15;
-	pixel_y = 5
-	},
-/obj/item/paper/crumpled{
-	inertia_dir = 0;
-	info = "Finally got a cell charger for the defib. next time someone dies because they forgot to turn on their oxygen, we won't have to wire the defib to the ships engines.<br><br>-D";
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"cZ" = (
+"dK" = (
 /obj/machinery/shower{
 	dir = 4;
 	icon_state = "shower"
@@ -632,181 +158,313 @@
 /obj/machinery/door/window/westright{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/item/soap/nanotrasen,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel/freezer,
 /area/shuttle/abandoned)
-"ea" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"eH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"eT" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/ore_box,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"fh" = (
-/obj/item/paper/crumpled{
-	info = "For the love of god, someone clean this place up. We eat in here.<br><br>-C"
+"dT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"fr" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium/white,
+"dW" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"fw" = (
-/obj/structure/table,
-/obj/item/storage/photo_album,
-/obj/item/paper/crumpled{
-	inertia_dir = 0;
-	info = "It was bugging me that we didn't have pens, so I looted a ruin for some more. They're in the emergency closet. -E";
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/turf/open/floor/mineral/titanium/white,
+"ek" = (
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"gv" = (
-/obj/effect/decal/cleanable/dirt,
+"eu" = (
+/obj/effect/mob_spawn/human/free_miner/engi,
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ex" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"eD" = (
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"eS" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"eZ" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"fp" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fq" = (
 /obj/machinery/syndicatebomb/training{
 	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
 	name = "self-destruct device"
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"gP" = (
-/obj/effect/decal/cleanable/xenoblood,
-/obj/machinery/iv_drip{
-	density = 0;
-	pixel_x = -8
+"fu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"ho" = (
+"fF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fM" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"gj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gv" = (
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"hl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"hy" = (
+/obj/machinery/light,
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/turf/open/floor/mineral/titanium/white,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"hs" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper/crumpled{
-	inertia_dir = 0;
-	info = "HA! FINALLY! All those years of hoarding parts finally payed off! All I have to do is take this old wreck apart with a welder, crowbar out the boards, and I can have my own mech! I can't let myself forget to DNA lock it so those damn miners don't steal it. Hopefully we don't fly through another rad storm that scrambles all our genes after I do.<br><br>-E";
-	pixel_x = 4;
-	pixel_y = 6
+"hD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"id" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"jc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
-/obj/item/mecha_parts/mecha_equipment/mining_scanner,
-/obj/item/mecha_parts/mecha_equipment/drill,
-/obj/structure/closet/crate{
-	moving_diagonally = 0;
-	name = "mech equipment crate"
-	},
-/obj/item/stack/sheet/metal{
-	alternate_worn_layer = null;
-	amount = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/machinery/light{
+"iD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/item/stock_parts/cell/hyper/empty,
-/obj/item/stock_parts/capacitor/adv,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/item/stack/rods{
-	amount = 10
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"iK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/item/mecha_parts/mecha_equipment/ripleyupgrade,
-/obj/item/borg/upgrade/panel_access_remover/freeminer,
-/turf/open/floor/mineral/titanium/white,
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"kL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/mineral/titanium/white,
+"iU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"kR" = (
+"je" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"jk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ka" = (
 /obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/paper/crumpled{
-	info = "Note to self - do not forget to turn internals on before leaving the airlock.<br><br>-M";
-	pixel_x = 4;
-	pixel_y = 6
+/obj/item/defibrillator/loaded,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"ku" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe,
-/turf/open/floor/mineral/titanium/white,
+/obj/structure/table/optable,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"lo" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/mineral/titanium/white,
+"kJ" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"lq" = (
-/obj/effect/decal/cleanable/dirt,
+"kP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"la" = (
+/obj/machinery/light,
 /obj/structure/table,
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 4
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 1
 	},
-/obj/item/kitchen/knife,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ls" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.7;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lD" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"lT" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"lZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ne" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ol" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"pf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"ps" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"pB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/mixedcubes,
 /obj/item/storage/box/fancy/egg_box{
 	pixel_y = 5
 	},
@@ -814,83 +472,169 @@
 	pixel_x = -3;
 	pixel_y = 4
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"lL" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"mu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"my" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/gloves/color/black,
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson,
-/obj/item/pickaxe,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ov" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/paper/crumpled{
-	info = "I found this while digging through another derelict, thought we could prank the rest of the crew with it.<br><br>-F"
+"pW" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/item/clothing/mask/breath,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"oy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mob_spawn/human/free_miner/captain,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"oH" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/clothing/suit/apron,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wirecutters,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light{
-	dir = 8
+"qc" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
 	},
-/obj/item/hatchet,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"oK" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"pa" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "engineering bay"
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"qC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"pg" = (
-/obj/structure/table,
-/obj/item/radio/off{
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"pu" = (
+"qN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qR" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"rh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"rv" = (
+/obj/structure/closet/crate/medical{
+	name = "medical crate"
+	},
+/obj/item/healthanalyzer,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"rO" = (
+/obj/machinery/vending/coffee{
+	pixel_x = -2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sa" = (
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"sr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ss" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"th" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"tn" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ts" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"uj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"ux" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"uO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"uT" = (
 /obj/docking_port/mobile{
 	callTime = 250;
 	dheight = 0;
@@ -905,48 +649,993 @@
 	preferred_direction = 4;
 	width = 28
 	},
-/obj/machinery/door/airlock/shuttle{
-	name = "free miner ship external airlock";
-	req_access_txt = "71"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"pP" = (
+"vo" = (
+/obj/machinery/button/door{
+	id = "freeship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "freeship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -24;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"vK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"vM" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"wg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"wj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wm" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"wp" = (
+/obj/structure/closet/crate{
+	name = "emergency supplies crate"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight/flare{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/wrench,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wq" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"wG" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"wJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"xs" = (
+/obj/structure/ore_box,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xL" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ym" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"yz" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"yO" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	req_access = list(71)
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"zt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Ac" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"AG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Ba" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"BC" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ch" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 12
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Cp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"CR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CS" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28;
+	req_access_txt = "0"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/iv_drip{
+	density = 0;
+	pixel_x = -8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"DN" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"DX" = (
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"DZ" = (
+/obj/structure/mecha_wreckage/clarke,
+/turf/open/floor/plasteel/recharge_floor,
+/area/shuttle/abandoned)
+"Ew" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 8
+	},
+/turf/template_noop,
+/area/shuttle/abandoned)
+"EZ" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Fk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Fn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/table,
+/obj/item/storage/box/fancy/donut_box,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"FD" = (
+/obj/machinery/door/airlock/shuttle{
+	icon_state = "closed";
+	name = "medbay";
+	welded = 0
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Gm" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"GU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Hd" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 4;
+	name = "R&D Console";
+	req_access_txt = "71";
+	research_control = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Hs" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Hu" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"HX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"IC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"IG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Jt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"Jx" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"JG" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"JI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science{
+	categories = list("Exosuit Modules");
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Kt" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"KQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"KY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Li" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Ls" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Mq" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"ME" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"MN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"MO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Nv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"Oo" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ON" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"OS" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"OV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Pe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"Pm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"PB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"PR" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Qx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"QE" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Rd" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Rj" = (
 /obj/machinery/computer/shuttle/white_ship/miner{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"qA" = (
+"RK" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"RN" = (
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"RQ" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"Sk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Sl" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"Ss" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Su" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Sw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SF" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/soap,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"SR" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"SU" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"TH" = (
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/stack/cable_coil,
+/obj/item/assembly/igniter,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Uq" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/defibrillator,
-/turf/open/floor/mineral/titanium/white,
+/obj/item/clothing/glasses/welding,
+/obj/item/wrench,
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"qR" = (
+"Uu" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/latex{
-	pixel_x = 9
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 12
-	},
-/obj/item/tank/internals/anesthetic{
-	pixel_x = -13;
-	pixel_y = 1
-	},
-/obj/item/clothing/mask/breath/medical{
-	pixel_x = -13
-	},
-/turf/open/floor/mineral/titanium/white,
+/obj/item/camera,
+/obj/item/storage/photo_album,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"ry" = (
+"Uz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"UC" = (
+/obj/structure/table,
+/obj/item/storage/box/ids/free_miners{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"UD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"UL" = (
+/obj/structure/table,
+/obj/item/megaphone,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/bag/ore,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/mining_scanner,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"UQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Vt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"VE" = (
+/turf/template_noop,
+/area/shuttle/abandoned)
+"VH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"VO" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Wq" = (
+/obj/structure/table,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Wz" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = -2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"WB" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"WJ" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/clothing/glasses/meson/sunglasses,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"WX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XF" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/chassis/clarke,
+/obj/item/circuitboard/mecha/clarke/peripherals,
+/obj/item/circuitboard/mecha/clarke/main,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XG" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"XX" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"YU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Zs" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Zv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Zw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Zx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ZB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"ZG" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"ZV" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 6
@@ -965,677 +1654,417 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"rT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/obj/effect/mob_spawn/human/free_miner/engi,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"ti" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/structure/mecha_wreckage/loaded_ripley,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"vK" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/ore_redemption,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"wj" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"zy" = (
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"zE" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Bd" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "recovery shuttle external airlock";
-	req_access_txt = "71"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"Ct" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"CQ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/dropper,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 12
-	},
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Di" = (
-/obj/effect/decal/cleanable/xenoblood,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"DS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"DY" = (
-/obj/item/storage/box/ids/free_miners{
-	pixel_y = 15
-	},
-/obj/structure/table,
-/obj/item/paper/crumpled{
-	info = "Damn corporates. Finally managed to scrap together enough parts for an ore redemption machine, so we can actually start cashing in on the ore we mine. Still have to put it together in the cargo bay. The catch is, the only place to sell anything around here is a Nanotrasen outpost - some screaming metal deathtrap called Space Station 13. If we want to get anything that is not in the vendor, we will have to go there.<br><br>-C";
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/pen/fountain,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Fj" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Ft" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9;
-	pixel_y = 2
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 6
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/welding,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Gy" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice{
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"HW" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"JR" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"LC" = (
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Mw" = (
-/obj/structure/table/optable,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Nt" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/xenoblood/xgibs/limb,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"Nw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/griddle,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Oj" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 15
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"PB" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"PO" = (
-/obj/machinery/light/broken,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"RI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/ore_box,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"TL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/equipment_vendor/free_miner,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Ua" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"VU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass{
-	amount = 25;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Xq" = (
-/obj/item/mecha_parts/chassis/ripley,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"XU" = (
-/obj/structure/dresser,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"XZ" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"YW" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "free miner ship interior airlock"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"Zb" = (
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/abandoned)
-"Zp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/abandoned)
-"ZB" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
+VE
+VE
+Ew
 aa
 aa
+Sl
+ME
+Sl
 aa
 aa
-bk
-bk
-ah
-bk
-bk
-aa
-aa
-aa
-aa
+VE
+VE
+Ew
 aa
 "}
 (2,1,1) = {"
 aa
-ak
-ak
-ak
-ak
-ae
-bv
-ax
-aB
-ae
-ak
-ak
-ak
-ak
+VE
+VE
+VE
+aa
+ex
+Sl
+bA
+zt
+da
+aa
+VE
+VE
+VE
 aa
 "}
 (3,1,1) = {"
-bk
-bk
-aD
-aD
-bk
-bk
-bk
-bC
-bk
-bk
-bk
-aD
-aD
-bk
+Sl
+qR
+qR
+qR
+Sl
+YC
+Sl
+Rd
+Sl
+Sl
+Sl
+qR
+qR
+qR
 bk
 "}
 (4,1,1) = {"
-bk
-bk
-bk
-bk
-bk
-bm
-bw
-ax
-bT
-bZ
-bk
-bk
-bk
-bk
+Sl
+wq
+aD
+wq
+Sl
+Wz
+rO
+Fk
+XX
+xL
+Sl
+bn
+bn
+bn
 bk
 "}
 (5,1,1) = {"
+Sl
+RN
 bk
-an
-bk
-cZ
-bk
-ay
-aL
-aL
-aL
-aE
-bk
-cl
-oH
-cH
+dK
+Sl
+xM
+ux
+hl
+ux
+pW
+Sl
+vM
+ts
+sw
 bk
 "}
 (6,1,1) = {"
-ae
-aj
-aG
-at
-bd
-aL
-bx
-bD
-bx
-aL
-ce
-cm
-ax
-cH
-ae
+QE
+lD
+eZ
+RQ
+eZ
+gv
+sa
+PB
+vK
+YU
+Sl
+fu
+Oo
+bu
+QE
 "}
 (7,1,1) = {"
-bk
-bk
-bk
-bk
-bk
-aL
-by
-bE
-bU
-aL
-cf
-ax
-aL
-cI
-ae
+Sl
+Sl
+Sl
+Sl
+ps
+gv
+Fn
+AG
+MO
+SJ
+WB
+Uz
+cj
+RK
+QE
 "}
 (8,1,1) = {"
-ae
-Gy
-JR
-aL
-bf
-JR
-by
-fh
-bU
-aL
+QE
+ZG
+Cp
+pf
+yz
+Ss
+rs
+Hs
+uO
+VO
 bk
-cn
-cw
-cH
-bk
+eu
+GV
+Uq
+Sl
 "}
 (9,1,1) = {"
+Sl
+fM
+SR
+Gm
 bk
-XU
-aq
-zE
-bg
-JR
-by
-bG
-bU
-aF
-bk
-bk
+XS
+gv
+iK
+lZ
+fp
 cx
 bk
-bk
+Sl
+Sl
+Sl
 "}
 (10,1,1) = {"
-bk
-bk
-bk
-bk
-bk
-az
-bz
-bH
-bx
-aL
-cg
-aL
-cy
-cJ
-bk
+Sl
+Sl
+Sl
+Sl
+Sl
+ZB
+gv
+qN
+UD
+cF
+DN
+HX
+PR
+Li
+Sl
 "}
 (11,1,1) = {"
-bk
-Oj
-kR
-VU
-bk
-zy
-aL
-ax
-aL
-aL
-bk
-aI
-mu
-Nw
-ae
+Sl
+SF
+wJ
+ss
+Sl
+Nv
+Pe
+IG
+SK
+th
+Sl
+pB
+wg
+dW
+QE
 "}
 (12,1,1) = {"
-ae
-kL
-Ua
-Ft
-bk
-bk
-bk
-bI
-bk
-bk
-bk
-lq
-cz
-CQ
-ae
+QE
+gv
+iU
+gv
+Sl
+Sl
+Sl
+tn
+Sl
+Sl
+Sl
+wm
+wg
+Ch
+QE
 "}
 (13,1,1) = {"
-ae
-kL
-JR
-JR
-aM
-JR
-JR
-JR
-JR
-JR
-bk
-fr
-eH
-ry
-bk
+QE
+sr
+Pm
+KY
+VH
+ne
+gL
+wj
+gv
+XG
+Sl
+wG
+uj
+ZV
+Sl
 "}
 (14,1,1) = {"
-bk
-au
-ar
-TL
-PB
-JR
-bx
-DS
-Zb
-JR
-bk
-bk
-bk
-bk
-bk
+Sl
+iD
+GU
+gv
+WX
+gv
+gv
+ag
+gv
+la
+Sl
+Sl
+Sl
+Sl
+Sl
 "}
 (15,1,1) = {"
-bk
-bk
-Ct
-bk
-bk
-az
-bx
-ov
-bx
-aE
-bk
-hs
-jc
-lo
-bk
+Sl
+Sl
+Jt
+Sl
+af
+gv
+gv
+ag
+gv
+gv
+XF
+JI
+Hd
+yO
+Sl
 "}
 (16,1,1) = {"
-pu
-aw
-aL
-ax
-YW
-JR
-JR
-gv
-JR
-JR
-pa
-aL
-ax
-Xq
-ae
+uT
+qc
+dh
+wP
+KY
+KY
+Zw
+fq
+gj
+gj
+qC
+fF
+rh
+BC
+QE
 "}
 (17,1,1) = {"
-Bd
-ax
-as
-aL
-YW
-aL
-JR
-bx
-aL
-JR
-bk
-rT
-ti
-id
-bk
+Sl
+Sl
+Sl
+Sl
+MN
+gv
+jk
+ym
+rh
+rh
+dA
+ol
+DZ
+Zs
+Sl
 "}
 (18,1,1) = {"
-bk
-bk
-bk
-bk
-bk
-JR
-aL
-bx
-JR
-JR
-bk
-bk
-bk
-bk
-bk
+Sl
+eS
+xs
+DX
+WX
+gv
+gv
+Zx
+UQ
+Wq
+Sl
+Sl
+Sl
+Sl
+Sl
 "}
 (19,1,1) = {"
-bk
-RI
-af
-JR
-bk
-az
-Zb
-my
-Zb
-aE
-bk
-XZ
-aO
-gP
-bk
+Sl
+gv
+CR
+gv
+WX
+gv
+gv
+Fk
+gv
+hy
+Sl
+Mq
+CS
+rv
+Sl
 "}
 (20,1,1) = {"
+Sl
+cQ
+Sw
+KY
+Zv
+KY
+KY
+oe
+gv
+EZ
 bk
-ao
-ag
-PO
-bk
-JR
-Zb
-LC
-bz
-JR
-ci
-JR
-JR
-qA
-bk
+ek
+dT
+kJ
+Sl
 "}
 (21,1,1) = {"
-ae
-vK
-aL
-aL
-ap
-aL
-JR
-ax
-aL
-JR
-cj
-JR
-Zp
-cL
-ae
+QE
+TH
+xy
+Qx
+Sl
+ls
+gv
+Vt
+Ba
+Ba
+FD
+Su
+hD
+Ac
+QE
 "}
 (22,1,1) = {"
-ae
-ad
-aL
-al
-bk
-bk
-bk
-bP
-bk
-bk
-bk
-aJ
-lL
-qR
-ae
+QE
+wp
+jk
+OS
+Sl
+Sl
+Sl
+aS
+Sl
+Sl
+Sl
+ku
+wg
+ka
+QE
 "}
 (23,1,1) = {"
-ab
-JR
-ai
-am
-bk
-eT
-HW
-JR
-wj
-Fj
-bk
-Mw
-Nt
-oK
+Ls
+JG
+gv
+OS
+Sl
+bx
+vo
+Sk
+eD
+ar
+Sl
+Jx
+Hu
+lT
 bk
 "}
 (24,1,1) = {"
 bk
 bk
-ae
-bk
-bk
-aA
-oy
-JR
-Di
-aH
-bk
-bk
-ae
+QE
+Sl
+Sl
+OV
+kP
+KQ
+IC
+UL
+Sl
+Sl
+QE
 bk
 bk
 "}
@@ -1644,13 +2073,13 @@ aa
 aa
 aa
 aa
-ae
-fw
-JR
-ZB
-JR
-ea
-ae
+aO
+UC
+je
+je
+je
+ON
+aO
 aa
 aa
 aa
@@ -1661,13 +2090,13 @@ aa
 aa
 aa
 aa
-ae
-ho
-DY
-pP
-aN
-pg
-ae
+aO
+Uu
+SU
+Rj
+Kt
+WJ
+aO
 aa
 aa
 aa
@@ -1679,11 +2108,11 @@ aa
 aa
 aa
 bk
-ae
-ae
-ae
-ae
-ae
+aO
+aO
+aO
+aO
+aO
 bk
 aa
 aa

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,35 +2,100 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ac" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"al" = (
-/obj/machinery/light{
-	dir = 1
+"ap" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/window{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"as" = (
+"aD" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"aU" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"aY" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"bg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"ay" = (
+"bk" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"bv" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"bK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"cm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"cx" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"cz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -45,1026 +110,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"aD" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"aH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"aQ" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"aU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"bk" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"bx" = (
-/obj/structure/closet/crate{
-	name = "emergency supplies crate"
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight/flare{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/wrench,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"cs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"cx" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"ds" = (
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"dG" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 8
-	},
-/turf/template_noop,
-/area/shuttle/abandoned)
-"dH" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"dO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"dZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ef" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"eq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"eu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"eA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"eC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/mixedcubes,
-/obj/item/storage/box/fancy/egg_box{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"eG" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"eH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"eI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"fB" = (
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/ore_redemption,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fS" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"gl" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gQ" = (
-/obj/structure/toilet{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"hP" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "engineering"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"hQ" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"hY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"ig" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"ih" = (
-/obj/docking_port/mobile{
-	callTime = 250;
-	dheight = 0;
-	dir = 2;
-	dwidth = 11;
-	height = 15;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Free Miner Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 28
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"iq" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"jb" = (
-/obj/machinery/door/airlock/shuttle{
-	icon_state = "closed";
-	name = "medbay";
-	welded = 0
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"jB" = (
+"cL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"jT" = (
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"kh" = (
-/obj/machinery/mecha_part_fabricator/maint{
-	req_access = list(71)
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"kr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"ks" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"kt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"kB" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"kN" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"kS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"lg" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"lr" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"lx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"lJ" = (
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"lQ" = (
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"md" = (
-/obj/machinery/vending/coffee{
-	pixel_x = -2
-	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mA" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"na" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"nn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"nD" = (
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = -32
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"nK" = (
-/obj/structure/table,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"nO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/mecha_parts/mecha_equipment/mining_scanner,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
-/obj/item/mecha_parts/mecha_equipment/drill,
-/obj/item/mecha_parts/chassis/clarke,
-/obj/item/circuitboard/mecha/clarke/peripherals,
-/obj/item/circuitboard/mecha/clarke/main,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"on" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ov" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oU" = (
-/obj/machinery/computer/shuttle/white_ship/miner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"pd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"pU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"qJ" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"qT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"rB" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"rR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"sa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"su" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bathroom"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"sN" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"ta" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -8
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 1;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"te" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"th" = (
-/obj/structure/ore_box,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ti" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"tI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 12
-	},
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"uq" = (
-/obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ut" = (
-/turf/template_noop,
-/area/shuttle/abandoned)
-"uH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 1;
-	name = "waste";
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"uO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"uV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"vh" = (
-/obj/machinery/button/door{
-	id = "freeship_bridge";
-	name = "Bridge Blast Door Control";
-	pixel_x = -24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "freeship_windows";
-	name = "Windows Blast Door Control";
-	pixel_x = -24;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"vJ" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"vP" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"wd" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"we" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"wi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"wH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wO" = (
-/obj/structure/mecha_wreckage/clarke,
-/turf/open/floor/plasteel/recharge_floor,
-/area/shuttle/abandoned)
-"wU" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = -2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"xd" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -28;
-	req_access_txt = "0"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/iv_drip{
-	density = 0;
-	pixel_x = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"xg" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"xn" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"xH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xQ" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"xY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"yu" = (
-/obj/structure/table,
-/obj/item/storage/box/ids/free_miners{
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/pen/fountain,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"yS" = (
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"yU" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"zd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"zk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"zJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Aa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Ao" = (
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"AB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"AD" = (
-/obj/structure/sign/departments/minsky/engineering/engineering{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"AE" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Bj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"CQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"CY" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/clothing/glasses/meson/sunglasses,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"De" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Dl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"DA" = (
-/obj/effect/mob_spawn/human/free_miner/captain,
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Ej" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "kitchen"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"EC" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"EY" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/welding,
-/obj/item/wrench,
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Fz" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"FF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"FQ" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"Ga" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Gd" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Gj" = (
+"cS" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 6
@@ -1088,7 +141,67 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Gw" = (
+"dk" = (
+/obj/structure/table,
+/obj/item/storage/box/ids/free_miners{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"dp" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 12
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"dJ" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/welding,
+/obj/item/wrench,
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"dY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"ea" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ek" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"eG" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"eL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
@@ -1097,56 +210,113 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Hc" = (
-/obj/structure/closet/crate/medical{
-	name = "medical crate"
+"eP" = (
+/obj/structure/mirror{
+	pixel_x = 28
 	},
-/obj/item/healthanalyzer,
-/obj/item/roller{
-	pixel_y = 4
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/shuttle/abandoned)
-"Hx" = (
+"fc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"fe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ft" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fJ" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fO" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"ge" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"if" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"HY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/table,
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/carpet/black,
+"ih" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"Ik" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/soap,
+"iO" = (
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+"iP" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"IB" = (
-/obj/machinery/computer/crew{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/carpet/cyan,
+/obj/structure/table,
+/obj/item/storage/box/mixedcubes,
+/obj/item/storage/box/fancy/egg_box{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"IL" = (
+"iW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
 	},
@@ -1156,422 +326,7 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"IX" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Jl" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"JQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Kv" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"KL" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"KZ" = (
-/obj/structure/table,
-/obj/item/megaphone,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/item/storage/bag/ore,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/mining_scanner,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Lb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"LN" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"LZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Mt" = (
-/obj/machinery/griddle,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"MV" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/camera,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Nk" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/machinery/door/window/westright{
-	dir = 4
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"Nl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/chair/americandiner/booth{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Nu" = (
-/obj/machinery/syndicatebomb/training{
-	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
-	name = "self-destruct device"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"NN" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Oc" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Ol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Ou" = (
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"OJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Pv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"QA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Rp" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice{
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"RS" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"RV" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"SX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"SZ" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"Tn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"TU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Uj" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Un" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"UF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"UN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/optable,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"UW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Va" = (
-/obj/effect/mob_spawn/human/free_miner/engi,
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Vp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Vv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"VA" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"VD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science{
-	categories = list("Exosuit Modules");
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"VV" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"Ws" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"WW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Xn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"XK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XQ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"XR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"XS" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_bridge"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Yd" = (
-/obj/machinery/computer/rdconsole/robotics{
-	dir = 4;
-	name = "R&D Console";
-	req_access_txt = "71";
-	research_control = 0
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Yo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Yp" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Yx" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"YJ" = (
+"jp" = (
 /obj/machinery/light,
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -1589,7 +344,482 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"YM" = (
+"kc" = (
+/obj/structure/table,
+/obj/item/megaphone,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/bag/ore,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/mining_scanner,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"kn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"lS" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"mb" = (
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/stack/cable_coil,
+/obj/item/assembly/igniter,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"md" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"mu" = (
+/obj/structure/closet/crate{
+	name = "emergency supplies crate"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight/flare{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/wrench,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"mz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"mU" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"nb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nt" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/camera,
+/obj/item/storage/photo_album,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"nz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/equipment_vendor/free_miner,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nB" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"nF" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"of" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"oh" = (
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oz" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"oG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oK" = (
+/obj/structure/ore_box,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"oL" = (
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"pk" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"pt" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"pE" = (
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"pK" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"qd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qu" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	req_access = list(71)
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"qX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rc" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"rs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"rF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sa" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"sn" = (
+/obj/machinery/computer/shuttle/white_ship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"st" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"sW" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"tq" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"tQ" = (
+/obj/effect/mob_spawn/human/free_miner/captain,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"uu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/table,
+/obj/item/storage/box/fancy/donut_box,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"ux" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"vt" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"ws" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.7;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wt" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"wu" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"wB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"wF" = (
+/obj/docking_port/mobile{
+	callTime = 250;
+	dheight = 0;
+	dir = 2;
+	dwidth = 11;
+	height = 15;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Free Miner Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 28
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"wG" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"wU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"xD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"xN" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"yl" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28;
+	req_access_txt = "0"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/iv_drip{
+	density = 0;
+	pixel_x = -8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"yy" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/chassis/clarke,
+/obj/item/circuitboard/mecha/clarke/peripherals,
+/obj/item/circuitboard/mecha/clarke/main,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"yS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"yT" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"yX" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
@@ -1605,42 +835,96 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"YS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+"yY" = (
+/obj/machinery/button/door{
+	id = "freeship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "freeship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -24;
+	pixel_y = -5
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"YT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/equipment_vendor/free_miner,
+"zI" = (
+/obj/structure/table,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"YZ" = (
-/obj/machinery/light{
+"zM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ae" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ai" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"AR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
-"ZL" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "dormitory"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
+"Bb" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned)
-"ZO" = (
+"Bf" = (
+/obj/machinery/computer/rdconsole/robotics{
+	dir = 4;
+	name = "R&D Console";
+	req_access_txt = "71";
+	research_control = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"BI" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"BJ" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"BK" = (
+/obj/structure/mecha_wreckage/clarke,
+/turf/open/floor/plasteel/recharge_floor,
+/area/shuttle/abandoned)
+"BY" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 8
+	},
+/turf/template_noop,
+/area/shuttle/abandoned)
+"Cm" = (
+/turf/template_noop,
+/area/shuttle/abandoned)
+"Cn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -1659,412 +943,1133 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"Cr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Cz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CB" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"CH" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Dk" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1;
+	name = "waste";
+	volume_rate = 200
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"DI" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"DO" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Eh" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Em" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"EF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"FA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"FC" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"FK" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"FS" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"FX" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Gk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GH" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"GM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GT" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = -32
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Hd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Hx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"HD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"HF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"HJ" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = -2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"HM" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Ig" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Ir" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"It" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"IV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"IX" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Je" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Jh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Kz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"KA" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/obj/machinery/door/window/westright{
+	dir = 4
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"Lx" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Md" = (
+/obj/machinery/door/airlock/shuttle{
+	icon_state = "closed";
+	name = "medbay";
+	welded = 0
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"MF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"MW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Na" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Nn" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"NN" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Oi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"OU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Pi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"Pj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Pp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Ps" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"PT" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Qh" = (
+/obj/machinery/vending/coffee{
+	pixel_x = -2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Ra" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science{
+	categories = list("Exosuit Modules");
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Rs" = (
+/obj/effect/mob_spawn/human/free_miner/engi,
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"RE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Sj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Sx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Sz" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"SA" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"SD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SE" = (
+/obj/structure/closet/crate/medical{
+	name = "medical crate"
+	},
+/obj/item/healthanalyzer,
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"SI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SY" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/soap,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Tl" = (
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Ty" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"TX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"UQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"US" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Vk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Wh" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Wq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Wt" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"Wz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"WE" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"WF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"WZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"XI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"XR" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/clothing/glasses/meson/sunglasses,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Ys" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YX" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"YZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Zy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ZA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ZW" = (
+/obj/machinery/syndicatebomb/training{
+	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
+	name = "self-destruct device"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ZZ" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_bridge"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
-ut
-ut
-dG
+Cm
+Cm
+BY
 aa
 aa
-XQ
-pU
-XQ
+Ty
+NN
+Ty
 aa
 aa
-ut
-ut
-dG
+Cm
+Cm
+BY
 aa
 "}
 (2,1,1) = {"
 aa
-ut
-ut
-ut
+Cm
+Cm
+Cm
 aa
-xQ
-XQ
-ay
-kr
-uH
+IX
+Ty
+cz
+Pp
+Dk
 aa
-ut
-ut
-ut
+Cm
+Cm
+Cm
 aa
 "}
 (3,1,1) = {"
-XQ
-lJ
-lJ
-lJ
-XQ
-SX
-XQ
-ZO
-XQ
-XQ
-XQ
-lJ
-lJ
-lJ
+Ty
+FS
+FS
+FS
+Ty
+Vk
+Ty
+Cn
+Ty
+Ty
+Ty
+FS
+FS
+FS
 bk
 "}
 (4,1,1) = {"
-XQ
-VV
+Ty
+OU
 aD
-VV
-XQ
-wU
-md
-cs
-rB
-lQ
-XQ
-sN
-sN
-sN
+OU
+Ty
+HJ
+Qh
+Wq
+eG
+ft
+Ty
+wt
+wt
+wt
 bk
 "}
 (5,1,1) = {"
-XQ
-gQ
+Ty
+oL
 bk
-Nk
-XQ
-eq
-FF
-ef
-FF
-Oc
-XQ
-VA
-eA
-Pv
+KA
+Ty
+gS
+bK
+ea
+bK
+FX
+Ty
+sW
+rc
+Wz
 bk
 "}
 (6,1,1) = {"
-LN
-Kv
-su
-xg
-su
-yS
-Ou
-Nl
-kt
-Ol
-XQ
-eu
-zJ
-dH
-LN
+ih
+FK
+oz
+eP
+oz
+oh
+Tl
+EF
+HD
+md
+Ty
+xD
+of
+nF
+ih
 "}
 (7,1,1) = {"
-XQ
-XQ
-XQ
-XQ
-SZ
-yS
-HY
-Ws
-xa
-De
-hP
-eH
-Aa
-vP
-LN
+Ty
+Ty
+Ty
+Ty
+Bb
+oh
+uu
+Cr
+bv
+MW
+pt
+mz
+WF
+PT
+ih
 "}
 (8,1,1) = {"
-LN
-Rp
-uO
-Tn
-ZL
-CQ
-sc
-Bj
-xY
-AD
+ih
+sa
+fc
+XI
+st
+fe
+Kz
+HM
+qH
+Wh
 bk
-Va
-rR
-EY
-XQ
+Rs
+ux
+dJ
+Ty
 "}
 (9,1,1) = {"
-XQ
-ac
-kB
-FQ
+Ty
+Wt
+FC
+fO
 bk
+GM
+oh
+aU
 Hx
-yS
-ti
-WW
-wd
+Em
 cx
 bk
-XQ
-XQ
-XQ
+Ty
+Ty
+Ty
 "}
 (10,1,1) = {"
-XQ
-XQ
-XQ
-XQ
-XQ
-YZ
-yS
-OJ
-pd
-sa
-Ej
-jB
-AE
-lr
-XQ
+Ty
+Ty
+Ty
+Ty
+Ty
+rs
+oh
+gz
+Je
+qd
+Lx
+cL
+vt
+BJ
+Ty
 "}
 (11,1,1) = {"
-XQ
-Ik
-TU
-Uj
-XQ
-wi
-qT
-dZ
-hY
-vJ
-XQ
-eC
-AB
-iq
-LN
+Ty
+SY
+nb
+US
+Ty
+AR
+wB
+ap
+Pi
+nB
+Ty
+iP
+RE
+GH
+ih
 "}
 (12,1,1) = {"
-LN
-yS
-Dl
-yS
-XQ
-XQ
-XQ
-Jl
-XQ
-XQ
-XQ
-Mt
-AB
-tI
-LN
+ih
+oh
+Ai
+oh
+Ty
+Ty
+Ty
+aY
+Ty
+Ty
+Ty
+CH
+RE
+dp
+ih
 "}
 (13,1,1) = {"
-LN
-QA
-ks
-wH
-Gd
-IL
-aH
-ov
-yS
-eG
-XQ
-ig
-UW
-Gj
-XQ
+ih
+Ir
+Jh
+SN
+Sj
+iW
+qX
+wU
+oh
+Nn
+Ty
+mU
+Ig
+cS
+Ty
 "}
 (14,1,1) = {"
-XQ
-XK
-UF
-yS
-XR
-yS
-yS
-uV
-yS
-YJ
-XQ
-XQ
-XQ
-XQ
-XQ
+Ty
+Oi
+Sx
+oh
+zM
+oh
+oh
+oG
+oh
+jp
+Ty
+Ty
+Ty
+Ty
+Ty
 "}
 (15,1,1) = {"
-XQ
-XQ
-eI
-XQ
-mK
-yS
-yS
-uV
-yS
-yS
-nO
-VD
-Yd
-kh
-XQ
+Ty
+Ty
+dY
+Ty
+SD
+oh
+oh
+oG
+oh
+oh
+yy
+Ra
+Bf
+qu
+Ty
 "}
 (16,1,1) = {"
+wF
+yX
+bg
+MF
+SN
+SN
+Pj
+ZW
+HF
+HF
+Eh
+Cz
+Hd
+ge
 ih
-YM
-na
-as
-wH
-wH
-te
-Nu
-Yo
-Yo
-Ga
-mz
-zd
-aQ
-LN
 "}
 (17,1,1) = {"
-XQ
-XQ
-XQ
-XQ
-al
-yS
-lx
-on
-zd
-zd
-gl
-KL
-wO
-qJ
-XQ
+Ty
+Ty
+Ty
+Ty
+ZA
+oh
+GR
+Zy
+Hd
+Hd
+UQ
+BI
+BK
+fJ
+Ty
 "}
 (18,1,1) = {"
-XQ
-Fz
-th
-nD
-XR
-yS
-yS
-zk
-kS
-nK
-XQ
-XQ
-XQ
-XQ
-XQ
+Ty
+wG
+oK
+iO
+zM
+oh
+oh
+It
+nc
+zI
+Ty
+Ty
+Ty
+Ty
+Ty
 "}
 (19,1,1) = {"
-XQ
-yS
-Lb
-yS
-XR
-yS
-yS
-cs
-yS
-Yx
-XQ
-yU
-xd
-Hc
-XQ
+Ty
+oh
+kn
+oh
+zM
+oh
+oh
+Wq
+oh
+DI
+Ty
+yT
+yl
+SE
+Ty
 "}
 (20,1,1) = {"
-XQ
-YT
-mu
-wH
-oz
-wH
-wH
-JQ
-yS
-ds
+Ty
+nz
+Gk
+SN
+SI
+SN
+SN
+rF
+oh
+GT
 bk
-lg
-nn
-xn
-XQ
+WE
+xb
+tq
+Ty
 "}
 (21,1,1) = {"
-LN
-fB
-xH
-Vp
-XQ
-uq
-yS
-Iv
-aU
-aU
-jb
-Vv
-Gw
-EC
-LN
+ih
+mb
+if
+cm
+Ty
+ws
+oh
+CA
+Ae
+Ae
+Md
+IV
+eL
+ek
+ih
 "}
 (22,1,1) = {"
-LN
-bx
-lx
-Ao
-XQ
-XQ
-XQ
-RV
-XQ
-XQ
-XQ
-UN
-AB
-Yp
-LN
+ih
+mu
+GR
+Ys
+Ty
+Ty
+Ty
+SA
+Ty
+Ty
+Ty
+lM
+RE
+Ps
+ih
 "}
 (23,1,1) = {"
-RS
-mA
-yS
-Ao
-XQ
-DA
-vh
-Un
-jT
-IX
-XQ
-kN
-NN
-ta
+pK
+xN
+oh
+Ys
+Ty
+tQ
+yY
+TX
+pE
+YX
+Ty
+pk
+DO
+lS
 bk
 "}
 (24,1,1) = {"
 bk
 bk
-LN
-XQ
-XQ
-LZ
-YS
-Xn
-dO
-KZ
-XQ
-XQ
-LN
+ih
+Ty
+Ty
+FA
+Na
+yS
+YZ
+kc
+Ty
+Ty
+ih
 bk
 bk
 "}
@@ -2073,13 +2078,13 @@ aa
 aa
 aa
 aa
-XS
-yu
-hQ
-hQ
-hQ
-we
-XS
+ZZ
+dk
+WZ
+WZ
+WZ
+wu
+ZZ
 aa
 aa
 aa
@@ -2090,13 +2095,13 @@ aa
 aa
 aa
 aa
-XS
-MV
-IB
-oU
-fS
-CY
-XS
+ZZ
+nt
+Sz
+sn
+CB
+XR
+ZZ
 aa
 aa
 aa
@@ -2108,11 +2113,11 @@ aa
 aa
 aa
 bk
-XS
-XS
-XS
-XS
-XS
+ZZ
+ZZ
+ZZ
+ZZ
+ZZ
 bk
 aa
 aa

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ap" = (
+"ay" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
@@ -13,6 +13,15 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"aC" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "aD" = (
 /obj/structure/shuttle/engine/heater{
@@ -24,25 +33,32 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"aU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"aY" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+"aI" = (
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"aY" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"ba" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"bk" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"bx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -50,74 +66,462 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"bg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"bk" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"bv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"bK" = (
-/obj/structure/disposalpipe/segment{
 	dir = 2
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"cm" = (
+"cq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ct" = (
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"cx" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"cF" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"cH" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"cK" = (
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"cR" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"dk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"dm" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_bridge"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"dN" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"fA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"fD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"cx" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/abandoned)
-"cz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"cL" = (
+"fW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gm" = (
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"cS" = (
+"gD" = (
+/obj/structure/shuttle/engine/huge{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"gE" = (
+/obj/structure/sign/departments/minsky/engineering/engineering{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"hf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"hE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"hU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"id" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ih" = (
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"io" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"iN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"jk" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"jV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"kn" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"kt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"nf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"nZ" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"oE" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"oS" = (
+/obj/structure/toilet{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"pp" = (
+/obj/effect/mob_spawn/human/free_miner/captain,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"pu" = (
+/obj/machinery/computer/shuttle/white_ship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"pH" = (
+/obj/structure/closet/crate{
+	name = "emergency supplies crate"
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight/flare{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/wrench,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"pJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"pN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"qe" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qs" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8;
+	icon_state = "heater"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"sw" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1;
+	name = "waste";
+	volume_rate = 200
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"sA" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"tr" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"uk" = (
+/obj/structure/table,
+/obj/item/megaphone,
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/item/storage/bag/ore,
+/obj/item/clothing/gloves/color/black,
+/obj/item/pickaxe,
+/obj/item/mining_scanner,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"uM" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"vo" = (
+/obj/structure/table,
+/obj/item/storage/box/ids/free_miners{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/gps{
+	gpstag = "NTREC1";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"vO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"vZ" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 6
@@ -141,583 +545,49 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"dk" = (
-/obj/structure/table,
-/obj/item/storage/box/ids/free_miners{
-	pixel_x = 1;
-	pixel_y = 7
+"wb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/item/gps{
-	gpstag = "NTREC1";
-	pixel_x = -1;
-	pixel_y = 2
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
 	},
-/obj/item/pen/fountain,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"dp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 12
-	},
-/obj/item/kitchen/rollingpin,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"dJ" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/welding,
-/obj/item/wrench,
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"dY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/abandoned)
-"ea" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ek" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"eG" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"eL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"eP" = (
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
 	},
 /obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"fc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"fe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ft" = (
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fJ" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fO" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/item/bedsheet/dorms,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"ge" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gS" = (
-/obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"if" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ih" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"iO" = (
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = -32
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/shuttle,
+"wu" = (
+/obj/structure/mecha_wreckage/clarke,
+/turf/open/floor/plasteel/recharge_floor,
 /area/shuttle/abandoned)
-"iP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/storage/box/mixedcubes,
-/obj/item/storage/box/fancy/egg_box{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/kitchen/knife,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"iW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"jp" = (
-/obj/machinery/light,
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"kc" = (
-/obj/structure/table,
-/obj/item/megaphone,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/item/storage/bag/ore,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/mining_scanner,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"kn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"lM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/optable,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"lS" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -8
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 1;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"mb" = (
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/ore_redemption,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"md" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mu" = (
-/obj/structure/closet/crate{
-	name = "emergency supplies crate"
-	},
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight/flare{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/wrench,
-/obj/item/grenade/chem_grenade/metalfoam,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"mz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"mU" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"nb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"nc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"nt" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/camera,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"nz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/mineral/equipment_vendor/free_miner,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"nB" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"nF" = (
+"wF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"of" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+"wS" = (
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"oh" = (
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oz" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bathroom"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"oG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oK" = (
-/obj/structure/ore_box,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"oL" = (
-/obj/structure/toilet{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"pk" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"pt" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "engineering"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"pE" = (
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"pK" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"qd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"qu" = (
-/obj/machinery/mecha_part_fabricator/maint{
-	req_access = list(71)
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"qH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"qX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"rc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"rs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"rF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sa" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice{
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"sn" = (
-/obj/machinery/computer/shuttle/white_ship/miner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"st" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "dormitory"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"sW" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"tq" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"tQ" = (
-/obj/effect/mob_spawn/human/free_miner/captain,
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"uu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/table,
-/obj/item/storage/box/fancy/donut_box,
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"ux" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"vt" = (
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"ws" = (
-/obj/structure/tank_dispenser/oxygen{
-	layer = 2.7;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wt" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"wu" = (
-/obj/structure/table,
-/obj/item/healthanalyzer,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"wB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"wF" = (
+"xz" = (
 /obj/docking_port/mobile{
 	callTime = 250;
 	dheight = 0;
@@ -741,35 +611,196 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"wG" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"wU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"yx" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"xb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"xD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/structure/rack{
+	dir = 8;
+	layer = 2.9;
+	pixel_y = 2
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"xN" = (
-/obj/structure/closet/emcloset,
+"yy" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"yN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"yl" = (
+"yT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"yW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"zc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"zd" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.7;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"zG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Al" = (
+/obj/machinery/vending/coffee{
+	pixel_x = -2
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Am" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"AQ" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"AS" = (
+/obj/machinery/suit_storage_unit/mining/eva,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Bh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Bw" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower"
+	},
+/obj/machinery/door/window/westright{
+	dir = 4
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"BC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"BO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"BV" = (
+/obj/machinery/door/airlock/shuttle{
+	icon_state = "closed";
+	name = "medbay";
+	welded = 0
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Cf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CM" = (
+/obj/machinery/light,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Db" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -28;
@@ -787,109 +818,34 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"yy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/mecha_parts/mecha_equipment/mining_scanner,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
-/obj/item/mecha_parts/mecha_equipment/drill,
-/obj/item/mecha_parts/chassis/clarke,
-/obj/item/circuitboard/mecha/clarke/peripherals,
-/obj/item/circuitboard/mecha/clarke/main,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"yS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"yT" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
+"Ds" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"yX" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
+"DV" = (
+/obj/effect/mob_spawn/human/free_miner/engi,
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"yY" = (
-/obj/machinery/button/door{
-	id = "freeship_bridge";
-	name = "Bridge Blast Door Control";
-	pixel_x = -24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "freeship_windows";
-	name = "Windows Blast Door Control";
-	pixel_x = -24;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"zI" = (
-/obj/structure/table,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/mining_scanner,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"zM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Ae" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Ai" = (
+"DX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"AR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 9
 	},
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
-"Bb" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+"Ej" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/soap,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Bf" = (
+"Eq" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Es" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 4;
 	name = "R&D Console";
@@ -898,52 +854,56 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"BI" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
+"EI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"EO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"EV" = (
+/obj/machinery/vending/cigarette{
+	pixel_x = -2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"BJ" = (
+"EX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Fb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"Fd" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"BK" = (
-/obj/structure/mecha_wreckage/clarke,
-/turf/open/floor/plasteel/recharge_floor,
-/area/shuttle/abandoned)
-"BY" = (
-/obj/structure/shuttle/engine/huge{
-	dir = 8
-	},
-/turf/template_noop,
-/area/shuttle/abandoned)
-"Cm" = (
-/turf/template_noop,
-/area/shuttle/abandoned)
-"Cn" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Cr" = (
+"Fm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -961,118 +921,65 @@
 /obj/structure/table,
 /turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"Cz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"CA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"CB" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"CH" = (
-/obj/machinery/griddle,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Dk" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 1;
-	name = "waste";
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"DI" = (
-/obj/machinery/light,
+"Fr" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"DO" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 1;
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Eh" = (
+"FG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/mineral/equipment_vendor/free_miner,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"GW" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "bathroom"
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"Hb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Em" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"EF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/chair/americandiner/booth{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"FA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"FC" = (
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/free_miner{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"FK" = (
+"HB" = (
 /obj/structure/mirror{
 	pixel_x = 28
 	},
@@ -1086,43 +993,199 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/abandoned)
-"FS" = (
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"FX" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"HC" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Gk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"GH" = (
-/obj/machinery/processor,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"GM" = (
+"Iu" = (
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/free_miner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/item/bedsheet/dorms,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"Ix" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"IA" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/welding,
+/obj/item/wrench,
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"IT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"IZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/chassis/clarke,
+/obj/item/circuitboard/mecha/clarke/peripherals,
+/obj/item/circuitboard/mecha/clarke/main,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Jl" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"JW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/seed_extractor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"GR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+"JZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Kl" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/whiteship/miner{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"KB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"KJ" = (
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"LE" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"LW" = (
+/obj/machinery/computer/mech_bay_power_console{
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"GT" = (
+"Mw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/mixedcubes,
+/obj/item/storage/box/fancy/egg_box{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/kitchen/knife,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Ng" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Ni" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/abandoned)
+"Np" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Nz" = (
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Od" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"OR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Pj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science{
+	categories = list("Exosuit Modules");
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Pu" = (
 /obj/structure/sign/departments/minsky/medical/medical2{
 	pixel_y = -32
 	},
@@ -1134,340 +1197,14 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Hd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Hx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"HD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"HF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"HJ" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = -2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"HM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Ig" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Ir" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"It" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"IV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"IX" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"Je" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Jh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Kz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"KA" = (
-/obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
-	},
-/obj/machinery/door/window/westright{
-	dir = 4
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"Lx" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "kitchen"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Md" = (
-/obj/machinery/door/airlock/shuttle{
-	icon_state = "closed";
-	name = "medbay";
-	welded = 0
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"MF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"MW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Na" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"Nn" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"NN" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Oi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"OU" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/shuttle/engine/heater{
-	dir = 8;
-	icon_state = "heater"
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"Pi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"Pj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Pp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Ps" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"PT" = (
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"Qh" = (
-/obj/machinery/vending/coffee{
-	pixel_x = -2
-	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Ra" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science{
-	categories = list("Exosuit Modules");
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Rs" = (
-/obj/effect/mob_spawn/human/free_miner/engi,
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"RE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Sj" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
+"PM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Sx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Sz" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"SA" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "bridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"SD" = (
+"PN" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1476,7 +1213,42 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"SE" = (
+"PW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"PY" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/clothing/glasses/meson/sunglasses,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"Qc" = (
+/obj/machinery/button/door{
+	id = "freeship_bridge";
+	name = "Bridge Blast Door Control";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "freeship_windows";
+	name = "Windows Blast Door Control";
+	pixel_x = -24;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Qf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Qg" = (
 /obj/structure/closet/crate/medical{
 	name = "medical crate"
 	},
@@ -1490,50 +1262,303 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"SI" = (
+"Qh" = (
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Qx" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"Qy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"QQ" = (
+/obj/machinery/mecha_part_fabricator/maint{
+	req_access = list(71)
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Rj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"RF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"RI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Sd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/table,
+/obj/item/storage/box/fancy/donut_box,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Sg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"So" = (
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/ore_redemption,
+/obj/item/stack/cable_coil,
+/obj/item/assembly/igniter,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SC" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"SV" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Tg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/shuttle/abandoned)
+"TK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"TR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
-"SN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"SY" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/soap,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Tl" = (
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Ty" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+"TW" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "TX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"TY" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_y = 3
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"Uf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"Uk" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Ux" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "freeship_windows"
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"UR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"US" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Vc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 12
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Vm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Vy" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"UQ" = (
+"VA" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/camera,
+/obj/item/storage/photo_album,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"VH" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"VJ" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"VL" = (
+/obj/machinery/syndicatebomb/training{
+	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
+	name = "self-destruct device"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"VY" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"VZ" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"WB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Xg" = (
+/obj/structure/table,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Xh" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -1543,533 +1568,505 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"US" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Vk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/poddoor{
-	id = "freeship_windows"
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"Wh" = (
-/obj/structure/sign/departments/minsky/engineering/engineering{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"Xm" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
 	},
-/turf/open/floor/plasteel/shuttle,
+/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"Wq" = (
+"Xq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Xr" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"XG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"XL" = (
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Wt" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"Wz" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+"Yk" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"WE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"WF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
+"YM" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"WZ" = (
-/obj/structure/chair/comfy/shuttle{
+"YV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"XI" = (
+"Ze" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/shuttle/abandoned)
-"XR" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/clothing/glasses/meson/sunglasses,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"Ys" = (
-/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"YX" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"YZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"Zy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+"ZV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ZA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ZW" = (
-/obj/machinery/syndicatebomb/training{
-	desc = "A sticky note on the side says 'DO NOT TOUCH, VERY DANGEROUS'.";
-	name = "self-destruct device"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ZZ" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "freeship_bridge"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
-Cm
-Cm
-BY
+tr
+tr
+gD
 aa
 aa
-Ty
-NN
-Ty
+EI
+id
+EI
 aa
 aa
-Cm
-Cm
-BY
+tr
+tr
+gD
 aa
 "}
 (2,1,1) = {"
 aa
-Cm
-Cm
-Cm
+tr
+tr
+tr
 aa
-IX
-Ty
-cz
-Pp
-Dk
+Ix
+EI
+wb
+BO
+sw
 aa
-Cm
-Cm
-Cm
+tr
+tr
+tr
 aa
 "}
 (3,1,1) = {"
-Ty
-FS
-FS
-FS
-Ty
-Vk
-Ty
-Cn
-Ty
-Ty
-Ty
-FS
-FS
-FS
+EI
+tr
+tr
+tr
+EI
+Fb
+EI
+wS
+EI
+EI
+EI
+tr
+tr
+tr
 bk
 "}
 (4,1,1) = {"
-Ty
-OU
+EI
+sg
 aD
-OU
-Ty
-HJ
-Qh
-Wq
-eG
-ft
-Ty
-wt
-wt
-wt
+sg
+EI
+EV
+Al
+JW
+SV
+sA
+EI
+Vy
+Vy
+Vy
 bk
 "}
 (5,1,1) = {"
-Ty
-oL
+EI
+oS
 bk
-KA
-Ty
-gS
-bK
-ea
-bK
-FX
-Ty
-sW
-rc
-Wz
+Bw
+EI
+TX
+kt
+bx
+kt
+qe
+EI
+nZ
+aI
+Uf
 bk
 "}
 (6,1,1) = {"
+dN
+HB
+GW
+VY
+GW
 ih
-FK
-oz
-eP
-oz
-oh
-Tl
-EF
-HD
-md
-Ty
-xD
-of
-nF
-ih
+Nz
+qd
+sC
+FG
+EI
+TK
+Xr
+wF
+dN
 "}
 (7,1,1) = {"
-Ty
-Ty
-Ty
-Ty
-Bb
-oh
-uu
-Cr
-bv
-MW
-pt
-mz
-WF
-PT
+EI
+EI
+EI
+EI
+Ni
 ih
+Sd
+Fm
+Xm
+YV
+VH
+cq
+Qy
+yx
+dN
 "}
 (8,1,1) = {"
-ih
-sa
-fc
-XI
-st
-fe
-Kz
-HM
-qH
-Wh
+dN
+TY
+Hb
+Am
+Od
+fW
+XG
+Ng
+yW
+gE
 bk
-Rs
-ux
-dJ
-Ty
+DV
+yT
+IA
+EI
 "}
 (9,1,1) = {"
-Ty
-Wt
-FC
-fO
+EI
+aY
+oE
+Iu
 bk
-GM
-oh
-aU
-Hx
-Em
+fA
+ih
+EX
+Vm
+VZ
 cx
 bk
-Ty
-Ty
-Ty
+EI
+EI
+EI
 "}
 (10,1,1) = {"
-Ty
-Ty
-Ty
-Ty
-Ty
-rs
-oh
-gz
-Je
-qd
-Lx
-cL
-vt
-BJ
-Ty
+EI
+EI
+EI
+EI
+EI
+Tg
+ih
+qg
+SB
+UR
+Uk
+SD
+KJ
+VJ
+EI
 "}
 (11,1,1) = {"
-Ty
-SY
-nb
-US
-Ty
-AR
-wB
-ap
-Pi
-nB
-Ty
-iP
-RE
-GH
-ih
+EI
+Ej
+nf
+SC
+EI
+PW
+IT
+ay
+DX
+Qx
+EI
+Mw
+hU
+cH
+dN
 "}
 (12,1,1) = {"
+dN
 ih
-oh
-Ai
-oh
-Ty
-Ty
-Ty
-aY
-Ty
-Ty
-Ty
-CH
-RE
-dp
+yN
 ih
+EI
+EI
+EI
+AQ
+EI
+EI
+EI
+Eq
+hU
+Vc
+dN
 "}
 (13,1,1) = {"
+dN
+rU
+dk
+PM
+kn
+RI
+qW
+OR
 ih
-Ir
-Jh
-SN
-Sj
-iW
-qX
-wU
-oh
-Nn
-Ty
-mU
-Ig
-cS
-Ty
+Fd
+EI
+HC
+zG
+vZ
+EI
 "}
 (14,1,1) = {"
-Ty
-Oi
-Sx
-oh
-zM
-oh
-oh
-oG
-oh
-jp
-Ty
-Ty
-Ty
-Ty
-Ty
+EI
+Cf
+KB
+ih
+pN
+ih
+ih
+Sg
+ih
+CM
+EI
+EI
+EI
+EI
+EI
 "}
 (15,1,1) = {"
-Ty
-Ty
-dY
-Ty
-SD
-oh
-oh
-oG
-oh
-oh
-yy
-Ra
-Bf
-qu
-Ty
+EI
+EI
+zc
+EI
+PN
+ih
+ih
+Sg
+ih
+ih
+IZ
+Pj
+Es
+QQ
+EI
 "}
 (16,1,1) = {"
-wF
-yX
-bg
-MF
-SN
-SN
-Pj
-ZW
-HF
-HF
-Eh
-Cz
-Hd
-ge
-ih
+xz
+io
+BC
+TR
+PM
+PM
+Bh
+VL
+qZ
+qZ
+Ze
+iN
+qq
+Np
+dN
 "}
 (17,1,1) = {"
-Ty
-Ty
-Ty
-Ty
-ZA
-oh
-GR
-Zy
-Hd
-Hd
-UQ
-BI
-BK
-fJ
-Ty
+EI
+EI
+EI
+EI
+US
+ih
+lv
+Jl
+qq
+qq
+Xh
+cF
+wu
+LW
+EI
 "}
 (18,1,1) = {"
-Ty
-wG
-oK
-iO
-zM
-oh
-oh
-It
-nc
-zI
-Ty
-Ty
-Ty
-Ty
-Ty
+EI
+jk
+Qf
+XL
+pN
+ih
+ih
+vO
+Rj
+Xg
+EI
+EI
+EI
+EI
+EI
 "}
 (19,1,1) = {"
-Ty
-oh
-kn
-oh
-zM
-oh
-oh
-Wq
-oh
-DI
-Ty
-yT
-yl
-SE
-Ty
+EI
+ih
+GG
+ih
+pN
+ih
+ih
+JW
+ih
+qs
+EI
+aC
+Db
+Qg
+EI
 "}
 (20,1,1) = {"
-Ty
-nz
-Gk
-SN
-SI
-SN
-SN
-rF
-oh
-GT
+EI
+GE
+hE
+PM
+CD
+PM
+PM
+EO
+ih
+Pu
 bk
-WE
-xb
-tq
-Ty
+Ds
+pJ
+gm
+EI
 "}
 (21,1,1) = {"
+dN
+So
+JZ
+fD
+EI
+zd
 ih
-mb
-if
-cm
-Ty
-ws
-oh
-CA
-Ae
-Ae
-Md
-IV
-eL
-ek
-ih
+qU
+nK
+nK
+BV
+WB
+ZV
+LE
+dN
 "}
 (22,1,1) = {"
-ih
-mu
-GR
-Ys
-Ty
-Ty
-Ty
-SA
-Ty
-Ty
-Ty
-lM
-RE
-Ps
-ih
+dN
+pH
+lv
+AS
+EI
+EI
+EI
+uM
+EI
+EI
+EI
+hf
+hU
+ct
+dN
 "}
 (23,1,1) = {"
-pK
-xN
-oh
-Ys
-Ty
-tQ
-yY
-TX
-pE
-YX
-Ty
-pk
-DO
-lS
+Ux
+cR
+ih
+AS
+EI
+pp
+Qc
+Xq
+Qh
+yy
+EI
+TW
+Yk
+Fr
 bk
 "}
 (24,1,1) = {"
 bk
 bk
-ih
-Ty
-Ty
-FA
-Na
-yS
-YZ
-kc
-Ty
-Ty
-ih
+dN
+EI
+EI
+lB
+YY
+ba
+RF
+uk
+EI
+EI
+dN
 bk
 bk
 "}
@@ -2078,13 +2075,13 @@ aa
 aa
 aa
 aa
-ZZ
-dk
-WZ
-WZ
-WZ
-wu
-ZZ
+dm
+vo
+jV
+jV
+jV
+cK
+dm
 aa
 aa
 aa
@@ -2095,13 +2092,13 @@ aa
 aa
 aa
 aa
-ZZ
-nt
-Sz
-sn
-CB
-XR
-ZZ
+dm
+VA
+YM
+pu
+Kl
+PY
+dm
 aa
 aa
 aa
@@ -2113,11 +2110,11 @@ aa
 aa
 aa
 bk
-ZZ
-ZZ
-ZZ
-ZZ
-ZZ
+dm
+dm
+dm
+dm
+dm
 bk
 aa
 aa

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,15 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"aC" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
 "aD" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8;
@@ -49,18 +40,42 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"bI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "hydroponics"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"cn" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/roller{
+	pixel_y = 4
+	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/structure/closet/crate/medical{
+	name = "medical crate"
+	},
+/obj/item/healthanalyzer,
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"ct" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "cx" = (
 /obj/machinery/smartfridge,
@@ -83,15 +98,6 @@
 /area/shuttle/abandoned)
 "cR" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"dk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "dm" = (
@@ -134,19 +140,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"fm" = (
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
+"fk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"fD" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plasteel/shuttle,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "fJ" = (
 /obj/machinery/door/airlock/external,
@@ -168,17 +166,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"gg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"gm" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
 "gD" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
@@ -196,14 +183,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"hf" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/optable,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "hE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -246,6 +225,28 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"iZ" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/clothing/suit/apron/surgical{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/obj/item/clothing/gloves/color/latex{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 2
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
 "jk" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/shuttle,
@@ -261,6 +262,11 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"kL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/table,
+/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -285,6 +291,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
+"np" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "nK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -293,6 +308,17 @@
 "nZ" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ow" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ox" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "oE" = (
 /obj/structure/bed,
@@ -333,6 +359,16 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
+"px" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
 "pH" = (
 /obj/structure/closet/crate{
 	name = "emergency supplies crate"
@@ -349,18 +385,16 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"pJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
 "pN" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"pZ" = (
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "qd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -380,6 +414,16 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"qh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
 "qq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -402,6 +446,21 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"qF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/iv_drip{
+	density = 0;
+	pixel_x = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
 "qU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -413,6 +472,16 @@
 /area/shuttle/abandoned)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"rJ" = (
+/obj/structure/frame/machine,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "sg" = (
@@ -442,6 +511,16 @@
 	},
 /turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
+"sM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "tr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -457,6 +536,15 @@
 /obj/item/pickaxe,
 /obj/item/mining_scanner,
 /turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"uF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/closet/crate/hydroponics,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "uM" = (
 /obj/machinery/door/airlock/shuttle{
@@ -498,6 +586,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"vW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "vZ" = (
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -546,6 +641,31 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"xw" = (
+/obj/machinery/door/airlock/shuttle{
+	icon_state = "closed";
+	name = "medbay";
+	welded = 0
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"xK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
 "xW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -572,26 +692,11 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"yN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "yT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"yW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/chair/americandiner/booth/end_left{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
 "zc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -610,6 +715,15 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Ai" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/chair/americandiner/booth{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
 "Al" = (
 /obj/machinery/vending/coffee{
@@ -635,6 +749,16 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light,
 /turf/open/floor/plating,
+/area/shuttle/abandoned)
+"AP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "AS" = (
 /obj/machinery/suit_storage_unit/mining/eva,
@@ -679,19 +803,9 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"BV" = (
-/obj/machinery/door/airlock/shuttle{
-	icon_state = "closed";
-	name = "medbay";
-	welded = 0
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
+"Cu" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "CD" = (
 /obj/machinery/door/firedoor/border_only,
@@ -722,40 +836,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"CS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Db" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -28;
-	req_access_txt = "0"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/iv_drip{
-	density = 0;
-	pixel_x = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Ds" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Dz" = (
-/obj/structure/sign/departments/minsky/supply/hydroponics{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "DV" = (
 /obj/effect/mob_spawn/human/free_miner/engi,
 /obj/structure/bed,
@@ -772,12 +852,6 @@
 	name = "R&D Console";
 	req_access_txt = "71";
 	research_control = 0
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"EE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -820,46 +894,6 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Fm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Fr" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -8
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/apron/surgical{
-	pixel_x = 1;
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "FG" = (
 /obj/structure/disposalpipe/segment{
@@ -1014,10 +1048,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"LE" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
 "LF" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1025,18 +1055,39 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"LT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/soap,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "LW" = (
 /obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Mq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
+"Mr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plasteel/shuttle,
@@ -1060,15 +1111,21 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"Mz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/shuttle/abandoned)
 "MB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"Ng" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth{
+"MP" = (
+/obj/structure/chair/americandiner/booth/end_right{
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
@@ -1082,14 +1139,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Nu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Nz" = (
@@ -1110,6 +1159,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
+"Oh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"OU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	pixel_x = -28;
+	req_access_txt = "0"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
 "Pj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1118,18 +1187,6 @@
 	categories = list("Exosuit Modules");
 	pixel_x = -2;
 	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Pu" = (
-/obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_y = -32
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods{
-	amount = 50
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1150,14 +1207,13 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"PP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+"PU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
-	},
-/turf/open/floor/plasteel/shuttle,
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "PY" = (
 /obj/structure/table,
@@ -1187,22 +1243,18 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Qg" = (
-/obj/structure/closet/crate/medical{
-	name = "medical crate"
-	},
-/obj/item/healthanalyzer,
-/obj/item/roller{
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
 "Qh" = (
 /turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "Qw" = (
 /obj/machinery/light{
@@ -1279,24 +1331,6 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Sy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "SC" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/shuttle,
@@ -1307,6 +1341,25 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"SF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"SU" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/soap,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "TK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1369,13 +1422,6 @@
 	},
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Vm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Vy" = (
 /obj/structure/shuttle/engine/heater{
@@ -1454,22 +1500,21 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"WB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
+"Wd" = (
+/obj/structure/sign/departments/minsky/medical/medical2{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Xf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"Wz" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods{
+	amount = 50
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "hydroponics"
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1493,17 +1538,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Xm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = -4
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
 "Xq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1519,20 +1553,8 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"XG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/chair/americandiner/booth/end_right{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/shuttle/abandoned)
-"Yk" = (
-/obj/structure/sink{
-	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+"YK" = (
+/obj/machinery/sleeper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1570,21 +1592,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Zz" = (
+"ZD" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -30
+	pixel_x = -32
 	},
 /obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ZV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -1697,8 +1710,8 @@ EI
 Ni
 ih
 Sd
-Fm
-Xm
+xK
+Mz
 YV
 VH
 cq
@@ -1713,9 +1726,9 @@ Hb
 Am
 Od
 fW
-XG
-Ng
-yW
+kL
+Mq
+px
 gE
 bk
 DV
@@ -1730,9 +1743,9 @@ oE
 Iu
 bk
 JZ
-ih
-EE
-Vm
+MP
+Ai
+qh
 VZ
 cx
 bk
@@ -1759,14 +1772,14 @@ EI
 "}
 (11,1,1) = {"
 EI
-dP
-gg
-dP
+TW
+OU
+cn
 EI
-EI
-EI
-Sy
-EI
+ih
+ih
+Sg
+ih
 LF
 EI
 Mw
@@ -1776,13 +1789,13 @@ dN
 "}
 (12,1,1) = {"
 dN
-ih
-yN
-ih
+pZ
+fk
+iZ
 EI
-Zz
-fm
-JW
+EI
+EI
+Mr
 EI
 EI
 EI
@@ -1793,12 +1806,12 @@ dN
 "}
 (13,1,1) = {"
 dN
-PP
-dk
-PM
-Xf
-PM
-Nu
+Qj
+Oh
+vW
+bI
+AP
+sM
 EO
 ih
 Fd
@@ -1810,11 +1823,11 @@ EI
 "}
 (14,1,1) = {"
 EI
-CS
-LT
-dP
+PU
+qF
+YK
 EI
-Dz
+Wd
 ih
 Sg
 ih
@@ -1905,9 +1918,9 @@ JW
 ih
 qs
 EI
-aC
-Db
-Qg
+ZD
+np
+SU
 EI
 "}
 (20,1,1) = {"
@@ -1920,35 +1933,35 @@ PM
 PM
 EO
 ih
-Pu
-bk
-Ds
-pJ
-gm
+Wz
+EI
+ox
+JZ
+Cu
 EI
 "}
 (21,1,1) = {"
 dN
 So
 JZ
-fD
+uF
 EI
 zd
 ih
 qU
 nK
 nK
-BV
-WB
-ZV
-LE
+xw
+nK
+SF
+rJ
 dN
 "}
 (22,1,1) = {"
 dN
 pH
 lv
-AS
+cR
 EI
 EI
 EI
@@ -1956,16 +1969,16 @@ uM
 EI
 EI
 EI
-hf
-hU
-ct
+dP
+GG
+dP
 dN
 "}
 (23,1,1) = {"
 Ux
-cR
 ih
-AS
+ih
+ih
 EI
 pp
 Qc
@@ -1973,16 +1986,16 @@ Xq
 Qh
 yy
 EI
-TW
-Yk
-Fr
-bk
+ow
+GG
+dP
+dN
 "}
 (24,1,1) = {"
 bk
-bk
-dN
-EI
+AS
+AS
+AS
 EI
 lB
 YY
@@ -1990,27 +2003,27 @@ ba
 RF
 uk
 EI
-EI
-dN
-bk
+dP
+rz
+dP
 bk
 "}
 (25,1,1) = {"
-aa
-aa
-aa
-aa
-dm
+bk
+bk
+dN
+EI
+EI
 vo
 jV
 jV
 jV
 cK
-dm
-aa
-aa
-aa
-aa
+EI
+EI
+dN
+bk
+bk
 "}
 (26,1,1) = {"
 aa

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -37,13 +37,6 @@
 "bk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"bn" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -53,16 +46,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"cl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -127,14 +110,35 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"eS" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"dP" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"dV" = (
+/obj/docking_port/mobile{
+	callTime = 250;
+	dheight = 0;
+	dir = 2;
+	dwidth = 11;
+	height = 15;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Free Miner Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 28
 	},
-/obj/structure/sign/departments/minsky/supply/cargo{
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
+"fm" = (
+/obj/structure/sign/warning/deathsposal{
 	pixel_x = -32
 	},
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "fD" = (
@@ -144,11 +148,31 @@
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"fJ" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"gg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "gm" = (
@@ -196,22 +220,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"id" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "ih" = (
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -242,22 +250,11 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"jK" = (
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "jV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"jW" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "kt" = (
 /obj/structure/disposalpipe/segment{
@@ -265,12 +262,13 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"lj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"lc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -296,27 +294,6 @@
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"oi" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "hydroponics"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"ok" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "oE" = (
 /obj/structure/bed,
 /obj/effect/mob_spawn/human/free_miner{
@@ -333,6 +310,16 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"pe" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "pp" = (
 /obj/effect/mob_spawn/human/free_miner/captain,
@@ -428,21 +415,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"rL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "sg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -486,15 +458,6 @@
 /obj/item/mining_scanner,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/abandoned)
-"uA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "uM" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "bridge"
@@ -526,12 +489,6 @@
 	},
 /obj/item/pen/fountain,
 /turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"vr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "vO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -589,48 +546,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"wS" = (
-/obj/machinery/door/firedoor/border_only{
+"xW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"xz" = (
-/obj/docking_port/mobile{
-	callTime = 250;
-	dheight = 0;
-	dir = 2;
-	dwidth = 11;
-	height = 15;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Free Miner Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 28
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/external,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "yx" = (
 /obj/item/storage/toolbox/mechanical{
@@ -706,6 +626,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
+/area/shuttle/abandoned)
+"Az" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "AS" = (
 /obj/machinery/suit_storage_unit/mining/eva,
@@ -793,6 +722,13 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"CS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "Db" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -811,26 +747,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"Dd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "Ds" = (
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Dz" = (
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "DV" = (
 /obj/effect/mob_spawn/human/free_miner/engi,
@@ -848,6 +772,12 @@
 	name = "R&D Console";
 	req_access_txt = "71";
 	research_control = 0
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"EE" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -940,13 +870,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"GA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "GE" = (
 /obj/machinery/light{
 	dir = 1
@@ -969,10 +892,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/abandoned)
-"Ha" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Hb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1002,16 +921,6 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"HH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/soap,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Iu" = (
 /obj/structure/bed,
@@ -1063,6 +972,12 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"JC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "JW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1103,6 +1018,23 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"LF" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"LT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/soap,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "LW" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -1128,6 +1060,12 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"MB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 "Ng" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/chair/americandiner/booth{
@@ -1144,6 +1082,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Nu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Nz" = (
@@ -1187,19 +1133,29 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Pv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
+"PE" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"PP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1248,15 +1204,18 @@
 "Qh" = (
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
+"Qw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"QO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "QQ" = (
 /obj/machinery/mecha_part_fabricator/maint{
@@ -1273,9 +1232,22 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"Rs" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/blue,
+/area/shuttle/abandoned)
+"RK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Sd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -1289,12 +1261,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Sl" = (
-/obj/structure/sign/departments/minsky/supply/hydroponics{
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1313,6 +1279,24 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"Sy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "SC" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/shuttle,
@@ -1327,21 +1311,6 @@
 "TK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
-"TR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
@@ -1386,13 +1355,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"Uz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "Vc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker{
@@ -1433,6 +1395,17 @@
 /obj/item/camera,
 /obj/item/storage/photo_album,
 /turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"VF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "VH" = (
 /obj/machinery/door/airlock/shuttle{
@@ -1485,6 +1458,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Xf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "hydroponics"
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Xg" = (
 /obj/structure/table,
@@ -1583,10 +1570,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"ZE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+"Zz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
 	},
+/obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "ZV" = (
@@ -1607,7 +1595,7 @@ gD
 aa
 aa
 EI
-id
+PE
 EI
 aa
 aa
@@ -1641,7 +1629,7 @@ tr
 EI
 Fb
 EI
-wS
+fJ
 EI
 EI
 EI
@@ -1659,7 +1647,7 @@ EI
 EV
 Al
 JW
-Ha
+Rs
 SC
 EI
 Vy
@@ -1680,8 +1668,8 @@ kt
 qe
 EI
 nZ
-vr
-Pv
+MB
+Az
 bk
 "}
 (6,1,1) = {"
@@ -1743,7 +1731,7 @@ Iu
 bk
 JZ
 ih
-QO
+EE
 Vm
 VZ
 cx
@@ -1758,11 +1746,11 @@ EI
 EI
 EI
 EI
-lj
+Qw
 qq
-rL
-ZE
-cl
+RK
+xW
+lc
 Uk
 SD
 KJ
@@ -1771,15 +1759,15 @@ EI
 "}
 (11,1,1) = {"
 EI
-jW
-ok
-jW
+dP
+gg
+dP
 EI
 EI
 EI
-Dd
+Sy
 EI
-bn
+LF
 EI
 Mw
 hU
@@ -1792,8 +1780,8 @@ ih
 yN
 ih
 EI
-GA
-jK
+Zz
+fm
 JW
 EI
 EI
@@ -1805,12 +1793,12 @@ dN
 "}
 (13,1,1) = {"
 dN
-uA
+PP
 dk
 PM
-oi
+Xf
 PM
-PM
+Nu
 EO
 ih
 Fd
@@ -1822,11 +1810,11 @@ EI
 "}
 (14,1,1) = {"
 EI
-Uz
-HH
-jW
+CS
+LT
+dP
 EI
-Sl
+Dz
 ih
 Sg
 ih
@@ -1843,7 +1831,7 @@ EI
 zc
 EI
 EI
-sb
+JC
 ih
 Sg
 ih
@@ -1855,10 +1843,10 @@ QQ
 EI
 "}
 (16,1,1) = {"
-xz
+dV
 io
 BC
-TR
+VF
 PM
 PM
 Bh
@@ -1877,7 +1865,7 @@ EI
 EI
 EI
 EI
-sb
+JC
 lv
 Jl
 qq
@@ -1893,7 +1881,7 @@ EI
 jk
 Qf
 jk
-eS
+pe
 ih
 ih
 vO

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -37,6 +37,13 @@
 "bk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
+"bn" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "bx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -49,11 +56,14 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"bG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+"cl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
-/obj/machinery/seed_extractor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "cq" = (
@@ -92,12 +102,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"dd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "dk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -115,20 +119,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"dy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"dB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "dN" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -137,12 +127,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"dW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+"eS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -251,15 +242,35 @@
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"jK" = (
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "jV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
+"jW" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "kt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"lj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -284,6 +295,27 @@
 "nZ" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
+/area/shuttle/abandoned)
+"oi" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "hydroponics"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ok" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "oE" = (
 /obj/structure/bed,
@@ -383,13 +415,6 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"qH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "qU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -403,21 +428,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"rP" = (
+"rL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sb" = (
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -430,16 +452,6 @@
 	icon_state = "heater"
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"si" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"sl" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "sw" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
@@ -461,15 +473,6 @@
 "tr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
-"tt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "uk" = (
 /obj/structure/table,
 /obj/item/megaphone,
@@ -482,6 +485,15 @@
 /obj/item/pickaxe,
 /obj/item/mining_scanner,
 /turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"uA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "uM" = (
 /obj/machinery/door/airlock/shuttle{
@@ -514,6 +526,12 @@
 	},
 /obj/item/pen/fountain,
 /turf/open/floor/carpet/cyan,
+/area/shuttle/abandoned)
+"vr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "vO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -590,16 +608,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"xa" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "xz" = (
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -623,13 +631,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"ye" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "yx" = (
 /obj/item/storage/toolbox/mechanical{
@@ -740,12 +741,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"BG" = (
-/obj/structure/sign/departments/minsky/supply/hydroponics{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "BO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/window/shuttle,
@@ -754,15 +749,6 @@
 	id = "freeship_windows"
 	},
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"BQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "BV" = (
 /obj/machinery/door/airlock/shuttle{
@@ -807,23 +793,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"CT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"CW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "Db" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -841,6 +810,24 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"Dd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Ds" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -878,12 +865,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"EY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -959,6 +940,13 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"GA" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "GE" = (
 /obj/machinery/light{
 	dir = 1
@@ -981,6 +969,10 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/freezer,
+/area/shuttle/abandoned)
+"Ha" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Hb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1010,6 +1002,16 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"HH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/soap,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Iu" = (
 /obj/structure/bed,
@@ -1186,11 +1188,13 @@
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Pv" = (
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
 	},
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1248,6 +1252,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"QO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "QQ" = (
 /obj/machinery/mecha_part_fabricator/maint{
 	req_access = list(71)
@@ -1279,6 +1289,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"Sl" = (
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1370,8 +1386,11 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"UY" = (
-/obj/machinery/hydroponics/constructable,
+"Uz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Vc" = (
@@ -1462,16 +1481,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"Wk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/soap,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "WB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1541,29 +1550,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"YC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "hydroponics"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"YL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "YM" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -1595,6 +1581,12 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"ZE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "ZV" = (
@@ -1667,7 +1659,7 @@ EI
 EV
 Al
 JW
-sl
+Ha
 SC
 EI
 Vy
@@ -1688,8 +1680,8 @@ kt
 qe
 EI
 nZ
-dd
-tt
+vr
+Pv
 bk
 "}
 (6,1,1) = {"
@@ -1751,7 +1743,7 @@ Iu
 bk
 JZ
 ih
-EY
+QO
 Vm
 VZ
 cx
@@ -1766,11 +1758,11 @@ EI
 EI
 EI
 EI
-YL
+lj
 qq
-BQ
-si
-CW
+rL
+ZE
+cl
 Uk
 SD
 KJ
@@ -1779,15 +1771,15 @@ EI
 "}
 (11,1,1) = {"
 EI
-UY
-ye
-UY
+jW
+ok
+jW
 EI
 EI
 EI
-rP
+Dd
 EI
-qH
+bn
 EI
 Mw
 hU
@@ -1800,8 +1792,8 @@ ih
 yN
 ih
 EI
-CT
-Pv
+GA
+jK
 JW
 EI
 EI
@@ -1813,12 +1805,12 @@ dN
 "}
 (13,1,1) = {"
 dN
-dW
+uA
 dk
 PM
-YC
+oi
 PM
-dB
+PM
 EO
 ih
 Fd
@@ -1830,11 +1822,11 @@ EI
 "}
 (14,1,1) = {"
 EI
-bG
-Wk
-UY
+Uz
+HH
+jW
 EI
-BG
+Sl
 ih
 Sg
 ih
@@ -1851,7 +1843,7 @@ EI
 zc
 EI
 EI
-dy
+sb
 ih
 Sg
 ih
@@ -1885,7 +1877,7 @@ EI
 EI
 EI
 EI
-dy
+sb
 lv
 Jl
 qq
@@ -1901,7 +1893,7 @@ EI
 jk
 Qf
 jk
-xa
+eS
 ih
 ih
 vO

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -2,18 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ay" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "aC" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -32,15 +20,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"aI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "aY" = (
 /obj/structure/dresser,
@@ -68,6 +47,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"bG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/seed_extractor,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "cq" = (
@@ -106,6 +92,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"dd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 "dk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -123,6 +115,20 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"dy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"dB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "dN" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle,
@@ -131,11 +137,13 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"fA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+"dW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/seed_extractor,
+/mob/living/simple_animal/moonrat{
+	name = "Frank"
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "fD" = (
@@ -249,17 +257,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"kn" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "kt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -278,13 +275,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"nf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "nK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -372,15 +362,6 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"qg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "qq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/shuttle,
@@ -402,6 +383,13 @@
 /obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"qH" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "qU" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -411,25 +399,25 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"qW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"rU" = (
+"rP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "living quarters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -443,6 +431,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
+"si" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"sl" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "sw" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 1;
@@ -450,10 +448,6 @@
 	volume_rate = 200
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"sA" = (
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "sC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -466,6 +460,15 @@
 /area/shuttle/abandoned)
 "tr" = (
 /turf/open/floor/plating/airless,
+/area/shuttle/abandoned)
+"tt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "uk" = (
 /obj/structure/table,
@@ -587,6 +590,16 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"xa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/sign/departments/minsky/supply/cargo{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "xz" = (
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -610,6 +623,13 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
+/area/shuttle/abandoned)
+"ye" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "yx" = (
 /obj/item/storage/toolbox/mechanical{
@@ -686,27 +706,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"AQ" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "living quarters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "AS" = (
 /obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/shuttle,
@@ -741,6 +740,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"BG" = (
+/obj/structure/sign/departments/minsky/supply/hydroponics{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "BO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/window/shuttle,
@@ -749,6 +754,15 @@
 	id = "freeship_windows"
 	},
 /turf/open/floor/plating,
+/area/shuttle/abandoned)
+"BQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "BV" = (
 /obj/machinery/door/airlock/shuttle{
@@ -763,13 +777,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"Cf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "CD" = (
 /obj/machinery/door/firedoor/border_only,
@@ -800,6 +807,23 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"CT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
+	},
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"CW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "Db" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -826,20 +850,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
 /turf/open/floor/plating,
-/area/shuttle/abandoned)
-"DX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
-"Ej" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/soap,
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Eq" = (
 /obj/machinery/griddle,
@@ -871,12 +881,9 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"EX" = (
+"EY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Frank"
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1031,11 +1038,6 @@
 /obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"IT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
 "IZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1079,12 +1081,6 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
-/area/shuttle/abandoned)
-"KB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "KJ" = (
 /obj/structure/sink{
@@ -1166,14 +1162,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"OR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "Pj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1197,28 +1185,19 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"Pv" = (
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = -32
+	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "PM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"PN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"PW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
 /area/shuttle/abandoned)
 "PY" = (
 /obj/structure/table,
@@ -1265,10 +1244,6 @@
 "Qh" = (
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"Qx" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/shuttle/abandoned)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
@@ -1291,16 +1266,6 @@
 "RF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/blue,
-/area/shuttle/abandoned)
-"RI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Sd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -1332,15 +1297,6 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
-"SB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "SC" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/shuttle,
@@ -1351,20 +1307,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
-/area/shuttle/abandoned)
-"SV" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"Tg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
 /area/shuttle/abandoned)
 "TK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1408,14 +1350,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
 /area/shuttle/abandoned)
-"Uf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1;
-	name = "Connector Port (Air Supply)"
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "Uk" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "kitchen"
@@ -1436,23 +1370,8 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
-"UR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
-"US" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
+"UY" = (
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Vc" = (
@@ -1543,6 +1462,16 @@
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
+"Wk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/soap,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "WB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1601,13 +1530,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"XL" = (
-/obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = -32
-	},
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "Yk" = (
 /obj/structure/sink{
 	dir = 4;
@@ -1618,6 +1540,29 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
+/area/shuttle/abandoned)
+"YC" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "hydroponics"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
+"YL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "YM" = (
 /obj/machinery/computer/crew{
@@ -1722,8 +1667,8 @@ EI
 EV
 Al
 JW
-SV
-sA
+sl
+SC
 EI
 Vy
 Vy
@@ -1743,8 +1688,8 @@ kt
 qe
 EI
 nZ
-aI
-Uf
+dd
+tt
 bk
 "}
 (6,1,1) = {"
@@ -1804,9 +1749,9 @@ aY
 oE
 Iu
 bk
-fA
+JZ
 ih
-EX
+EY
 Vm
 VZ
 cx
@@ -1821,11 +1766,11 @@ EI
 EI
 EI
 EI
-Tg
-ih
-qg
-SB
-UR
+YL
+qq
+BQ
+si
+CW
 Uk
 SD
 KJ
@@ -1834,15 +1779,15 @@ EI
 "}
 (11,1,1) = {"
 EI
-Ej
-nf
-SC
+UY
+ye
+UY
 EI
-PW
-IT
-ay
-DX
-Qx
+EI
+EI
+rP
+EI
+qH
 EI
 Mw
 hU
@@ -1855,9 +1800,9 @@ ih
 yN
 ih
 EI
-EI
-EI
-AQ
+CT
+Pv
+JW
 EI
 EI
 EI
@@ -1868,13 +1813,13 @@ dN
 "}
 (13,1,1) = {"
 dN
-rU
+dW
 dk
 PM
-kn
-RI
-qW
-OR
+YC
+PM
+dB
+EO
 ih
 Fd
 EI
@@ -1885,11 +1830,11 @@ EI
 "}
 (14,1,1) = {"
 EI
-Cf
-KB
-ih
-pN
-ih
+bG
+Wk
+UY
+EI
+BG
 ih
 Sg
 ih
@@ -1905,8 +1850,8 @@ EI
 EI
 zc
 EI
-PN
-ih
+EI
+dy
 ih
 Sg
 ih
@@ -1939,8 +1884,8 @@ EI
 EI
 EI
 EI
-US
-ih
+EI
+dy
 lv
 Jl
 qq
@@ -1955,8 +1900,8 @@ EI
 EI
 jk
 Qf
-XL
-pN
+jk
+xa
 ih
 ih
 vO

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -511,16 +511,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/shuttle/abandoned)
-"sM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "tr" = (
 /turf/open/floor/plating/airless,
 /area/shuttle/abandoned)
@@ -1048,10 +1038,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
-"LF" = (
+"Ld" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1780,7 +1773,7 @@ ih
 ih
 Sg
 ih
-LF
+Ld
 EI
 Mw
 hU
@@ -1811,7 +1804,7 @@ Oh
 vW
 bI
 AP
-sM
+PM
 EO
 ih
 Fd


### PR DESCRIPTION
# Document the changes in your pull request

Freeminers have had the same stuffy dusty old shitty ship for a long time now. This PR modernizes it, and remodels the internals a lot.

Biggest notable changes:
Freeminers now get an Exosuit fabricator that requires **FREEMINER** access instead of robotics, as well as an R&D computer and circuit imprinter that is only capable of making mech boards; R&D comp has had R&D control stripped.

Hydroponics has been gutted completely and replaced with a proper atmospherics/engineering room
the Engineer spawner has been moved here.

The Cargo, EVA storage, and Mech Bay have all been made Open Plan, and the airlocks in & out of the ship now are actual airlocks with no tiny fans, but proper controllers and vents.

The whole ship now features a functional atmos setup as well, though no fire or air alarms. I can add these if requested.

Floors ship-wide have been largely replaced, and are no longer titanium floors.

Replaced the Ripley wreck with a Clarke wreck. Note, as deconstructing broken map-spawned mechs is not working, this serves as flavor for the moment.

The freeminer ship now features a seed extractor, hydro trays, and a garden variant seed vendor, and a nutrivendor; this is in an attempt to preserve their ability to make food, slightly expanding options.

Added Frank, the MoonRat pet.

the bridge now features a crew suit sensors monitor.

![ss (2022-10-12 at 10 49 11)](https://user-images.githubusercontent.com/1534478/195495116-5a7f8ee9-6bac-4d88-94fe-d371971512bb.png)



# Changelog

:cl:  
mapping: Massively updates the Freeminer ship
/:cl:
