### PR TITLE
Wirecutters + pizza box = cardboard

### DIFF
--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -207,6 +207,10 @@
 	else if(is_wire_tool(I))
 		if(wires && bomb)
 			wires.interact(user)
+		else if(open && !bomb && !pizza)
+			var/obj/item/cardbd = new /obj/item/stack/sheet/cardboard
+			qdel(src)
+			user.put_in_hands(cardbd)
 	else if(istype(I, /obj/item/reagent_containers/food))
 		to_chat(user, span_warning("That's not a pizza!"))
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

Must be open and pizzaless and bombless

# Changelog

:cl:  
tweak: You can now apply wirecutters to open pizza boxes to return them to cardboard
/:cl:
