### PR TITLE
cybebrnetic

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -290,5 +290,5 @@
 
 /datum/quirk/cyberorgan/check_quirk(datum/preferences/prefs)
 	if(prefs.pref_species && istype(prefs.pref_species, /datum/species/ipc)) // IPCs are already cybernetic
-		return "You already have cybebrnetic organs!"
+		return "You already have cybernetic organs!"
 	return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a typo in one of the quirks
"You already have cybebrnetic organs!" - > "You already have cybernetic organs!"

# Changelog

:cl:  
spellcheck: cybebrnetic - cybernetic
/:cl:
