### PR TITLE
removes the 10 day timelock for zombies completely

### DIFF
--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -17,7 +17,6 @@ GLOBAL_LIST_EMPTY(zombies)
 	required_players = 40
 	required_enemies = 3
 	recommended_enemies = 3
-	enemy_minimum_age = 14
 
 	announce_span = "zombie"
 	announce_text = "Some crew members have been infected with a zombie virus!\n\


### PR DESCRIPTION

# Document the changes in your pull request
To be able to be a zombie you need to wait about 10 days (if you are new) i feel that this is a bit too long to be a zombie as it isn't a very difficult antagonist to play, for comparison bloodsuckers only require 3 days. It doesn't make sense for such a easy antag to have such a high timelock


# Changelog


:cl:  
rscdel: the 10 day zombie timelock has been completely removed
/:cl:
