### PR TITLE
Adds 2 of The Follin Brothers' Great Tracks (Pictionary + Solstice Main Themes) to the lobby music list

### DIFF
--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -48,11 +48,13 @@
 		"https://www.youtube.com/watch?v=uiPJQgw6M_g",						// Ribbiks - Chasing Suns
 		"https://www.youtube.com/watch?v=7F_xOzLWy5U",						// Ataraxia - Deja Vuzz
 		"https://www.youtube.com/watch?v=VJ817kvh_DM",						// Ben Prunty - FTL - Theme Song
-		"https://www.youtube.com/watch?v=7F_xOzLWy5U",						// Ataraxia - Deja Vuzz
-		"https://www.youtube.com/watch?v=hZb_6_WfquU",            // Steam Powered Giraffe - Fire Fire
-		"https://www.youtube.com/watch?v=52Gg9CqhbP8",  					//Stuck in the Sound - Let's G
-		"https://www.youtube.com/watch?v=8GW6sLrK40k",						//HOME - Resonance
-		"https://www.youtube.com/watch?v=8DNoXUnaQ9k")						//Chris Christodoulou - Dies Irae
+		"https://www.youtube.com/watch?v=hZb_6_WfquU",						// Steam Powered Giraffe - Fire Fire
+		"https://www.youtube.com/watch?v=52Gg9CqhbP8",  					// Stuck in the Sound - Let's Go
+		"https://www.youtube.com/watch?v=8GW6sLrK40k",						// HOME - Resonance
+		"https://www.youtube.com/watch?v=8DNoXUnaQ9k",						// Chris Christodoulou - Dies Irae
+		"https://www.youtube.com/watch?v=4_gObHt1uZA",						// Solstice Main Menu Theme - Tim Follin
+		"https://www.youtube.com/watch?v=SJwh3erQlyE",						// Pictionary Main Menu Theme - Tim FOllin
+		)
 	selected_lobby_music = pick(songs)
 
 	if(SSevents.holidays) // What's this? Events are initialized before tickers? Let's do something with that!


### PR DESCRIPTION
# Document the changes in your pull request

Tim Follin was somewhat of a god when it came to squeezing every last byte out of the NES sound-chip
these two songs he and his brother made capture it excellently, as does the other PR Molti has open containing Plok's boss theme

Songs in question:
https://www.youtube.com/watch?v=4_gObHt1uZA - Solstice
https://www.youtube.com/watch?v=SJwh3erQlyE - Pictionary

# Changelog

:cl:  
soundadd: Lobby Music now features the Pictionary and Solstice main themes by The Follin Brothers
/:cl:
