### PR TITLE
Adds a hypospray speed upgrade

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -265,6 +265,7 @@
 	//  Misc Vars  //
 	var/quickload = FALSE
 	var/penetrates = FALSE
+	var/speedup = FALSE
 	var/can_remove_container = TRUE
 
 	//	Sound Vars	//
@@ -677,6 +678,20 @@
 		return FALSE
 	else
 		hypo.penetrates = TRUE
+		return TRUE
+
+/obj/item/hypospray_upgrade/speed
+	name = "hypospray speed upgrade"
+	desc = "An upgrade for hyposprays that installs a springloaded mechanism, allowing it to inject with reduced delay."
+
+/obj/item/hypospray_upgrade/speed/install(var/obj/item/hypospray/hypo, mob/user)
+	if(hypo.speedup)
+		to_chat(user, span_notice("[hypo] already has a speed mechanism!"))
+		return FALSE
+	else
+		hypo.inject_wait = clamp(hypo.inject_wait, 0, hypo.inject_wait - 0.5 SECONDS)
+		hypo.inject_self = 0 SECONDS
+		hypo.speedup = TRUE
 		return TRUE
 
 #undef HYPO_INJECT

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -270,6 +270,16 @@
 	materials = list(/datum/material/glass = 2000, /datum/material/diamond = 1000)
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	
+/datum/design/hyposprayspeedupg
+	name = "Hypospray Speed Upgrade"
+	desc = "An upgrade for hyposprays that installs a springloaded mechanism, allowing it to inject with reduced delay."
+	id = "hyposprayspeedupg"
+	build_path = /obj/item/hypospray_upgrade/speed
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 2000, /datum/material/silver = 1000, /datum/material/titanium = 500)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /////////////////////////////////////////
 //////////Cybernetic Implants////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -70,7 +70,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("hypospray", "piercesyringe", "hypospraypierceupg", "pinpointer_crew", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "detective_scanner", "detective_scanner_advanced" , "defibrillator_compact")
+	design_ids = list("hypospray", "piercesyringe", "hypospraypierceupg", "hyposprayspeedupg", "pinpointer_crew", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "detective_scanner", "detective_scanner_advanced" , "defibrillator_compact")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/xenoorgan_biotech


### PR DESCRIPTION
A hypospray can only ever inject 5u at a time, comparable to drinking from a vial or beaker.
This will allow people to use it as a semi-reliable self-healing option, without enabling it's use as a weapon.

**This adds a researchable speed upgrade that:**
makes self-injection instant, similar to syringes
removes 0.5 seconds from injecting others (regular hypo will be at 1.5 seconds with this upgrade)

:cl:  
rscadd: Adds a hypospray speed upgrade
/:cl:
