### PR TITLE
No longer lets geneless species use genetics injectors

### DIFF
--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -74,6 +74,7 @@
 
 	if(!inject(target, user))	//Now we actually do the heavy lifting.
 		to_chat(user, span_notice("It appears that [target] does not have compatible DNA."))
+		return //don't use up the injector if the target doesn't have compatible DNA
 
 	used = 1
 	icon_state = "dnainjector0"


### PR DESCRIPTION
IPC could waste activators on themselves and recycle them for chromosomes, this let them get effectively infinite chromosomes

:cl:  
bugfix: species without genes can't use injectors anymore
/:cl:
