### PR TITLE
Rename the sanguirite vial to actually tell you what's inside it

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -558,7 +558,7 @@
 	custom_premium_price = 50
 
 /obj/item/reagent_containers/glass/bottle/vial/coagulant
-	name = "vial (Coagulant)"
+	name = "vial (Sanguirite)"
 	icon_state = "vial_red"
 	list_reagents = list(/datum/reagent/medicine/coagulant = 15)
 	custom_premium_price = 50


### PR DESCRIPTION
# Document the changes in your pull request
All the vials you can buy for the hypospray were telling you what is inside them except the sanguirite vial, I guess it's because in the code sanguirite is called coagulant while other medicines are properly called by their name.
To keep it in line with the other vials and also let new MD know what they are buying it's now called "vial (Sanguirite)" instead of "vial (Coagulant)"

# Changelog

:cl:  
spellcheck: The coagulant vial is now called a sanguirite vial so you know what's inside it like with other vials 
/:cl:
