### PR TITLE
Bag of Storing

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -37,6 +37,20 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 12
 
+/obj/item/storage/backpack/storing
+	name = "bag of storing"
+	desc = "A small backpack that opens into a localized pocket of bluespace."
+	icon_state = "holdingpack"
+	item_state = "holdingpack"
+	resistance_flags = FIRE_PROOF
+	item_flags = NO_MAT_REDEMPTION
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
+	
+/obj/item/storage/backpack/storing/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 35
+
 /obj/item/boh_shell
 	name = "bag of holding shell"
 	desc = "An inert shell, it looks like you could activate it with an anomaly core."

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -24,7 +24,7 @@
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/bag_holding
+/datum/design/bag_storing
 	name = "Bag of Storing"
 	desc = "A small backpack that opens into a localized pocket of bluespace."
 	id = "bag_storing"
@@ -32,7 +32,6 @@
 	materials = list(/datum/material/iron = 1000, /datum/material/gold = 2000, /datum/material/diamond = 1000, /datum/material/uranium = 200, /datum/material/bluespace = 1500)
 	build_path = /obj/item/storage/backpack/storing
 	category = list("Bluespace Designs")
-	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/bluespace_crystal

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -24,6 +24,17 @@
 	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/bag_holding
+	name = "Bag of Storing"
+	desc = "A small backpack that opens into a localized pocket of bluespace."
+	id = "bag_storing"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/gold = 2000, /datum/material/diamond = 1000, /datum/material/uranium = 200, /datum/material/bluespace = 1500)
+	build_path = /obj/item/storage/backpack/storing
+	category = list("Bluespace Designs")
+	dangerous_construction = TRUE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/bluespace_crystal
 	name = "Artificial Bluespace Crystal"
 	desc = "A small blue crystal with mystical properties."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -220,7 +220,7 @@
 	display_name = "Advanced Bluespace Storage"
 	description = "With the use of bluespace we can create even more advanced storage devices than we could have ever done"
 	prereq_ids = list("micro_bluespace", "janitor")
-	design_ids = list("bag_holding")
+	design_ids = list("bag_holding", "bag_storing")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/practical_bluespace


### PR DESCRIPTION
Some jobs are pretty tight for items they need to carry for their job, a lot of them used the BoH to remove that strain
This adds a "downgrade" to the bag of holding that doesn't require an anomaly core, but also doesn't allow for larger items to be put inside it.

:cl:  
rscadd: Adds storage upgrade that doesn't "break balance"
/:cl:
