### PR TITLE
Disables TEG from engine rotation, new engine rotation is 50/50 SM:Sing/Tesla

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 30, "Engine TEG" = 20)
+	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 50, "Engine TEG" = 0)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -137,7 +137,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Transfer 1", "Transfer 2", "Transfer 3", "Transfer 4", "Transfer 5", "Transfer 6", "Transfer 7", "Transfer 8", "Transfer 9", "Transfer 10")
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta Singulo And Tesla" = 30, "Meta SM" = 50, "Meta TEG" = 20)
+	template_names = list("Meta Singulo And Tesla" = 50, "Meta SM" = 50, "Meta TEG" = 0)
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION

# Document the changes in your pull request

TEG can no longer be randomly chosen. Map file still exists and it can still be forced in config.

# Why this is a good change

The TEG is stupidly complicated and isn't beginner friendly at all. It relies more on atmospherics knowledge than engineering knowledge, which makes it stupid to be an engine the ENGINEERS have to set up. Atmos also has a spot to put a TEG on both box and meta (those are the only ones I know of), so there really isn't a huge loss here.

# Spriting
.

# Wiki Documentation

Note on the TEG engine page it doesn't randomly spawn
# Changelog



:cl:  
rscdel: removes teg from roundstart rotation
tweak: tesla/sing and SM have a 50/50 chance to spawn
/:cl:
