### PR TITLE
Exosuit fabricator wires and hacking

### DIFF
--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -7,7 +7,7 @@
 		///Allows anyone to use the fabricator, still makes it unable to make combat mechs
 		WIRE_HACK,
 		///Instead of shocking, makes fabricator hands lash out and break a random limb
-		WIRE_ZAP,
+		WIRE_BREAK,
 		///This one shocks the machine, but only temporarily.
 		WIRE_SHOCK
 	)
@@ -34,9 +34,9 @@
 			holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's control panel blinks temporarily."))
 			F.hacked = TRUE
 			addtimer(CALLBACK(F, /obj/machinery/mecha_part_fabricator.proc/reset, wire), 5)
-		if(WIRE_ZAP)
+		if(WIRE_BREAK)
 			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The fabricator's hands shake and twist aggresively, grapping at limbs!"))
-			F.wire_zap(usr)
+			F.wire_break(usr)
 		if(WIRE_SHOCK)
 			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The cable sparks faintly."))
 			F.seconds_electrified = MACHINE_DEFAULT_ELECTRIFY_TIME

--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -22,7 +22,7 @@
 /datum/wires/mecha_part_fabricator/get_status()
 	var/obj/machinery/mecha_part_fabricator/F = holder
 	var/list/status = list()
-	status += "The purple light is [F.hacked ? "on" : "off"]."
+	status += "The purple light is [F.hacked ? "off" : "on"]."
 	return status
 
 /datum/wires/mecha_part_fabricator/on_pulse(wire)
@@ -33,9 +33,10 @@
 			F.hacked = TRUE
 			addtimer(CALLBACK(F, /obj/machinery/mecha_part_fabricator.proc/reset, wire), 5)
 		if(WIRE_ZAP)
-			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The fabricator's hands grapple aggresively into the air!"))
+			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The fabricator's hands shake and twist aggresively, grapping at limbs!"))
 			F.wire_zap(usr)
 		if(WIRE_SHOCK)
+			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The cable sparks faintly."))
 			F.seconds_electrified = MACHINE_DEFAULT_ELECTRIFY_TIME
 
 /datum/wires/mecha_part_fabricator/on_cut(wire, mend)

--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -7,7 +7,7 @@
 		///Allows anyone to use the fabricator, still makes it unable to make combat mechs
 		WIRE_HACK,
 		///Instead of shocking, makes fabricator hands lash out and break a random limb
-		WIRE_BREAK,
+		WIRE_ZAP,
 		///This one shocks the machine, but only temporarily.
 		WIRE_SHOCK
 	)
@@ -34,7 +34,7 @@
 			holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's control panel blinks temporarily."))
 			F.hacked = TRUE
 			addtimer(CALLBACK(F, /obj/machinery/mecha_part_fabricator.proc/reset, wire), 5)
-		if(WIRE_BREAK)
+		if(WIRE_ZAP)
 			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The fabricator's hands shake and twist aggresively, grapping at limbs!"))
 			F.wire_break(usr)
 		if(WIRE_SHOCK)

--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -1,0 +1,39 @@
+/datum/wires/mecha_part_fabricator
+	holder_type = /obj/machinery/mecha_part_fabricator
+	proper_name = "Exosuit fabricator"
+
+/datum/wires/mecha_part_fabricator/New(atom/holder)
+	wires = list(
+		///Allows anyone to use the fabricator, still makes it unable to make combat mechs
+		WIRE_HACK,
+		///Instead of shocking, makes fabricator hands lash out and break a random limb
+		WIRE_ZAP
+	)
+	add_duds(6)
+	..()
+
+/datum/wires/mecha_part_fabricator/interactable(mob/user)
+	var/obj/machinery/mecha_part_fabricator/F = holder
+	if(F.panel_open)
+		return TRUE
+
+/datum/wires/mecha_part_fabricator/get_status()
+	var/obj/machinery/mecha_part_fabricator/F = holder
+	var/list/status = list()
+	status += "The purple light is [F.hacked ? "on" : "off"]."
+	return status
+
+/datum/wires/mecha_part_fabricator/on_pulse(wire)
+	var/obj/machinery/mecha_part_fabricator/F = holder
+		switch(wire)
+			if(WIRE_HACK)
+				holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's control panel blinks temporarily."))
+			if(WIRE_ZAP)
+				holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's hands grapple aggresively into the air!"))
+				F.wire_zap(usr)
+
+/datum/wires/mecha_part_fabricator/on_cut(wire, mend)
+	var/obj/machinery/mecha_part_fabricator/F = holder
+	switch(wire)
+		if(WIRE_HACK)
+			F.hacked = !mend

--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -16,6 +16,8 @@
 
 /datum/wires/mecha_part_fabricator/interactable(mob/user)
 	var/obj/machinery/mecha_part_fabricator/F = holder
+	if(!issilicon(user) && F.seconds_electrified && F.shock(user, 100))
+		return FALSE
 	if(F.panel_open)
 		return TRUE
 

--- a/code/datums/wires/mech_fabricator.dm
+++ b/code/datums/wires/mech_fabricator.dm
@@ -7,9 +7,11 @@
 		///Allows anyone to use the fabricator, still makes it unable to make combat mechs
 		WIRE_HACK,
 		///Instead of shocking, makes fabricator hands lash out and break a random limb
-		WIRE_ZAP
+		WIRE_ZAP,
+		///This one shocks the machine, but only temporarily.
+		WIRE_SHOCK
 	)
-	add_duds(6)
+	add_duds(2)
 	..()
 
 /datum/wires/mecha_part_fabricator/interactable(mob/user)
@@ -25,12 +27,16 @@
 
 /datum/wires/mecha_part_fabricator/on_pulse(wire)
 	var/obj/machinery/mecha_part_fabricator/F = holder
-		switch(wire)
-			if(WIRE_HACK)
-				holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's control panel blinks temporarily."))
-			if(WIRE_ZAP)
-				holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's hands grapple aggresively into the air!"))
-				F.wire_zap(usr)
+	switch(wire)
+		if(WIRE_HACK)
+			holder.visible_message(span_notice("[icon2html(F, viewers(holder))] The fabricator's control panel blinks temporarily."))
+			F.hacked = TRUE
+			addtimer(CALLBACK(F, /obj/machinery/mecha_part_fabricator.proc/reset, wire), 5)
+		if(WIRE_ZAP)
+			holder.visible_message(span_danger("[icon2html(F, viewers(holder))] The fabricator's hands grapple aggresively into the air!"))
+			F.wire_zap(usr)
+		if(WIRE_SHOCK)
+			F.seconds_electrified = MACHINE_DEFAULT_ELECTRIFY_TIME
 
 /datum/wires/mecha_part_fabricator/on_cut(wire, mend)
 	var/obj/machinery/mecha_part_fabricator/F = holder

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -169,14 +169,12 @@
 	var/datum/wound/blunt/severe/break_it = new
 	///Picks limb to break. People with less limbs have a chance of it grapping at air
 	var/obj/item/bodypart/bone = C.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
-	if(bone){
+	if(bone)
 		to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
 		break_it.apply_wound(bone)
 		bone.receive_damage(brute=50, updating_health=TRUE)
-	}
-	else{
+	else
 		to_chat(C,span_userdanger("The manipulator arms attempt to grab one of your limbs, but grapple air instead!"))
-	}
 	qdel(break_it)
 	qdel(bone)
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -168,8 +168,7 @@
 	var/mob/living/carbon/C = user
 	var/datum/wound/blunt/severe/break_it = new
 	///Picks limb to break. People with less limbs have a chance of it grapping at air
-	var/picked_bodypart = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
-	var/obj/item/bodypart/bone = C.get_bodypart(picked_bodypart)
+	var/obj/item/bodypart/bone = C.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 	if(bone){
 		to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
 		break_it.apply_wound(bone)
@@ -178,6 +177,8 @@
 	else{
 		to_chat(C,span_userdanger("The manipulator arms attempt to grab one of your limbs, but grapple air instead!"))
 	}
+	qdel(break_it)
+	qdel(bone)
 
 /obj/machinery/mecha_part_fabricator/proc/reset(wire)
 	switch(wire)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -151,9 +151,14 @@
 		return
 	return ..()
 /**
- * All the negative wire effect
+ * All the negative wire effects
  * Zap doesnt actually zap, it breaks one limb (Because pain is to be had)
 */
+/obj/machinery/mecha_part_fabricator/_try_interact(mob/user)
+	if(seconds_electrified && !(stat & NOPOWER))
+		if(shock(user, 100))
+			return
+
 /obj/machinery/mecha_part_fabricator/proc/wire_zap(mob/user)
 	if(stat & (BROKEN|NOPOWER))
 		return FALSE
@@ -179,6 +184,27 @@
 		if(WIRE_HACK)
 			if(!wires.is_cut(wire))
 				hacked = FALSE
+/**
+  * Shock the passed in user
+  *
+  * This checks we have power and that the passed in prob is passed, then generates some sparks
+  * and calls electrocute_mob on the user
+  *
+  * Arguments:
+  * * user - the user to shock
+  * * prb - probability the shock happens
+  */
+/obj/machinery/mecha_part_fabricator/proc/shock(mob/user, prb)
+	if(stat & (BROKEN|NOPOWER))		// unpowered, no shock
+		return FALSE
+	if(!prob(prb))
+		return FALSE
+	do_sparks(5, TRUE, src)
+	var/check_range = TRUE
+	if(electrocute_mob(user, get_area(src), src, 0.7, check_range))
+		return TRUE
+	else
+		return FALSE
 /**
   * Generates an info list for a given part.
   *
@@ -415,7 +441,10 @@
 		if(process_queue)
 			build_next_in_queue(FALSE)
 		return TRUE
-
+	
+	// Deelectrifies the machine
+	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)
+		seconds_electrified--
 /**
   * Dispenses a part to the tile infront of the Exosuit Fab.
   *

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -161,22 +161,18 @@
 	s.set_up(5, 1, src)
 	s.start()
 	var/mob/living/carbon/C = user
-	var/chosen_limb = rand(1,4)
 	var/datum/wound/blunt/severe/break_it = new
-	var/obj/item/bodypart/bone = new
 	///Picks limb to break. People with less limbs have a chance of it grapping at air
-	switch(chosen_limb)
-		if(1)
-			bone = C.get_bodypart(BODY_ZONE_L_LEG)
-		if(2)
-			bone = C.get_bodypart(BODY_ZONE_R_LEG)
-		if(3)
-			bone = C.get_bodypart(BODY_ZONE_R_ARM)
-		if(4)
-			bone = C.get_bodypart(BODY_ZONE_L_ARM)
-	to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
-	break_it.apply_wound(bone)
-	bone.receive_damage(brute=50, updating_health=TRUE)
+	var/picked_bodypart = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
+	var/obj/item/bodypart/bone = C.get_bodypart(picked_bodypart)
+	if(bone){
+		to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
+		break_it.apply_wound(bone)
+		bone.receive_damage(brute=50, updating_health=TRUE)
+	}
+	else{
+		to_chat(C,span_userdanger("The manipulator arms attempt to grab one of your limbs, but grapple air instead!"))
+	}
 
 /obj/machinery/mecha_part_fabricator/proc/reset(wire)
 	switch(wire)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -164,7 +164,7 @@
 	var/chosen_limb = rand(1,4)
 	var/datum/wound/blunt/severe/break_it = new
 	var/obj/item/bodypart/bone = new
-	C.emote("scream")
+	///Picks limb to break. People with less limbs have a chance of it grapping at air
 	switch(chosen_limb)
 		if(1)
 			bone = C.get_bodypart(BODY_ZONE_L_LEG)
@@ -175,6 +175,7 @@
 		if(4)
 			bone = C.get_bodypart(BODY_ZONE_L_ARM)
 	break_it.apply_wound(bone)
+	bone.receive_damage(brute=50, updating_health=TRUE)
 
 /obj/machinery/mecha_part_fabricator/proc/reset(wire)
 	switch(wire)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -175,8 +175,7 @@
 		bone.receive_damage(brute=50, updating_health=TRUE)
 	else
 		to_chat(C,span_userdanger("The manipulator arms attempt to grab one of your limbs, but grapple air instead!"))
-	qdel(break_it)
-	qdel(bone)
+		qdel(break_it)
 
 /obj/machinery/mecha_part_fabricator/proc/reset(wire)
 	switch(wire)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -152,14 +152,14 @@
 	return ..()
 /**
  * All the negative wire effects
- * Zap doesnt actually zap, it breaks one limb (Because pain is to be had)
+ * Break wire breaks one limb (Because pain is to be had)
 */
 /obj/machinery/mecha_part_fabricator/_try_interact(mob/user)
 	if(seconds_electrified && !(stat & NOPOWER))
 		if(shock(user, 100))
 			return
 
-/obj/machinery/mecha_part_fabricator/proc/wire_zap(mob/user)
+/obj/machinery/mecha_part_fabricator/proc/wire_break(mob/user)
 	if(stat & (BROKEN|NOPOWER))
 		return FALSE
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -9,8 +9,12 @@
 	active_power_usage = 5000
 	
 	req_access = list(ACCESS_ROBOTICS)
+	///Whether the access is hacked or not
 	var/hacked = FALSE
-	
+	///World ticks the machine is electified for
+	var/seconds_electrified = MACHINE_NOT_ELECTRIFIED
+
+
 	circuit = /obj/item/circuitboard/machine/mechfab
 	subsystem_type = /datum/controller/subsystem/processing/fastprocess
 	/// Controls whether or not the more dangerous designs have been unlocked by a head's id manually, rather than alert level unlocks
@@ -126,7 +130,7 @@
 		. += span_notice("The status display reads: Storing up to <b>[rmat.local_size]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.")
 
 /obj/machinery/mecha_part_fabricator/attackby(obj/item/I, mob/living/user, params)
-	if(panel_open && is_wire_tool(O))
+	if(panel_open && is_wire_tool(I))
 		wires.interact(user)
 		return TRUE
 	if(I.GetID())
@@ -146,16 +150,31 @@
 			update_static_data(user)
 		return
 	return ..()
-
+/**
+ * All the negative wire effect
+ * Zap doesnt actually zap, it breaks one limb (Because pain is to be had)
+*/
 /obj/machinery/mecha_part_fabricator/proc/wire_zap(mob/user)
 	if(stat & (BROKEN|NOPOWER))
-		return FALSE
-	if(!prob(prb))
 		return FALSE
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()
-
+	var/mob/living/carbon/C = user
+	var/chosen_limb = rand(1,4)
+	var/datum/wound/blunt/severe/break_it = new
+	var/obj/item/bodypart/bone = new
+	C.emote("scream")
+	switch(chosen_limb)
+		if(1)
+			bone = C.get_bodypart(BODY_ZONE_L_LEG)
+		if(2)
+			bone = C.get_bodypart(BODY_ZONE_R_LEG)
+		if(3)
+			bone = C.get_bodypart(BODY_ZONE_R_ARM)
+		if(4)
+			bone = C.get_bodypart(BODY_ZONE_L_ARM)
+	break_it.apply_wound(bone)
 
 /obj/machinery/mecha_part_fabricator/proc/reset(wire)
 	switch(wire)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -414,6 +414,10 @@
 	return TRUE
 
 /obj/machinery/mecha_part_fabricator/process()
+	// Deelectrifies the machine
+	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)
+		seconds_electrified--
+
 	// If there's a stored part to dispense due to an obstruction, try to dispense it.
 	if(stored_part)
 		var/turf/exit = get_step(src,(dir))
@@ -441,9 +445,7 @@
 			build_next_in_queue(FALSE)
 		return TRUE
 	
-	// Deelectrifies the machine
-	if(seconds_electrified > MACHINE_NOT_ELECTRIFIED)
-		seconds_electrified--
+
 /**
   * Dispenses a part to the tile infront of the Exosuit Fab.
   *

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -158,6 +158,7 @@
 	if(seconds_electrified && !(stat & NOPOWER))
 		if(shock(user, 100))
 			return
+	return ..()
 
 /obj/machinery/mecha_part_fabricator/proc/wire_break(mob/user)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -174,6 +174,7 @@
 			bone = C.get_bodypart(BODY_ZONE_R_ARM)
 		if(4)
 			bone = C.get_bodypart(BODY_ZONE_L_ARM)
+	to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
 	break_it.apply_wound(bone)
 	bone.receive_damage(brute=50, updating_health=TRUE)
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -636,6 +636,7 @@
 #include "code\datums\wires\emitter.dm"
 #include "code\datums\wires\explosive.dm"
 #include "code\datums\wires\igniter.dm"
+#include "code\datums\wires\mech_fabricator.dm"
 #include "code\datums\wires\microwave.dm"
 #include "code\datums\wires\mulebot.dm"
 #include "code\datums\wires\particle_accelerator.dm"


### PR DESCRIPTION
# This does not allow for making combat designs
The reason for this change is simple: Exofabs in their current state need a **roboticist id to even open and use**. This is usually an issue during lowpops (Forces you to greytide all the way for the spare), also an issue for multiple ghost roles.
It is also inconsistent with the rest of the potentially dangerous machines (Chemistry, basically every lathe, etc.), which don't have any id checks whilst being potentially more destructive (The only potentially harmful thing in the fab is flashes)

# Document the changes in your pull request
Adds wires to the exofab, 2 duds 3 functional:

Hack wire: When cut, allows you to open the exofab without an id. When pulsed, blinks a light.
Shock wire: When pulsed, shocks the exofab for a short time.
Zap wire: When pulsed, makes the manipulator hands spazz out and break one of the hacker's limbs.

close #15322 
close #15305

# Wiki Documentation
Needs to be added to the Hacking page with a small mention on the robotics/roboticist one.

# Changelog

:cl:  
rscadd: Added wires to the exosuit fabricator
tweak: The exosuit fabricator can now be hacked
/:cl:
