### PR TITLE
Makes the grey fedora in the detective clothing bag share the armor of the tan one

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -716,7 +716,7 @@
 	new /obj/item/clothing/suit/det_suit/grey(src)
 	new /obj/item/clothing/suit/det_suit/noir(src)
 	new /obj/item/clothing/suit/det_suit/tan(src)
-	new /obj/item/clothing/head/fedora(src)
+	new /obj/item/clothing/head/fedora/det_hat/grey(src)
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/clothing/under/yogs/forensictech(src)
 	new /obj/item/clothing/under/yogs/bluedetective(src)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -68,7 +68,7 @@
 //Detective
 /obj/item/clothing/head/fedora/det_hat
 	name = "detective's fedora"
-	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat."
+	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat. Woven with lightly protective fibers."
 	armor = list(MELEE = 25, BULLET = 5, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 50, WOUND = 5)
 	icon_state = "detective"
 	var/candy_cooldown = 0
@@ -94,6 +94,11 @@
 				candy_cooldown = world.time+1200
 			else
 				to_chat(user, "You just took a candy corn! You should wait a couple minutes, lest you burn through your stash.")
+
+/obj/item/clothing/head/fedora/det_hat/grey
+	name = "detective's grey fedora"
+	desc = "A darker tone of P.I. headwear for those thick-skinned detectives. Woven with lightly protective fibers."
+	icon_state = "fedora"
 
 /obj/item/clothing/head/det_hat/evil
 	name = "suspicious fedora"


### PR DESCRIPTION
# Document the changes in your pull request

Going to scream

Copies the sprites of the black fedora onto a new detective hat so it can properly inherit the armor of the tan hat and also the MASSIVELY IMPORTANT candy corn functionality

Done so you don't lose out on sweet melee armor for not wanting to sport a different color

The normal fedora that's a donor item and one you can get out of the drobe should be unchanged

# Wiki Documentation

Detective fedora items should probably be documented in Guide to Combat and Clothing & Accessories as having their armor and candy corn gimmick

# Changelog

:cl:  
rscadd: Adds a new detective hat that looks exactly like the black one that exists but actually gives it armor because the TAN HAT has armor but this one DOESN'T because it just takes the one you can buy from the drobe
/:cl:
