### PR TITLE
Removes the Bag of Holding steal objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -89,12 +89,6 @@
 	difficulty = 5
 	excludefromjob = list("Research Director")
 
-/datum/objective_item/steal/holding
-	name = "the bag of holding."
-	targetitem = /obj/item/storage/backpack/holding
-	difficulty = 7
-	excludefromjob = list("Research Director")
-
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization."
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's


### PR DESCRIPTION
# Document the changes in your pull request

Does not remove the ninja version of the objective.

# Changelog

:cl:  
rscdel: Traitors will no longer be tasked to steal a bag of holding
/:cl:
