### PR TITLE
Sheet snatcher now can be held in utility belt, also fix mats inserting fuckery for sheet snatcher

### DIFF
--- a/code/datums/components/storage/concrete/stack.dm
+++ b/code/datums/components/storage/concrete/stack.dm
@@ -1,4 +1,4 @@
-//Stack-only storage.
+// _process_numerical_display() for stack-only storage.
 /datum/component/storage/concrete/stack
 	display_numerical_stacking = TRUE
 	max_items = 300

--- a/code/datums/components/storage/concrete/stack.dm
+++ b/code/datums/components/storage/concrete/stack.dm
@@ -1,57 +1,9 @@
 //Stack-only storage.
 /datum/component/storage/concrete/stack
 	display_numerical_stacking = TRUE
-	var/max_combined_stack_amount = 300
+	max_items = 300
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = WEIGHT_CLASS_NORMAL * 14
-
-/datum/component/storage/concrete/stack/proc/total_stack_amount()
-	. = 0
-	var/atom/real_location = real_location()
-	for(var/i in real_location)
-		var/obj/item/stack/S = i
-		if(!istype(S))
-			continue
-		. += S.amount
-
-/datum/component/storage/concrete/stack/proc/remaining_space()
-	return max(0, max_combined_stack_amount - total_stack_amount())
-
-//emptying procs do not need modification as stacks automatically merge.
-
-/datum/component/storage/concrete/stack/_insert_physical_item(obj/item/I, override = FALSE)
-	if(!istype(I, /obj/item/stack))
-		if(override)
-			return ..()
-		return FALSE
-	var/atom/real_location = real_location()
-	var/obj/item/stack/S = I
-	var/can_insert = min(S.amount, remaining_space())
-	if(!can_insert)
-		return FALSE
-	for(var/i in real_location)				//combine.
-		if(QDELETED(I))
-			return
-		var/obj/item/stack/_S = i
-		if(!istype(_S))
-			continue
-		if(_S.merge_type == S.merge_type)
-			_S.add(can_insert)
-			S.use(can_insert, TRUE)
-			return TRUE
-	return ..(S.change_stack(null, can_insert), override)
-
-/datum/component/storage/concrete/stack/remove_from_storage(obj/item/I, atom/new_location)
-	var/atom/real_location = real_location()
-	var/obj/item/stack/S = I
-	if(!istype(S))
-		return ..()
-	if(S.amount > S.max_amount)
-		var/overrun = S.amount - S.max_amount
-		S.amount = S.max_amount
-		var/obj/item/stack/temp = new S.type(real_location, overrun)
-		handle_item_insertion(temp)
-	return ..(S, new_location)
 
 /datum/component/storage/concrete/stack/_process_numerical_display()
 	var/atom/real_location = real_location()

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -116,7 +116,7 @@
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/stack/ore))
 	STR.max_w_class = WEIGHT_CLASS_HUGE
-	STR.max_combined_stack_amount = 50
+	STR.max_items = 50
 
 /obj/item/storage/bag/ore/equipped(mob/user)
 	. = ..()
@@ -179,7 +179,6 @@
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.max_items = INFINITY
 	STR.max_combined_w_class = INFINITY
-	STR.max_combined_stack_amount = INFINITY
 
 /obj/item/storage/bag/gem
 	name = "gem satchel"
@@ -293,7 +292,7 @@
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
 	STR.set_holdable(list(/obj/item/stack/sheet), list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
-	STR.max_combined_stack_amount = 500
+	STR.max_items = 500
 
 // -----------------------------
 //    Sheet Snatcher (Cyborg)
@@ -307,7 +306,7 @@
 /obj/item/storage/bag/sheetsnatcher/borg/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
-	STR.max_combined_stack_amount = 1000
+	STR.max_items = 1000
 
 // -----------------------------
 //           Book bag

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -77,7 +77,8 @@
 		/obj/item/handdrill,
 		/obj/item/jawsoflife,
 		/obj/item/shuttle_creator, //Yogs: Added this here cause I felt it fits
-		/obj/item/barrier_taperoll/engineering
+		/obj/item/barrier_taperoll/engineering,
+		/obj/item/storage/bag/sheetsnatcher
 		))
 
 /obj/item/storage/belt/utility/makeshift


### PR DESCRIPTION
# Document the changes in your pull request
Sheet snatcher now can be held in utility belt

Removing shit codes in /datum/component/storage/concrete/stack because its causing some fuckery to the sheet snatcher

- It has some weird bugs i don't know how to describe here, i reverted it so it uses the base datum instead
- **TEsted, worked better**

# Wiki Documentation

- Fix mats inserting fuckery for sheet snatcher
- Sheet snatcher now can be held in utility belt

# Changelog



:cl:  
tweak: Sheet snatcher now can be held in utility belt
bugfix: Fixed mats inserting fuckery for sheet snatcher
/:cl:
