### PR TITLE
IPCs are now selectable by magic mirrors and charged black extracts

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -40,7 +40,7 @@
 	deathsound = 'sound/voice/borg_deathsound.ogg'
 	wings_icon = "Robotic"
 	var/saved_screen //for saving the screen when they die
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | SLIME_EXTRACT
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	// Hats need to be 1 up
 	offset_features = list(OFFSET_HEAD = list(0,1))
 

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -40,7 +40,7 @@
 	deathsound = 'sound/voice/borg_deathsound.ogg'
 	wings_icon = "Robotic"
 	var/saved_screen //for saving the screen when they die
-	changesource_flags = MIRROR_BADMIN | WABBAJACK
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | SLIME_EXTRACT
 	// Hats need to be 1 up
 	offset_features = list(OFFSET_HEAD = list(0,1))
 


### PR DESCRIPTION
I thought about adding shadowpeople (plus their fun subtypes) to the charged black pool since the pride mirror can do them, but then I remembered I was working with xenobio players

# Document the changes in your pull request

IPCs are now selectable by magic mirrors and charged black extracts

# Changelog

:cl:  
rscadd: IPCs are now selectable by magic mirrors and charged black extracts
/:cl: