### PR TITLE
Adds a cooldown to Communications Console Emergency Maint revocation

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -346,6 +346,9 @@
 			if (!authenticated_as_silicon_or_captain(usr))
 				return
 			if (GLOB.emergency_access)
+				if (!COOLDOWN_FINISHED(src, important_action_cooldown))
+					to_chat(usr, span_alert("Maintenance airlock communications relays recharging. Please stand by."))
+					return
 				revoke_maint_all_access()
 				log_game("[key_name(usr)] disabled emergency maintenance access.")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] disabled emergency maintenance access.")
@@ -355,6 +358,7 @@
 				log_game("[key_name(usr)] enabled emergency maintenance access.")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] enabled emergency maintenance access.")
 				deadchat_broadcast(" enabled emergency maintenance access at [span_name("[get_area_name(usr, TRUE)]")].", span_name("[usr.real_name]"), usr)
+				COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 		if ("printSpare")
 			if (authenticated_as_non_silicon_head(usr))
 				if (!COOLDOWN_FINISHED(src, important_action_cooldown))


### PR DESCRIPTION
Back again with another cooldown timeout (related: #3125) because we had a fun little Halloween communications incident today. 🎃

This ties in the Emergency Maint **revocation** action to the same cooldown everything else in the console uses. The cooldown is a bit long, so it only prevents the *revocation*, not the activation of the emergency maint. This way, you won't be forced to wait when the radstorm rolls in, but you will need to wait to remove it afterwards (60 seconds). I could have made a new shorter cooldown, but it seemed like it was an unclean way to handle this, given the rest of the console all uses one cooldown already. 

This is why we can't have nice things.

One good thing about these trolls/griefers, I suppose: they do expose areas we need to clean up in our codebase. Don't get any ideas, though.

# Changelog

:cl:  
tweak: Due to budget cuts, Centcom has delayed the Emergency Maint. circuits.
/:cl:
