### PR TITLE
Removes Sulfur-Trioxide Chem and Reaction, makes Sulfuric Acid reaction just 1to1 Sulfur and Water

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2119,13 +2119,6 @@
 	if(method == INGEST || method == TOUCH || method == INJECT)
 		L.ForceContractDisease(new /datum/disease/plague(), FALSE, TRUE)
 
-/datum/reagent/sulfur_trioxide
-	name = "Sulfur Trioxide"
-	description = "A super-oxygenated sulfur compound."
-	color = "#ebf0ff"
-	taste_description = "metallic rotten eggs"
-	reagent_state = SOLID
-
 /datum/reagent/adrenaline
 	name = "Adrenaline"
 	description = "Powerful chemical that termporarily makes the user immune to slowdowns"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -784,18 +784,11 @@
 	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/ashresin(location)
 
-/datum/chemical_reaction/sulfur_trioxide
-	name = /datum/reagent/sulfur_trioxide
-	id = /datum/reagent/sulfur_trioxide
-	results = list(/datum/reagent/sulfur_trioxide = 4)
-	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/oxygen = 3)
-	required_catalysts = list(/datum/reagent/hydrogen = 1)
-
 /datum/chemical_reaction/sulfuric_acid
 	name = /datum/reagent/toxin/acid
 	id = /datum/reagent/toxin/acid
 	results = list(/datum/reagent/toxin/acid = 2)
-	required_reagents = list(/datum/reagent/sulfur_trioxide = 1, /datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/sulfur = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/sugar
 	name = /datum/reagent/consumable/sugar


### PR DESCRIPTION
# Document the changes in your pull request

See: title

turns out I nerfed chem a liiiiitle too hard there

# Wiki Documentation

If Sulfur Trioxide is on the wiki by the time this gets merged, it needs to be removed, and the recipe for Sulfuric Acid needs to be adjusted to be 1u water and sulfur to 2u acid.

# Changelog

:cl:  
rscdel: Sulfur Trioxide has been removed
tweak: Sulfuric Acid now only takes 1:1 water and sulfur to make
/:cl:
