### PR TITLE
Fixes NTSL scripts not working

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -67,7 +67,7 @@
 
 
 //Returns null if there is any bad text in the string
-/proc/reject_bad_text(text, max_length = 512, ascii_only = TRUE, require_pretty=TRUE)
+/proc/reject_bad_text(text, max_length = 512, ascii_only = TRUE, require_pretty=TRUE, allow_newline=FALSE, allow_code=FALSE)
 	if(require_pretty && isnotpretty(text))
 		return
 	var/char_count = 0
@@ -80,9 +80,17 @@
 		if(char_count > max_length)
 			return
 		switch(text2ascii(char))
-			if(62, 60, 92, 47) // <, >, \, /
+			if(9, 62, 60, 92, 47) // tab, <, >, \, /
+				if(!allow_code)
+					return
+			if(10, 13) //Carriage returns (CR) and newline (NL)
+				if(!allow_newline)
+					return
+			if(0 to 8)
 				return
-			if(0 to 31)
+			if(11, 12)
+				return
+			if(14 to 31)
 				return
 			if(32)
 				continue

--- a/yogstation/code/game/machinery/telecomms/machines/server.dm
+++ b/yogstation/code/game/machinery/telecomms/machines/server.dm
@@ -54,7 +54,7 @@
 		to_chat(user, span_warning("You are banned from using NTSL."))
 		return
 	if(Compiler)
-		if(!reject_bad_text(rawcode, 20000, require_pretty = FALSE))
+		if(!reject_bad_text(rawcode, 20000, require_pretty = FALSE, allow_newline = TRUE, allow_code = TRUE))
 			rawcode = null
 			to_chat(user, span_warning("Server is out of memory. Please shorten your script."))
 			return

--- a/yogstation/code/game/machinery/telecomms/machines/server.dm
+++ b/yogstation/code/game/machinery/telecomms/machines/server.dm
@@ -52,14 +52,13 @@
 /obj/machinery/telecomms/server/proc/compile(mob/user = usr)
 	if(is_banned_from(user.ckey, "Network Admin"))
 		to_chat(user, span_warning("You are banned from using NTSL."))
-		return
+		return "Unauthorized access."
 	if(Compiler)
 		if(!reject_bad_text(rawcode, 20000, require_pretty = FALSE, allow_newline = TRUE, allow_code = TRUE))
 			rawcode = null
-			return
+			return "Please use galactic common characters only."
 		if(!COOLDOWN_FINISHED(src, compile_cooldown))
-			to_chat(user, span_warning("Compiler recharging, please wait..."))
-			return
+			return "Servers are recharging, please wait."
 		var/list/compileerrors = Compiler.Compile(rawcode)
 		COOLDOWN_START(src, compile_cooldown, 2 SECONDS)
 		if(!compileerrors.len && (compiledcode != rawcode))

--- a/yogstation/code/game/machinery/telecomms/machines/server.dm
+++ b/yogstation/code/game/machinery/telecomms/machines/server.dm
@@ -56,10 +56,9 @@
 	if(Compiler)
 		if(!reject_bad_text(rawcode, 20000, require_pretty = FALSE, allow_newline = TRUE, allow_code = TRUE))
 			rawcode = null
-			to_chat(user, span_warning("Server is out of memory. Please shorten your script."))
 			return
 		if(!COOLDOWN_FINISHED(src, compile_cooldown))
-			to_chat(user, span_warning("Recharging. Please wait"))
+			to_chat(user, span_warning("Compiler recharging, please wait..."))
 			return
 		var/list/compileerrors = Compiler.Compile(rawcode)
 		COOLDOWN_START(src, compile_cooldown, 2 SECONDS)

--- a/yogstation/code/modules/scripting/IDE.dm
+++ b/yogstation/code/modules/scripting/IDE.dm
@@ -52,7 +52,7 @@
 					if(!compileerrors)
 						src << output("<b>NTSL.exe Error</b>", "tcserror")
 						src << output("<font color = red>\t><b>A fatal error has occured. Please contact your local network adminstrator.</b></font color>", "tcserror")
-					else if(istext(compileerrors)
+					else if(istext(compileerrors))
 						src << output("<b>NTSL.exe Error</b>", "tcserror")
 						src << output("<font color = red>\t><b>[compileerrors]</b></font color>", "tcserror")
 					else if(length(compileerrors))

--- a/yogstation/code/modules/scripting/IDE.dm
+++ b/yogstation/code/modules/scripting/IDE.dm
@@ -49,7 +49,10 @@
 					if(!telecomms_check(mob))
 						return
 
-					if(compileerrors.len)
+					if(!compileerrors)
+						src << output("<b>Memory Error:</b> Script ran out of memory. Please ensure that the script does not have a large file size and contains no special characters.", "tcserror")
+
+					else if(compileerrors.len)
 						src << output("<b>Compile Errors</b>", "tcserror")
 						var/i = 1
 						for(var/scriptError/e in compileerrors)

--- a/yogstation/code/modules/scripting/IDE.dm
+++ b/yogstation/code/modules/scripting/IDE.dm
@@ -45,14 +45,17 @@
 					src << output(null, "tcserror")
 					src << output("Compiling on [Server.name]...", "tcserror")
 
-					var/list/compileerrors = Server.compile(mob) // then compile the code!
+					var/list/compileerrors = Server.compile(mob) // then compile the code! this can return a string or a list.
 					if(!telecomms_check(mob))
 						return
 
 					if(!compileerrors)
-						src << output("<b>Memory Error:</b> Script ran out of memory. Please ensure that the script does not have a large file size and contains no special characters.", "tcserror")
-
-					else if(compileerrors.len)
+						src << output("<b>NTSL.exe Error</b>", "tcserror")
+						src << output("<font color = red>\t><b>A fatal error has occured. Please contact your local network adminstrator.</b></font color>", "tcserror")
+					else if(istext(compileerrors)
+						src << output("<b>NTSL.exe Error</b>", "tcserror")
+						src << output("<font color = red>\t><b>[compileerrors]</b></font color>", "tcserror")
+					else if(length(compileerrors))
 						src << output("<b>Compile Errors</b>", "tcserror")
 						var/i = 1
 						for(var/scriptError/e in compileerrors)
@@ -78,7 +81,7 @@
 								M << output("([compileerrors.len] errors)", "tcserror")
 
 
-					else // If no errors
+					else // Returned a blank list, means no errors.
 						src << output("<font color = blue>TCS compilation successful!</font color>", "tcserror")
 						src << output("Time of compile: [gameTimestamp("hh:mm:ss")]","tcserror")
 						//. ^ To make it obvious that it's done a new compile


### PR DESCRIPTION
This should theoretically fix tcomms by allowing more characters to be used. The proc ``reject_bad_text()`` was edited to accept more args so that characters essential to making an NTSL script (such as tab, newlines, carriage returns, < and >, / and \) can be accepted.

You can cross check the ASCII codes here: https://www.w3schools.com/charsets/ref_html_ascii.asp

# Changelog

:cl:  BurgerBB
bugfix: Fixes NTSL script sanitization being too strict.
/:cl:
