### PR TITLE
makes ghost roles capable of science again

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -482,7 +482,7 @@
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
-	if(!allowed(user) && !combat_parts_allowed && !isobserver(user))
+	if((!allowed(user) && !combat_parts_allowed && !isobserver(user)) && !is_station_level)
 		to_chat(user, span_warning("You do not have the proper credentials to operate this device!"))
 		return
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if((!locked && (allowed(user) || (obj_flags & EMAGGED)) || !is_station_level(src)))
+	if((!locked && (allowed(user) || (obj_flags & EMAGGED)) || !is_station_level(get_turf(src))))
 		return TRUE
 	return FALSE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if((!locked && (allowed(user) || (obj_flags & EMAGGED))) || !is_station_level(src))
+	if((!locked && (allowed(user) || (obj_flags & EMAGGED)) || !is_station_level(src))
 		return TRUE
 	return FALSE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if((!locked && (allowed(user) || (obj_flags & EMAGGED)) || !is_station_level(src))
+	if((!locked && (allowed(user) || (obj_flags & EMAGGED)) || !is_station_level(src)))
 		return TRUE
 	return FALSE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -706,7 +706,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if(!locked && (allowed(user) || (obj_flags & EMAGGED)))
+	if((!locked && (allowed(user) || (obj_flags & EMAGGED))) || !is_station_level(src))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
literally just removes the lock on the rnd console and mechfab if you're off the zlevel because the hugbox was stupid in the first place. 
also not a stealth revert i am openly announcing that this is not a stealth revert it is a very vocal and obvious revert because these mechanics break the game for ghostrole players

should make ghost roles less unbearable to play, also i havent tested this but im sure its fine

# Changelog

:cl:  
tweak: rnd console and mechfab do not require access off the station
/:cl:
