### PR TITLE
removes tasers

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -291,7 +291,7 @@
 /obj/item/pneumatic_cannon/pie/selfcharge
 	automatic = TRUE
 	selfcharge = TRUE
-	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
+	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream/stunning/admin
 	maxWeightClass = 60	//20 pies.
 
 /obj/item/pneumatic_cannon/pie/selfcharge/compact
@@ -300,9 +300,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg
-	name = "low velocity pie cannon"
+	name = "pie cannon"
 	automatic = FALSE
-	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream/nostun
+	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
 	maxWeightClass = 6		//2 pies
 	charge_ticks = 2		//4 second/pie
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1463,13 +1463,13 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		log_admin("[key_name(usr)] has [newstate ? "activated" : "deactivated"] job exp exempt status on [key_name(C)]")
 
 /mob/living/carbon/proc/adminpie(mob/user)
-	var/obj/item/reagent_containers/food/snacks/pie/cream/admin/p = new (get_turf(pick(oview(3,user))))
+	var/obj/item/reagent_containers/food/snacks/pie/cream/stunning/admin/p = new (get_turf(pick(oview(3,user))))
 	p.item_flags = UNCATCHABLE
 	p.throw_at(user, 10, 0.5, usr)
 	sleep(0.5 SECONDS)
 	var/mob/living/carbon/human/T = user
 	if(!T.IsParalyzed())
-		var/obj/item/reagent_containers/food/snacks/pie/cream/admin/pie = new (get_turf(pick(oview(1,user))))
+		var/obj/item/reagent_containers/food/snacks/pie/cream/stunning/admin/pie = new (get_turf(pick(oview(1,user))))
 		pie.item_flags = UNCATCHABLE
 		pie.throw_at(user, 10, 0.5, usr)
 

--- a/code/modules/buildmode/submodes/throwing.dm
+++ b/code/modules/buildmode/submodes/throwing.dm
@@ -29,7 +29,7 @@
 			throw_atom.throw_at(object, 10, 1, c.mob)
 			log_admin("Build Mode: [key_name(c)] threw [throw_atom] at [object] ([AREACOORD(object)])")
 	if(left_click && alt_click)
-		var/obj/item/reagent_containers/food/snacks/pie/cream/admin/p = new (get_turf(pick(oview(3,c.mob))))
+		var/obj/item/reagent_containers/food/snacks/pie/cream/stunning/admin/p = new (get_turf(pick(oview(3,c.mob))))
 		throw_atom = p
 		throw_atom.throw_at(object, 10, 0.5, c.mob)
 		log_admin("Build Mode: [key_name(c)] threw [throw_atom] at [object] ([AREACOORD(object)])")

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -26,7 +26,7 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/banana = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("pie" = 1)
 	foodtype = GRAIN | DAIRY | SUGAR
-	var/stunning = TRUE
+	var/stunning = FALSE
 
 /obj/item/reagent_containers/food/snacks/pie/cream/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
@@ -58,10 +58,10 @@
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "creampie", /datum/mood_event/creampie)
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/pie/cream/nostun
-	stunning = FALSE
+/obj/item/reagent_containers/food/snacks/pie/cream/stunning
+	stunning = TRUE
 
-/obj/item/reagent_containers/food/snacks/pie/cream/admin
+/obj/item/reagent_containers/food/snacks/pie/cream/stunning/admin
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSBLOB | PASSCLOSEDTURF | LETPASSTHROW | PASSDOOR | PASSMACHINES | PASSCOMPUTER
 
 /obj/item/reagent_containers/food/snacks/pie/berryclafoutis


### PR DESCRIPTION
clown taser gone, rip
admin pies and the 10tc traitor pie cannon as well as the honksquad pie cannon still stun people, stun pies are just gone from normal gameplay because 1. tasers are bad and 2. it's the meta to shove one or more up your ass to get free disarms and ranged stuns especially on nuclear emergency because the pies ignore block chance

# Changelog

:cl:  
tweak: most clown pies are no longer tasers
/:cl:
