### PR TITLE
Fixes the underlying problem

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -560,7 +560,6 @@
 			if(my_atom && isliving(my_atom))
 				var/mob/living/M = my_atom
 				if(R.metabolizing)
-					R.metabolizing = FALSE
 					R.on_mob_end_metabolize(M)
 				R.on_mob_delete(M)
 			qdel(R)


### PR DESCRIPTION
Calling Delete reagent also clears metabolizing effects
I don't know why this works, but it does

:cl:  
bugfix: fixes deleting chems not remove effects
/:cl:
