### PR TITLE
Make firing pins actually serve their intended purpose

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -15,7 +15,7 @@
 	result = /obj/item/firing_pin/implant/mindshield
 	reqs = list(/obj/item/firing_pin = 1,
 				/obj/item/mindshield_upgrade =1)
-	blacklist = list(/obj/item/firing_pin/clockie, /obj/item/firing_pin/implant, /obj/item/firing_pin/clown, /obj/item/firing_pin/fucked, /obj/item/firing_pin/dna, /obj/item/firing_pin/tag)
+	blacklist = list(/obj/item/firing_pin/clockie,/obj/item/firing_pin/test_range, /obj/item/firing_pin/implant, /obj/item/firing_pin/clown, /obj/item/firing_pin/fucked, /obj/item/firing_pin/dna, /obj/item/firing_pin/tag)
 	time = 2 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -10,6 +10,16 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/mindshield_pin
+	name = "Mindshield Firing Pins"
+	result = /obj/item/firing_pin/implant/mindshield
+	reqs = list(/obj/item/firing_pin = 1,
+				/obj/item/mindshield_upgrade =1)
+	blacklist = list(/obj/item/firing_pin/clockie, /obj/item/firing_pin/implant, /obj/item/firing_pin/clown, /obj/item/firing_pin/fucked, /obj/item/firing_pin/dna, /obj/item/firing_pin/tag)
+	time = 2 SECONDS
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/IED
 	name = "IED"
 	result = /obj/item/grenade/iedcasing

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -397,12 +397,11 @@
     crate_name = "secway crate"
 
 /datum/supply_pack/security/firingpins
-	name = "Standard Firing Pins Crate"
-	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
-	cost = 2000
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/firingpins,
-					/obj/item/storage/box/firingpins)
+	name = "Standard Firing Pins Pack"
+	desc = "Upgrade your arsenal with 5 standard firing pins. Requires Security access to open."
+	cost = 6000
+	small_item = TRUE
+	contains = list(/obj/item/storage/box/firingpins)
 	crate_name = "firing pins crate"
 
 /datum/supply_pack/security/justiceinbound

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -245,3 +245,9 @@
 	if(gun)
 		gun.pin = null
 	return ..()
+
+/obj/item/mindshield_upgrade
+	name = "mindshield detector"
+	desc = "A small circuit compatible with electronic firing pins to make them check for mindshiel implant in their user."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "cyborg_upgrade3"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -248,6 +248,6 @@
 
 /obj/item/mindshield_upgrade
 	name = "mindshield detector"
-	desc = "A small circuit compatible with electronic firing pins to make them check for mindshiel implant in their user."
+	desc = "A small circuit compatible with electronic firing pins to make them check for mindshield implant in their user."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade3"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -92,17 +92,17 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 300)
 	build_path = /obj/item/firing_pin/test_range
-	category = list("Firing Pins")
+	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/pin_mindshield
-	name = "Mindshield Firing Pin"
-	desc = "This is a security firing pin which only authorizes users who are mindshield-implanted."
+	name = "Mindshield detector"
+	desc = "A security upgrade for firing pins to only authorizes users who are mindshield-implanted."
 	id = "pin_loyalty"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
-	build_path = /obj/item/firing_pin/implant/mindshield
-	category = list("Firing Pins")
+	build_path = /obj/item/mindshield_upgrade
+	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/stunmine/sec //mines ported from BeeStation

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -14,7 +14,6 @@
 								"Electronics",
 								"Weapons",
 								"Ammo",
-								"Firing Pins",
 								"Computer Parts",
 								"Spacepod Designs", // yoggers
 								"Service",


### PR DESCRIPTION
# Document the changes in your pull request

Alternative to #16232

The mindshield firing pin has always been a problem in that it completely invalidated the purpose of firing pins while being necessary for sci to research before any of the good weapons. You had a strictly better firing pin and it was always unlocked when you had the possibility to print advanced eguns, xray, decloner, temp gun and hardlight bow

So now mindshield firing pins are obtained by crafting them using a regular pin and an mindshield detector which design replace the mindshield firing pin in the protolathe.
The firing pin section in the protolathe has been removed because there was literally only one item that mattered in it, the pins have been moved to be in the weapon category like attachments.

This mean you get 10 mindshield pins with what's at roundstart in the brig, this limit both expanding the arsenal of the armory and making your guns unuseable against you while not just making all the research weapons that aren't the xray gun or aegun worthless because they are very niche compared to lasers and make pins actually matter.

The price of the firing pin crate also has been increased to 6000 credits andonly contain one box of 5 pins now, making crafting a new gun cost 1200 credits after the ressources of the brig have been depleted. The crate is also sec access now so officers can still get pins for a temp gun if there's no warden or HoS, the real roadblock for obtening the guns as a secoff is access to the armory, not to a crate you can force open easily.

# Wiki Documentation

Mindshield pins can no longer be printed, instead you print a mindshield detector. The design is at the same place as the old mindshield pin in the techweb.
Mindshield pin can now be crafted with a firing pin and a mindshield detector, it's in the weapon category of the crafting menu, no tools required.
Firing pin crate now cost 6000 credits, contain only one box of 5 firing pins and is security access.

# Changelog

:cl:  
rscadd: Added mindshield upgrade for firing pins, the mindshield detector
rscdel: Removed printable mindshield pins, instead you print the mindshield detector
tweak: Firing pin crate cost 6000 credits from 2000, contain only 5 firing pins and require basic security access instead of armory access
/:cl:
