### PR TITLE
Make pump up useful

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -135,7 +135,6 @@
 #define TRAIT_DISFIGURED		"disfigured"
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
-#define TRAIT_STUNRESISTANCE    "stun_resistance"
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"
 #define TRAIT_PUSHIMMUNE		"push_immunity"
 #define TRAIT_SHOCKIMMUNE		"shock_immunity"

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -598,6 +598,16 @@
 				/datum/reagent/medicine/atropine = 10)
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/maint_pumpup
+	name = "Maintenance Pump-Up"
+	result = /obj/item/reagent_containers/autoinjector/medipen/pumpup
+	tools = list(TOOL_SCREWDRIVER)
+	time = 4 SECONDS
+	reqs = list(/obj/item/pen = 1, // You feel a tiny prick!
+				/obj/item/reagent_containers/syringe = 1,
+				/datum/reagent/drug/pumpup = 15)
+	category = CAT_MEDICAL
+
 /datum/crafting_recipe/refill_epinephrine_medipen
 	name = "Refill Epinephrine Medipen"
 	result = /obj/item/reagent_containers/autoinjector/medipen
@@ -612,6 +622,14 @@
 	time = 4 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen/atropine,
 				/datum/reagent/medicine/atropine = 10)
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/refill_maint_pumpup
+	name = "Refill Maintenance Pump_Up"
+	result = /obj/item/reagent_containers/autoinjector/medipen/pumpup
+	time = 4 SECONDS
+	reqs = list(/obj/item/reagent_containers/autoinjector/medipen/pumpup,
+				/datum/reagent/drug/pumpup = 15)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/mothplush

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -625,7 +625,7 @@
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/refill_maint_pumpup
-	name = "Refill Maintenance Pump_Up"
+	name = "Refill Maintenance Pump-Up"
 	result = /obj/item/reagent_containers/autoinjector/medipen/pumpup
 	time = 4 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen/pumpup,

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -25,8 +25,6 @@
 
 	user.do_attack_animation(M)
 
-	var/trait_check = HAS_TRAIT(M, TRAIT_STUNRESISTANCE)
-
 	var/obj/item/bodypart/affecting = M.get_bodypart(user.zone_selected)
 	var/armor_block = M.run_armor_check(affecting, ENERGY)
 	M.apply_damage(stamina_damage, STAMINA, user.zone_selected, armor_block)
@@ -36,8 +34,6 @@
 	if(current_stamina_damage >= 90)
 		if(!M.IsParalyzed())
 			to_chat(M, span_warning("You muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
-		if(trait_check)
-			M.Paralyze(stunforce * 0.1)
 		else
 			M.Paralyze(stunforce)
 		M.Jitter(20)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -33,7 +33,7 @@
 
 	if(current_stamina_damage >= 90)
 		if(!M.IsParalyzed())
-			to_chat(M, span_warning("You muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
+			to_chat(M, span_warning("You muscles seize, making you collapse"))
 		else
 			M.Paralyze(stunforce)
 		M.Jitter(20)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -33,7 +33,7 @@
 
 	if(current_stamina_damage >= 90)
 		if(!M.IsParalyzed())
-			to_chat(M, span_warning("You muscles seize, making you collapse"))
+			to_chat(M, span_warning("You muscles seize, making you collapse!"))
 		else
 			M.Paralyze(stunforce)
 		M.Jitter(20)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -243,7 +243,7 @@
 
 	if(current_stamina_damage >= 90)
 		if(!L.IsParalyzed())
-			to_chat(L, span_warning("You muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
+			to_chat(L, span_warning("You muscles seize, making you collapse"))
 		else
 			L.Paralyze(stunforce)
 		L.Jitter(20)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -233,8 +233,6 @@
 		if(!deductcharge(hitcost))
 			return FALSE
 
-	var/trait_check = HAS_TRAIT(L, TRAIT_STUNRESISTANCE)
-
 	var/obj/item/bodypart/affecting = L.get_bodypart(user? user.zone_selected : BODY_ZONE_CHEST)
 	var/armor_block = L.run_armor_check(affecting, ENERGY) //check armor on the limb because that's where we are slapping...
 	L.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST, armor_block) //...then deal damage to chest so we can't do the old hit-a-disabled-limb-200-times thing, batons are electrical not directed.
@@ -246,8 +244,6 @@
 	if(current_stamina_damage >= 90)
 		if(!L.IsParalyzed())
 			to_chat(L, span_warning("You muscles seize, making you collapse[trait_check ? ", but your body quickly recovers..." : "!"]"))
-		if(trait_check)
-			L.Paralyze(stunforce * 0.1)
 		else
 			L.Paralyze(stunforce)
 		L.Jitter(20)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -243,7 +243,7 @@
 
 	if(current_stamina_damage >= 90)
 		if(!L.IsParalyzed())
-			to_chat(L, span_warning("You muscles seize, making you collapse"))
+			to_chat(L, span_warning("You muscles seize, making you collapse!"))
 		else
 			L.Paralyze(stunforce)
 		L.Jitter(20)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -540,10 +540,10 @@
 
 /datum/reagent/drug/pumpup/on_mob_metabolize(mob/living/L)
 	..()
-	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	L.physiology.stamina_mod *= 0.85
 
 /datum/reagent/drug/pumpup/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	L.physiology.stamina_mod /= 0.85
 	..()
 
 /datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -540,7 +540,9 @@
 
 /datum/reagent/drug/pumpup/on_mob_metabolize(mob/living/L)
 	..()
-	L.physiology.stamina_mod *= 0.85
+	if(istype(L, /mob/living/carbon/human))
+		var/mob/living/carbon/human/HM = L
+		HM.physiology.stamina_mod *= 0.85
 
 /datum/reagent/drug/pumpup/on_mob_end_metabolize(mob/living/L)
 	L.physiology.stamina_mod /= 0.85

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -545,7 +545,9 @@
 		HM.physiology.stamina_mod *= 0.85
 
 /datum/reagent/drug/pumpup/on_mob_end_metabolize(mob/living/L)
-	L.physiology.stamina_mod /= 0.85
+	if(istype(L, /mob/living/carbon/human))
+		var/mob/living/carbon/human/HM = L
+		HM.physiology.stamina_mod /= 0.85
 	..()
 
 /datum/reagent/drug/pumpup/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -204,8 +204,8 @@
 	list_reagents = list(/datum/reagent/medicine/atropine = 10)
 
 /obj/item/reagent_containers/autoinjector/medipen/pumpup
-	name = "maintanance pump-up"
-	desc = "A ghetto looking autoinjector filled with a cheap adrenaline shot... Great for shrugging off the effects of stunbatons."
+	name = "maintenance pump-up"
+	desc = "A ghetto looking autoinjector filled with a cheap adrenaline shot... Great for shrugging off the effects of disablers."
 	volume = 15
 	amount_per_transfer_from_this = 15
 	list_reagents = list(/datum/reagent/drug/pumpup = 15)


### PR DESCRIPTION
# Document the changes in your pull request

Currently Pump up is a completely useless drug that damage you  while providing a resistance against stunbatons that is irrelevant now that they do stamina damage. You can find it maintenance rarely to serve no purpose other than denying you something that could be useful or cool.

Now Pump up will give a 0.85 stammod when in your system, letting you take one additional disabler shot so you have another option against the stamina machinegun in an attempt to make a step toward removing the EMP tax (don't worry you will still have to pay it because of everything else existing, just with that you can maybe flee without needing an EMP when the secborg is shooting down the hallway the blue beams of pain).

Since the stun resistance trait is no longer obtainable with that PR (and was useless anyway) it has been deleted entirely so it's doesn't stay for millenias to bloat our code.

This also make the maintenance pump up autoinjectors craftable and refillable like epinephrine and atropine.

# Wiki Documentation

Pump up now reduce stamina damage taken by 15% when in your system.
You can craft maintenance pump-up using a pen, a syringe, 15u of pump up and a screwdriver,you can also refill them with a spent injector and 15u of pump up.

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: Added craftable pump up autoinjectors and refill
tweak: Pump up now reduce stamina damage by 15%
spellcheck: maintenance pump-up
/:cl:
