### PR TITLE
Revert "MOSTLY* removes printable bags of holding, instead the RD gets one as a grand theft item"

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -89,12 +89,6 @@
 	difficulty = 5
 	excludefromjob = list("Research Director")
 
-/datum/objective_item/steal/holding
-	name = "the bag of holding."
-	targetitem = /obj/item/storage/backpack/holding
-	difficulty = 7
-	excludefromjob = list("Research Director")
-
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization."
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -37,23 +37,6 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 12
 
-/obj/item/boh_shell
-	name = "bag of holding shell"
-	desc = "An inert shell, it looks like you could activate it with an anomaly core."
-	icon = 'icons/obj/storage.dmi'
-	icon_state = "brokenpack"
-	item_state = "brokenpack"
-	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
-
-/obj/item/boh_shell/attackby(obj/item/I, mob/user, params)
-	..()
-	if(istype(I, /obj/item/assembly/signaler/anomaly))
-		to_chat(user, "[src] roars to life as you insert the anomaly core!")
-		new /obj/item/storage/backpack/holding(get_turf(src))
-		qdel(src)
-		qdel(I)
-
 /obj/item/storage/backpack/holding
 	name = "bag of holding"
 	desc = "A backpack that opens into a localized pocket of bluespace."
@@ -63,10 +46,6 @@
 	item_flags = NO_MAT_REDEMPTION
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
 	component_type = /datum/component/storage/concrete/bluespace/bag_of_holding
-
-/obj/item/storage/backpack/holding/rd
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	cryo_preserve = TRUE
 
 /obj/item/storage/backpack/holding/clown
 	name = "bag of honking"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,7 +18,6 @@
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
-	new /obj/item/storage/backpack/holding/rd(src)
 	new /obj/item/storage/photo_album/RD(src)
 	new /obj/item/clipboard/yog/paperwork/rd(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/rd(src)

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -14,12 +14,12 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/bag_holding
-	name = "Bag of Holding shell"
-	desc = "A backpack that opens into a localized pocket of bluespace. Requires an anomaly core to function."
+	name = "Bag of Holding"
+	desc = "A backpack that opens into a localized pocket of bluespace."
 	id = "bag_holding"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/gold = 3000, /datum/material/diamond = 1500, /datum/material/uranium = 250, /datum/material/bluespace = 2000)
-	build_path = /obj/item/boh_shell
+	build_path = /obj/item/storage/backpack/holding
 	category = list("Bluespace Designs")
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
Reverts yogstation13/Yogstation#15957

It seems the author of #16179 backtracked and closed their PR so I am hosting this replacement one

:cl:
rscdel: the research director's locker no longer contains a bag of holding, and the bag of holding is no longer a grand theft item
tweak: bags of holding no longer requires an anomaly core to become functional
/:cl: