### PR TITLE
Zombie antag no longer has a timelock

### DIFF
--- a/code/modules/antagonists/zombie/zombie.dm
+++ b/code/modules/antagonists/zombie/zombie.dm
@@ -1,4 +1,4 @@
-#define TIER_2_TIME 4500
+
 
 /datum/antagonist/zombie
 	name = "Zombie"
@@ -429,4 +429,4 @@
 	cooldown_ends = world.time + cooldown_time
 	ready = FALSE
 
-#undef TIER_2_TIME
+


### PR DESCRIPTION


# Document the changes in your pull request
This PR will remove the 10 day timelock for being a zombie, i feel that being a zombie is not hard enough to require a timelock of 10 days it is not advanced enough of a antag to be that long, for comparison the bloodsucker (a difficult antag)  has a 3 day timelock so this is only fair.








. 

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscdel: the zombie antagonist no longer has a 10 day timelock
/:cl: 
