### PR TITLE
(ided) Significantly reduces the weight of the floor cluwne event

### DIFF
--- a/yogstation/code/modules/events/floorcluwne.dm
+++ b/yogstation/code/modules/events/floorcluwne.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/floor_cluwne
 	max_occurrences = 1
 	min_players = 20
-	weight = 2
+	weight = 5
 
 /datum/round_event/floor_cluwne/start()
 	var/list/spawn_locs = list()

--- a/yogstation/code/modules/events/floorcluwne.dm
+++ b/yogstation/code/modules/events/floorcluwne.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/floor_cluwne
 	max_occurrences = 1
 	min_players = 20
-
+	weight = 2
 
 /datum/round_event/floor_cluwne/start()
 	var/list/spawn_locs = list()


### PR DESCRIPTION
# Document the changes in your pull request

Today I will have my antag round ruined by a funny little trickster (has not actually happened to me but I've seen it too many times)

I have seen this deadass almost every single round lately because it has weight 10 (other neat funny events have a weight of like 2). Should still happen every now and then

# Wiki Documentation

Weight will have to be updated on random events page

# Changelog

:cl:  
tweak: Floor cluwne weight to 5 instead of 10
/:cl:
