### PR TITLE
Chemical bombs no longer ignore bomb cap

### DIFF
--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -104,4 +104,4 @@
 	if(explosion_message)
 		location.visible_message(span_danger("The solution violently explodes!"), \
 								span_italics("You hear an explosion!"))
-	dyn_explosion(location, amount, flashing_factor)
+	dyn_explosion(location, amount, flashing_factor, ignorecap = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request
Chemical bombs no longer ignore the bomb cap, they're too easy to make as-is and can nuke the entire station as it. Murderbone bait

# Changelog

:cl:  
tweak: Chemical bombs no longer ignore the bomb cap.
/:cl:
