### PR TITLE
Extreme rooms let space and heat adapt return to comfortable temps

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1945,7 +1945,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(ismovable(human_loc))
 			var/atom/movable/occupied_space = human_loc
 			thermal_protection *= (1 - occupied_space.contents_thermal_insulation)
-		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING) || loc_temp > BODYTEMP_NORMAL+200) //if the room is very hot, it will allow heat adapt people to warm up
+		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING) || loc_temp > BODYTEMP_NORMAL+1000) //if the room is very hot, it will allow heat adapt people to warm up
 			if(H.bodytemperature < BODYTEMP_NORMAL) //and we're cold, insulation enhances our ability to retain body heat but reduces the heat we get from the environment
 				H.adjust_bodytemperature((thermal_protection+1)*natural + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
 		else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1930,7 +1930,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 			if(ismovable(human_loc))
 				var/atom/movable/occupied_space = human_loc
 				thermal_protection *= (1 - occupied_space.contents_thermal_insulation)
-			if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_COOLING))
+			if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_COOLING) || loc_temp < BODYTEMP_NORMAL-200) //if the room is very cold, it will allow space adapt people to cool down
 				if(H.bodytemperature < BODYTEMP_NORMAL) //we're cold, insulation helps us retain body heat and will reduce the heat we lose to the environment
 					H.adjust_bodytemperature((thermal_protection+1)*natural + max(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_COLD_DIVISOR, BODYTEMP_COOLING_MAX))
 				else //we're sweating, insulation hinders our ability to reduce heat - and it will reduce the amount of cooling you get from the environment
@@ -1945,11 +1945,11 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(ismovable(human_loc))
 			var/atom/movable/occupied_space = human_loc
 			thermal_protection *= (1 - occupied_space.contents_thermal_insulation)
-		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING))
+		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING) || loc_temp > BODYTEMP_NORMAL+200) //if the room is very hot, it will allow heat adapt people to warm up
 			if(H.bodytemperature < BODYTEMP_NORMAL) //and we're cold, insulation enhances our ability to retain body heat but reduces the heat we get from the environment
 				H.adjust_bodytemperature((thermal_protection+1)*natural + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
-			else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
-				H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
+		else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
+			H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
 
 	// +/- 50 degrees from 310K is the 'safe' zone, where no damage is dealt.
 	if(H.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTHEAT))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1948,8 +1948,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(!HAS_TRAIT(H, TRAIT_NO_PASSIVE_HEATING) || loc_temp > BODYTEMP_NORMAL+1000) //if the room is very hot, it will allow heat adapt people to warm up
 			if(H.bodytemperature < BODYTEMP_NORMAL) //and we're cold, insulation enhances our ability to retain body heat but reduces the heat we get from the environment
 				H.adjust_bodytemperature((thermal_protection+1)*natural + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
-		else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
-			H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
+			else //we're sweating, insulation hinders out ability to reduce heat - but will reduce the amount of heat we get from the environment
+				H.adjust_bodytemperature(natural*(1/(thermal_protection+1)) + min(thermal_protection * (loc_temp - H.bodytemperature) / BODYTEMP_HEAT_DIVISOR, BODYTEMP_HEATING_MAX))
 
 	// +/- 50 degrees from 310K is the 'safe' zone, where no damage is dealt.
 	if(H.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTHEAT))


### PR DESCRIPTION
Currently, space adapt prevents people from cooling down if too hot
and heat adapt prevents people from heating up if too cold
This is good to balance out the power it gives you

The problem comes from always needing to use a shower or chems to fix your temp
This will allow extreme room temps to override the "no passive heating" or "no passive cooling"

**This is will make it so:**
someone with heat adapt won't freeze to death in a post-plasma fire room
And someone with space adapt won't burn to death in space

but they will still need to worry about being too warm or cold under normal circumstances

:cl:  
tweak: being in a super hot room will let heat adapt people warm up
tweak: being in a super cool room will let space adapt people cool down
/:cl:
