### PR TITLE
Drinking water will slowly equalize your body temp

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -186,8 +186,8 @@
 
 /datum/reagent/water/on_mob_life(mob/living/carbon/M)
 	. = ..()	
-	var/body_temperature_difference = BODYTEMP_NORMAL - owner.bodytemperature
-	owner.adjust_bodytemperature(min(3,body_temperature_difference))
+	var/body_temperature_difference = BODYTEMP_NORMAL - M.bodytemperature
+	M.adjust_bodytemperature(min(3,body_temperature_difference))
 	if(M.blood_volume)
 		M.blood_volume += 0.1 // water is good for you!
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -185,7 +185,9 @@
 	..()
 
 /datum/reagent/water/on_mob_life(mob/living/carbon/M)
-	. = ..()
+	. = ..()	
+	var/body_temperature_difference = BODYTEMP_NORMAL - owner.bodytemperature
+	owner.adjust_bodytemperature(min(3,body_temperature_difference))
 	if(M.blood_volume)
 		M.blood_volume += 0.1 // water is good for you!
 


### PR DESCRIPTION
Currently there only ways to heat up or cool down with heat/space adapt is to use a shower or a few limited drinks/chems
This will allow drinking water to do the same, albeit much slower

Mainly to combat plasmafloods from giving a death sentence to all people with space adapt without removing it's main weakness

:cl:  
rscadd: drinking water will equalize your body temp
/:cl:
