### PR TITLE
Fixes some on_hits that were ignoring shields

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -45,12 +45,12 @@
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 
 /obj/item/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.IgniteMob()
 	else if(isturf(target))
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
+	return ..()
 
 /obj/item/projectile/beam/weak
 	damage = 15
@@ -150,12 +150,12 @@
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(ishuman(target))
+	if((blocked != 100) && ishuman(target)) //Anyone who knows the cheaters that held up objects to block their tag position knows that adding the block check to this is valid
 		var/mob/living/carbon/human/M = target
 		if(istype(M.wear_suit))
 			if(M.wear_suit.type in suit_types)
 				M.adjustStaminaLoss(34)
+	return ..()
 
 /obj/item/projectile/beam/lasertag/redtag
 	icon_state = "laser"

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -40,11 +40,11 @@
 	eyeblur = 20
 
 /obj/item/projectile/bullet/c10mm/sp/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(isliving(target))
+	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		if(L.getStaminaLoss() >= 100)
 			L.Sleeping(400)
+	return ..()
 
 /obj/item/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -39,10 +39,10 @@
 	var/temperature = 100
 
 /obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
+	..()
 	if(isliving(target))
 		var/mob/living/M = target
 		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
-	return ..()
 
 /obj/item/projectile/bullet/c38/gutterpunch //Vomit bullets my favorite
 	name = ".38 Gutterpunch bullet"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -71,6 +71,7 @@
 		if(!imp)
 			imp = new /obj/item/implant/tracking/tra32(M)
 			imp.implant(M)
+	return ..()
 
 // .357 (Syndie Revolver)
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -26,11 +26,11 @@
 	stamina = 0
 
 /obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.adjust_fire_stacks(2)
 		M.IgniteMob()
+	return ..()
 
 /obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
@@ -39,10 +39,10 @@
 	var/temperature = 100
 
 /obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
-	. = ..()
 	if(isliving(target))
 		var/mob/living/M = target
 		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
+	return ..()
 
 /obj/item/projectile/bullet/c38/gutterpunch //Vomit bullets my favorite
 	name = ".38 Gutterpunch bullet"
@@ -50,10 +50,10 @@
 	stamina = 0
 
 /obj/item/projectile/bullet/c38/gutterpunch/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target 
 		M.adjust_disgust(20)
+	return ..()
 
 // .32 TRAC (Caldwell Tracking Revolver)
 
@@ -62,15 +62,15 @@
 	damage = 5
 
 /obj/item/projectile/bullet/tra32/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	var/mob/living/carbon/M = target
-	var/obj/item/implant/tracking/tra32/imp
-	for(var/obj/item/implant/tracking/tra32/TI in M.implants) //checks if the target already contains a tracking implant
-		imp = TI
-		return
-	if(!imp)
-		imp = new /obj/item/implant/tracking/tra32(M)
-		imp.implant(M)
+	if(blocked != 100)
+		var/mob/living/carbon/M = target
+		var/obj/item/implant/tracking/tra32/imp
+		for(var/obj/item/implant/tracking/tra32/TI in M.implants) //checks if the target already contains a tracking implant
+			imp = TI
+			return
+		if(!imp)
+			imp = new /obj/item/implant/tracking/tra32(M)
+			imp.implant(M)
 
 // .357 (Syndie Revolver)
 

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -23,10 +23,10 @@
 	damage = 20
 
 /obj/item/projectile/bullet/c45/venom/on_hit(atom/target, blocked)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/victim = target
 		victim.reagents.add_reagent(/datum/reagent/toxin/venom, 4)
+	return ..()
 
 // 4.6x30mm (WT-550 Autocarbine)
 

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -26,7 +26,7 @@
 	damage = 40
 
 /obj/item/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)
+	return ..()

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -136,12 +136,12 @@
 	desc = "A burning arrow"
 
 /obj/item/projectile/bullet/reusable/arrow/flaming/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.apply_damage(8, BURN)
 		M.adjust_fire_stacks(1)
 		M.IgniteMob()
+	return ..()
 
 /obj/item/projectile/energy/arrow //Hardlight projectile. Significantly more robust than a standard laser. Capable of hardening in target's flesh
 	name = "energy bolt"
@@ -152,12 +152,12 @@
 	var/obj/item/embed_type = /obj/item/ammo_casing/caseless/arrow/energy
 	
 /obj/item/projectile/energy/arrow/on_hit(atom/target, blocked = FALSE)
-	..()
-	if(!blocked && iscarbon(target))
+	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/embede = target
 		var/obj/item/bodypart/part = embede.get_bodypart(def_zone)
 		if(prob(embed_chance * clamp((100 - (embede.getarmor(part, flag) - armour_penetration)), 0, 100)))
 			embede.embed_object(new embed_type(), part, FALSE)
+	return ..()
 
 /obj/item/projectile/energy/arrow/disabler //Hardlight projectile. Much more draining than a standard disabler. Needs to be competitive in DPS
 	name = "disabler bolt"


### PR DESCRIPTION
# Document the changes in your pull request

Not all of them have been adjusted but a handful of on_hit procs that make zero sense to proc if the attack is blocked have been given the .50 Soporific code treatment to make them less bullshit. Shouldn't break anything as far as I know.

# Changelog

:cl:  
tweak: Technically not a bugfix but some on_hit effects from some projectiles should be properly blockable now
/:cl:
