### PR TITLE
flutes shouldn't be fakeable

### DIFF
--- a/code/modules/events/flutes.dm
+++ b/code/modules/events/flutes.dm
@@ -13,6 +13,7 @@
 	max_occurrences = 1
 	weight = 1
 	min_players = 30
+	fakeable = FALSE
 
 //--------------------
 //ROUND EVENT "FLUTES"

--- a/code/modules/events/flutes.dm
+++ b/code/modules/events/flutes.dm
@@ -13,13 +13,13 @@
 	max_occurrences = 1
 	weight = 1
 	min_players = 30
-	fakeable = FALSE
 
 //--------------------
 //ROUND EVENT "FLUTES"
 //--------------------
 //OBJECT DEF
 /datum/round_event/flutes
+	fakeable = FALSE
 	var/list/mob/living/carbon/chosen_players = list()
 
 //EVENT START PROC


### PR DESCRIPTION
# Document the changes in your pull request

No alerts occur for the crew if it is faked, it adds nothing gameplay wise when faked.

# Changelog
Oversight fix: Flutes shouldn't be fakeable.

:cl:  Xoxeyos
bugfix: Oversight fix: Flutes shouldn't be fakeable.
/:cl:
