### PR TITLE
Bartenders can now craft lemoline

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -131,6 +131,12 @@
 	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 2)
 	required_temp = 525
 
+/datum/chemical_reaction/lemolime
+	name = "Lemoline"
+	id = /datum/reagent/lemoline
+	required_reagents = list(/datum/reagent/consumable/lemonjuice = 2, /datum/reagent/consumable/limejuice = 2, /datum/reagent/consumable/ethanol = 4)
+	results = list(/datum/reagent/lemoline = 4)
+
 //Technically a mutation toxin
 /datum/chemical_reaction/mulligan
 	name = "Mulligan"


### PR DESCRIPTION
# Document the changes in your pull request

- 2u Lemon Juice
- 2u Lime Juice
- 4u Ethanol

Results
- 4u Lemoline

It's not super useful so its not really going to be ordered by cargo
Adds a simple recipe the bartender can make giving chemist and bartenders some opportunity/reason to work together

# Changelog

:cl:  
rscadd: Lemoline can be crafted now
/:cl:
