### PR TITLE
Fixes an oldstation double APC and adds a comment to the singulo doc

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2573,7 +2573,9 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper/fluff/ruins/oldstation/protosing,
+/obj/item/paper/fluff/ruins/oldstation/protosing{
+	info = "<b>*Singularity Generator*</b><br><br>Modern power generation typically comes in two forms, a Fusion Generator or a Fission Generator. Fusion provides the best space to power ratio, and is typically seen on military or high security ships and stations, however Fission reactors require the usage of expensive, and rare, materials in its construction.. Fission generators are massive and bulky, and require a large reserve of uranium to power, however they are extremely cheap to operate and oft need little maintenance once operational.<br><br>The Singularity aims to alter this, a functional Singularity is essentially a controlled Black Hole, a Black Hole that generates far more power than Fusion or Fission generators can ever hope to produce. If you keep the containment field running, that is."
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/proto)
 "kA" = (
@@ -7208,12 +7210,6 @@
 /area/ruin/space/has_grav/ancientstation/deltaai)
 "Mk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Charlie Security APC";
-	pixel_x = -25;
-	start_charge = 0
-	},
 /obj/structure/closet/secure_closet/personal/prisoner{
 	req_access = null
 	},


### PR DESCRIPTION
bugs

# Document the changes in your pull request

Removes a double APC from Charlie Station.
Double APCs are bad.

The comment in the singulo document was just a reminder to use containment fields.

# Spriting

no

# Wiki Documentation

no

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: adds a reminder to the Oldstation singulo generator document to add containment fields
bugfix: removes a double APC from Oldstation
/:cl:
