### PR TITLE
[Port] Adds Lean

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -572,3 +572,10 @@
 	desc = "A fresh bottle of stout, popularized by inhabitants of Space Ireland."
 	icon_state = "stout_bottle" 
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer/stout = 40)
+
+/obj/item/reagent_containers/food/drinks/colocup/lean
+	name = "lean"
+	desc = "A cup of that purple drank, the stuff that makes you go WHEEZY BABY."
+	icon_state = "lean"
+	list_reagents = list(/datum/reagent/consumable/lean = 50)
+	random_sprite = FALSE

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -117,3 +117,12 @@
 	result = /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing
 	category = CAT_DRINK
 
+/datum/crafting_recipe/lean
+	name = "Lean"
+	result = /obj/item/reagent_containers/food/drinks/colocup/lean
+	time = 30
+	reqs = list(/obj/item/reagent_containers/food/drinks/colocup = 1,
+				/obj/item/reagent_containers/food/snacks/candy_strawberry = 1,
+				/datum/reagent/medicine/morphine = 5,
+				/datum/reagent/consumable/space_up = 15)
+	category = CAT_DRINK

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1042,3 +1042,22 @@
 		M.adjustOxyLoss(-0.5 * REM * delta_time, 0)
 	..()
 	. = TRUE
+
+/datum/reagent/consumable/lean
+	name = "Lean"
+	description = "The drank that makes you go wheezy."
+	color = "#ac24bb"
+	quality = DRINK_NICE
+	taste_description = "purple and a hint of opiod."
+	glass_icon_state = "lean"
+	glass_name = "Lean"
+	glass_desc = "A drink that makes your life less miserable."
+
+/datum/reagent/consumable/lean/on_mob_life(mob/living/carbon/M)
+	if(M.slurring < 3)
+		M.slurring+= 2
+	if(M.druggy < 3)
+		M.adjust_drugginess(1)
+	if(M.drowsyness < 3)
+		M.drowsyness++
+	return ..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1048,7 +1048,7 @@
 	description = "The drank that makes you go wheezy."
 	color = "#ac24bb"
 	quality = DRINK_NICE
-	taste_description = "purple and a hint of opiod."
+	taste_description = "grape and a hint of opioid."
 	glass_icon_state = "lean"
 	glass_name = "Lean"
 	glass_desc = "A drink that makes your life less miserable."


### PR DESCRIPTION
# Document the changes in your pull request

The Lean portion of https://github.com/tgstation/tgstation/pull/50029

Why? Because it's funny. And a modern cultural reference. Also potentially maint-craftable drugs.

changed the recipe to use strawberry candies so its craftable without borgs

# Wiki Documentation

Requires addition to the guide to drinks

makes you slur your speech, gives you a weak drug overlay, and makes you drowsy too

also provides a mood buff

# Changelog

:cl:  
rscadd: Adds Lean as a craftable beverage
/:cl:
