### PR TITLE
Reduces pipe volume

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -200,7 +200,7 @@
 /// (kPa) What pressure pumps and powered equipment max out at.
 #define MAX_OUTPUT_PRESSURE					4500
 /// (L/s) Maximum speed powered equipment can work at.
-#define MAX_TRANSFER_RATE					200
+#define MAX_TRANSFER_RATE					50
 /// 10% of an overclocked volume pump leaks into the air
 #define VOLUME_PUMP_LEAK_AMOUNT				0.1
 //used for device_type vars

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -132,6 +132,7 @@ GLOBAL_LIST_EMPTY(atmos_air_controllers)
 	var/data = list()
 
 	data["sensors"] = list()
+	data["max_rate"] = MAX_TRANSFER_RATE
 	for(var/id_tag in sensors)
 		var/long_name = sensors[id_tag]
 		var/list/info = sensor_information[id_tag]

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -749,6 +749,7 @@ GENE SCANNER
 			combined_msg += span_notice("Temperature: [round(temperature - T0C,0.01)] &deg;C ([round(temperature, 0.01)] K)")
 
 		else
+			combined_msg += span_notice("Volume: [volume] L")
 			if(airs.len > 1)
 				combined_msg += span_notice("This node is empty!")
 			else

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -16,7 +16,7 @@
 	..()
 
 	for(var/i in 1 to device_type)
-		var/datum/gas_mixture/A = new(200)
+		var/datum/gas_mixture/A = new(MAX_TRANSFER_RATE)
 		airs[i] = A
 
 // Iconnery

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -12,7 +12,7 @@
 
 	var/injecting = 0
 
-	var/volume_rate = 50
+	var/volume_rate = MAX_TRANSFER_RATE
 
 	var/frequency = 0
 	var/id = null
@@ -23,6 +23,10 @@
 
 	pipe_state = "injector"
 
+/obj/machinery/atmospherics/components/unary/vent_scrubber/New()
+	..()
+	var/datum/gas_mixture/N = airs[1]
+	N.set_volume(200) // Increase the volume of the scrubber's node.
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/CtrlClick(mob/user)
 	if(can_interact(user))
@@ -155,7 +159,7 @@
 	var/data = list()
 	data["on"] = on
 	data["rate"] = round(volume_rate)
-	data["max_rate"] = round(MAX_TRANSFER_RATE)
+	data["max_rate"] = round(200)
 	return data
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/ui_act(action, params)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -34,7 +34,8 @@
 	..()
 	if(!id_tag)
 		id_tag = assign_uid_vents()
-
+	var/datum/gas_mixture/N = airs[1]
+	N.set_volume(200) // Increase the volume of the scrubber's node.
 	for(var/f in filter_types)
 		if(istext(f))
 			filter_types -= f

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -8,7 +8,7 @@
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE
 	piping_layer = PIPING_LAYER_DEFAULT
 	device_type = 0
-	volume = 260
+	volume = 65
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
 

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/atmospherics/pipe/New()
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
-	volume = 35 * device_type
+	volume = 25 * device_type
 	..()
 
 /obj/machinery/atmospherics/pipe/nullifyNode(i)

--- a/tgui/packages/tgui/interfaces/AtmosControlConsole.js
+++ b/tgui/packages/tgui/interfaces/AtmosControlConsole.js
@@ -64,7 +64,7 @@ export const AtmosControlConsole = (props, context) => {
                   unit="L/s"
                   width="63px"
                   minValue={0}
-                  maxValue={200}
+                  maxValue={data.max_rate}
                   // This takes an exceptionally long time to update
                   // due to being an async signal
                   suppressFlicker={2000}

--- a/tgui/packages/tgui/interfaces/AtmosFilter.js
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.js
@@ -27,7 +27,7 @@ export const AtmosFilter = (props, context) => {
                 width="63px"
                 unit="L/s"
                 minValue={0}
-                maxValue={200}
+                maxValue={data.max_rate}
                 onDrag={(e, value) => act('rate', {
                   rate: value,
                 })} />

--- a/tgui/packages/tgui/interfaces/AtmosPump.js
+++ b/tgui/packages/tgui/interfaces/AtmosPump.js
@@ -26,7 +26,7 @@ export const AtmosPump = (props, context) => {
                   width="63px"
                   unit="L/s"
                   minValue={0}
-                  maxValue={200}
+                  maxValue={data.max_rate}
                   onChange={(e, value) => act('rate', {
                     rate: value,
                   })} />


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the volume of pipes from 200 liters for everything to 50 liters for straight/bent pipes, 75 liters for 3-way manifolds, and 100 liters for 4-way manifolds. This reduces the volume of most atmospherics components/machines from 200 to 50 liters per node as well.

The point of this is that currently whenever you connect a canister to anything at all at least 1/6th of the gas that was in it will be left behind in whatever it's connected to. Reducing the volume mitigates the loss significantly.

# Changelog

:cl:  
tweak: reduces the volume of pipes and most atmospherics components
/:cl:
