### PR TITLE
Fixes an oversight with picking up the energy katana

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -67,6 +67,12 @@
 				to_chat(user, span_warning("[src] attempts to shock you."))
 				user.electrocute_act(15,src)
 				return
+			to_chat(user, span_userdanger("[src] shocks you!")) //duplicate code because wearing gloves did nothing beforehand
+			user.emote("scream")
+			user.electrocute_act(15,src)
+			user.dropItemToGround(src, TRUE)
+			user.Paralyze(50)
+			return
 		else
 			to_chat(user, span_userdanger("[src] shocks you!"))
 			user.emote("scream")


### PR DESCRIPTION
Oops.

# Document the changes in your pull request

- Adds in duplicate code to the if user is wearing gloves check

Wearing gloves did nothing and doesn't even attempt to shock you if you weren't wearing insuls.

# Changelog

:cl:  
bugfix: Wearing gloves should no longer stop the energy katana from attempting to kill you
/:cl:
