### PR TITLE
band aid fixes darklord bundle for now

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -185,6 +185,7 @@
 			new /obj/item/clothing/mask/chameleon/syndicate(src) //Not even 1 TC, the real value of the chameleon kit is the jumpsuit. However this is absolutely necessary for your Sithsona
 			new /obj/item/card/id/syndicate(src) //2 TC, so you can give yourself a proper name
 			new /obj/item/clothing/suit/wizrobe/black(src) //Dark robes for the dark lord. Free
+			new /obj/item/clothing/head/wizard/black(src) //Works as a fix for the robe check now until I think of something new
 			new /obj/item/clothing/gloves/combat(src) //Maybe 1 TC, so you don't shock yourself
 			new /obj/item/book/granter/spell/teslablast(src) //Lightning bolt, LIGHTNING BOLT. A 2 SP cost spell that requires robes
 			new /obj/item/book/granter/spell/repulse(src) //"Force Push". 2 SP cost spell that requires robes


### PR DESCRIPTION
# Document the changes in your pull request

pov I'm stupid and forgot that wizard spells that require robes require both robe and hat so you can't even use the spells in this bundle rn

# Wiki Documentation

Darklord bundle has a black wizard hat now

# Changelog

:cl:  
tweak: Darklord bundle should now be able to cast magic properly-ish
/:cl:
