### PR TITLE
Adds 10x10 Halloween Dance Floor Maint Ruin

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
@@ -1,9 +1,192 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"c" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"d" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/grown/pumpkin,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"e" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"f" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_strawberry,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/suit/ghost_sheet,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"h" = (
+/obj/structure/railing,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/schoolgirl/orange,
+/obj/item/clothing/head/kitty{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"i" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
-"b" = (
+"j" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/scratch{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/cueball{
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"k" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_strawberry,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"l" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"m" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"n" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/remains/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/yogs/ronaldmcdonald,
+/obj/item/clothing/mask/yogs/ronald{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"o" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"p" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"r" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"s" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"u" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/machinery/jukebox/disco,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"w" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"y" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/candy_strawberry,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"z" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/mask/rat/fox{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/obj/item/clothing/under/redeveninggown,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"A" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"B" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"C" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/grown/pumpkin,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"D" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"F" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_strawberry,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"G" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"H" = (
 /obj/effect/decal/remains/human{
 	pixel_x = 2;
 	pixel_y = 1
@@ -18,9 +201,38 @@
 	},
 /obj/item/clothing/under/lawyer/black,
 /obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/template_noop)
-"c" = (
+"I" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/remains/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/head/pharaoh{
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/nemes{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"J" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"K" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"L" = (
 /obj/structure/railing{
 	dir = 1
 	},
@@ -37,56 +249,59 @@
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/template_noop)
-"d" = (
+"M" = (
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"e" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"g" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"i" = (
 /obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/template_noop)
-"m" = (
-/obj/machinery/light{
-	dir = 1
+"N" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil,
+/obj/item/clothing/mask/yogs/foxy{
+	pixel_x = 3;
+	pixel_y = 7
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/blackwhite,
+/obj/item/clothing/under/yogs/ocelot{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
 /area/template_noop)
-"n" = (
+"O" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"P" = (
 /obj/structure/railing,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/schoolgirl/orange,
-/obj/item/clothing/head/kitty{
-	pixel_y = 8
-	},
 /obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/template_noop)
-"p" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"q" = (
-/obj/effect/decal/cleanable/glitter/pink,
+"Q" = (
+/obj/item/reagent_containers/food/snacks/grown/pumpkin,
 /turf/open/floor/plasteel/blackwhite,
 /area/template_noop)
-"t" = (
+"R" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"T" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"U" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/candy_strawberry,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"V" = (
 /obj/structure/railing{
 	dir = 8
 	},
@@ -101,284 +316,148 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/glitter/pink,
+/obj/item/reagent_containers/food/snacks/candy_corn,
 /turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"v" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/scratch{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/cueball{
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"w" = (
-/turf/open/floor/plasteel/blackwhite,
-/area/template_noop)
-"y" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"B" = (
-/obj/machinery/jukebox/disco,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"C" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"D" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"E" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/blackwhite,
-/area/template_noop)
-"F" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"G" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"I" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"J" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/remains/plasma,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/yogs/ronaldmcdonald,
-/obj/item/clothing/mask/yogs/ronald{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/plasma,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"L" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/mask/rat/fox{
-	pixel_x = -2;
-	pixel_y = 11
-	},
-/obj/item/clothing/under/redeveninggown,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"N" = (
-/obj/effect/decal/remains/xeno,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/suit/ghost_sheet,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"O" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/glitter/pink,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"P" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/remains/plasma,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/head/pharaoh{
-	pixel_y = 7
-	},
-/obj/item/clothing/suit/nemes{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/plasma,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/template_noop)
-"S" = (
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"U" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"V" = (
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/template_noop)
 "W" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"X" = (
-/obj/effect/decal/remains/robot,
-/obj/effect/decal/cleanable/oil,
-/obj/item/clothing/mask/yogs/foxy{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/clothing/under/yogs/ocelot{
-	pixel_x = 1;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/glitter/pink,
-/turf/open/floor/light/colour_cycle/dancefloor_b,
-/area/template_noop)
-"Z" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"X" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"Y" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"Z" = (
+/turf/open/floor/plasteel/blackwhite,
 /area/template_noop)
 
 (1,1,1) = {"
-m
-w
-E
-q
-w
-w
-w
-w
-q
-a
+W
+Z
+R
+d
+Z
+Z
+Z
+Z
+b
+i
 "}
 (2,1,1) = {"
-w
-W
+Z
+M
+A
 V
-t
-y
-J
-V
-C
-w
-i
+G
+n
+A
+P
+Q
+r
 "}
 (3,1,1) = {"
-w
-d
-p
-V
-p
-v
-U
-g
-q
-I
+Z
+Y
+D
+T
+y
+j
+f
+m
+b
+J
 "}
 (4,1,1) = {"
-q
-D
-V
+b
+a
+A
+s
 U
-e
-U
-L
-C
+s
+z
+P
+Z
 w
-S
 "}
 (5,1,1) = {"
-E
-d
+C
+Y
+N
+F
+v
+A
 X
-V
-B
-V
-U
-O
+o
+Q
 w
-S
 "}
 (6,1,1) = {"
-w
-D
-V
-U
-V
-N
-V
-C
-w
-I
+Z
+a
+B
+X
+A
+g
+O
+K
+Z
+J
 "}
 (7,1,1) = {"
+Z
+L
+D
+H
+X
+k
+l
+h
+Z
 w
-c
-p
-b
-U
-V
-U
-n
-w
-S
 "}
 (8,1,1) = {"
-E
-d
-U
-F
-G
-P
-U
-g
+R
+Y
+s
+c
+e
+I
+X
+p
+Q
 w
-S
 "}
 (9,1,1) = {"
+Z
+Z
+R
+Z
+Z
+b
+Z
+b
+R
 w
-w
-E
-w
-w
-q
-w
-q
-E
-S
 "}
 (10,1,1) = {"
-Z
-S
+u
+w
+r
+w
+w
+w
+J
+w
+w
 i
-S
-S
-S
-I
-S
-S
-a
 "}

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
@@ -1,0 +1,384 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/remains/human{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/mask/rat/raven{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/yogs/tailcoat{
+	pixel_x = -4
+	},
+/obj/item/clothing/under/lawyer/black,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"c" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/mask/yogs/dallas{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/clothing/under/suit_jacket/navy{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"d" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"g" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"m" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"n" = (
+/obj/structure/railing,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/schoolgirl/orange,
+/obj/item/clothing/head/kitty{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"p" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"q" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"t" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/soviet{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/obj/item/clothing/mask/rat/bear{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"v" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/scratch{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/cueball{
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"w" = (
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"y" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"B" = (
+/obj/machinery/jukebox/disco,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"C" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"D" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"E" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/blackwhite,
+/area/template_noop)
+"F" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"G" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"I" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"J" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/remains/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/under/yogs/ronaldmcdonald,
+/obj/item/clothing/mask/yogs/ronald{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"L" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/mask/rat/fox{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/obj/item/clothing/under/redeveninggown,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"N" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/suit/ghost_sheet,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"O" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/glitter/pink,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"P" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/remains/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/head/pharaoh{
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/nemes{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"S" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"U" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"V" = (
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/template_noop)
+"W" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"X" = (
+/obj/effect/decal/remains/robot,
+/obj/effect/decal/cleanable/oil,
+/obj/item/clothing/mask/yogs/foxy{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/clothing/under/yogs/ocelot{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/glitter/pink,
+/turf/open/floor/light/colour_cycle/dancefloor_b,
+/area/template_noop)
+"Z" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+
+(1,1,1) = {"
+m
+w
+E
+q
+w
+w
+w
+w
+q
+a
+"}
+(2,1,1) = {"
+w
+W
+V
+t
+y
+J
+V
+C
+w
+i
+"}
+(3,1,1) = {"
+w
+d
+p
+V
+p
+v
+U
+g
+q
+I
+"}
+(4,1,1) = {"
+q
+D
+V
+U
+e
+U
+L
+C
+w
+S
+"}
+(5,1,1) = {"
+E
+d
+X
+V
+B
+V
+U
+O
+w
+S
+"}
+(6,1,1) = {"
+w
+D
+V
+U
+V
+N
+V
+C
+w
+I
+"}
+(7,1,1) = {"
+w
+c
+p
+b
+U
+V
+U
+n
+w
+S
+"}
+(8,1,1) = {"
+E
+d
+U
+F
+G
+P
+U
+g
+w
+S
+"}
+(9,1,1) = {"
+w
+w
+E
+w
+w
+q
+w
+q
+E
+S
+"}
+(10,1,1) = {"
+Z
+S
+i
+S
+S
+S
+I
+S
+S
+a
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -1306,3 +1306,8 @@
 	id = "wizard"
 	suffix = "10x10_wizard.dmm"
 	name = "Maint wizard"
+
+/datum/map_template/ruin/station/maint/tenxten/halloween
+	id = "halloween"
+	suffix = "10x10_halloween.dmm"
+	name = "Maint halloween"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 
 /obj/effect/landmark/stationroom/maint/tenxten
 	template_names = list("Maint aquarium", "Maint bigconstruction", "Maint bigtheatre", "Maint deltalibrary", "Maint graffitiroom", "Maint junction", "Maint podrepairbay", "Maint pubbybar", "Maint roosterdome", "Maint sanitarium", "Maint snakefighter", "Maint vault", "Maint ward", "Maint assaultpod", "Maint maze", "Maint maze2", "Maint boxfactory",
-	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops", "Maint fishinghole", "Maint fakewalls", "Maint wizard")
+	"Maint sixsectorsdown", "Maint advbotany", "Maint beach", "Maint botany_apiary", "Maint gamercave", "Maint ladytesla_altar", "Maint olddiner", "Maint smallmagician", "Maint fourshops", "Maint fishinghole", "Maint fakewalls", "Maint wizard", "Maint halloween")
 
 /// Type of landmark that find all others of the same type, and only spawns count number of ruins at them
 /obj/effect/landmark/stationroom/limited_spawn


### PR DESCRIPTION
# Document the changes in your pull request

![ss (2022-10-08 at 03 55 13)](https://user-images.githubusercontent.com/1534478/194727526-5680ade4-b349-460c-84f9-0863e29b45e6.png)


# Wiki Documentation

Maybe a page that details all the maint ruins would be nice? there's a LOT

# Changelog

:cl:  
mapping: Adds new 10x10 Maint Ruin themed around Halloween!
/:cl:
