### PR TITLE
Crew pinpointer/lifeline program can track mob has monitor nanite, also fix mob has same name overwriting each others in lifeline app

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -88,12 +88,16 @@
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
-	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
-		var/obj/item/clothing/under/U = H.w_uniform
+	var/nanite_sensors = FALSE
+	if(H in SSnanites.nanite_monitored_mobs)
+		nanite_sensors = TRUE
+	if((H.z == 0 || H.z == here.z) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
+		if(!nanite_sensors) // Does the mob have monitoring nanite?
+			var/obj/item/clothing/under/U = H.w_uniform
 
-		// Suit sensors must be on maximum.
-		if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && !ignore_suit_sensor_level))
-			return FALSE
+			// Suit sensors must be on maximum.
+			if(!U.has_sensor || (U.sensor_mode < SENSOR_COORDS && !ignore_suit_sensor_level))
+				return FALSE
 
 		var/turf/there = get_turf(H)
 		return (H.z != 0 || (there && there.z == here.z))

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -354,11 +354,11 @@
 				var/obj/item/card/id/ID = humanoid.wear_id.GetID()
 				if(ID && ID.registered_name)
 					crewmember_name = ID.registered_name
-		while(crewmember_name in humanoids)
-			humanoids[crewmember_name]++
-			crewmember_name = text("[] ([])", crewmember_name, humanoids[crewmember_name])
-		names[crewmember_name] = target
-		humanoids[crewmember_name] = 1
+			while(crewmember_name in humanoids)
+				humanoids[crewmember_name]++
+				crewmember_name = text("[] ([])", crewmember_name, humanoids[crewmember_name])
+			names[crewmember_name] = humanoid
+			humanoids[crewmember_name] = 1
 	for(var/N in sortList(names))
 		var/list/crewinfo = list(
 			ref = REF(names[N]),

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -243,23 +243,30 @@
 			var/obj/item/card/id/ID = humanoid.wear_id.GetID()
 			if(ID && ID.registered_name)
 				crewmember_name = ID.registered_name
-		names += crewmember_name
-		humanoids[crewmember_name] = i
+		while(crewmember_name in humanoids)
+			humanoids[crewmember_name]++
+			crewmember_name = text("[] ([])", crewmember_name, humanoids[crewmember_name])
+		names[crewmember_name] = humanoid
+		humanoids[crewmember_name] = 1
 	for(var/N in sortList(names))
 		var/list/crewinfo = list(
-			ref = REF(humanoids[N]),
+			ref = REF(names[N]),
 			name = N
 			)
 		objects += list(crewinfo)
 
 /datum/computer_file/program/radar/lifeline/trackable(mob/living/carbon/human/humanoid)
+	var/nanite_sensors = FALSE
+	if(humanoid in SSnanites.nanite_monitored_mobs)
+		nanite_sensors = TRUE
 	if(!humanoid || !istype(humanoid))
 		return FALSE
-	if(..() && istype(humanoid.w_uniform, /obj/item/clothing/under))
+	if(..() && (istype(humanoid.w_uniform, /obj/item/clothing/under) || nanite_sensors))
+		if(!nanite_sensors)
 
-		var/obj/item/clothing/under/uniform = humanoid.w_uniform
-		if(!uniform.has_sensor || (uniform.sensor_mode < SENSOR_COORDS)) // Suit sensors must be on maximum.
-			return FALSE
+			var/obj/item/clothing/under/uniform = humanoid.w_uniform
+			if(!uniform.has_sensor || (uniform.sensor_mode < SENSOR_COORDS)) // Suit sensors must be on maximum.
+				return FALSE
 
 		return TRUE
 
@@ -332,6 +339,8 @@
 		return
 	next_scan = world.time + (2 SECONDS)
 	objects = list()
+	var/list/names = list()
+	var/list/humanoids = list()
 	for(var/obj/item/implant/imp in GLOB.tracked_implants)
 		var/mob/living/target = imp.imp_in
 		if(!istype(target))
@@ -345,9 +354,15 @@
 				var/obj/item/card/id/ID = humanoid.wear_id.GetID()
 				if(ID && ID.registered_name)
 					crewmember_name = ID.registered_name
+		while(crewmember_name in humanoids)
+			humanoids[crewmember_name]++
+			crewmember_name = text("[] ([])", crewmember_name, humanoids[crewmember_name])
+		names[crewmember_name] = target
+		humanoids[crewmember_name] = 1
+	for(var/N in sortList(names))
 		var/list/crewinfo = list(
-			ref = REF(target),
-			name = crewmember_name,
+			ref = REF(names[N]),
+			name = N
 			)
 		objects += list(crewinfo)
 


### PR DESCRIPTION
resolve #16352 
resolve #13186 (FIxed awhile ago)


# Document the changes in your pull request
- Crew pinpointer/lifeline program can track mob has monitor nanite
- fix mob has same name overwriting each others in lifeline app

![image](https://user-images.githubusercontent.com/89688125/200179611-a8492907-1e86-4834-a798-9c56213cc687.png)



# Wiki Documentation

- Crew pinpointer/lifeline program can track mob has monitor nanite
- fix mob has same name overwriting each others in lifeline app

# Changelog


:cl:  
rscadd: Crew pinpointer/lifeline program can track mob has monitor nanite
bugfix: Fix lifeline name overwriting each others
/:cl:
