### PR TITLE
Reduces the amount of buffs the monk staff gets over literally every other nullrod

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -765,9 +765,8 @@
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass the clown."
 	w_class = WEIGHT_CLASS_BULKY
 	damtype = STAMINA
-	force = 18
+	force = 15
 	block_chance = 40
-	armour_penetration = 20
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_NONE
 	hitsound = "swing_hit"


### PR DESCRIPTION
# Document the changes in your pull request

The monk sgaff now has 15 damage down from 18 and no armor piercing, effectively returning it to its original state because both were added for some stupid reason when it was given stamina damage. Most nullrods get one gimmick or two at the cost of some damage, this one got all of them for free

And don't try to tell me "stamina damage" is a downside because if you are capable of saying that you know damn well it isnt

# Wiki Documentation

There's no way this got documented because if someone did document it i jave no doubts they as a member of the wiki team would have said anything other than "what the fuck is this" and brought it up

# Changelog

:cl:  
tweak: monk staff no longer gets armor piercing
tweak: monl staff deals 15 damage, down from 18, so it's not simply a better claymore
/:cl:
