### PR TITLE
[ASTEROID] adjust id in exterior airlock cycle button on ai sat to exterior instead of interior (Please review this baiomu)

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -23022,30 +23022,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"gSV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat  Antechamber";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = 23;
-	pixel_y = -7
-	},
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "ai_core_airlock_exterior";
-	idInterior = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "gSW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -25466,6 +25442,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hHn" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat  Antechamber";
+	dir = 8;
+	network = list("minisat","ss13")
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_exterior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 23;
+	pixel_y = -7
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "ai_core_airlock_exterior";
+	idInterior = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 25;
+	pixel_y = 7
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "hHA" = (
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
@@ -130051,7 +130051,7 @@ cFh
 nZa
 aSh
 gsy
-gSV
+hHn
 tPg
 qEP
 ndM


### PR DESCRIPTION
 # It was set to interior, so when you press it, the interior door gets opened instead so i set it back to exterior
![image](https://user-images.githubusercontent.com/89688125/199660606-56eec9b6-3c34-46c5-bd6c-8244e43fbc2b.png)

# Document of changes
Adjust exterior airlock cycle button id to exterior



# Changelog



:cl:  

mapping: Adjust exterior airlock cycle button id to exterior

/:cl:
