### PR TITLE
Adds item image previews to uplink

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -181,6 +181,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 				"name" = I.name,
 				"cost" = I.manufacturer && user.mind.is_employee(I.manufacturer) ? CEILING(I.cost * 0.8, 1) : I.cost,
 				"desc" = I.desc,
+				"path" = replacetext(replacetext("[I.item]", "/obj/item/", ""), "/", "-"),
 				"manufacturer" = I.manufacturer ? initial(I.manufacturer.name) : null,
 			))
 		data["categories"] += list(cat)
@@ -214,6 +215,11 @@ GLOBAL_LIST_EMPTY(uplinks)
 		if("compact_toggle")
 			compact_mode = !compact_mode
 			return TRUE
+
+/datum/component/uplink/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/spritesheet/uplink),
+	)
 
 /datum/component/uplink/proc/MakePurchase(mob/user, datum/uplink_item/U)
 	if(!istype(U))

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -119,6 +119,7 @@
 	desc = "A shield that stops most melee attacks, protects user from almost all energy projectiles, and can be thrown to slip opponents."
 	throw_speed = 1
 	clumsy_check = 0
+	icon_state = "bananaeshield1"
 	base_icon_state = "bananaeshield"
 	force = 0
 	throwforce = 0

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -208,6 +208,7 @@
 	desc = "A shield that reflects almost all energy projectiles, but is useless against physical attacks. It can be retracted, expanded, and stored anywhere."
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
+	icon_state = "eshield1" // So it can display without initializing
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("shoved", "bashed")
 	throw_range = 5

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -361,6 +361,52 @@
 
 		var/icon_file = initial(item.icon)
 		var/icon_state = initial(item.icon_state)
+		if(ispath(item, /obj/item/ammo_box))
+			var/obj/item/ammo_box/ammoitem = item
+			if(initial(ammoitem.multiple_sprites))
+				icon_state = "[icon_state]-[initial(ammoitem.max_ammo)]"
+		var/icon/I
+
+		var/icon_states_list = icon_states(icon_file)
+		if(icon_state in icon_states_list)
+			I = icon(icon_file, icon_state, SOUTH)
+			var/c = initial(item.color)
+			if (!isnull(c) && c != "#FFFFFF")
+				I.Blend(c, ICON_MULTIPLY)
+		else
+			var/icon_states_string
+			for (var/an_icon_state in icon_states_list)
+				if (!icon_states_string)
+					icon_states_string = "[json_encode(an_icon_state)](\ref[an_icon_state])"
+				else
+					icon_states_string += ", [json_encode(an_icon_state)](\ref[an_icon_state])"
+			stack_trace("[item] does not have a valid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)](\ref[icon_state]), icon_states=[icon_states_string]")
+			I = icon('icons/turf/floors.dmi', "", SOUTH)
+
+		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
+
+		Insert(imgid, I)
+	return ..()
+
+/datum/asset/spritesheet/uplink
+	name = "uplink"
+
+/datum/asset/spritesheet/uplink/register()
+	for(var/path in GLOB.uplink_items)
+		var/datum/uplink_item/U = path
+		if (!ispath(U, /datum/uplink_item))
+			continue
+
+		var/atom/item = initial(U.item)
+		if (!ispath(item, /atom))
+			continue
+
+		var/icon_file = initial(item.icon)
+		var/icon_state = initial(item.icon_state)
+		if(ispath(item, /obj/item/ammo_box))
+			var/obj/item/ammo_box/ammoitem = item
+			if(initial(ammoitem.multiple_sprites))
+				icon_state = "[icon_state]-[initial(ammoitem.max_ammo)]"
 		var/icon/I
 
 		var/icon_states_list = icon_states(icon_file)

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -427,7 +427,8 @@
 
 		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
 
-		Insert(imgid, I)
+		if(!sprites[sprite_name])
+			Insert(imgid, I)
 	return ..()
 
 /datum/asset/simple/genetics

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -427,7 +427,7 @@
 
 		var/imgid = replacetext(replacetext("[item]", "/obj/item/", ""), "/", "-")
 
-		if(!sprites[sprite_name])
+		if(!sprites[imgid])
 			Insert(imgid, I)
 	return ..()
 

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_box/magazine/recharge
 	name = "power pack"
 	desc = "A rechargeable, detachable battery that serves as a magazine for laser rifles."
-	icon_state = "oldrifle-20"
+	icon_state = "oldrifle"
 	ammo_type = /obj/item/ammo_casing/caseless/laser
 	caliber = LASER
 	max_ammo = 20

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -273,8 +273,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/bundles_TC/random
 	name = "Random Item"
 	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't decided on a strategy yet."
-	item = /obj/effect/gibspawner/generic // non-tangible item because techwebs use this path to determine illegal tech
+	item = /obj/item/stack/sheet/cardboard
 	cost = 0
+	illegal_tech = FALSE
 
 /datum/uplink_item/bundles_TC/random/purchase(mob/user, datum/component/uplink/U)
 	var/list/uplink_items = U.uplink_items
@@ -1583,12 +1584,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/failsafe
 	name = "Failsafe Uplink Code"
 	desc = "When entered the uplink will self-destruct immediately."
-	item = /obj/effect/gibspawner/generic
+	item = /obj/item/computer_hardware/hard_drive/portable/syndicate // Doesn't spawn
 	cost = 1
 	manufacturer = /datum/corporation/traitor/waffleco
 	surplus = 0
 	restricted = TRUE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // Yogs: infiltration
+	illegal_tech = FALSE
 
 /datum/uplink_item/device_tools/failsafe/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
 	if(!U)

--- a/tgui/packages/tgui/interfaces/Uplink.js
+++ b/tgui/packages/tgui/interfaces/Uplink.js
@@ -4,6 +4,7 @@ import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Flex, Input, Section, Table, Tabs, NoticeBox } from '../components';
 import { formatMoney } from '../format';
 import { Window } from '../layouts';
+import { classes } from 'common/react';
 
 const MAX_SEARCH_RESULTS = 25;
 
@@ -152,6 +153,19 @@ const ItemList = (props, context) => {
           <Table.Row
             key={item.name}
             className="candystripe">
+            <Table.Cell>
+              {" "}
+              {<span
+                className={classes([
+                  'uplink32x32',
+                  item.path,
+                ])}
+                style={{
+                  'vertical-align': 'middle',
+                  'horizontal-align': 'right',
+                }} />}
+              {" "}
+            </Table.Cell>
             <Table.Cell bold>
               {decodeHtmlEntities(item.name)}
             </Table.Cell>
@@ -176,7 +190,22 @@ const ItemList = (props, context) => {
   return items.map(item => (
     <Section
       key={item.name}
-      title={item.name}
+      title={
+        <Box inline>
+          {" "}
+          <span
+            className={classes([
+              'uplink32x32',
+              item.path,
+            ])}
+            style={{
+              'vertical-align': 'middle',
+              'horizontal-align': 'right',
+            }} />
+          {" "}
+          {item.name}
+        </Box>
+      }
       level={2}
       buttons={(
         <Button

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -66,10 +66,11 @@
 /datum/uplink_item/device_tools/arm
 	name = "Additional Arm"
 	desc = "An additional arm, automatically added to your body upon purchase, allows you to use more items at once"
-	item = /obj/item/melee/supermatter_sword //doesn't actually spawn a supermatter sword, but it needs an object to show up in the menu :^)
+	item = /obj/item/bodypart/l_arm //doesn't actually spawn an arm, but it needs an object to show up in the menu :^)
 	cost = 5
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear)
+	illegal_tech = FALSE // ARMS ARE NOT ILLEGAL
 
 /datum/uplink_item/device_tools/arm/spawn_item(spawn_item, mob/user)
 	var/limbs = user.held_items.len


### PR DESCRIPTION
# Document the changes in your pull request

<details>
    <summary>Nuke Ops: Conspicuous Weapons</summary>

![](https://i.imgur.com/Mcm304P.png)
</details>
<details>
    <summary>Nuke Ops: Support and Exosuits</summary>

![](https://i.imgur.com/u10GbRS.png)
</details>
<details>
    <summary>Nuke Ops: Ammunition (compact) (still doesn't fit)</summary>

![](https://i.imgur.com/s0f1XSb.png)
</details>
<details>
    <summary>ERT: Close Quarters Combat</summary>

![](https://i.imgur.com/9mubwj5.png)
</details>
<details>
    <summary>ERT: Support</summary>

![](https://i.imgur.com/rYC3hNJ.png)
</details>

##

Gave some items that didn't have sprites sprites

Gave some uplink items that didn't have real items real items

NT uplink displays fine

# Changelog

:cl:  
rscadd: Added image previews to uplink items
/:cl:
