### PR TITLE
Fixes firelocks not updating atmos when destroyed

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -69,6 +69,9 @@
 /obj/machinery/door/firedoor/Destroy()
 	remove_from_areas()
 	affecting_areas.Cut()
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.ImmediateCalculateAdjacentTurfs()
 	return ..()
 
 /obj/machinery/door/firedoor/Bumped(atom/movable/AM)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -71,7 +71,8 @@
 	affecting_areas.Cut()
 	var/turf/T = get_turf(src)
 	spawn(0)
-		T.ImmediateCalculateAdjacentTurfs()
+		if(T)
+			T.ImmediateCalculateAdjacentTurfs()
 	return ..()
 
 /obj/machinery/door/firedoor/Bumped(atom/movable/AM)


### PR DESCRIPTION
# Document the changes in your pull request

Forces atmos to recalculate all adjacent turfs the tick after the firelock is destroyed (The firelock is not yet destroyed on the same tick)

# Changelog

:cl:  
bugfix: fixed firelocks not updating atmos when destroyed
/:cl:
