### PR TITLE
Fix fire alarm icon not updating when burglar alarm is triggered

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -310,8 +310,10 @@
 		return  // do nothing if we're already active
 	if(fire)
 		set_light(l_power = 0.8)
+		update_icon()
 	else
 		set_light(l_power = 0)
+		update_icon()
 
 /*
  * Return of the Return of the Party button


### PR DESCRIPTION


# Document the changes in your pull request

fixed fire alarm icon not updating when burglar alarm is triggered

# Changelog



:cl:  
bugfix: fixed fire alarm icon not updating when burglar alarm is triggered
/:cl:
