### PR TITLE
Getting Shocked by Wires/Grilles/Machines Hurts Significantly More

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -375,7 +375,7 @@
 		shock_damage = PN_damage
 	else
 		power_source = cell
-		shock_damage = cell_damage
+		shock_damage = cell_damage*2.3
 	var/drained_hp = victim.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	log_combat(source, victim, "electrocuted")
 


### PR DESCRIPTION
# Document the changes in your pull request

Causes being shocked by a wire, grille, hacking machines and such, to do MUCH more damage, so its actually a present danger when someone wires a 10Mw engine to the grid, instead of a mild annoyance at worst.

# Changelog

:cl:  
tweak: Shocks from wires, grilles, and machines is over twice as dangerous now
/:cl:
