### PR TITLE
Remove vorecode

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3751,7 +3751,6 @@
 #include "yogstation\code\modules\mob\living\carbon\reindex_screams.dm"
 #include "yogstation\code\modules\mob\living\carbon\alien\humanoid\alienpowers.dm"
 #include "yogstation\code\modules\mob\living\carbon\alien\humanoid\humanoid.dm"
-#include "yogstation\code\modules\mob\living\carbon\alien\humanoid\humanoid_defense.dm"
 #include "yogstation\code\modules\mob\living\carbon\alien\humanoid\queen.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\human.dm"
 #include "yogstation\code\modules\mob\living\carbon\human\human_defense.dm"

--- a/yogstation/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/yogstation/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,5 +1,0 @@
-/mob/living/carbon/alien/humanoid/grabbedby(mob/living/carbon/user, supress_message = 0)
-	if(user == src && pulling && grab_state >= GRAB_AGGRESSIVE && !pulling.anchored && iscarbon(pulling))
-		devour_mob(pulling, devour_time = 60)
-	else
-		..()

--- a/yogstation/code/modules/mob/living/carbon/carbon.dm
+++ b/yogstation/code/modules/mob/living/carbon/carbon.dm
@@ -29,16 +29,3 @@
 						A.forceMove(drop_location())
 						stomach_contents.Remove(A)
 					src.gib()
-
-
-/mob/living/carbon/proc/devour_mob(mob/living/carbon/C, devour_time = 130)
-	C.visible_message(span_danger("[src] is attempting to devour [C]!"), \
-					span_userdanger("[src] is attempting to devour you!"))
-	if(!do_mob(src, C, devour_time))
-		return
-	if(pulling && pulling == C && grab_state >= GRAB_AGGRESSIVE && a_intent == INTENT_GRAB)
-		C.visible_message(span_danger("[src] devours [C]!"), \
-						span_userdanger("[src] devours you!"))
-		C.forceMove(src)
-		stomach_contents.Add(C)
-		log_combat(src, C, "devoured")

--- a/yogstation/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_defense.dm
@@ -3,9 +3,3 @@
 		if(wear_neck.type == /obj/item/clothing/neck/petcollar)
 			return ..(user, TRUE)
 	.=..()
-
-/mob/living/carbon/human/grabbedby(mob/living/carbon/user, supress_message = 0)	
-	if(user == src && pulling && !pulling.anchored && grab_state >= GRAB_AGGRESSIVE && (HAS_TRAIT(src, TRAIT_FAT)) && ismonkey(pulling))	
-		devour_mob(pulling)	
-	else	
-		.=..()


### PR DESCRIPTION
# Document the changes in your pull request
It's attracting the wrong kind of people and nobody ever uses it, and it is a good thing nobody did because it is grossly overpowered. It deletes corpses and makes it so you can't escape from a single stun by a xeno.

# Wiki Documentation
Fat people can no longer devour, as well as xenos.
# Changelog
:cl:  
rscdel: Fat people can no longer devour, as well as xenos.
/:cl:
