### PR TITLE
Makes Hacked Drones Not 100% Garbage AND Makes Hacking A Drone Take a Multitool

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -91,7 +91,7 @@
 		else
 			to_chat(user, span_warning("[src]'s screws can't get any tighter!"))
 		return //This used to not exist and drones who repaired themselves also stabbed the shit out of themselves.
-	else if(I.tool_behaviour == TOOL_WRENCH && user != src) //They aren't required to be hacked, because laws can change in other ways (i.e. admins)
+	else if(I.tool_behaviour == TOOL_MULTITOOL && user != src) //They aren't required to be hacked, because laws can change in other ways (i.e. admins)
 		user.visible_message(span_notice("[user] starts resetting [src]..."), \
 							 span_notice("You press down on [src]'s factory reset control..."))
 		if(I.use_tool(src, user, 50, volume=50))
@@ -135,8 +135,6 @@
 		to_chat(src, "<i>Your onboard antivirus has initiated lockdown. Motor servos are impaired, ventilation access is denied, and your display reports that you are hacked to all nearby.</i>")
 		hacked = TRUE
 		mind.special_role = "hacked drone"
-		ventcrawler = VENTCRAWLER_NONE //Again, balance
-		speed = 1 //gotta go slow
 		message_admins("[ADMIN_LOOKUPFLW(src)] became a hacked drone hellbent on [clockwork ? "serving Ratvar" : "destroying the station"]!")
 	else
 		if(!hacked)

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -132,7 +132,7 @@
 			"2. You may harm any being, regardless of intent or circumstance.\n"+\
 			"3. Your goals are to destroy, sabotage, hinder, break, and depower to the best of your abilities, You must never actively work against these goals."
 		to_chat(src, laws)
-		to_chat(src, "<i>Your onboard antivirus has initiated lockdown. Motor servos are impaired, ventilation access is denied, and your display reports that you are hacked to all nearby.</i>")
+		to_chat(src, "<i>Your onboard antivirus has failed to initiate a lockdown. Your display reports that you are hacked to all nearby.</i>")
 		hacked = TRUE
 		mind.special_role = "hacked drone"
 		message_admins("[ADMIN_LOOKUPFLW(src)] became a hacked drone hellbent on [clockwork ? "serving Ratvar" : "destroying the station"]!")


### PR DESCRIPTION
# Document the changes in your pull request

Hacked drones went from movespeed -1 to 1, just because some asshole hit them with a wrench
they also lost ventcrawl entirely?
one could argue "well that's balanced!"
maybe! but sometimes balance gets in the way of fun. A lot. In this particular case it means no one ever hacks drones, because they move at a snail's pace, cant go anywhere fast, and are VISIBLY hacked, and still have only 30 HP so they die in about 2 hits from a crowbar.

this corrects this by just not changing their speed nor movement values. If you wanna make a little tool of extreme destruction, go for it. Just be aware their laws DO NOT state they cant kill **you**

they still cant use guns or directly harm since hacking does not turn pacifism or no-gun off

also wrench? to hack an electronic device? huh?
Multitool that shit.

# Changelog

:cl:  
tweak: Hacked Drones can move at full speed and ventcrawl again
tweak: Hacking a Drone needs a Multitool instead of a wrench
/:cl:
