### PR TITLE
Makes NTDownload not runtime when it downloads a file

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -108,6 +108,7 @@
 		return
 	if(download_completion >= downloaded_file.size)
 		complete_file_download()
+		return
 	// Download speed according to connectivity state. NTNet server is assumed to be on unlimited speed so we're limited by our local connectivity
 	download_netspeed = 0
 	// Speed defines are found in code/__DEFINES/machines.dm


### PR DESCRIPTION
# Document the changes in your pull request

It shouldn't keep going after a file download is downloaded (and loses reference to it)

# Changelog

:cl:  
bugfix: Downloading programs will no longer runtime
/:cl:
