### PR TITLE
AsteroidStation minimum player count required 34 -> 40

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -18,7 +18,7 @@ map yogstation
 endmap
 
 map asteroidstation
-	minplayers 34
+	minplayers 40
 	votable
 endmap
 


### PR DESCRIPTION
# Document the changes in your pull request

Asteroid is a huge map and anything under 35 (because 50% of people are ghosted) players makes it feel empty

Also there should never be a situation in the world where a population fit for GaxStation (max 40 players) is also fit for AsteroidStation (min 40 players)

# Changelog

:cl:  
tweak: AsteroidStation requires 40 players minimum instead of 34
/:cl:
