### PR TITLE
adds a single spark visual to malf ai's machine overload

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -522,7 +522,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	if(is_type_in_typecache(target, GLOB.blacklisted_malf_machines))
 		to_chat(ranged_ability_user, span_warning("You cannot overload that device!"))
 		return
-	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, 0)
+	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 4 SECONDS, 0)
 	attached_action.adjust_uses(-1)
 	target.audible_message(span_userdanger("You hear a loud electrical buzzing sound coming from [target]!"))
 	var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -528,7 +528,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
 	spark_system.attach(target)
 	spark_system.set_up(1, 0, target)
-	addtimer(CALLBACK(attached_action, /datum/action/innate/ai/ranged/overload_machine.proc/detonate_machine, target), 50) //kaboom!
+	addtimer(CALLBACK(attached_action, /datum/action/innate/ai/ranged/overload_machine.proc/detonate_machine, target), 4 SECONDS) //kaboom!
 	remove_ranged_ability(span_danger("Overcharging machine..."))
 	return TRUE
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -525,6 +525,9 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	ranged_ability_user.playsound_local(ranged_ability_user, "sparks", 50, 0)
 	attached_action.adjust_uses(-1)
 	target.audible_message(span_userdanger("You hear a loud electrical buzzing sound coming from [target]!"))
+	var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
+	spark_system.attach(target)
+	spark_system.set_up(1, 0, target)
 	addtimer(CALLBACK(attached_action, /datum/action/innate/ai/ranged/overload_machine.proc/detonate_machine, target), 50) //kaboom!
 	remove_ranged_ability(span_danger("Overcharging machine..."))
 	return TRUE


### PR DESCRIPTION
This is mainly for situations where there's several of the same type of machine in a room
removes the need to just guess and hope to not get blown up if one's attentive enough
especially since the explosion has a heavy size of 2

if adding a tell makes it too easy to avoid, the explosion could always be made bigger to compensate
probably only increase light explosion though

Example
firelocks on a shuttle

technically not an ided because someone else asked me to do it, can't remember who though

:cl:  
tweak: machine overload will spawn a single spark on the exploding machine
/:cl:
