### PR TITLE
Replaces Colombus Day with Indigenous Peoples Day

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -495,11 +495,15 @@
 	begin_month = OCTOBER
 	begin_weekday = MONDAY
 
-/datum/holiday/indiginous
-	name = "Indiginous Peoples Day"
-	begin_week = 2
+/datum/holiday/indigenous
+	name = "Indigenous Peoples Day in the United States"
+	begin_day = 10
 	begin_month = OCTOBER
-	begin_weekday = MONDAY
+
+/datum/holiday/indigenous
+	name = "Indigenous Peoples Day in Canada"
+	begin_day = 21
+	begin_month = JUNE
 
 /datum/holiday/mother
 	name = "Mother's Day"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -495,8 +495,8 @@
 	begin_month = OCTOBER
 	begin_weekday = MONDAY
 
-/datum/holiday/columbus
-	name = "Columbus Day"
+/datum/holiday/indiginous
+	name = "Indiginous Peoples Day"
 	begin_week = 2
 	begin_month = OCTOBER
 	begin_weekday = MONDAY

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -500,7 +500,7 @@
 	begin_day = 10
 	begin_month = OCTOBER
 
-/datum/holiday/indigenous
+/datum/holiday/indigenous/canada
 	name = "Indigenous Peoples Day in Canada"
 	begin_day = 21
 	begin_month = JUNE


### PR DESCRIPTION
# Document the changes in your pull request

This is the direction that things are going in the USA IRL, and realistically, the way they SHOULD be going.
Kills off a reference to a colonizer, human trafficker, rapist, and tyrant; replaces that with the better option, culturally speaking.

also adds a separate instance for Canada, who has their own holiday for this earlier in the year

# Wiki Documentation

If we have a page that covers Holidays, this needs updating; if we DONT, maybe we should add one

# Changelog

:cl:  
spellcheck: Colombus Day is now Indigenous Peoples Day
/:cl:
