### PR TITLE
Fixes attack and floating animations

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -788,7 +788,7 @@
 		pixel_x_diff = -8
 
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 0.2 SECONDS)
-	animate(src, pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 0.2 SECONDS)
+	animate(pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 0.2 SECONDS)
 
 /atom/movable/vv_get_dropdown()
 	. = ..()
@@ -810,8 +810,7 @@
 		return
 	if(on && !(movement_type & FLOATING))
 		animate(src, pixel_y = pixel_y + 2, time = 1 SECONDS, loop = -1)
-		sleep(1 SECONDS)
-		animate(src, pixel_y = pixel_y - 2, time = 1 SECONDS, loop = -1)
+		animate(pixel_y = pixel_y - 2, time = 1 SECONDS)
 		setMovetype(movement_type | FLOATING)
 	else if (!on && (movement_type & FLOATING))
 		animate(src, pixel_y = initial(pixel_y), time = 1 SECONDS)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -834,8 +834,7 @@
 		fixed = 1
 	if(on && !(movement_type & FLOATING) && !fixed)
 		animate(src, pixel_y = pixel_y + 2, time = 1 SECONDS, loop = -1)
-		sleep(1 SECONDS)
-		animate(src, pixel_y = pixel_y - 2, time = 1 SECONDS, loop = -1)
+		animate(pixel_y = pixel_y - 2, time = 1 SECONDS)
 		setMovetype(movement_type | FLOATING)
 	else if(((!on || fixed) && (movement_type & FLOATING)))
 		animate(src, pixel_y = get_standard_pixel_y_offset(lying), time = 1 SECONDS)


### PR DESCRIPTION

# Document the changes in your pull request

I have not tested this. Fixes the animations, caused by improper usage of animate() proc. I don't know how long this has been broken.

# Changelog

:cl:  
fix: Fix attack and floating animations
/:cl:
