### PR TITLE
Conveyor now costs less to build in autolathe and is now printable in cargo protolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1002,7 +1002,7 @@
 	materials = list(/datum/material/iron = 450, /datum/material/glass = 190)
 	build_path = /obj/item/conveyor_switch_construct
 	category = list("initial", "Construction", "Assemblies")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/laptop
 	name = "Laptop Frame"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -988,11 +988,11 @@
 	name = "Conveyor Belt"
 	id = "conveyor_belt"
 	build_type = AUTOLATHE | MECHFAB | PROTOLATHE
-	materials = list(/datum/material/iron = 3000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/stack/conveyor
 	category = list("initial", "Construction", "Misc", "Assemblies")
 	maxstack = 30
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO
 
 
 /datum/design/conveyor_switch

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -989,7 +989,7 @@
 	id = "conveyor_belt"
 	build_type = AUTOLATHE | MECHFAB | PROTOLATHE
 	materials = list(/datum/material/iron = 1000)
-	build_path = /obj/item/stack/conveyor
+	build_path = /obj/item/stack/conveyor/thirty
 	category = list("initial", "Construction", "Misc", "Assemblies")
 	maxstack = 30
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO


### PR DESCRIPTION
 - Conveyor belt material is 1000 iron by the lastest pr #15751  but the the cost to build it is 3000, which doesnt make sense so i changed it

	`materials = list(/datum/material/iron = 1000)`


# Document the changes in your pull request

Conveyor now costs less to build in autolathe (1000 iron) and is now printable in cargo protolathe


# Wiki Documentation
Conveyor now costs less to build in autolathe (1000 iron) and is now printable in cargo protolathe

# Changelog



:cl:  

tweak: Conveyor now costs less to build in autolathe (1000 iron) and is now printable in cargo protolathe
/:cl:
