### PR TITLE
bluespace bodybags no longer trigger disko relocation

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -130,6 +130,7 @@
 	visible_message("<span class='notice'>[usr] folds up [src].</span>")
 	var/obj/item/bodybag/B = foldedbag_instance || new foldedbag_path
 	var/max_weight_of_contents = initial(B.w_class)
+	usr.put_in_hands(B)
 	for(var/am in contents)
 		var/atom/movable/content = am
 		content.forceMove(B)
@@ -143,7 +144,6 @@
 			continue
 		max_weight_of_contents = A_is_item.w_class
 	B.w_class = max_weight_of_contents
-	usr.put_in_hands(B)
 
 /// Environmental bags
 


### PR DESCRIPTION
# Document the changes in your pull request

Causes the bluespace bodybag to give itself an actual location before shoving stuff in it so the disk won't leave and you can put it inside a box inside a bag inside a bluespace bodybag inside another bag as god intended

# Wiki Documentation

this is not documented and I'm pretty sure everyone would expect it to not be documented

# Changelog

:cl:  
tweak: the disk will no longer instant transmission when put in a bluespace bodybag
/:cl:
