### PR TITLE
hugboxxes the surgical drill because i hate medbay players

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -123,8 +123,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
 	sharpness = SHARP_POINTY
-	wound_bonus = 10
-	bare_wound_bonus = 10
+	wound_bonus = -15
+	bare_wound_bonus = 5
 
 /obj/item/surgicaldrill/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] rams [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
reduces the crazy wounding bonuses on the surgical drill (10 and 10 bare wound bonus) because these are backpack sized and pointy so because of our crackhead wounding system they usually cause t2 puncture wounds on the first hit. medbay players know its useless but take it anyways because funny murder


# Changelog
:cl:  
tweak: the surgical drill is now less robust
/:cl:
