### PR TITLE
Checks pockets for advanced health analyzers in addition to off-hand

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -99,8 +99,9 @@
 	if(istype(SB))
 		adv_surgeries |= SB.get_surgeries()
 
-	//Get the advanced health analyzer in the off had if available and adds available surgeries to the list
-	var/obj/item/healthanalyzer/advanced/adv = user.get_inactive_held_item()
+	//Get the advanced health analyzer in the off hand or pockets if available and adds available surgeries to the list
+	var/analyzerlocations = list(user.get_inactive_held_item(), user.get_item_by_slot(SLOT_L_STORE), user.get_item_by_slot(SLOT_R_STORE))
+	var/obj/item/healthanalyzer/advanced/adv = locate() in analyzerlocations
 	if(iscyborg(user) && !istype(adv))
 		var/mob/living/silicon/robot/R = user
 		adv = locate() in R.module.modules


### PR DESCRIPTION
This is both to remove tedium from the surgical process and mostly to make rod of Asclepius not useless.

:cl:  
tweak: Pockets are also checked for advanced health analyzers for fancy surgeries
/:cl:
