### PR TITLE
Malf AIs with hijack no longer need to kill IPCs

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -463,7 +463,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return TRUE
 	for(var/mob/living/player in GLOB.player_list)
-		if(player.mind && player.stat != DEAD && !issilicon(player))
+		if(player.mind && player.stat != DEAD && !(issilicon(player) || isipc(player)))
 			if(get_area(player) in SSshuttle.emergency.shuttle_areas)
 				return FALSE
 	return TRUE


### PR DESCRIPTION
"Do not allow any organic lifeforms to escape on the shuttle alive"
Well, ackshually IPCs aren't organic *\*snort*\*, so they should be allowed on the shuttle.

The AI can still totally just kill everyone, but it lets IPCs RP their way out of getting killed like all the other fleshbags.

:cl:    
tweak: Malf AI with hijack don't need to kill IPCs anymore
/:cl:
