### PR TITLE
Borgs can no longer be on discount for nukies

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1291,6 +1291,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 65
 	restricted = TRUE
+	cant_discount = TRUE
 
 /datum/uplink_item/support/reinforcement/medical_borg
 	name = "Syndicate Medical Cyborg"
@@ -1301,7 +1302,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
-
+	cant_discount = TRUE
 /datum/uplink_item/support/reinforcement/saboteur_borg
 	name = "Syndicate Saboteur Cyborg"
 	desc = "A streamlined engineering cyborg, equipped with covert modules. Also incapable of leaving the welder in the shuttle. \
@@ -1311,7 +1312,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	refundable = TRUE
 	cost = 35
 	restricted = TRUE
-
+	cant_discount = TRUE
 /datum/uplink_item/support/gygax
 	name = "Dark Gygax Exosuit"
 	desc = "A lightweight exosuit, painted in a dark scheme. Its speed and equipment selection make it excellent \


### PR DESCRIPTION
# Document the changes in your pull request

Borgs can no longer be on discount for nukies. Too cheap asis and very volatile to be on discount.

# Wiki Documentation

Borgs can no longer be on discount for nukies
# Changelog

:cl:  
tweak: Borgs can no longer be on discount for nukies
/:cl:
