### PR TITLE
Fixes various bugs picked up by an OpenDream compile attempt

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -42,6 +42,7 @@
 #define BLOOD_DEAD 0
 
 //Defines to get the actual volumes for these varying states
+//YOGS: Keep in mind that in BYOND, initial() is a non-const function and doesn't work correctly in switch statements!
 #define BLOOD_VOLUME_MAXIMUM(L)		(initial(##L.blood_volume) * BLOOD_MAXIMUM_MULTI)
 #define BLOOD_VOLUME_NORMAL(L)		(initial(##L.blood_volume))
 #define BLOOD_VOLUME_SAFE(L)		(initial(##L.blood_volume) * BLOOD_SAFE_MULTI)

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
@@ -137,10 +137,10 @@
 	// Special check: Nosferatu will always be Pale Death
 	if(HAS_TRAIT(src, TRAIT_MASQUERADE))
 		return BLOODSUCKER_HIDE_BLOOD
-	switch(blood_volume)
-		if(BLOOD_VOLUME_OKAY(user) to BLOOD_VOLUME_SAFE(user))
+	if(blood_volume <= BLOOD_VOLUME_SAFE(user)) // Not a lotta blood!
+		if(blood_volume > BLOOD_VOLUME_OKAY(user))
 			return "[p_they(TRUE)] [p_have()] pale skin.\n"
-		if(BLOOD_VOLUME_BAD(user) to BLOOD_VOLUME_OKAY(user))
+		else
 			return "<b>[p_they(TRUE)] look[p_s()] like pale death.</b>\n"
 	// If a Bloodsucker is malnourished, AND if his temperature matches his surroundings (aka he hasn't fed recently and looks COLD)
 //	return blood_volume < BLOOD_VOLUME_OKAY // && !(bodytemperature <= get_temperature() + 2)

--- a/code/modules/antagonists/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/code/modules/antagonists/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -672,7 +672,7 @@
 	/// Conversion Process
 	if(convert_progress > 0)
 		to_chat(user, span_notice("You spill some blood and prepare to initiate [target] into your service."))
-		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_COST)
+		bloodsuckerdatum.AddBloodVolume(-text2num(TORTURE_BLOOD_COST))
 		if(!do_torture(user,target))
 			to_chat(user, span_danger("<i>The ritual has been interrupted!</i>"))
 		else
@@ -717,7 +717,7 @@
 		to_chat(user, span_danger("<i>They're mindshielded! Break their mindshield with a candelabrum or surgery before continuing!</i>"))
 		return
 	/// Convert to Vassal!
-	bloodsuckerdatum.AddBloodVolume(-TORTURE_CONVERSION_COST)
+	bloodsuckerdatum.AddBloodVolume(-text2num(TORTURE_CONVERSION_COST))
 	if(bloodsuckerdatum && bloodsuckerdatum.attempt_turn_vassal(target))
 		bloodsuckerdatum.bloodsucker_level_unspent++
 		user.playsound_local(null, 'sound/effects/explosion_distant.ogg', 40, TRUE)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -969,7 +969,7 @@ nobliumformation = 1001
 		air.adjust_moles(/datum/gas/bz, -consumed_amount)
 	else
 		for(var/mob/living/carbon/L in location)
-			L.hallucination += (air.get_moles(/datum/gas/bz * 0.7))
+			L.hallucination += (air.get_moles(/datum/gas/bz) * 0.7) // Yogs -- fixed accidental "path * number"
 	energy_released += 100
 	if(energy_released)
 		var/new_heat_capacity = air.heat_capacity()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -220,7 +220,7 @@
 		var/obj/item/I = target
 		I.item_state = initial(picked_item.item_state)
 		I.mob_overlay_icon = initial(picked_item.mob_overlay_icon)
-		if(istype(I, /obj/item/clothing) && istype(initial(picked_item), /obj/item/clothing))
+		if(istype(I, /obj/item/clothing) && istype(picked_item, /obj/item/clothing))
 			var/obj/item/clothing/CL = I
 			var/obj/item/clothing/PCL = picked_item
 			CL.flags_cover = initial(PCL.flags_cover)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1896,7 +1896,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	generate_data_info(data)
 
 /datum/reagent/consumable/ethanol/fruit_wine/proc/generate_data_info(list/data)
-	var/minimum_percent = 0.15 //Percentages measured between 0 and 1.
+	var/const/minimum_percent = 0.15 //Percentages measured between 0 and 1.
+	//Yogs -- Fixed missing const specifier. Following code doesn't work right otherwise!
 	var/list/primary_tastes = list()
 	var/list/secondary_tastes = list()
 	glass_name = "glass of [name]"

--- a/yogstation/code/game/objects/items/plushes.dm
+++ b/yogstation/code/game/objects/items/plushes.dm
@@ -137,8 +137,7 @@
 		new/obj/item/toy/plush/goatplushie/angry/guardgoat(location)
 		new/obj/item/toy/plush/goatplushie/angry/guardgoat(location)
 
-/obj/item/toy/plush/goatplushie/angry/kinggoat/attackby(/obj/item/reagent_containers/food/snacks/grown/cabbage/C,mob/living/user,params)
-		var/C = /obj/item/reagent_containers/food/snacks/grown/cabbage
+/obj/item/toy/plush/goatplushie/angry/kinggoat/attackby(obj/item/reagent_containers/food/snacks/grown/cabbage/C,mob/living/user,params)
 		user.visible_message(span_notice("[user] watches as [src] takes a bite out of the cabbage!"), span_notice("[src]'s fur now starts glowing it seems it has ascended!"))
 		playsound(src, 'sound/items/eatfood.ogg', 50, 1)
 		qdel(C)


### PR DESCRIPTION
## Summary
Hi guys, I'm back for a second.

I tried to compile Yogstation on OD again. I've been working on improving the const-folding available, and this resulted in OD picking up a lot of broken arithmetic and switch statements scattered about the place, which under BYOND just mysteriously runtimes or causes strange behaviour silently.

So, guess what, here's a bunch of fixes for that!

## Changelog

:cl:  Altoids
bugfix: Fixed non-bloodsuckers not consistently showing that they have pale skin.
bugfix: Fixed some sorts of bloodsucking not reducing blood volume.
bugfix: Fixed some wines not always displaying their taste correctly.
bugfix: Fixed the King Goat plushie maybe not correctly eating his cabbage.
/:cl:
