### PR TITLE
Reduce taser range

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -7,7 +7,7 @@
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
-	range = 7
+	range = 5
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun


### PR DESCRIPTION
# Document the changes in your pull request
The taser has a very high range for being an instant point & click stun. 7 tiles is almost the entire screen horizontally so I've made it into more of a close-range weapon.

# Changelog

:cl:  
tweak: Taser range goes from 7 to 5
/:cl:
