### PR TITLE
Network Admin Alt Titles are now under Engineering

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(alt_engineering_positions, list(
 	"Head of Engineering", "Engineering Director",
 	"Engine Technician", "Solar Engineer", "Project Engineer", "Junior Engineer", "Construction Specialist",
 	"Life-support Technician", "Fire Suppression Specialist", "Atmospherics Trainee", "Environmental Maintainer",
-	"NTSL Programmer", "Comms Tech", "Station IT Support"
+	"AI Tech Support", "SysOp"
 	))
 
 GLOBAL_LIST_INIT(alt_medical_positions, list(


### PR DESCRIPTION
I've just updated the old Signal Technician Alt Jobs to the new Network Admin ones.

Spotted the "AI Tech Support" was under misc on the Crew Manifest. So.. this moves it to the right place.

![image](https://user-images.githubusercontent.com/14105827/196917366-10825ad6-81b5-46c4-a3d2-1ed51a88791b.png)

# Changelog

:cl: Foxtrot (Funce)
bugfix: "AI Tech Support" and "SysOp" now appear under Engineering in the Crew Manifest
/:cl:
