### PR TITLE
Reduces cybernetic stun times by half, makes getting hit with an ion a little less brutal as IPC

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -258,6 +258,8 @@
 	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/brain/positron/emp_act(severity)
+	if(prob(25))
+		return
 	switch(severity)
 		if(1)
 			owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 60)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -552,10 +552,10 @@
 			switch(severity)
 				if(1)
 					L.receive_damage(0,10)
-					Paralyze(200)
+					Paralyze(10 SECONDS)
 				if(2)
 					L.receive_damage(0,5)
-					Paralyze(100)
+					Paralyze(5 SECONDS)
 
 			if((TRAIT_EASYDISMEMBER in L.owner.dna.species.species_traits) && L.body_zone != "chest")
 				if(prob(5))

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -156,11 +156,11 @@
 		if(1)
 			owner.Jitter(30)
 			owner.Dizzy(30)
-			owner.Knockdown(200)
+			owner.Knockdown(5 SECONDS)
 			deaf = 30
 			to_chat(owner, "<span class='warning'>Your robotic ears are ringing, uselessly.</span>")
 		if(2)
 			owner.Jitter(15)
 			owner.Dizzy(15)
-			owner.Knockdown(100)
+			owner.Knockdown(10 SECONDS)
 			to_chat(owner, "<span class='warning'>Your robotic ears buzz.</span>") 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -262,6 +262,8 @@
 	desc = "An electronic device that appears to mimic the functions of an organic heart."
 
 /obj/item/organ/heart/cybernetic/ipc/emp_act()
+	if(prob(30))
+		return
 	. = ..()
 	to_chat(owner, "<span class='warning'>Alert: Cybernetic heart failed one heartbeat</span>")
 	addtimer(CALLBACK(src, .proc/Restart), 10 SECONDS)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -129,6 +129,8 @@
 	status = ORGAN_ROBOTIC
 
 /obj/item/organ/liver/cybernetic/upgraded/ipc/emp_act(severity)
+	if(prob(10))
+		return
 	to_chat(owner, "<span class='warning'>Alert: Your Substance Processor has been damaged. An internal chemical leak is affecting performance.</span>")
 	switch(severity)
 		if(1)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -140,10 +140,10 @@
 /obj/item/organ/stomach/cell/emp_act(severity)
 	switch(severity)
 		if(1)
-			owner.adjust_nutrition(-50)
+			owner.adjust_nutrition(-150)
 			to_chat(owner, "<span class='warning'>Alert: Heavy EMP Detected. Rebooting power cell to prevent damage.</span>")
 		if(2)
-			owner.adjust_nutrition(-150)
+			owner.adjust_nutrition(-50)
 			to_chat(owner, "<span class='warning'>Alert: EMP Detected. Cycling battery.</span>")
 
 /obj/item/organ/stomach/cell/Insert(mob/living/carbon/M, special, drop_if_replaced)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -140,10 +140,10 @@
 /obj/item/organ/stomach/cell/emp_act(severity)
 	switch(severity)
 		if(1)
-			owner.nutrition = 50
+			owner.adjust_nutrition(-50)
 			to_chat(owner, "<span class='warning'>Alert: Heavy EMP Detected. Rebooting power cell to prevent damage.</span>")
 		if(2)
-			owner.nutrition = 250
+			owner.adjust_nutrition(-150)
 			to_chat(owner, "<span class='warning'>Alert: EMP Detected. Cycling battery.</span>")
 
 /obj/item/organ/stomach/cell/Insert(mob/living/carbon/M, special, drop_if_replaced)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -260,7 +260,9 @@
 	taste_sensitivity = NO_TASTE_SENSITIVITY // not as good as an organic tongue
 
 /obj/item/organ/tongue/robot/emp_act(severity)
-	owner.apply_effect(EFFECT_STUTTER, 120)
+	if(prob(5))
+		return 
+	owner.apply_effect(EFFECT_STUTTER, rand(5 SECONDS, 2 MINUTES))
 	owner.emote("scream")
 	to_chat(owner, "<span class='warning'>Alert: Vocal cords are malfunctioning.</span>")
 


### PR DESCRIPTION
# Document the changes in your pull request

We've been throwing out stunbased combat however it doesnt make alot of sense to not be a stun.

I halved the values to bring some reasonableness (although I might half it again) due to the fact you can just keep hitting them with more ions.

Reduced ear knockdown by half
Made the nutrition emp effect use better code and slightly nerfed the heavy emp
Tongue will stutter from 5 seconds to 2 minutes

Additionally adds some rng chance to not cause an emp effect for IPC organs
- Brain: 25% chance to not emp
- Heart: 30% chance to not emp
- Liver: 10% chance to not emp
- Ears: 5% chance to not emp

# Changelog

:cl:  
tweak: Halfed stuntimes for getting hit with ions and robotic limbs
tweak: IPC organs have slight emp resistance now
tweak: robotic tounge will now stutter for 5 seconds to 2 minutes
bugfix: IPC cell wont set nutrition when emped now
/:cl:
