### PR TITLE
zombie resurrection removes clone damage

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -85,6 +85,7 @@
 	//Fully heal the zombie's damage the first time they rise
 	owner.setToxLoss(0, 0)
 	owner.setOxyLoss(0, 0)
+	owner.setCloneLoss(0, 0)
 	owner.heal_overall_damage(INFINITY, INFINITY, INFINITY, null, TRUE)
 
 	if(!owner.revive())


### PR DESCRIPTION
# Document the changes in your pull request

Prevents people with absurd amounts of clone damage (shadowlings) from being permadeaded despite romerol infection
Also idk makes abductors less of a pain for them if that was ever an issue

Sling zombie is an interaction that needs to be allowed to happen whenever the stars align for it and I can't believe Nyx took this from us on purpose

# Changelog

:cl:  
tweak: Zombie resurrection removes clone damage
/:cl: