### PR TITLE
Ups gummy bear capacity to 30u

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -266,7 +266,7 @@
 		else if (item_type == "bottle")
 			vol_each_max = min(30, vol_each_max)
 		else if (item_type == "gummy")
-			vol_each_max = min(15, vol_each_max)
+			vol_each_max = min(30, vol_each_max)
 		else if (item_type == "condimentPack")
 			vol_each_max = min(10, vol_each_max)
 		else if (item_type == "condimentBottle")

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -319,7 +319,7 @@ const PackagingControls = (props, context) => {
           label="Gummy Bears"
           amount={gummyAmount}
           amountUnit="gummies"
-          sideNote="max 15u"
+          sideNote="max 30u"
           onChangeAmount={(e, value) => setGummyAmount(value)}
           onCreate={() => act('create', {
             type: 'gummy',

--- a/yogstation/code/modules/reagents/reagent_containers/gummies.dm
+++ b/yogstation/code/modules/reagents/reagent_containers/gummies.dm
@@ -5,7 +5,7 @@
 	icon_state = "gummy"
 	item_state = "gummy"
 	possible_transfer_amounts = list()
-	volume = 15
+	volume = 30
 	grind_results = list()
 	color = null
 	var/apply_type = INGEST


### PR DESCRIPTION
Gummy bears are a great idea, "strong" healing items that take time to eat.
The problem resides in them only being 15u, making them barely larger than pills which are instant.
And at a point, it might just be better to carry a vial or beaker and just drink from it.

Increasing them to pill's prior 50u is probably overkill, but bringing it up to 30u which aligns with many reagent's overdose amount seems to be a good middle ground, allowing for good use, without being oppressive.

:cl:  
tweak: Gummy bears can hold 30u
/:cl:
