### PR TITLE
makes the syndicate hardlight bow 33% cheaper because the mini ebow still exists lmao

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Hardlight Bow"
 	desc = "A modern bow that can fabricate hardlight arrows, designed for silent takedowns of targets."
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
-	cost = 12
+	cost = 8
 	surplus = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
# Document the changes in your pull request

Mini ebow: 10 TC, recharges quickly, guaranteed knockdown and toxin and stamina which causes instant slowdown, can be held in one hand and doesn't have to be drawn.

Hardlight bow: 12 TC, requires both hands, does okay damage, has a neat x ray mode IF you buy thermals which means you can harass the heck out of sec (that rhymes) but it's still clunky to use and takes a while to fire.

Solution: Never nerf the mini ebow (it will never be merged) and instead make the hardlight bow cheaper (8 TC instead of 12)

# Wiki Documentation

Cost will have to be updated on Syndicate Items and Guide to Combat

# Changelog

:cl:  
tweak: Hardlight bow for Syndicate is 33% cheaper
/:cl:
