### PR TITLE
Buff bioterror syringes

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -225,7 +225,9 @@
 /obj/item/reagent_containers/syringe/bioterror
 	name = "bioterror syringe"
 	desc = "Contains several paralyzing reagents."
-	list_reagents = list(/datum/reagent/consumable/ethanol/neurotoxin = 5, /datum/reagent/toxin/mutetoxin = 5, /datum/reagent/toxin/sodium_thiopental = 5)
+	amount_per_transfer_from_this = 30
+	volume = 30
+	list_reagents = list(/datum/reagent/consumable/ethanol/neurotoxin = 10, /datum/reagent/toxin/mutetoxin = 10, /datum/reagent/toxin/sodium_thiopental = 10)
 
 /obj/item/reagent_containers/syringe/stimulants
 	name = "Stimpack"


### PR DESCRIPTION
# Document the changes in your pull request

Basically non-existent in the meta and I found out why

I shot myself with one of these in testing and it finished metabolizing all chems before I even fell asleep (likely due to liver)

The worst I walked off with was a very delayed temporarily disabled limb, incredibly slow acting stamina damage, 11 brute damage, and 13 brain damage

Now carries 10u of each chemical instead of 5u

list(/datum/reagent/consumable/ethanol/neurotoxin = 10, /datum/reagent/toxin/mutetoxin = 10, /datum/reagent/toxin/sodium_thiopental = 10)

When testing this, they now succumb to stam crit and fall asleep at around the same time, and sleep for around 30 seconds before getting up with 25 brain damage.

# Changelog

:cl:  
tweak: Doubled bioterror syringe contents
/:cl:
