### PR TITLE
burning stun combat: fuck flashes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -135,6 +135,7 @@
 #define TRAIT_DISFIGURED		"disfigured"
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
+#define TRAIT_FLASHED		"flashed_recently"
 #define TRAIT_STUNRESISTANCE    "stun_resistance"
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"
 #define TRAIT_PUSHIMMUNE		"push_immunity"

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -93,13 +93,14 @@
 	else
 		return typecache_filter_list(target_loc.GetAllContents(), GLOB.typecache_living)
 
-/obj/item/assembly/flash/proc/try_use_flash(mob/user = null, nocooldown)
+/obj/item/assembly/flash/proc/try_use_flash(mob/user = null, nocooldown = FALSE)
 	if(user && HAS_TRAIT(user, TRAIT_NO_STUN_WEAPONS))
 		to_chat(user, span_warning("You can't seem to remember how this works!"))
 		return FALSE
 	if(burnt_out || ((world.time < last_trigger + cooldown) && !nocooldown))
 		return FALSE
-	last_trigger = world.time
+	if(!nocooldown)
+		last_trigger = world.time
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 	flash_lighting_fx(FLASH_LIGHT_RANGE, light_power, light_color)
 	times_used++

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -1,4 +1,4 @@
-#define CONFUSION_STACK_MAX_MULTIPLIER 4
+#define CONFUSION_STACK_MAX_MULTIPLIER 4 
 /obj/item/assembly/flash
 	name = "flash"
 	desc = "A powerful and versatile flashbulb device, with applications ranging from disorienting attackers to acting as visual receptors in robot production."

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -74,7 +74,7 @@
 
 //BYPASS CHECKS ALSO PREVENTS BURNOUT!
 /obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 3, power = 5, targeted = FALSE, mob/user)
-	if(!bypass_checks && !try_use_flash())
+	if(!bypass_checks && !try_use_flash(nocooldown = TRUE))
 		return FALSE
 	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)
 	if(user)
@@ -93,11 +93,11 @@
 	else
 		return typecache_filter_list(target_loc.GetAllContents(), GLOB.typecache_living)
 
-/obj/item/assembly/flash/proc/try_use_flash(mob/user = null)
+/obj/item/assembly/flash/proc/try_use_flash(mob/user = null, nocooldown)
 	if(user && HAS_TRAIT(user, TRAIT_NO_STUN_WEAPONS))
 		to_chat(user, span_warning("You can't seem to remember how this works!"))
 		return FALSE
-	if(burnt_out || (world.time < last_trigger + cooldown))
+	if(burnt_out || ((world.time < last_trigger + cooldown) && !nocooldown))
 		return FALSE
 	last_trigger = world.time
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)


### PR DESCRIPTION
stun combat is not fun combat
flashes are not in limited supply (robotics can make infinite) and our maps are absolutely lousy with them, some maintenance ruins even have flashes ripe to be stolen.
doing this can let us walk back from 'EVERYONE IMPORTANT NEEDS FLASH PROTECTION' and should discourage powergaming a little bit
mounted flashes unaffected
would pair best with #16110

flashes now do not instantly stun people, instead being an 8-12 second knockdown. flash confusion has been doubled to accommodate for this, flashes now also do 80 stamina. also flashes now have a 9 second cooldown so that your victim has time to flip down their welding helmet or whatever instead of just being fucked. i also preemptively prevented you from carrying 2 flashes to instantly cuck somebody because i know our playerbase would do it.

use cases this affects:
security: flash first and then stun baton instead of click once to win
heads: your flash is for self defense and disarming and knocking down whoever's attacking you is pretty good especially because you can then stamcrit them in 1 telescopic baton hit
borgs: validhunter borgs can get fucked for all i care, emagged/malf ones have their hacked modules
antags: pair with stunprod or something or use your antag abilities instead of shitty stun combat

aoe flash retains its 0 cooldown
as a side effect makes rev speedrun (convert 30 people in 2 seconds) less prevalent because the 9 second flash cooldown applies to revs converting people too

# Changelog

:cl:   
tweak: flashes are now not 1 click wins lol
/:cl:
