### PR TITLE
Removes Water Creation Reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -820,13 +820,6 @@
 	required_temp = 100
 	is_cold_recipe = TRUE
 
-/datum/chemical_reaction/waterformation
-	name = /datum/reagent/water
-	id = /datum/reagent/water
-	results = list(/datum/reagent/water = 3)
-	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/hydrogen = 2)
-	required_temp = 380
-
 /datum/chemical_reaction/ice
 	name = /datum/reagent/consumable/ice
 	id = /datum/reagent/consumable/ice


### PR DESCRIPTION
# Document the changes in your pull request

Linter failed to catch a recipe conflict with this one; morphine creates water before it ever lets you make morphine

# Wiki Documentation

Just needs this reaction removed from the guide to chemistry

# Changelog

:cl:  
rscdel: Removed Water Creation Chemical Reaction
/:cl:
