### PR TITLE
returns the plastic recipe to making plastic instead of needing to becooled because plastic didn't die it was MURDERED

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -760,9 +760,13 @@
 /datum/chemical_reaction/plastic_polymers
 	name = "plastic polymers"
 	id = /datum/reagent/plastic_polymers
-	results = list(/datum/reagent/plastic_polymers = 10)
 	required_reagents = list(/datum/reagent/oil = 5, /datum/reagent/toxin/acid = 2, /datum/reagent/ash = 3)
 	required_temp = 374
+
+/datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i in 1 to created_volume)
+		new /obj/item/stack/sheet/plastic(location)
 
 /datum/chemical_reaction/plastic_solidification
 	name = "plastic solidification"


### PR DESCRIPTION
# Document the changes in your pull request

idk what the beef is against roundstart chemicals you are expected to make and being mixable without taking 50 different steps

# Wiki Documentation

this wasn't ever updated on the wiki, so no change needed

# Changelog

:cl:  
tweak: plastic is now actually mixed on being mixed and  heated rather than needing to be cooled immediately after because I HATE FUN
/:cl:
