### PR TITLE
PLASMAFLOOD POOL PARTY

### DIFF
--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -302,6 +302,10 @@ GLOBAL_LIST_EMPTY(pool_filters)
 					if(!HAS_TRAIT(C, TRAIT_RESISTHEAT))
 						C.adjustFireLoss(5)
 					to_chat(M, "<span class='danger'>The water is searing hot!</span>")
+				else
+					if(iscarbon(M))	//if temperature is comfy, can be used to warm up or cool down
+						var/body_temperature_difference = current_temperature - C.bodytemperature
+						C.adjust_bodytemperature(min(100, body_temperature_difference))
 
 /obj/structure/pool_ladder/attack_hand(mob/user)
 	var/datum/component/swimming/S = user.GetComponent(/datum/component/swimming)

--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -224,6 +224,7 @@ GLOBAL_LIST_EMPTY(pool_filters)
 	var/current_temperature = 300 //current temp
 	var/preset_reagent_type = null //Set this if you want your pump to start filled with a given reagent. SKEWIUM POOL SKEWIUM POOL!
 	var/temp_rate = 0.5
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 /obj/machinery/pool_filter/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
If the pool is set to be at a comfortable temperature it will bring the body of people in the pool to be closer to temperature of the pool
This will let people use it to stay warm if the room is spaced, or cool if the room is plasmaflooded

Also makes the pool filter indestructible because it can't be made by people, only placed by mappers and if it breaks, the pool functionality does too

:cl:  
tweak: a comfy pool will give you a good body temperature
/:cl:
