### PR TITLE
Buff war clockcult

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
@@ -6,7 +6,8 @@
 /proc/adjust_clockwork_power(amount) //Adjusts the global clockwork power by this amount (min 0.)
 	var/current_power
 	if(GLOB.ratvar_approaches)
-		amount *= 0.25 //The herald's beacon reduces power costs by 25% across the board!
+	/*yogs start*/
+		amount *= 0.25 //The herald's beacon reduces power costs by 50% across the board!
 	if(GLOB.ratvar_awakens)
 		current_power = GLOB.clockwork_power = INFINITY
 	else

--- a/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/power_helpers.dm
@@ -6,7 +6,7 @@
 /proc/adjust_clockwork_power(amount) //Adjusts the global clockwork power by this amount (min 0.)
 	var/current_power
 	if(GLOB.ratvar_approaches)
-		amount *= 0.75 //The herald's beacon reduces power costs by 25% across the board!
+		amount *= 0.25 //The herald's beacon reduces power costs by 25% across the board!
 	if(GLOB.ratvar_awakens)
 		current_power = GLOB.clockwork_power = INFINITY
 	else

--- a/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/heralds_beacon.dm
@@ -108,10 +108,6 @@
 			continue
 		C.update_values()
 		to_chat(C, C.empower_string)
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		if(is_servant_of_ratvar(H))
-			to_chat(H, "<span class='bold alloy'>The beacon's power warps your body into a clockwork form! You are now immune to many hazards, and your body is more robust against damage!</span>")
-			H.set_species(/datum/species/golem/clockwork/no_scrap)
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar
 	G.grace_period = FALSE //no grace period if we've declared war
 	G.recalls_remaining++


### PR DESCRIPTION
# Document the changes in your pull request
Clockcult is inherently a gamemode about an early stealth blitz and wins and losses are almost always dependent upon this factor. War mode removes this win condition, so it should get incredible buffs in return. Something that isn't a buff is being unable to be healed by medkits, being unable to use guns and being instantly spotted if on the station for more than 5 seconds. I have removed clockwork golems from the herald's beacon for that reason, and reduced power costs by 50%.

# Wiki Documentation
Herald's beacon no longer turns you into a golem and lowers power cost by 50%.

# Changelog
:cl:  
tweak: Herald's beacon no longer turns you into a golem and lowers power cost by 50%.
/:cl:
