### PR TITLE
Makes Meth Cause You To Warm Up

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -215,6 +215,7 @@
 	M.adjustStaminaLoss(-2, 0)
 	M.Jitter(2)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,4))
+	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, BODYTEMP_NORMAL) //meth makes you warm
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()
@@ -232,6 +233,7 @@
 	..()
 	M.adjustToxLoss(1, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
+	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL, INFINITY) //meth OD makes you VERY warm
 	. = 1
 
 /datum/reagent/drug/methamphetamine/addiction_act_stage1(mob/living/M)


### PR DESCRIPTION
# Document the changes in your pull request

Partially a realism thing, partially making there be another drawback to meth (or an upside if you're full of cryo poison/frost oil?)

Meth makes you warm, just like coffee
it however also makes you slowly boil to death if OD'd

# Wiki Documentation

Absolutely needs a mention in the Guide To Chemistry's entry for Meth

# Changelog

:cl:  
tweak: Meth makes your body heat up (A lot when overdosing)
/:cl:
