### PR TITLE
Suit sensor monitor minor visual changes for QoL

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -221,7 +221,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					//warnings checks
 					if(!is_wounded && !is_onfire && !is_irradiated && !is_husked && !is_disabled && !is_bonecrack)
 						no_warnings = TRUE
-
+					else
+						no_warnings = FALSE
+										
 					//check if has disabled limbs
 					for(var/obj/item/bodypart/part in H.bodyparts)
 						if(part.bodypart_disabled == TRUE)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -158,7 +158,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				var/is_onfire = FALSE
 				var/is_bonecrack = FALSE
 				var/is_disabled = FALSE
-				var/no_warnings = FALSE
+				var/has_warnings = FALSE
 
 				if (I)
 					name = I.registered_name
@@ -217,12 +217,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 						species = "Alien"
 					if (isandroid(H))
 						species = "Android"
-
-					//warnings checks
-					if(!is_wounded && !is_onfire && !is_irradiated && !is_husked && !is_disabled && !is_bonecrack)
-						no_warnings = TRUE
-					else
-						no_warnings = FALSE
 										
 					//check if has disabled limbs
 					for(var/obj/item/bodypart/part in H.bodyparts)
@@ -254,6 +248,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					if(H.on_fire == TRUE) //check if on fire
 						is_onfire = TRUE
 
+					//warnings checks
+					if(is_wounded || is_onfire || is_irradiated || is_husked || is_disabled || is_bonecrack)
+						has_warnings = TRUE
+					else
+						has_warnings = FALSE
+
 				else
 					oxydam = null
 					toxdam = null
@@ -275,7 +275,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				if(life_status == FALSE)
 					new_death_list.Add(H)
 
-				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "no_warnings" = no_warnings, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
+				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "has_warnings" = has_warnings, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
 
 	data_by_z["[z]"] = sortTim(results,/proc/sensor_compare)
 	last_update["[z]"] = world.time

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -218,11 +218,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					if (isandroid(H))
 						species = "Android"
 										
-					//check if has disabled limbs
 					for(var/obj/item/bodypart/part in H.bodyparts)
-						if(part.bodypart_disabled == TRUE)
+						if(part.bodypart_disabled == TRUE) //check if has disabled limbs
 							is_disabled = TRUE
-					if(length(H.get_missing_limbs()))
+						if(locate(/obj/item) in part.embedded_objects) //check if has embed objects
+							is_wounded = TRUE
+					if(length(H.get_missing_limbs())) //check if has missing limbs
 						is_disabled = TRUE
 					
 					//check if has generic wounds except for bone one

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -251,8 +251,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					//warnings checks
 					if(is_wounded || is_onfire || is_irradiated || is_husked || is_disabled || is_bonecrack)
 						no_warnings = TRUE
-					else
-						no_warnings = FALSE
 
 				else
 					oxydam = null

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -158,7 +158,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				var/is_onfire = FALSE
 				var/is_bonecrack = FALSE
 				var/is_disabled = FALSE
-				var/has_warnings = FALSE
+				var/no_warnings = FALSE
 
 				if (I)
 					name = I.registered_name
@@ -250,9 +250,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 					//warnings checks
 					if(is_wounded || is_onfire || is_irradiated || is_husked || is_disabled || is_bonecrack)
-						has_warnings = TRUE
+						no_warnings = TRUE
 					else
-						has_warnings = FALSE
+						no_warnings = FALSE
 
 				else
 					oxydam = null
@@ -275,7 +275,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				if(life_status == FALSE)
 					new_death_list.Add(H)
 
-				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "has_warnings" = has_warnings, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
+				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "no_warnings" = no_warnings, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
 
 	data_by_z["[z]"] = sortTim(results,/proc/sensor_compare)
 	last_update["[z]"] = world.time

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -158,6 +158,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				var/is_onfire = FALSE
 				var/is_bonecrack = FALSE
 				var/is_disabled = FALSE
+				var/no_warnings = FALSE
 
 				if (I)
 					name = I.registered_name
@@ -217,6 +218,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 					if (isandroid(H))
 						species = "Android"
 
+					//warnings checks
+					if(!is_wounded && !is_onfire && !is_irradiated && !is_husked && !is_disabled && !is_bonecrack)
+						no_warnings = TRUE
+
 					//check if has disabled limbs
 					for(var/obj/item/bodypart/part in H.bodyparts)
 						if(part.bodypart_disabled == TRUE)
@@ -268,7 +273,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				if(life_status == FALSE)
 					new_death_list.Add(H)
 
-				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
+				results[++results.len] = list("name" = name, "assignment_title" = assignment_title, "assignment" = assignment, "ijob" = ijob, "is_wounded" = is_wounded, "no_warnings" = no_warnings, "is_onfire" = is_onfire, "is_husked" = is_husked, "is_bonecrack" = is_bonecrack, "is_disabled" = is_disabled, "is_irradiated" = is_irradiated, "species" = species, "life_status" = life_status, "oxydam" = oxydam, "toxdam" = toxdam, "burndam" = burndam, "brutedam" = brutedam, "area" = area, "pos_x" = pos_x, "pos_y" = pos_y, "can_track" = H.can_track(null))
 
 	data_by_z["[z]"] = sortTim(results,/proc/sensor_compare)
 	last_update["[z]"] = world.time

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -232,7 +232,7 @@ export const CrewConsoleContent = (props, context) => {
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   {sensor.oxydam !== null ? (
-                    sensor.has_warnings ? (
+                    sensor.no_warnings ? (
                       <Box>
                         {sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : ""}
                         {sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : ""}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -231,12 +231,21 @@ export const CrewConsoleContent = (props, context) => {
                   ({!originalTitles ? sensor.assignment_title : sensor.assignment})
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
-                  {sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : ""}
-                  {sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : ""}
-                  {sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : ""}
-                  {sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : ""}
-                  {sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : ""}
-                  {sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : ""}
+                  {sensor.oxydam !== null ? (
+                    sensor.no_warnings ? (
+                      <Box inline>
+                        {sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : ""}
+                        {sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : ""}
+                        {sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : ""}
+                        {sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : ""}
+                        {sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : ""}
+                        {sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : ""}
+                      </Box>
+                    ) : (
+                      <Icon name="check" color="#10d820" size={1} />)
+                  ) : (
+                    <Icon name="question" color="#f70505" size={1} />
+                  )}
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   {speciesmap[sensor.species] ? <Icon name={speciesmap[sensor.species].icon} color={speciesmap[sensor.species].color} size={1} /> : <Icon name="question" color="#f70505" size={1} />}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -232,15 +232,17 @@ export const CrewConsoleContent = (props, context) => {
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   {sensor.oxydam !== null ? (
-                    sensor.no_warnings ? (
-                      <Icon name="check" color="#10d820" size={1} />
+                    sensor.has_warnings ? (
+                      <Box>
+                        {sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : ""}
+                        {sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : ""}
+                        {sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : ""}
+                        {sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : ""}
+                        {sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : ""}
+                        {sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : ""}
+                      </Box>
                     ) : (
-                      sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : "",
-                      sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : "",
-                      sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : "",
-                      sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : "",
-                      sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : "",
-                      sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : "")
+                      <Icon name="check" color="#10d820" size={1} />)
                   ) : (
                     <Icon name="question" color="#f70505" size={1} />
                   )}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -233,16 +233,14 @@ export const CrewConsoleContent = (props, context) => {
                 <Table.Cell collapsing textAlign="center">
                   {sensor.oxydam !== null ? (
                     sensor.no_warnings ? (
-                      <Box inline>
-                        {sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : ""}
-                        {sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : ""}
-                        {sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : ""}
-                        {sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : ""}
-                        {sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : ""}
-                        {sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : ""}
-                      </Box>
+                      <Icon name="check" color="#10d820" size={1} />
                     ) : (
-                      <Icon name="check" color="#10d820" size={1} />)
+                      sensor.is_irradiated ? <Icon name="radiation" color="#f0e21d" size={1} /> : "",
+                      sensor.is_husked ? <Icon name="ribbon" color="#ad1c09" size={1} /> : "",
+                      sensor.is_onfire ? <Icon name="fire" color="#f24f0f" size={1} /> : "",
+                      sensor.is_wounded ? <Icon name="star-of-life" color="#d412ff" size={1} /> : "",
+                      sensor.is_bonecrack ? <Icon name="bone" color="#f50505" size={1} /> : "",
+                      sensor.is_disabled ? <Icon name="crutch" color="#fafcfb" size={1} /> : "")
                   ) : (
                     <Icon name="question" color="#f70505" size={1} />
                   )}


### PR DESCRIPTION
This is for indicating status below warnings column if the person has no hazardous effects or when the person has binary sensor. Because it will help other people to notice the difference between binary sensor and vital sensor/tracking sensor on warning column

# Document the changes in your pull request
wound check will now detect embed objs in body
icon "check" will appear in warnings column when there are no harazdous icons
icon "question" will appear in warnings column when suit sensor is at binary level
## new:
![image](https://user-images.githubusercontent.com/89688125/199241697-bc9c1b58-74a7-44f8-87d4-7b759ac9d04d.png)
## old:
![image](https://user-images.githubusercontent.com/89688125/199402456-5a741ba1-54a5-4c18-afa4-e54b58c938f6.png)







# Wiki Documentation
<details><summary>In document of changes</summary>

> icon "check" will appearon warnings column when there are no harazdous icons
icon "question" will appear on warnings column when suit sensor is at binary level
wound check will now detect embed objs in body
new:
![image](https://user-images.githubusercontent.com/89688125/199241697-bc9c1b58-74a7-44f8-87d4-7b759ac9d04d.png)
old:
![image](https://user-images.githubusercontent.com/89688125/199402456-5a741ba1-54a5-4c18-afa4-e54b58c938f6.png)


</details>

# Changelog



:cl:  
rscadd: icon "check" will now appear in warnings column when there are no harazdous icons
rscadd: icon "question" will now appear in warnings column when suit sensor is at binary level
rscadd: wound check will now detect embed objs in body
/:cl: