### PR TITLE
Re-enables jungle fever

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -792,7 +792,6 @@
 	else
 		return FALSE
 
-// This does not get called. Look into making it work.
 /datum/dynamic_ruleset/roundstart/monkey/round_result()
 	if(check_monkey_victory())
 		SSticker.mode_result = "win - monkey win"

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -743,7 +743,7 @@
 //                                          //
 //////////////////////////////////////////////
 
-/*/datum/dynamic_ruleset/roundstart/monkey
+/datum/dynamic_ruleset/roundstart/monkey
 	name = "Monkey"
 	antag_flag = ROLE_MONKEY
 	antag_datum = /datum/antagonist/monkey/leader
@@ -797,7 +797,7 @@
 	if(check_monkey_victory())
 		SSticker.mode_result = "win - monkey win"
 	else
-		SSticker.mode_result = "loss - staff stopped the monkeys"*/
+		SSticker.mode_result = "loss - staff stopped the monkeys"
 
 //////////////////////////////////////////////
 //                                          //


### PR DESCRIPTION
# Document the changes in your pull request
Pretty interesting and unique game mode, didn't really have a reason to be disabled. Re-enables monkey mode/jungle fever in the dynamic roundstart rules.
# Wiki Documentation
Monkey is back in rotation.
# Changelog
:cl:  
tweak: Jungle fever is back in rotation.
/:cl:
