### PR TITLE
Organs, Implants, and Limbs now check for EMP_PROTECT_SELF

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -331,7 +331,7 @@
 
 /mob/living/carbon/emp_act(severity)
 	. = ..()
-	if(. & EMP_PROTECT_CONTENTS)
+	if(. & EMP_PROTECT_SELF)
 		return
 	for(var/X in internal_organs)
 		var/obj/item/organ/O = X

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -541,7 +541,7 @@
 /mob/living/carbon/human/emp_act(severity)
 	dna?.species.spec_emp_act(src, severity)
 	. = ..()
-	if(. & EMP_PROTECT_CONTENTS)
+	if(. & EMP_PROTECT_SELF)
 		return
 	var/informed = FALSE
 	for(var/obj/item/bodypart/L in src.bodyparts)


### PR DESCRIPTION
Why wasn't it this way from the start?
There was no way to have the body be emp immune without making all items carried emp immune also

:cl:  
tweak: Organs, Implants, and Limbs now check for EMP_PROTECT_SELF
/:cl:
