### PR TITLE
Removes 1.6 alert from IPC revival

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -176,7 +176,6 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H, admin_revive)
 	if(admin_revive)
 		return ..()
-	to_chat(H, span_notice("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
 	H.Stun(9 SECONDS) // No moving either
 	H.dna.features["ipc_screen"] = "BSOD"
 	H.update_body()


### PR DESCRIPTION
# Document the changes in your pull request

Reading the 1.6 rules means IPCs do not suffer from CMD in their current form. This removes the alert because it is wrong.

# Changelog

:cl:  ToasterBiome, Adamsogm, Margot, Cowboy93, BritishGrace
rscdel: Removes 1.6 alert from IPC revival
/:cl:
