### PR TITLE
Clown buff

### DIFF
--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -135,3 +135,13 @@
 /obj/item/grown/bananapeel/specialpeel/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 40)
+
+/obj/item/reagent_containers/food/snacks/grown/banana/clown
+	name = "clown banana"
+	trash = /obj/item/grown/bananapeel/clown
+
+/obj/item/grown/bananapeel/clown/Initialize(newloc, obj/item/seeds/new_seed)
+	. = ..()
+	var/datum/component/slippery/slip = GetComponent(/datum/component/slippery)
+	slip.stun_time = slip.knockdown_time
+	

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -48,7 +48,7 @@
 	backpack_contents = list(
 		/obj/item/stamp/clown = 1,
 		/obj/item/reagent_containers/spray/waterflower = 1,
-		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
+		/obj/item/reagent_containers/food/snacks/grown/banana/clown = 1,
 		/obj/item/instrument/bikehorn = 1,
 		)
 


### PR DESCRIPTION
# Document the changes in your pull request
The banana that spawns in the clown's inventory now gets a full stun. Clowns can now steal shoes again, and being a clown has a job-specific perk like every other job.
# Wiki Documentation
The banana that spawns in the clown's inventory now gets a full stun
# Changelog
:cl:  
tweak: The banana that spawns in the clown's inventory now gets a full stun
/:cl:
