### PR TITLE
Revert "Reduces Reagent Capacity of Pills to 10u" This removes one of the few late game tasks chemists can do which is making insane one off healing pills

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -260,7 +260,7 @@
 		var/vol_each_text = params["volume"]
 		var/vol_each_max = reagents.total_volume / amount
 		if (item_type == "pill")
-			vol_each_max = min(10, vol_each_max)
+			vol_each_max = min(50, vol_each_max)
 		else if (item_type == "patch")
 			vol_each_max = min(40, vol_each_max)
 		else if (item_type == "bottle")

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	possible_transfer_amounts = list()
-	volume = 10
+	volume = 50
 	grind_results = list()
 	var/apply_type = INGEST
 	var/apply_method = "swallow"
@@ -246,7 +246,6 @@
 	var/static/list/names = list("maintenance pill","floorpill","mystery pill","suspicious pill","strange pill")
 	var/static/list/descs = list("Your feeling is telling you no, but...","Drugs are expensive, you can't afford not to eat any pills that you find."\
 	, "Surely, there's no way this could go bad.")
-	volume = 50
 
 /obj/item/reagent_containers/pill/floorpill/Initialize()
 	list_reagents = list(get_random_reagent_id() = rand(10,50))

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -263,7 +263,7 @@ const PackagingControls = (props, context) => {
           label="Pills"
           amount={pillAmount}
           amountUnit="pills"
-          sideNote="max 10u"
+          sideNote="max 50u"
           onChangeAmount={(e, value) => setPillAmount(value)}
           onCreate={() => act('create', {
             type: 'pill',


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16013

It takes a lot of time to make all the chems used in 50u mix pills and even more time to determine safe dosage and whatnot. I have never seen anyone take the time to make any exorbitant amount of 50u mix pills nor have I ever in my 1,500 hours of chem made any more than maybe 8 50u mix pills in one round. Even then, the 50u mix pills were used for tooth implants for other people that specifically asked for them.