### PR TITLE
Better informs users why they can't buy objective-restricted items

### DIFF
--- a/yogstation/code/datums/components/uplink.dm
+++ b/yogstation/code/datums/components/uplink.dm
@@ -18,5 +18,5 @@
     if(canBuy)
         return ..()
 
-    to_chat(user, span_warning("The Syndicate only permits [U.name][U.name[LAZYLEN(U.name)] == "s" ? "s" : ""] to specific agents. \
+    to_chat(user, span_warning("The Syndicate only permits [U.name][U.name[LAZYLEN(U.name)] != "s" ? "s" : ""] to specific agents. \
 								Your mission does not require this equipment."))

--- a/yogstation/code/datums/components/uplink.dm
+++ b/yogstation/code/datums/components/uplink.dm
@@ -18,4 +18,5 @@
     if(canBuy)
         return ..()
 
-    to_chat(user, span_warning("The Syndicate lacks resources to provide you with this item."))
+    to_chat(user, span_warning("The Syndicate only permits [U.name][U.name[LAZYLEN(U.name)] == "s" ? "s" : ""] to specific agents. \
+								Your mission does not require this equipment."))


### PR DESCRIPTION
# Document the changes in your pull request

"The Syndicate lacks resources to provide you with this item."
->
"The Syndicate only permits Neural Overclocker Implants to specific agents. Your mission does not require this equipment."

# Changelog

:cl:  
tweak: Better informed users why they can't buy objective-restricted items
/:cl:
