### PR TITLE
Adds Limb Autosurgeons and two Syndicate augmentation kits

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -153,3 +153,23 @@
 	name = "implanter (internal syndicate radio)"
 	imp_type = /obj/item/implant/radio/syndicate
 
+/obj/item/implant/empshield
+	name = "EMP shield implant"
+	activated = 0
+
+/obj/item/implant/empshield/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	if(..())
+		if(ishuman(target))
+			target.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
+		return TRUE
+
+/obj/item/implant/empshield/removed(mob/target, silent = FALSE, special = 0)
+	if(..())
+		if(ishuman(target))
+			var/datum/component/empprotection/empshield = target.GetExactComponent(/datum/component/empprotection)
+			empshield.RemoveComponent()
+		return TRUE
+
+/obj/item/implanter/empshield
+	name = "implanter (EMP shield)"
+	imp_type = /obj/item/implant/empshield

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -530,14 +530,14 @@
 	new /obj/item/reagent_containers/syringe(src)
 
 /obj/item/storage/box/syndie_kit/pistolammo
-	name = "10mm magazine box"
+	real_name = "10mm magazine box"
 
 /obj/item/storage/box/syndie_kit/pistolammo/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/ammo_box/magazine/m10mm(src)
 
 /obj/item/storage/box/syndie_kit/pistolsleepyammo
-	name = "10mm soporific magazine box"
+	real_name = "10mm soporific magazine box"
 
 /obj/item/storage/box/syndie_kit/pistolsleepyammo/PopulateContents()
 	for(var/i in 1 to 2)
@@ -668,3 +668,25 @@
 /obj/item/storage/box/official_posters/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/poster/random_official(src)
+
+/obj/item/storage/box/syndie_kit/augmentation
+	real_name = "augmentation kit"
+
+/obj/item/storage/box/syndie_kit/augmentation/PopulateContents()
+	new /obj/item/autosurgeon/limb/head/robot(src)
+	new /obj/item/autosurgeon/limb/chest/robot(src)
+	new /obj/item/autosurgeon/limb/l_arm/robot(src)
+	new /obj/item/autosurgeon/limb/r_arm/robot(src)
+	new /obj/item/autosurgeon/limb/l_leg/robot(src)
+	new /obj/item/autosurgeon/limb/r_leg/robot(src)
+
+/obj/item/storage/box/syndie_kit/augmentation/superior
+	real_name = "superior augmentation kit"
+
+/obj/item/storage/box/syndie_kit/augmentation/superior/PopulateContents()
+	..()
+	new /obj/item/autosurgeon/upgraded_cyberheart(src)
+	new /obj/item/autosurgeon/upgraded_cyberliver(src)
+	new /obj/item/autosurgeon/upgraded_cyberlungs(src)
+	new /obj/item/autosurgeon/upgraded_cyberstomach(src)
+	new /obj/item/implanter/empshield(src)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -95,6 +95,21 @@
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
 
+/obj/item/autosurgeon/upgraded_cyberheart
+	uses = 1
+	starting_organ = /obj/item/organ/heart/cybernetic/upgraded
+
+/obj/item/autosurgeon/upgraded_cyberliver
+	uses = 1
+	starting_organ = /obj/item/organ/liver/cybernetic/upgraded
+
+/obj/item/autosurgeon/upgraded_cyberlungs
+	uses = 1
+	starting_organ = /obj/item/organ/lungs/cybernetic/upgraded
+
+/obj/item/autosurgeon/upgraded_cyberstomach
+	uses = 1
+	starting_organ = /obj/item/organ/stomach/cybernetic/upgraded
 
 /obj/item/autosurgeon/thermal_eyes
 	starting_organ = /obj/item/organ/eyes/robotic/thermals
@@ -160,3 +175,89 @@
 
 /obj/item/autosurgeon/syndicate/spinalspeed
 	starting_organ = /obj/item/organ/cyberimp/chest/spinalspeed
+
+//Limb autosurgeons
+
+/obj/item/autosurgeon/limb
+	name = "limb autosurgeon"
+	desc = "A experimental device that can automatically augment or replace a pre-existing limb with one stored in the autosurgeon. It has a slot to insert limbs and a screwdriver slot for removing accidentally added items."
+	organ_type = /obj/item/bodypart //Not an organ but guh
+
+/obj/item/autosurgeon/limb/attack_self(mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+	if(!uses)
+		to_chat(user, span_warning("[src] has already been used. The tools are dull and won't reactivate."))
+		return
+	else if(!storedorgan)
+		to_chat(user, span_notice("[src] currently has no limb stored."))
+		return
+	var/obj/item/bodypart/augmentor = storedorgan
+	augmentor.replace_limb(user, TRUE)
+	user.visible_message(span_danger("[user] presses a button on [src], and you watch as the device replaces one of their limbs!"), span_danger("A flash of agony washes over you as [src] replaces one of your limbs."))
+	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
+	storedorgan = null
+	name = initial(name)
+	if(uses != INFINITE)
+		uses--
+	if(!uses)
+		desc = "[initial(desc)] Looks like it's been used up."
+
+/obj/item/autosurgeon/limb/attackby(obj/item/I, mob/user, params)
+	if(istype(I, organ_type))
+		if(storedorgan)
+			to_chat(user, span_notice("[src] already has a limb stored."))
+			return
+		else if(!uses)
+			to_chat(user, span_notice("[src] has already been used up."))
+			return
+		if(!user.transferItemToLoc(I, src))
+			return
+		storedorgan = I
+		to_chat(user, span_notice("You insert the [I] into [src]."))
+	else
+		return ..()
+
+/obj/item/autosurgeon/limb/screwdriver_act(mob/living/user, obj/item/I)
+	if(..())
+		return TRUE
+	if(!storedorgan)
+		to_chat(user, span_notice("There's no limb in [src] for you to remove."))
+	else
+		var/atom/drop_loc = user.drop_location()
+		for(var/J in src)
+			var/atom/movable/AM = J
+			AM.forceMove(drop_loc)
+
+		to_chat(user, span_notice("You remove the [storedorgan] from [src]."))
+		I.play_tool_sound(src)
+		storedorgan = null
+		if(uses != INFINITE)
+			uses--
+		if(!uses)
+			desc = "[initial(desc)] Looks like it's been used up."
+	return TRUE
+
+/obj/item/autosurgeon/limb/head/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/head/robot
+
+/obj/item/autosurgeon/limb/chest/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/chest/robot
+
+/obj/item/autosurgeon/limb/l_arm/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/l_arm/robot
+
+/obj/item/autosurgeon/limb/r_arm/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/r_arm/robot
+
+/obj/item/autosurgeon/limb/l_leg/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/l_leg/robot
+
+/obj/item/autosurgeon/limb/r_leg/robot
+	uses = 1
+	starting_organ = /obj/item/bodypart/r_leg/robot

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1984,6 +1984,22 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	limited_stock = 1
 	include_objectives = list(/datum/objective/martyr, /datum/objective/nuclear) //martyr traitors "straight to the top" or nukies
 
+/datum/uplink_item/implants/augmentation
+	name = "Full Augmentation Kit"
+	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Provides superior damage resistance, immunity to cold and vacuum, \
+			but renders the subject vulnerable to electromagnetic pulses. They will also require repair with a welder and wires, rather than traditional medicine."
+	item = /obj/item/storage/box/syndie_kit/augmentation
+	cost = 15
+	surplus = 0
+
+/datum/uplink_item/implants/augmentation/superior
+	name = "Superior Augmentation Kit"
+	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
+			Finally, it includes an implant to render the subject and their innards immune to EMP. Repair of body will still require a welder and wires."
+	item = /obj/item/storage/box/syndie_kit/augmentation/superior
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
 // Events
 /datum/uplink_item/services
 	category = "Services"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a subtype of autosurgeon known as the limb autosurgeon that stores limbs, rather than organs, specifically for augmentation purposes. Because it calls upon the augmentation check, they should not interfere with any organs or implants present in any limb they replace.

Also adds autosurgeons specifically holding upgraded organs, and an EMP shield implant which renders a user, their organs, limbs, and implants immune to EMP. Does not affect objects on their person or in their inventory.

Adds an augmentation kit to the uplink for 15 TC which contains a full set of limb autosurgeons with cyborg bodyparts. Adds a superior augmentation kit to the nuclear uplink for 25 TC which contains said limb autosurgeons plus the upgraded organ ones and an EMP shield implanter.

Prices might be worth tweaking considering the massive utility of DR to nukies, completely open to suggestions.

Minor adjustment also worth mentioning; I made stechkin ammo box a long time ago not use real_name, fix technically scooched into this PR.

# Wiki Documentation

The two kits will need to be documented on Syndicate Items page

# Changelog

:cl:  
rscadd: Adds limb autosurgeons that are designed specifically for limbs, a full set found in both augmentation kits
rscadd: Adds upgraded cyberorgan autosurgeons, found in the superior augmentation kit
rscadd: Adds the EMP shield implanter, which renders the subject's limbs, organs, and implants immune to EMP, found in the superior augmentation kit
rscadd: Adds the augmentation and superior augmentation kit. The former is 15 TC for any uplink, the latter is 25 TC for nukies only
tweak: Stechkin magazine boxes should now only be readable by Syndicate
/:cl:
