### PR TITLE
reworking borg combat to be less reliant on 1 click instant kills for both sides

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -14,7 +14,9 @@
 	if(check_click_intercept(params,A))
 		return
 
-	if(stat || (lockcharge) || IsParalyzed() || IsStun() || IsUnconscious())
+	if(stat || IsParalyzed() || IsStun() || IsUnconscious())
+		return
+	if(lockcharge && !A.Adjacent(src))
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -84,8 +84,6 @@
 				return
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
-				if(R.connected_ai != usr)
-					return
 				if(can_control(usr, R) && !..())
 					var/turf/T = get_turf(R)
 					message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(R, R.client)] at [ADMIN_VERBOSEJMP(T)]!"))

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -38,7 +38,9 @@
 			data["can_hack"] = TRUE
 	else if(IsAdminGhost(user))
 		data["can_hack"] = TRUE
-
+	data["can_detonate"] = FALSE
+	if(isAI(user))
+		data["can_detonate"] = TRUE
 	data["cyborgs"] = list()
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 		if(!can_control(user, R))
@@ -78,8 +80,12 @@
 
 	switch(action)
 		if("killbot")
+			if(!isAI(usr))
+				return
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
+				if(R.connected_ai != usr)
+					return
 				if(can_control(usr, R) && !..())
 					var/turf/T = get_turf(R)
 					message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(R, R.client)] at [ADMIN_VERBOSEJMP(T)]!"))

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -10,7 +10,8 @@
 	icon_state = "elecarm"
 	var/charge_cost = 750
 	var/stunforce = 100
-	var/stamina_damage = 90
+	var/stamina_damage = 60
+	var/cooldown = 0
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -24,7 +25,9 @@
 			return
 
 	user.do_attack_animation(M)
-
+	if(cooldown + 1.2 SECONDS > world.time)
+		return
+	cooldown = world.time
 	var/trait_check = HAS_TRAIT(M, TRAIT_STUNRESISTANCE)
 
 	var/obj/item/bodypart/affecting = M.get_bodypart(user.zone_selected)
@@ -137,7 +140,7 @@
 			if(scooldown < world.time)
 				if(M.health >= 0)
 					if(ishuman(M)||ismonkey(M))
-						M.electrocute_act(5, "[user]", safety = 1)
+						electrocute_mob(M, user.cell, src, 1)
 						user.visible_message(span_userdanger("[user] electrocutes [M] with [user.p_their()] touch!"), \
 							span_danger("You electrocute [M] with your touch!"))
 						M.update_mobility()
@@ -150,7 +153,6 @@
 							user.visible_message(span_userdanger("[user] shocks [M]. It does not seem to have an effect"), \
 								span_danger("You shock [M] to no effect."))
 					playsound(loc, 'sound/effects/sparks2.ogg', 50, 1, -1)
-					user.cell.charge -= 500
 					scooldown = world.time + 20
 		if(3)
 			if(ccooldown < world.time)
@@ -354,7 +356,7 @@
 					C.stuttering += 10
 					C.Jitter(10)
 				if(2)
-					C.Paralyze(40)
+					C.Knockdown(40)
 					C.confused += 10
 					C.stuttering += 15
 					C.Jitter(25)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -1,3 +1,5 @@
+#define BORG_STUNARM_COOLDOWN 1.2 SECONDS
+
 /**********************************************************************
 						Cyborg Spec Items
 ***********************************************************************/
@@ -25,7 +27,7 @@
 			return
 
 	user.do_attack_animation(M)
-	if(cooldown + 1.2 SECONDS > world.time)
+	if(cooldown + BORG_STUNARM_COOLDOWN > world.time)
 		return
 	cooldown = world.time
 	var/trait_check = HAS_TRAIT(M, TRAIT_STUNRESISTANCE)
@@ -771,3 +773,5 @@
 /obj/item/borg/sight/hud/sec/Initialize()
 	. = ..()
 	hud = new /obj/item/clothing/glasses/hud/security(src)
+
+#undef BORG_STUNARM_COOLDOWN

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -152,7 +152,7 @@
 		if(!R.sensor_protection)
 			log_combat(user, R, "flashed", src)
 			update_icon(1)
-			R.Paralyze(rand(80,120))
+			R.Immobilize(rand(80,120))
 			var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 			R.confused += min(5, diff)
 			R.flash_act(affect_silicon = 1)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -157,7 +157,7 @@
 			else
 				R.mobility_flags &= ~MOBILITY_MOVE
 				var/stuntime = rand(8 SECONDS, 12 SECONDS)
-				addtimer(CALLBACK(R, /mob/living/silicon/robot/update_mobility), stuntime)
+				addtimer(CALLBACK(R, /mob/living/silicon/robot/.proc/update_mobility), stuntime)
 				R.overlay_fullscreen("flash", /obj/screen/fullscreen/flash/static)
 				addtimer(CALLBACK(R, /mob/living/silicon/robot/.proc/clear_fullscreen, "flash"), stuntime)
 			var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -152,7 +152,14 @@
 		if(!R.sensor_protection)
 			log_combat(user, R, "flashed", src)
 			update_icon(1)
-			R.Immobilize(rand(80,120))
+			if(R.lockcharge)
+				R.Paralyze(rand(8 SECONDS, 12 SECONDS))
+			else
+				R.mobility_flags &= ~MOBILITY_MOVE
+				var/stuntime = rand(8 SECONDS, 12 SECONDS)
+				addtimer(CALLBACK(R, /mob/living/silicon/robot/update_mobility), stuntime)
+				R.overlay_fullscreen("flash", /obj/screen/fullscreen/flash/static)
+				addtimer(CALLBACK(R, /mob/living/silicon/robot/.proc/clear_fullscreen, "flash"), stuntime)
 			var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 			R.confused += min(5, diff)
 			R.flash_act(affect_silicon = 1)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -94,10 +94,12 @@
 /mob/living/silicon/robot/update_mobility()
 	if(stat || buckled)
 		mobility_flags &= ~MOBILITY_MOVE
-	else if(lockcharge)
-		add_movespeed_modifier("SAFEMODE", update=TRUE, priority=100, multiplicative_slowdown=4, blacklisted_movetypes=(FLYING|FLOATING))
 	else
 		mobility_flags = MOBILITY_FLAGS_DEFAULT
+	
+	if(lockcharge)
+		add_movespeed_modifier("SAFEMODE", update=TRUE, priority=100, multiplicative_slowdown=4, blacklisted_movetypes=(FLYING|FLOATING))
+	else
 		remove_movespeed_modifier("SAFEMODE")
 	update_transform()
 	update_action_buttons_icon()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -92,9 +92,12 @@
 		cut_overlay(fire_overlay)
 
 /mob/living/silicon/robot/update_mobility()
-	if(stat || buckled || lockcharge)
+	if(stat || buckled)
 		mobility_flags &= ~MOBILITY_MOVE
+	else if(lockcharge)
+		add_movespeed_modifier("SAFEMODE", update=TRUE, priority=100, multiplicative_slowdown=4, blacklisted_movetypes=(FLYING|FLOATING))
 	else
 		mobility_flags = MOBILITY_FLAGS_DEFAULT
+		remove_movespeed_modifier("SAFEMODE")
 	update_transform()
 	update_action_buttons_icon()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -122,7 +122,6 @@
 	spark_system.attach(src)
 
 	wires = new /datum/wires/robot(src)
-	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/charge)
 
@@ -732,10 +731,14 @@
 		state = TRUE
 	if(state)
 		throw_alert("locked", /obj/screen/alert/locked)
+		break_cyborg_slot(3)
+		break_cyborg_slot(2)
 	else
 		clear_alert("locked")
+		updatehealth()
 	lockcharge = state
 	update_mobility()
+	updatehealth()
 
 /mob/living/silicon/robot/proc/SetEmagged(new_state)
 	emagged = new_state
@@ -961,25 +964,30 @@
 
 	/// the current percent health of the robot (-1 to 1)
 	var/percent_hp = health/maxHealth
-	if(health <= previous_health) //if change in health is negative (we're losing hp)
-		if(percent_hp <= 0.5)
-			break_cyborg_slot(3)
+	if(percent_hp <= 0.5 && !lockcharge)
+		break_cyborg_slot(3)
+	else if(percent_hp <= 0.5 && lockcharge)
+		break_cyborg_slot(1)
 
-		if(percent_hp <= 0)
-			break_cyborg_slot(2)
+	if(percent_hp <= 0)
+		break_cyborg_slot(2)
 
-		if(percent_hp <= -0.5)
-			break_cyborg_slot(1)
+	if(percent_hp <= -0.5)
+		break_cyborg_slot(1)
 
-	else //if change in health is positive (we're gaining hp)
-		if(percent_hp >= 0.5)
-			repair_cyborg_slot(3)
+	if(percent_hp >= 0.5 && !lockcharge)
+		repair_cyborg_slot(3)
 
-		if(percent_hp >= 0)
-			repair_cyborg_slot(2)
+	else if(percent_hp >= 0.5 && lockcharge)
+		repair_cyborg_slot(1)
 
-		if(percent_hp >= -0.5)
-			repair_cyborg_slot(1)
+	if(percent_hp >= 0 && !lockcharge)
+		repair_cyborg_slot(2)
+
+	if(percent_hp >= -0.5 && !lockcharge)
+		repair_cyborg_slot(1)
+	else if(percent_hp >= 0.5 && lockcharge)
+		repair_cyborg_slot(1)
 
 	previous_health = health
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -945,7 +945,10 @@
 			to_chat(connected_ai, "<br><br>[span_notice("NOTICE - Remote telemetry lost with [name].")]<br>")
 
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
-	if(stat || lockcharge || low_power_mode)
+	if(lockcharge && !in_range(M, src))
+		to_chat(src, span_warning("Remote interfaces are currently disabled!"))
+		return FALSE
+	if(stat || low_power_mode)
 		to_chat(src, span_warning("You can't do that right now!"))
 		return FALSE
 	if(be_close && !in_range(M, src))

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -79,11 +79,16 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
+	uneq_all()
+	stop_pulling()
+	break_all_cyborg_slots(TRUE)
+	var/breaktime
 	switch(severity)
 		if(1)
-			Stun(160)
+			breaktime = 16 SECONDS
 		if(2)
-			Stun(60)
+			breaktime = 6 SECONDS
+	addtimer(CALLBACK(src, /mob/living/silicon/robot/.proc/repair_all_cyborg_slots), breaktime)
 
 
 /mob/living/silicon/robot/emag_act(mob/user)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -91,9 +91,9 @@
 		return
 	switch(severity)
 		if(1)
-			src.take_bodypart_damage(20)
+			src.take_bodypart_damage(40)
 		if(2)
-			src.take_bodypart_damage(10)
+			src.take_bodypart_damage(20)
 	to_chat(src, span_userdanger("*BZZZT*"))
 	for(var/mob/living/M in buckled_mobs)
 		if(prob(severity*50))

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -87,7 +87,7 @@
 /mob/living/silicon/robot/shared_ui_interaction(src_object)
 	// Disable UIs if the object isn't installed in the borg AND the borg is either locked, has a dead cell, or no cell.
 	var/atom/device = src_object
-	if((istype(device) && device.loc != src) && (!cell || cell.charge <= 0 || lockcharge))
+	if((istype(device) && device.loc != src) && (!cell || cell.charge <= 0) || (lockcharge && !src.Adjacent(device)))
 		return UI_DISABLED
 	return ..()
 

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -8,6 +8,7 @@ export const RoboticsControlConsole = (props, context) => {
   const [tab, setTab] = useSharedState(context, 'tab', 1);
   const {
     can_hack,
+    can_detonate,
     cyborgs = [],
     drones = [],
   } = data;
@@ -34,7 +35,10 @@ export const RoboticsControlConsole = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {tab === 1 && (
-          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} />
+          <Cyborgs 
+           cyborgs={cyborgs}
+           can_detonate={can_detonate}
+           can_hack={can_hack} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -45,7 +49,7 @@ export const RoboticsControlConsole = (props, context) => {
 };
 
 const Cyborgs = (props, context) => {
-  const { cyborgs, can_hack } = props;
+  const { cyborgs, can_hack, can_detonate } = props;
   const { act, data } = useBackend(context);
   if (!cyborgs.length) {
     return (
@@ -77,13 +81,15 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-            <Button.Confirm
-              icon="bomb"
-              content="Detonate"
-              color="bad"
-              onClick={() => act('killbot', {
-                ref: cyborg.ref,
-              })} />
+             {!!can_detonate && (
+               <Button.Confirm
+               icon="bomb"
+               content="Detonate"
+               color="bad"
+               onClick={() => act('killbot', {
+                 ref: cyborg.ref,
+               })} />
+            )}
           </Fragment>
         )}>
         <LabeledList>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -36,9 +36,9 @@ export const RoboticsControlConsole = (props, context) => {
         </Tabs>
         {tab === 1 && (
           <Cyborgs 
-             cyborgs={cyborgs}
-             can_detonate={can_detonate}
-             can_hack={can_hack} />
+            cyborgs={cyborgs}
+            can_detonate={can_detonate}
+            can_hack={can_hack} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -87,7 +87,7 @@ const Cyborgs = (props, context) => {
                 content="Detonate"
                 color="bad"
                 onClick={() => act('killbot', {
-                   ref: cyborg.ref,
+                  ref: cyborg.ref,
                 })} />
             )}
           </Fragment>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -34,11 +34,11 @@ export const RoboticsControlConsole = (props, context) => {
             Drones ({drones.length})
           </Tabs.Tab>
         </Tabs>
-         {tab === 1 && (
-           <Cyborgs 
-            cyborgs={cyborgs}
-            can_detonate={can_detonate}
-            can_hack={can_hack} />
+        {tab === 1 && (
+          <Cyborgs 
+             cyborgs={cyborgs}
+             can_detonate={can_detonate}
+             can_hack={can_hack} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -81,14 +81,14 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-           {!!can_detonate && (
-             <Button.Confirm
-               icon="bomb"
-               content="Detonate"
-               color="bad"
-               onClick={() => act('killbot', {
-                  ref: cyborg.ref,
-               })} />
+            {!!can_detonate && (
+              <Button.Confirm
+                icon="bomb"
+                content="Detonate"
+                color="bad"
+                onClick={() => act('killbot', {
+                   ref: cyborg.ref,
+                })} />
             )}
           </Fragment>
         )}>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -34,11 +34,11 @@ export const RoboticsControlConsole = (props, context) => {
             Drones ({drones.length})
           </Tabs.Tab>
         </Tabs>
-        {tab === 1 && (
-          <Cyborgs 
-           cyborgs={cyborgs}
-           can_detonate={can_detonate}
-           can_hack={can_hack} />
+         {tab === 1 && (
+           <Cyborgs 
+            cyborgs={cyborgs}
+            can_detonate={can_detonate}
+            can_hack={can_hack} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -81,13 +81,13 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-             {!!can_detonate && (
-               <Button.Confirm
+           {!!can_detonate && (
+             <Button.Confirm
                icon="bomb"
                content="Detonate"
                color="bad"
                onClick={() => act('killbot', {
-                 ref: cyborg.ref,
+                  ref: cyborg.ref,
                })} />
             )}
           </Fragment>

--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -79,7 +79,7 @@
 	set category = "Robot Commands"
 	set name = "Self Destruct"
 
-	if(usr.stat == DEAD || usr.incapacitated())
+	if(usr.stat == DEAD || usr.incapacitated() || lockcharge)
 		return //won't work if dead or incapacitated
 
 	if(alert("WARNING: Are you sure you wish to self-destruct? This action cannot be undone!",,"Yes","No") != "Yes")


### PR DESCRIPTION
borg combat is currently 1 click wins on both sides which is fucking awful 2011 combat that we got rid of for humans a couple years ago, this changes a bunch of borg stuff to be less binary

Flashes:
Immobilize and blur the cyborg's vision for the same time as old flashes. They can still act. Down from instantly locking them in an inescapable chainstun. Locked borgs are affected the same way they previously were

Lockdown:
Locked down borgs can now move and act instead of being trapped forever, HOWEVER, locked borgs move 4x slower, have 2 of their module slots disabled, and their remaining module breaks at the same damage threshold as the third module on unlocked cyborgs. They can only interact with stuff they're next to, and borgs with guns cannot shoot. This is down from lockdown being an instant inescapable GBJ button

Detonate:
Remote detonation of cyborgs can only be done by the cyborg's connected master AI. Down from instantly gibbing the cyborg at literally the press of a button.

EMPS:
Emps do double damage against borgs (40 on heavy, 20 on light) and their ability to pulse internal wires has been restored as lockdown is no longer a stupid infinite stun. EMPs now only disable the borg's modules (16 seconds heavy like how it was before, jesus christ, 6 seconds light) Down from being an instant kill on hit.

Stun arm:
Now has a 1.2 second cooldown between attacks, and only does 60 stamina damage.

Harm alarm:
Knocks down instead of being a fucking paralyze because ranged stuns are stupid

Self destruct:
Can't be done while locked.

Hugging module:
Shock hugs now respect insulation when electrocuting people. This is down from it being an instant inescapable chainstun for humans.

# Changelog

:cl:  
tweak: borg combat has been reworked to be a lot less binary
/:cl:
