### PR TITLE
Darkmode station trait

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -71,7 +71,7 @@
 	. = ..()
 	var/list/st_turfs = list()
 	for(var/area/A in GLOB.the_station_areas)
-		st_turfs += get_area_turfs(A, SSmapping.level_trait(z, ZTRAIT_STATION))
+		st_turfs += get_area_turfs(A, SSmapping.levels_by_trait(ZTRAIT_STATION)[1])
 	for(var/turf/open/floor/plasteel/F in st_turfs)
 		if(!F.broken && !F.burnt)
 			F.icon_regular_floor = 'icons/turf/floors.dmi'

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -70,7 +70,7 @@
 /datum/station_trait/darkmode/New()
 	. = ..()
 	for(var/turf/open/floor/plasteel/F in world)
-		if((F.z == 2 || F.z == 1) && (!broken && !burnt))
+		if(F.z == 2 && (!F.broken && !F.burnt))
 			F.icon_regular_floor = 'icons/turf/floors.dmi'
 			F.icon_state_regular_floor = "darkfull"
 			F.icon = 'icons/turf/floors.dmi'

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -70,7 +70,7 @@
 /datum/station_trait/darkmode/New()
 	. = ..()
 	for(var/turf/open/floor/plasteel/F in world)
-		if(F.z == 2 && (!F.broken && !F.burnt))
+		if(is_station_level(F.z) && (!F.broken && !F.burnt))
 			F.icon_regular_floor = 'icons/turf/floors.dmi'
 			F.icon_state_regular_floor = "darkfull"
 			F.icon = 'icons/turf/floors.dmi'

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -75,3 +75,4 @@
 			F.icon_state_regular_floor = "darkfull"
 			F.icon = 'icons/turf/floors.dmi'
 			F.icon_state = "darkfull"
+			CHECK_TICK

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -59,3 +59,19 @@
 /datum/station_trait/announcement_medbot/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/medbot
+
+/datum/station_trait/darkmode
+	name = "Dark Mode"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 2
+	show_in_report = TRUE
+	report_message = "This station has a dark finish."
+
+/datum/station_trait/darkmode/New()
+	. = ..()
+	for(var/turf/open/floor/plasteel/F in world)
+		if((F.z == 2 || F.z == 1) && (!broken && !burnt))
+			F.icon_regular_floor = 'icons/turf/floors.dmi'
+			F.icon_state_regular_floor = "darkfull"
+			F.icon = 'icons/turf/floors.dmi'
+			F.icon_state = "darkfull"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -73,7 +73,7 @@
 	for(var/area/A in GLOB.the_station_areas)
 		st_turfs += get_area_turfs(A, SSmapping.level_trait(z, ZTRAIT_STATION))
 	for(var/turf/open/floor/plasteel/F in st_turfs)
-		if(is_station_level(F.z) && (!F.broken && !F.burnt))
+		if(!F.broken && !F.burnt)
 			F.icon_regular_floor = 'icons/turf/floors.dmi'
 			F.icon_state_regular_floor = "darkfull"
 			F.icon = 'icons/turf/floors.dmi'

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -69,7 +69,10 @@
 
 /datum/station_trait/darkmode/New()
 	. = ..()
-	for(var/turf/open/floor/plasteel/F in world)
+	var/list/st_turfs = list()
+	for(var/area/A in GLOB.the_station_areas)
+		st_turfs += get_area_turfs(A, SSmapping.level_trait(z, ZTRAIT_STATION))
+	for(var/turf/open/floor/plasteel/F in st_turfs)
 		if(is_station_level(F.z) && (!F.broken && !F.burnt))
 			F.icon_regular_floor = 'icons/turf/floors.dmi'
 			F.icon_state_regular_floor = "darkfull"


### PR DESCRIPTION
# Document the changes in your pull request

Players resoundingly appreciate whenever I do this for bus, so let's make it a station trait

Makes every plasteel tile on station z-level have the "darkfull" icon

<details>
  <summary>Looks like this if you've never seen it before</summary>

![image](https://user-images.githubusercontent.com/28408322/197073686-68e40f1e-ae6b-4af8-8994-b9d2f6d9fc4c.png)
![image](https://user-images.githubusercontent.com/28408322/197073707-93907626-6dc0-4f74-aff4-b516cada49b0.png)
![image](https://user-images.githubusercontent.com/28408322/197073717-ae525fc9-abe7-489e-830f-6b152dc854d9.png)
![image](https://user-images.githubusercontent.com/28408322/197073757-5cbe3859-dde8-42b0-844a-59036ecb8f0f.png)
![image](https://user-images.githubusercontent.com/28408322/197073794-956baecf-9b03-4459-99d0-63b559d22bb1.png)

</details>

# Changelog

:cl:  
rscadd: Added a 'dark mode' station trait
/:cl:
