### PR TITLE
Standardizes arrow speed to be slower than shotgun slugs (but energy arrows are faster WOW!)

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -2,6 +2,7 @@
 	name = "Arrow"
 	desc = "Woosh!"
 	damage = 20
+	speed = 0.6
 	flag = MELEE
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow
@@ -148,6 +149,7 @@
 	icon_state = "arrow_energy"
 	damage = 32
 	damage_type = BURN
+	speed = 0.6
 	var/embed_chance = 0.4
 	var/obj/item/embed_type = /obj/item/ammo_casing/caseless/arrow/energy
 	


### PR DESCRIPTION
# Document the changes in your pull request

School is sapping most of my energy, will, and creativity, so this will have to be some minor precursor to the bow expansion I intend to do

Basically when bullets were made super fast this made arrows ALSO super fast (hilarious, especially since they're as fast as a bullet). Considering shotgun pellets and slugs were intentionally made slower than your average bullet, I found it a little absurd that bows should travel as fast. So this is technically a nerf to most standard arrows, since they're now traveling at a speed of 0.6 rather than 0.4

HOWEVER because of funny inherits and pathing, energy arrows did not obtain ANY of these cool awesome speedy drugs that their "real" versions got (hardlight is a... physical thing that's launched, right?) So now energy arrow projectiles travel at 0.6 too, I'm pretty sure all energy projectiles travel at a standard of 1, but I don't care to check. It should make using the secbow, syndiebow, and clockiebow even better (yay?)

I'll probably make arrows semi-relevant again at some undated point in the future

# Wiki Documentation

Maybe some mention of arrow's properties in Guide to Combat, both under the ballistic bows and the energy bows

# Changelog

:cl:  
tweak: Ballistic arrows and energy arrows now have the same projectile speed (ballistic ones are slower, energy ones are faster)
/:cl:
