### PR TITLE
makes roundstart pepperspray not insufferable

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1443,6 +1443,13 @@
 	color = "#DA0000" // red
 	random_color_list = list("#DA0000")
 
+// Pepperspray coloring, only affects mobs
+/datum/reagent/colorful_reagent/crayonpowder/red/pepperspray/reaction_obj(obj/O, reac_volume)
+	return
+
+/datum/reagent/colorful_reagent/crayonpowder/red/pepperspray/reaction_turf(turf/T, reac_volume)
+	return
+
 /datum/reagent/colorful_reagent/crayonpowder/orange
 	name = "Orange Crayon Powder"
 	colorname = "orange"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -220,7 +220,7 @@
 	volume = 60
 	stream_range = 4
 	amount_per_transfer_from_this = 5
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40, /datum/reagent/colorful_reagent/crayonpowder/red = 20) //red dye)
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 40, /datum/reagent/colorful_reagent/crayonpowder/red/pepperspray = 20) //red dye)
 
 /obj/item/reagent_containers/spray/pepper/empty //for protolathe printing
 	list_reagents = null

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -126,8 +126,8 @@
 		desc = "IT'S PEPPER TIME, BITCH!"
 	// I am cheating
 	// Sets 1/3 of the tank to be pepperspray coloring
-	reagents.remove_reagent(reagent_id, tank_volume * 0.3333)
-	reagents.add_reagent(/datum/reagent/colorful_reagent/crayonpowder/red/pepperspray, tank_volume * 0.3333)
+	reagents.remove_reagent(reagent_id, tank_volume / 3)
+	reagents.add_reagent(/datum/reagent/colorful_reagent/crayonpowder/red/pepperspray, tank_volume / 3)
 
 /obj/structure/reagent_dispensers/water_cooler
 	name = "liquid cooler"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -124,7 +124,10 @@
 	. = ..()
 	if(prob(1))
 		desc = "IT'S PEPPER TIME, BITCH!"
-
+	// I am cheating
+	// Sets 1/3 of the tank to be pepperspray coloring
+	reagents.remove_reagent(reagent_id, tank_volume * 0.3333)
+	reagents.add_reagent(/datum/reagent/colorful_reagent/crayonpowder/red/pepperspray, tank_volume * 0.3333)
 
 /obj/structure/reagent_dispensers/water_cooler
 	name = "liquid cooler"


### PR DESCRIPTION
# Document the changes in your pull request

Pepperspray now has a snowflake subtype of red colorful reagent that doesn't have turf or object reactions, only mob

Pepperspray dispensers now carry this (they previously only carried condensed capsaicin) as 1/3 of their tank, similar to roundstart pepperspray

# Changelog

:cl:  
tweak: pepperspray now only tags mobs and the refill dispenser has coloring
/:cl:
