### PR TITLE
clown ops fucking suck so in attempt to change that kind of removes clumsiness from them

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -47,11 +47,6 @@
 /datum/outfit/syndicate/clownop/no_crystals
 	tc = 0
 
-/datum/outfit/syndicate/clownop/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(visualsOnly)
-		return
-	H.dna.add_mutation(CLOWNMUT)
 
 /datum/outfit/syndicate/clownop/leader
 	name = "Clown Operative Leader - Basic"


### PR DESCRIPTION
i get that clown ops are supposed to honk and shit, but when you cant use multiple items your able to buy, and your shop is neutered to 90% nonlethals it just ends up being completely unfun for both the crew and the nuke ops
:cl:  
tweak: removed clumsiness from clown ops
/:cl:
