### PR TITLE
severely powercreeps syndicate mechs because we're charging nuclear operatives 140tc for a durand

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -22,7 +22,6 @@
 	deflect_chance = 25
 	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 35000
-	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 250
 	deflect_chance = 5
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 6
 	wreckage = /obj/structure/mecha_wreckage/gygax
@@ -20,7 +20,7 @@
 	icon_state = "darkgygax"
 	max_integrity = 300
 	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD =20, FIRE = 100, ACID = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)
@@ -28,10 +28,12 @@
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 4
 	destruction_sleep_duration = 20
+	leg_overload_coeff = 50
+	leg_overload_damage = FALSE
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
 	. = ..()
-	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/syndicate
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang
 	ME.attach(src)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -27,7 +27,7 @@
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 4
 	destruction_sleep_duration = 20
-	leg_overload_coeff = 50
+	leg_overload_coeff = 75
 	leg_overload_damage = FALSE
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
@@ -38,7 +38,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay/advanced
 	ME.attach(src)
 	max_ammo()
 

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 250
 	deflect_chance = 5
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 6
 	wreckage = /obj/structure/mecha_wreckage/gygax
@@ -19,8 +19,8 @@
 	name = "\improper Dark Gygax"
 	icon_state = "darkgygax"
 	max_integrity = 300
-	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD =20, FIRE = 100, ACID = 100)
+	deflect_chance = 25
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 35000
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -5,7 +5,7 @@
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25
-	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 60, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -5,7 +5,7 @@
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25
-	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 60, FIRE = 100, ACID = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3
@@ -81,9 +81,9 @@
 
 /obj/mecha/combat/marauder/mauler/loaded/Initialize()
 	. = ..()
-	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg(src)
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/syndicate(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/syndicate(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
 	ME.attach(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -87,7 +87,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay/advanced(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -280,6 +280,7 @@
 	energy_drain = 0
 	range = 0
 	var/coeff = 100
+	var/chargeper = 20
 	var/list/use_channels = list(EQUIP,ENVIRON,LIGHT)
 	selectable = 0
 
@@ -348,10 +349,15 @@
 					pow_chan = c
 					break
 			if(pow_chan)
-				var/delta = min(20, chassis.cell.maxcharge-cur_charge)
+				var/delta = min(chargeper, chassis.cell.maxcharge-cur_charge)
 				chassis.give_power(delta)
 				A.use_power(delta*coeff, pow_chan)
 
+/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay/advanced
+	name = "advanced tesla energy relay"
+	desc = "A high-quality, finely tuned telsa energy relay that draws power substantially more efficiently than its mass produced counterpart."
+	coeff = 50
+	chargeper = 100
 
 
 

--- a/code/game/mecha/equipment/weapons/mecha_ammo.dm
+++ b/code/game/mecha/equipment/weapons/mecha_ammo.dm
@@ -53,12 +53,22 @@
 	rounds = 40
 	ammo_type = "scattershot"
 
+/obj/item/mecha_ammo/scattershot/syndicate
+	name = "mutilator ammo"
+	desc = "A box of military grade shotgun ammunition, scaled up for use in Syndicate exosuits."
+	ammo_type = "mutilator"
+
 /obj/item/mecha_ammo/lmg
 	name = "machine gun ammo"
 	desc = "A box of linked ammunition, designed for the Ultra AC 2 exosuit weapon."
 	icon_state = "lmg"
 	rounds = 300
 	ammo_type = "lmg"
+
+/obj/item/mecha_ammo/lmg/syndicate
+	name = "heavy machine gun ammo"
+	desc = "A box containing a long chain of ammunition for use in Syndicate combat exosuits. Cannot be removed by hand."
+	ammo_type = "devastator"
 
 /obj/item/mecha_ammo/missiles_br
 	name = "breaching missiles"

--- a/code/game/mecha/equipment/weapons/mecha_ammo.dm
+++ b/code/game/mecha/equipment/weapons/mecha_ammo.dm
@@ -57,6 +57,7 @@
 	name = "mutilator ammo"
 	desc = "A box of military grade shotgun ammunition, scaled up for use in Syndicate exosuits."
 	ammo_type = "mutilator"
+	rounds = 186
 
 /obj/item/mecha_ammo/lmg
 	name = "machine gun ammo"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -352,6 +352,13 @@
 	harmful = TRUE
 	ammo_type = "scattershot"
 
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/syndicate
+	name = "\improper SND-E \"Mutilator\" Shotgun"
+	desc = "A heavy-duty shotgun that fires a scaled-up version of the Syndicate's proprietary shotgun ammunition. Great for taking down toolbox-wielding assistants."
+	projectiles_per_shot = 10
+	projectile = /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
+	ammo_type = "mutilator"
+
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
 	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst."
@@ -367,6 +374,12 @@
 	projectile_delay = 2
 	harmful = TRUE
 	ammo_type = "lmg"
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/syndicate
+	name = "\improper AS-39 \"Devastator\" Mounted Heavy Machine Gun"
+	desc = "A mounted version of the infamous L6 SAW. Fires in bursts of 3."
+	projectile = /obj/item/projectile/bullet/mm712x82
+	ammo_type = "devastator"
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
 	name = "\improper SRM-8 missile rack"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -355,7 +355,10 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot/syndicate
 	name = "\improper SND-E \"Mutilator\" Shotgun"
 	desc = "A heavy-duty shotgun that fires a scaled-up version of the Syndicate's proprietary shotgun ammunition. Great for taking down toolbox-wielding assistants."
-	projectiles_per_shot = 10
+	projectiles_per_shot = 12
+	projectiles_cache = 144
+	projectiles = 144
+	projectiles_cache_max = 576
 	projectile = /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
 	ammo_type = "mutilator"
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -116,6 +116,7 @@
 	var/defence_mode_deflect_chance = 35
 	var/leg_overload_mode = FALSE
 	var/leg_overload_coeff = 100
+	var/leg_overload_damage = TRUE
 	var/zoom_mode = FALSE
 	var/smoke = 5
 	var/smoke_ready = 1
@@ -625,7 +626,7 @@
 		move_result = mechstep(direction)
 	if(move_result || loc != oldloc)// halfway done diagonal move still returns false
 		use_power(step_energy_drain)
-		if(leg_overload_mode)
+		if(leg_overload_mode && leg_overload_damage)
 			take_damage(2, BRUTE)
 		can_move = world.time + step_in
 		return TRUE

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -540,9 +540,9 @@
 	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo/dark_gygax/PopulateContents()
-	new /obj/item/mecha_ammo/incendiary(src)
-	new /obj/item/mecha_ammo/incendiary(src)
-	new /obj/item/mecha_ammo/incendiary(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
 	new /obj/item/mecha_ammo/flashbang(src)
 	new /obj/item/mecha_ammo/flashbang(src)
 	new /obj/item/mecha_ammo/flashbang(src)
@@ -551,12 +551,12 @@
 	desc = "A large duffel bag, packed to the brim with various exosuit ammo."
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo/mauler/PopulateContents()
-	new /obj/item/mecha_ammo/lmg(src)
-	new /obj/item/mecha_ammo/lmg(src)
-	new /obj/item/mecha_ammo/lmg(src)
-	new /obj/item/mecha_ammo/scattershot(src)
-	new /obj/item/mecha_ammo/scattershot(src)
-	new /obj/item/mecha_ammo/scattershot(src)
+	new /obj/item/mecha_ammo/lmg/syndicate(src)
+	new /obj/item/mecha_ammo/lmg/syndicate(src)
+	new /obj/item/mecha_ammo/lmg/syndicate(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
+	new /obj/item/mecha_ammo/scattershot/syndicate(src)
 	new /obj/item/mecha_ammo/missiles_he(src)
 	new /obj/item/mecha_ammo/missiles_he(src)
 	new /obj/item/mecha_ammo/missiles_he(src)


### PR DESCRIPTION
ok basically, i added 2 new mech weapons, one of them is a reskin of the LMG except it fires l6 SAW bullets and a reskin of the scattershot shotgun except it fires syndicate shotgun bullets and also fires 12 pellets per shot
dark gygax and mauler have had their ultra ACs and scattershots replaced with these new weapons, ammo bundles updated so no bamboozle.
dark gygax is currently super awful so i made it use 3/4 the energy of a normal gygax when overload walking, also it no longer fucking breaks itself while overload walking, and i increased its deflect chance to 25 from 15
also the energy tesla relays in the mechs have been replaced with an upgraded version that charges about 5x faster. this may seem like a lot, but gygax burns through this very quickly while overload walking and then has to sit out to recharge, this is mostly to stop nukie mechs from running out of battery and then getting stuck in place because operatives cant get inducers without stealing them from scientists or engineers
:cl:  
tweak: operative mechs are now less bad
/:cl:
