### PR TITLE
Adds darkspawn and androids to the magic mirror pool

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -10,7 +10,7 @@
 	mutanttongue = /obj/item/organ/tongue/robot
 	species_language_holder = /datum/language_holder/synthetic
 	limbs_id = "synth"
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	changesource_flags = MIRROR_BADMIN | MIRROR_MAGIC | WABBAJACK | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
 /datum/species/android/on_species_gain(mob/living/carbon/C)
 	. = ..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/darkspawn.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/darkspawn.dm
@@ -6,7 +6,7 @@
 	limbs_id = "darkspawn"
 	sexes = FALSE
 	nojumpsuit = TRUE
-	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
+	changesource_flags = MIRROR_BADMIN | MIRROR_MAGIC | WABBAJACK | ERT_SPAWN //never put this in the pride pool because they look super valid
 	siemens_coeff = 0
 	brutemod = 0.9
 	heatmod = 1.5


### PR DESCRIPTION
# Document the changes in your pull request

Wizards can now come to the station as darkspawn or androids
Note that the darkspawn species is not the same as the antag: these are just shadowpeople with more dramatic light interactions and a much more valid appearance

# Changelog

:cl:  
rscadd: Wizard magic mirrors can now select darkspawn or androids
/:cl: