### PR TITLE
Re-enables the "Oh, Hi Daniel" shuttle

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -373,8 +373,7 @@
 	description = "How was space work today? Oh, pretty good. We got a new space station and the company will make a lot of money. What space station? I cannot tell you; it's space confidential. \
 	Aw, come space on. Why not? No, I can't. Anyway, how is your space roleplay life?"
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
-	credit_cost = 7500
-	emag_buy = TRUE
+	credit_cost = 30000
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon


### PR DESCRIPTION
# Document the changes in your pull request
Believe it or not, this shuttle is actually one of the safest in the game. It has no windows which are the easiest to break and it is quite tight which means traitors can't kite 24/7 like they can on a shuttle. The reason people remember it being such a hellhole is because back in the day you couldn't rest, which means this shuttle could be filled quite easily which gave it a notorious reputation for being a grief shuttle, which it no longer is. I've increased the credit cost significantly since I assume people will want to buy it at random, however.

# Wiki Documentation
the "Oh, Hi Daniel" shuttle is enabled once more.
# Changelog

:cl:  
tweak: Re-enables the "Oh, Hi Daniel" shuttle
/:cl:
