### PR TITLE
Makes aggressive grabs significantly less bad for the game

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -198,7 +198,7 @@
 		changeNext_move(CLICK_CD_RANGE)
 
 /mob/living/carbon/restrained(ignore_grab)
-	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE))
+	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state > GRAB_AGGRESSIVE))
 
 /mob/living/carbon/proc/canBeHandcuffed()
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -198,7 +198,7 @@
 		changeNext_move(CLICK_CD_RANGE)
 
 /mob/living/carbon/restrained(ignore_grab)
-	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state > GRAB_AGGRESSIVE))
+	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_NECK))
 
 /mob/living/carbon/proc/canBeHandcuffed()
 	return 0

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -106,7 +106,7 @@
 				hurt = FALSE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
+			Knockdown(20)
 			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 			visible_message(span_danger("[src] crashes into [hit_atom][extra_speed ? " really hard" : ""]!"),\
 				span_userdanger("You violently crash into [hit_atom][extra_speed ? " extra hard" : ""]!"))
@@ -118,8 +118,8 @@
 		if(hurt)
 			victim.take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
 			take_bodypart_damage(10 + 5 * extra_speed, check_armor = TRUE, wound_bonus = extra_speed * 5)
-			victim.Paralyze(20)
-			Paralyze(20)
+			victim.Knockdown(20)
+			Knockdown(20)
 			visible_message(span_danger("[src] crashes into [victim][extra_speed ? "really hard" : ""], knocking them both over!"),\
 				span_userdanger("You violently crash into [victim][extra_speed ? "extra hard" : ""]!"))
 		playsound(src,'sound/weapons/punch1.ogg',50,1)


### PR DESCRIPTION
# Document the changes in your pull request

Can now use items while aggressively grabbed (no longer counts as restrained)

Can shove your captor, it will not release you but if you hit them into a wall they'll drop their active item like normal

Can grab your captor, if you manage an aggressive grab they will release their grip on you, which should result in interesting grab trades, though this results in not being able to neck grab someone who is intent on grabbing you to get out. You will now need to stun someone to reliably neck grab them.

Being thrown into a wall or person is now a knockdown (slip) instead of a paralyze (hardstun)

## Goals

Makes aggressive grab meta a lot more possible to fight against while keeping it strong for disarms and debilitating your opponent

Deletes wall chainstunning

Throwing bodies at people is still effective for sake of disarm and slow, but no longer hardstun

Martial arts have been a problem child for a long while since they have instant aggressive grabs. The reason *why* they have these is because hitting your opponent with combos is a nigh pointless task if you don't have a way to keep them still. This created a very bad balancing issue where martial arts users would just grab and use their effective RNG stun to either chainstun or simply keep hold and beat the person they were holding to death because they couldn't roll a breakout.

This change keeps that effectiveness of keeping your opponent still to land combos, but allows them to fight back with whatever they want. You still have the major advantage, forcing them into melee range, but it is no longer an instant free game-ender.

# Changelog

:cl:  
tweak: Players can now use items while under the effects of an aggressive grab instead of being hardstunned
tweak: Crashing into walls and other players is now a knockdown instead of a hardstun
/:cl:
