### PR TITLE
Reduces reagent amount in saly/oxandrolone pills from 24 to 5

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -159,14 +159,14 @@
 	name = "salicylic acid pill"
 	desc = "Used to stimulate bruise healing."
 	icon_state = "pill9"
-	list_reagents = list(/datum/reagent/medicine/sal_acid = 24)
+	list_reagents = list(/datum/reagent/medicine/sal_acid = 5)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/oxandrolone
 	name = "oxandrolone pill"
 	desc = "Used to stimulate burn healing."
 	icon_state = "pill11"
-	list_reagents = list(/datum/reagent/medicine/oxandrolone = 24)
+	list_reagents = list(/datum/reagent/medicine/oxandrolone = 5)
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/insulin


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the reagent amount of saly acid and oxandrolone pills found in medkits from just under their od to 5 units since they are quite strong at healing and probably shouldnt be given out in doses that effectively remove the need for other medicines and healing for the next few minutes. If you want 200 units of 4 point healing chems you can get them from the chemistry department.

# Wiki Documentation

Saly acid and oxandrolone 24 unit pills found in medkits and probably elsewhere are now 5 units

# Changelog

:cl:  
tweak: saly acid and oxandrolone pills from medkits have had their reagent amount reduced from 24 units to 5 units so the rest of the kit isnt comparable to garbage
/:cl:
