### PR TITLE
Removes Bowl of Blood From Necro Chest, Moves it to the necropolis, adds replacement item Blindfold of Telepathy

### DIFF
--- a/_maps/map_files/mining/Lavaland.dmm
+++ b/_maps/map_files/mining/Lavaland.dmm
@@ -118,6 +118,14 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"bh" = (
+/obj/structure/stone_tile/center,
+/obj/structure/stone_tile/surrounding_tile,
+/obj/structure/stone_tile/surrounding/cracked,
+/obj/item/reagent_containers/glass/bottle/necropolis_seed,
+/obj/structure/closet/crate/necropolis,
+/turf/open/lava/smooth/lava_land_surface,
+/area/ruin/unpowered/dragonslair)
 "bi" = (
 /obj/structure/gulag_beacon,
 /turf/open/floor/plasteel,
@@ -2366,12 +2374,6 @@
 	dir = 1
 	},
 /obj/structure/stone_tile/cracked,
-/turf/open/lava/smooth/lava_land_surface,
-/area/ruin/unpowered/dragonslair)
-"BP" = (
-/obj/structure/stone_tile/center,
-/obj/structure/stone_tile/surrounding_tile,
-/obj/structure/stone_tile/surrounding/cracked,
 /turf/open/lava/smooth/lava_land_surface,
 /area/ruin/unpowered/dragonslair)
 "BW" = (
@@ -48167,7 +48169,7 @@ aa
 aa
 aa
 aa
-BP
+bh
 lL
 EG
 aa

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -333,7 +333,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 
 /obj/item/clothing/glasses/telepathy
 	name = "blindfold of telepathy"
-	desc = "Covers the eyes, preventing natural sight, but provides thought-sense to those who focus and stay dedicated"
+	desc = "Covers the eyes, preventing natural sight. In return for committing oneself forever to the senses of the mind, the senses of the body are allowed to rest."
 	icon_state = "blindfoldwhite"
 	item_state = "blindfoldwhite"
 	flash_protect = 10 //they're blind, yo

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(9)
 			new /obj/item/ship_in_a_bottle(src)
 		if(10)
-			new /obj/item/reagent_containers/glass/bottle/necropolis_seed(src)
+			new /obj/item/clothing/glasses/telepathy(src)
 		if(11)
 			new /obj/item/jacobs_ladder(src)
 		if(12)
@@ -330,6 +330,25 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 	user.sight |= sight_flags
 	if(!isnull(lighting_alpha))
 		user.lighting_alpha = min(user.lighting_alpha, lighting_alpha)
+
+/obj/item/clothing/glasses/telepathy
+	name = "blindfold of telepathy"
+	desc = "Covers the eyes, preventing natural sight, but provides thought-sense to those who focus and stay dedicated"
+	icon_state = "blindfoldwhite"
+	item_state = "blindfoldwhite"
+	flash_protect = 10 //they're blind, yo
+	tint = 2
+	darkness_view = 0
+	var/sight_flags = SEE_MOBS
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/clothing/glasses/telepathy/equipped(mob/living/carbon/human/user, slot)
+	. = ..()
+	if(slot == SLOT_GLASSES)
+		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+		user.sight |= sight_flags
+		item_flags = DROPDEL
 
 //Red/Blue Cubes
 /obj/item/warp_cube


### PR DESCRIPTION
# Document the changes in your pull request

Bowl of blood is a garbage tier loot from a necro chest
so it's being relocated to the Necropolis, inside a chest there.
In its place you can now find the Blindfold of Telepathy, a cursed item (cant take it off) that has basically insurmountable flash protect, but also gives you the welding goggles overlay
however it also lets you have thermal vision :)

# Wiki Documentation

Requires an update to the Necropolis Chest loot pool on the Shaft Miner wiki page, to remove the Bowl of Blood and swap in the Blindfold of Telepathy

# Changelog

:cl:  
rscadd: Added Blindfold of Telepathy to the Necropolis Chest loot pool
rscdel: Removed Bowl of Blood from the Necropolis Chest loot pool
mapping: Necropolis now features a bowl of blood in a chest as loot
/:cl:
