### PR TITLE
ruins lavaland teleport cubes 

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -389,6 +389,10 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		return
 	if(teleporting)
 		return
+	if(!is_mining_level(current_location.z))
+		user.visible_message(span_danger("[user] starts fiddling with [src]!"))
+		if(!do_after(user, 3 SECONDS, user))
+			return
 	teleporting = TRUE
 	linked.teleporting = TRUE
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
# Document the changes in your pull request

not a fan of people teleporting to a safe area instantly at the first sign of danger so i'm making cubes take 3 seconds to use when you're not using one on lavaland

# Wiki Documentation

include the 3 second channel time for using a cube while off lavaland in this bit where the cubes are https://wiki.yogstation.net/wiki/Shaft_Miner#Necropolis_Chest_Loot


# Changelog

:cl:  
tweak: 3 second channel to use cube off lavaland  
/:cl:
