### PR TITLE
Paperwork Printing Program for Modular Computers

### DIFF
--- a/code/modules/modular_computers/computers/item/phone/phone_presets.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone_presets.dm
@@ -39,7 +39,8 @@
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,
 								/obj/item/computer_hardware/card_slot,
-								/obj/item/computer_hardware/card_slot/secondary)
+								/obj/item/computer_hardware/card_slot/secondary,
+								/obj/item/computer_hardware/printer/mini)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/cap
 	finish_color = "yellow"

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -15,9 +15,9 @@
 	var/list/papers = list()
 	//filter out paperwork we're not allowed to have
 	for(var/R in subtypesof(/obj/item/paper/paperwork))
-		var/obj/item/paper/paperwork/P = new R
-		if(P.printable)
-			papers += list(list("name" = P.name, "id" = P.id))
+		var/obj/item/paper/paperwork/P = R
+		if(initial(P.printable))
+			papers += list(list("name" = initial(P.name), "id" = initial(P.id)))
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		printer = computer.all_components[MC_PRINT]
@@ -33,10 +33,12 @@
 	//this variable stores the object of which we're actually going to print
 	if(action == "PRG_print")
 		var/paperworkToPick = params["paperworkID"]
-		for(var/obj/item/paper/paperwork/P in subtypesof(/obj/item/paper/paperwork))
-			if(P.id==paperworkToPick)
+		for(var/R in subtypesof(/obj/item/paper/paperwork))
+			var/obj/item/paper/paperwork/P = R
+			if(initial(P.id)==paperworkToPick)
 				src.print(P)
 				break
+			
 
 /datum/computer_file/program/paperwork_printer/proc/print(var/obj/item/paper/paperwork/T)
 	var/obj/item/computer_hardware/printer/printer

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -51,8 +51,6 @@
 			src.doprint(11)
 
 /datum/computer_file/program/paperwork_printer/proc/doprint(ftype)
-	if(..())
-		return
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		printer = computer.all_components[MC_PRINT]

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -11,8 +11,7 @@
 	program_icon = "clipboard-list"
 
 /datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
-		var/list/data = get_header_data()
-
+	var/list/data = get_header_data()
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		printer = computer.all_components[MC_PRINT]

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -10,8 +10,8 @@
 	tgui_id = "NtosPaperworkPrinter"
 	program_icon = "clipboard-list"
 
-/datum/computer_file/program/paperwork_printer/ui_data(mob/user)
-	var/list/data = get_header_data()
+/datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
+		var/list/data = get_header_data()
 
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -12,67 +12,41 @@
 
 /datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
 	var/list/data = get_header_data()
+	var/list/papers = list()
+	//filter out paperwork we're not allowed to have
+	for(var/R in subtypesof(/obj/item/paper/paperwork))
+		var/obj/item/paper/paperwork/P = new R
+		if(P.printable)
+			papers += list(list("name" = P.name, "id" = P.id))
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		printer = computer.all_components[MC_PRINT]
 		data["have_printer"] = !!printer
 	else
 		data["have_printer"] = FALSE
+	data["printable_papers"] = papers
 	return data
 
 /datum/computer_file/program/paperwork_printer/ui_act(action, params, datum/tgui/ui)
 	if(..())
 		return
 	//this variable stores the object of which we're actually going to print
-	var/obj/item/paper/paperwork/which
-	//this flag determines if anything is actually printed
-	var/print = FALSE
 	if(action == "PRG_print")
-		var/paperworkToPick = params["whichpaperwork"]
-		switch(paperworkToPick)
-			if("GeneralRequest")
-				which = /obj/item/paper/paperwork/general_request_form
-				print = TRUE
-			if("ComplaintForm")
-				which = /obj/item/paper/paperwork/complaint_form
-				print = TRUE
-			if("IncidentForm")
-				which = /obj/item/paper/paperwork/incident_report
-				print = TRUE
-			if("ItemRequest")
-				which = /obj/item/paper/paperwork/item_form
-				print = TRUE
-			if("CyberizationConsent")
-				which = /obj/item/paper/paperwork/cyborg_request_form
-				print = TRUE
-			if("HOPAccessRequest")
-				which = /obj/item/paper/paperwork/hopaccessrequestform
-				print = TRUE
-			if("JobReassignment")
-				which = /obj/item/paper/paperwork/hop_job_change_form
-				print = TRUE
-			if("RDRequestForm")
-				which = /obj/item/paper/paperwork/rd_form
-				print = TRUE
-			if("MechRequest")
-				which = /obj/item/paper/paperwork/mech_form
-				print = TRUE
-			if("JobChangeCertificate")
-				which = /obj/item/paper/paperwork/jobchangecert
-				print = TRUE
-			if("SecIncidentForm")
-				which = /obj/item/paper/paperwork/sec_incident_report
-				print = TRUE
-	if(print)
-		var/obj/item/computer_hardware/printer/printer
-		print = !print
-		if(computer)
-			printer = computer.all_components[MC_PRINT]
-		if(computer && printer) //This option should never be called if there is no printer
-			if(!printer.print_type(which))
-				to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
-				return
-			else
-				//it printed, how many pages are left?
-				var/pages_left = printer.stored_paper
-				computer.visible_message(span_notice("\The [computer] prints out a paper. There are [pages_left] pages left."))
+		var/paperworkToPick = params["paperworkID"]
+		for(var/obj/item/paper/paperwork/P in subtypesof(/obj/item/paper/paperwork))
+			if(P.id==paperworkToPick)
+				src.print(P)
+				break
+
+/datum/computer_file/program/paperwork_printer/proc/print(var/obj/item/paper/paperwork/T)
+	var/obj/item/computer_hardware/printer/printer
+	if(computer)
+		printer = computer.all_components[MC_PRINT]
+	if(computer && printer) //This option should never be called if there is no printer
+		if(!printer.print_type(T))
+			to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
+			return
+		else
+			//it printed, how many pages are left?
+			var/pages_left = printer.stored_paper
+			computer.visible_message(span_notice("\The [computer] prints out a paper. There are [pages_left] pages left."))

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -10,10 +10,6 @@
 	tgui_id = "NtosPaperworkPrinter"
 	program_icon = "clipboard-list"
 
-/datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
-	var/list/data = list()
-	return data
-
 /datum/computer_file/program/paperwork_printer/ui_data(mob/user)
 	var/list/data = get_header_data()
 

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -9,8 +9,6 @@
 	size = 4
 	tgui_id = "NtosPaperworkPrinter"
 	program_icon = "clipboard-list"
-	var/obj/item/paper/paperwork/which
-	var/print = 1
 
 /datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
 	var/list/data = get_header_data()
@@ -27,41 +25,46 @@
 /datum/computer_file/program/paperwork_printer/ui_act(action, params, datum/tgui/ui)
 	if(..())
 		return
-
-	switch(action)
-		if("PRG_print_GenReqForm")
-			which = /obj/item/paper/paperwork/general_request_form
-			print = 1
-		if("PRG_print_ComplaintForm")
-			which = /obj/item/paper/paperwork/complaint_form
-			print = 1
-		if("PRG_print_IncidentRepForm")
-			which = /obj/item/paper/paperwork/incident_report
-			print = 1
-		if("PRG_print_ItemReqForm")
-			which = /obj/item/paper/paperwork/item_form
-			print = 1
-		if("PRG_print_CyberConsentForm")
-			which = /obj/item/paper/paperwork/cyborg_request_form
-			print = 1
-		if("PRG_print_HOPAccessForm")
-			which = /obj/item/paper/paperwork/hopaccessrequestform
-			print = 1
-		if("PRG_print_JobReassignForm")
-			which = /obj/item/paper/paperwork/hop_job_change_form
-			print = 1
-		if("PRG_print_RDReqForm")
-			which = /obj/item/paper/paperwork/rd_form
-			print = 1
-		if("PRG_print_MechReqForm")
-			which = /obj/item/paper/paperwork/mech_form
-			print = 1
-		if("PRG_print_JobChangeCert")
-			which = /obj/item/paper/paperwork/jobchangecert
-			print = 1
-		if("PRG_print_SecRepForm")
-			which = /obj/item/paper/paperwork/sec_incident_report
-			print = 1
+	//this variable stores the object of which we're actually going to print
+	var/obj/item/paper/paperwork/which
+	//this flag determines if anything is actually printed
+	var/print = FALSE
+	if(action == "PRG_print")
+		var/paperworkToPick = params["whichpaperwork"]
+		switch(paperworkToPick)
+			if("GeneralRequest")
+				which = /obj/item/paper/paperwork/general_request_form
+				print = TRUE
+			if("ComplaintForm")
+				which = /obj/item/paper/paperwork/complaint_form
+				print = TRUE
+			if("IncidentForm")
+				which = /obj/item/paper/paperwork/incident_report
+				print = TRUE
+			if("ItemRequest")
+				which = /obj/item/paper/paperwork/item_form
+				print = TRUE
+			if("CyberizationConsent")
+				which = /obj/item/paper/paperwork/cyborg_request_form
+				print = TRUE
+			if("HOPAccessRequest")
+				which = /obj/item/paper/paperwork/hopaccessrequestform
+				print = TRUE
+			if("JobReassignment")
+				which = /obj/item/paper/paperwork/hop_job_change_form
+				print = TRUE
+			if("RDRequestForm")
+				which = /obj/item/paper/paperwork/rd_form
+				print = TRUE
+			if("MechRequest")
+				which = /obj/item/paper/paperwork/mech_form
+				print = TRUE
+			if("JobChangeCertificate")
+				which = /obj/item/paper/paperwork/jobchangecert
+				print = TRUE
+			if("SecIncidentForm")
+				which = /obj/item/paper/paperwork/sec_incident_report
+				print = TRUE
 	if(print)
 		var/obj/item/computer_hardware/printer/printer
 		print = !print
@@ -72,4 +75,6 @@
 				to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
 				return
 			else
-				computer.visible_message(span_notice("\The [computer] prints out a paper."))
+				//it printed, how many pages are left?
+				var/pages_left = printer.stored_paper
+				computer.visible_message(span_notice("\The [computer] prints out a paper. There are [pages_left] pages left."))

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -15,8 +15,6 @@
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		printer = computer.all_components[MC_PRINT]
-
-	if(computer)
 		data["have_printer"] = !!printer
 	else
 		data["have_printer"] = FALSE

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -9,6 +9,8 @@
 	size = 4
 	tgui_id = "NtosPaperworkPrinter"
 	program_icon = "clipboard-list"
+	var/obj/item/paper/paperwork/which
+	var/print = 1
 
 /datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
 	var/list/data = get_header_data()
@@ -28,59 +30,46 @@
 
 	switch(action)
 		if("PRG_print_GenReqForm")
-			src.doprint(1)
-		if("PRG_print_ComplaintForm")
-			src.doprint(2)
-		if("PRG_print_IncidentRepForm")
-			src.doprint(3)
-		if("PRG_print_ItemReqForm")
-			src.doprint(4)
-		if("PRG_print_CyberConsentForm")
-			src.doprint(5)
-		if("PRG_print_HOPAccessForm")
-			src.doprint(6)
-		if("PRG_print_JobReassignForm")
-			src.doprint(7)
-		if("PRG_print_RDReqForm")
-			src.doprint(8)
-		if("PRG_print_MechReqForm")
-			src.doprint(9)
-		if("PRG_print_JobChangeCert")
-			src.doprint(10)
-		if("PRG_print_SecRepForm")
-			src.doprint(11)
-
-/datum/computer_file/program/paperwork_printer/proc/doprint(ftype)
-	var/obj/item/computer_hardware/printer/printer
-	if(computer)
-		printer = computer.all_components[MC_PRINT]
-	var/obj/item/paper/paperwork/which = /obj/item/paper/paperwork
-	switch(ftype)
-		if(1)
 			which = /obj/item/paper/paperwork/general_request_form
-		if(2)
+			print = 1
+		if("PRG_print_ComplaintForm")
 			which = /obj/item/paper/paperwork/complaint_form
-		if(3)
+			print = 1
+		if("PRG_print_IncidentRepForm")
 			which = /obj/item/paper/paperwork/incident_report
-		if(4)
+			print = 1
+		if("PRG_print_ItemReqForm")
 			which = /obj/item/paper/paperwork/item_form
-		if(5)
+			print = 1
+		if("PRG_print_CyberConsentForm")
 			which = /obj/item/paper/paperwork/cyborg_request_form
-		if(6)
+			print = 1
+		if("PRG_print_HOPAccessForm")
 			which = /obj/item/paper/paperwork/hopaccessrequestform
-		if(7)
+			print = 1
+		if("PRG_print_JobReassignForm")
 			which = /obj/item/paper/paperwork/hop_job_change_form
-		if(8)
+			print = 1
+		if("PRG_print_RDReqForm")
 			which = /obj/item/paper/paperwork/rd_form
-		if(9)
+			print = 1
+		if("PRG_print_MechReqForm")
 			which = /obj/item/paper/paperwork/mech_form
-		if(10)
+			print = 1
+		if("PRG_print_JobChangeCert")
 			which = /obj/item/paper/paperwork/jobchangecert
-		if(11)
+			print = 1
+		if("PRG_print_SecRepForm")
 			which = /obj/item/paper/paperwork/sec_incident_report
-	if(computer && printer) //This option should never be called if there is no printer
-		if(!printer.print_type(which))
-			to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
-			return
-		else
-			computer.visible_message(span_notice("\The [computer] prints out a paper."))
+			print = 1
+	if(print)
+		var/obj/item/computer_hardware/printer/printer
+		print = !print
+		if(computer)
+			printer = computer.all_components[MC_PRINT]
+		if(computer && printer) //This option should never be called if there is no printer
+			if(!printer.print_type(which))
+				to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
+				return
+			else
+				computer.visible_message(span_notice("\The [computer] prints out a paper."))

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -1,0 +1,93 @@
+//TODO: add more sane printing handling
+/datum/computer_file/program/paperwork_printer
+	filename = "ppwrkprnt"
+	filedesc = "Paperwork Printing"
+	category = PROGRAM_CATEGORY_MISC
+	program_icon_state = "id"
+	extended_desc = "Program for dispensing paperwork"
+	requires_ntnet = FALSE
+	size = 4
+	tgui_id = "NtosPaperworkPrinter"
+	program_icon = "clipboard-list"
+
+/datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
+	var/list/data = list()
+	return data
+
+/datum/computer_file/program/paperwork_printer/ui_data(mob/user)
+	var/list/data = get_header_data()
+
+	var/obj/item/computer_hardware/printer/printer
+	if(computer)
+		printer = computer.all_components[MC_PRINT]
+
+	if(computer)
+		data["have_printer"] = !!printer
+	else
+		data["have_printer"] = FALSE
+	return data
+
+/datum/computer_file/program/paperwork_printer/ui_act(action, params, datum/tgui/ui)
+	if(..())
+		return
+
+	switch(action)
+		if("PRG_print_GenReqForm")
+			src.doprint(1)
+		if("PRG_print_ComplaintForm")
+			src.doprint(2)
+		if("PRG_print_IncidentRepForm")
+			src.doprint(3)
+		if("PRG_print_ItemReqForm")
+			src.doprint(4)
+		if("PRG_print_CyberConsentForm")
+			src.doprint(5)
+		if("PRG_print_HOPAccessForm")
+			src.doprint(6)
+		if("PRG_print_JobReassignForm")
+			src.doprint(7)
+		if("PRG_print_RDReqForm")
+			src.doprint(8)
+		if("PRG_print_MechReqForm")
+			src.doprint(9)
+		if("PRG_print_JobChangeCert")
+			src.doprint(10)
+		if("PRG_print_SecRepForm")
+			src.doprint(11)
+
+/datum/computer_file/program/paperwork_printer/proc/doprint(ftype)
+	if(..())
+		return
+	var/obj/item/computer_hardware/printer/printer
+	if(computer)
+		printer = computer.all_components[MC_PRINT]
+	var/obj/item/paper/paperwork/which = /obj/item/paper/paperwork
+	switch(ftype)
+		if(1)
+			which = /obj/item/paper/paperwork/general_request_form
+		if(2)
+			which = /obj/item/paper/paperwork/complaint_form
+		if(3)
+			which = /obj/item/paper/paperwork/incident_report
+		if(4)
+			which = /obj/item/paper/paperwork/item_form
+		if(5)
+			which = /obj/item/paper/paperwork/cyborg_request_form
+		if(6)
+			which = /obj/item/paper/paperwork/hopaccessrequestform
+		if(7)
+			which = /obj/item/paper/paperwork/hop_job_change_form
+		if(8)
+			which = /obj/item/paper/paperwork/rd_form
+		if(9)
+			which = /obj/item/paper/paperwork/mech_form
+		if(10)
+			which = /obj/item/paper/paperwork/jobchangecert
+		if(11)
+			which = /obj/item/paper/paperwork/sec_incident_report
+	if(computer && printer) //This option should never be called if there is no printer
+		if(!printer.print_type(which))
+			to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
+			return
+		else
+			computer.visible_message(span_notice("\The [computer] prints out a paper."))

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -6,6 +6,7 @@ export const NtosPaperworkPrinter = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     have_printer,
+    printable_papers,
   } = data;
   if (have_printer) {
     return (
@@ -22,76 +23,15 @@ export const NtosPaperworkPrinter = (props, context) => {
               onClick={() => act('PRG_print', {
                 whichpaperwork: "GeneralRequest",
               })} />
-            <Button
-              icon="print"
-              content="Print NT-021 Complaint Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "ComplaintForm",
-              })} />
-            <Button
-              icon="print"
-              content="Print NT-400 Incident Report Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "IncidentForm",
-              })} />
-            <Button
-              icon="print"
-              content="Print NT-089 Item Request Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "ItemRequest",
-              })} />
-            <Button
-              icon="print"
-              content="Print NT-203 Cyberization Consent Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "CyberizationConsent",
-              })} />
-            <Button
-              icon="print"
-              content="Print NT-022 HoP Access Request Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "HOPAccessRequest",
-              })} />
-            <Button
-              icon="print"
-              content="Print NT-059 Job Reassignment Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "JobReassignment",
-              })} />
-            <Button
-              icon="print"
-              content="Print SCI-3 R&D Request Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "RDRequestForm",
-              })} />
-            <Button
-              icon="print"
-              content="Print SCI-9 Mech Request Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "MechRequest",
-              })} />
-            <Button
-              icon="print"
-              content="Print Job Change Certificate"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "JobChangeCertificate",
-              })} />
-            <Button
-              icon="print"
-              content="Print SEC-030 Security Incident Report Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "SecIncidentForm",
-              })} />
+            {printable_papers.map(paper => (
+              <Button
+                icon="print"
+                content={"Print " + paper.name}
+                width="100%"
+                onClick={() => act('PRG_print', {
+                  paperworkID: paper.id,
+                })} />
+            ))}
           </Section>
         </NtosWindow.Content>
       </NtosWindow>

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -20,56 +20,67 @@ export const NtosPaperworkPrinter = (props, context) => {
             icon="print"
             content="Print NT-010 General Request Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_GenReqForm')} />
           <Button
             icon="print"
             content="Print NT-021 Complaint Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_ComplaintForm')} />
           <Button
             icon="print"
             content="Print NT-400 Incident Report Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_IncidentRepForm')} />
           <Button
             icon="print"
             content="Print NT-089 Item Request Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_ItemReqForm')} />
           <Button
             icon="print"
             content="Print NT-203 Cyberization Consent Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_CyberConsentForm')} />
           <Button
             icon="print"
             content="Print NT-022 HoP Access Request Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_HOPAccessForm')} />
           <Button
             icon="print"
             content="Print NT-059 Job Reassignment Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_JobReassignForm')} />
           <Button
             icon="print"
             content="Print SCI-3 R&D Request Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_RDReqForm')} />
           <Button
             icon="print"
             content="Print SCI-9 Mech Request Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_MechReqForm')} />
           <Button
             icon="print"
             content="Print Job Change Certificate"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_JobChangeCert')} />
           <Button
             icon="print"
             content="Print SEC-030 Security Incident Report Form"
             disabled={!have_printer}
+            width="100%"
             onClick={() => act('PRG_print_SecRepForm')} />
         </Section>
       </NtosWindow.Content>

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -15,66 +15,64 @@ export const NtosPaperworkPrinter = (props, context) => {
       height={480}
       resizable>
       <NtosWindow.Content scrollable>
-        <Section
-          title="NTOS Paperwork Printer"
-        >
+        <Section title="NTOS Paperwork Printer">
           <Button
-              icon="print"
-              content="Print NT-010 General Request Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_GenReqForm')} />
+            icon="print"
+            content="Print NT-010 General Request Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_GenReqForm')} />
           <Button
-              icon="print"
-              content="Print NT-021 Complaint Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_ComplaintForm')} />
+            icon="print"
+            content="Print NT-021 Complaint Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_ComplaintForm')} />
           <Button
-              icon="print"
-              content="Print NT-400 Incident Report Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_IncidentRepForm')} />
+            icon="print"
+            content="Print NT-400 Incident Report Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_IncidentRepForm')} />
           <Button
-              icon="print"
-              content="Print NT-089 Item Request Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_ItemReqForm')} />
+            icon="print"
+            content="Print NT-089 Item Request Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_ItemReqForm')} />
           <Button
-              icon="print"
-              content="Print NT-203 Cyberization Consent Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_CyberConsentForm')} />
+            icon="print"
+            content="Print NT-203 Cyberization Consent Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_CyberConsentForm')} />
           <Button
-              icon="print"
-              content="Print NT-022 HoP Access Request Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_HOPAccessForm')} />
+            icon="print"
+            content="Print NT-022 HoP Access Request Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_HOPAccessForm')} />
           <Button
-              icon="print"
-              content="Print NT-059 Job Reassignment Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_JobReassignForm')} />
+            icon="print"
+            content="Print NT-059 Job Reassignment Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_JobReassignForm')} />
           <Button
-              icon="print"
-              content="Print SCI-3 R&D Request Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_RDReqForm')} />
+            icon="print"
+            content="Print SCI-3 R&D Request Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_RDReqForm')} />
           <Button
-              icon="print"
-              content="Print SCI-9 Mech Request Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_MechReqForm')} />
+            icon="print"
+            content="Print SCI-9 Mech Request Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_MechReqForm')} />
           <Button
-              icon="print"
-              content="Print Job Change Certificate"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_JobChangeCert')} />
+            icon="print"
+            content="Print Job Change Certificate"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_JobChangeCert')} />
           <Button
-              icon="print"
-              content="Print SEC-030 Security Incident Report Form"
-              disabled={!have_printer}
-              onClick={() => act('PRG_print_SecRepForm')} />
+            icon="print"
+            content="Print SEC-030 Security Incident Report Form"
+            disabled={!have_printer}
+            onClick={() => act('PRG_print_SecRepForm')} />
         </Section>
       </NtosWindow.Content>
     </NtosWindow>
   );
-          }
+};

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -17,63 +17,63 @@ export const NtosPaperworkPrinter = (props, context) => {
       <NtosWindow.Content scrollable>
         <Section
           title="NTOS Paperwork Printer"
-          >
-            <Button
+        >
+          <Button
               icon="print"
               content="Print NT-010 General Request Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_GenReqForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-021 Complaint Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_ComplaintForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-400 Incident Report Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_IncidentRepForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-089 Item Request Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_ItemReqForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-203 Cyberization Consent Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_CyberConsentForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-022 HoP Access Request Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_HOPAccessForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print NT-059 Job Reassignment Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_JobReassignForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print SCI-3 R&D Request Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_RDReqForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print SCI-9 Mech Request Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_MechReqForm')} />
-            <Button
+          <Button
               icon="print"
               content="Print Job Change Certificate"
               disabled={!have_printer}
               onClick={() => act('PRG_print_JobChangeCert')} />
-            <Button
+          <Button
               icon="print"
               content="Print SEC-030 Security Incident Report Form"
               disabled={!have_printer}
               onClick={() => act('PRG_print_SecRepForm')} />
-          </Section>
+        </Section>
       </NtosWindow.Content>
     </NtosWindow>
   );

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -16,13 +16,6 @@ export const NtosPaperworkPrinter = (props, context) => {
         resizable>
         <NtosWindow.Content scrollable>
           <Section title="NTOS Paperwork Printer">
-            <Button
-              icon="print"
-              content="Print NT-010 General Request Form"
-              width="100%"
-              onClick={() => act('PRG_print', {
-                whichpaperwork: "GeneralRequest",
-              })} />
             {printable_papers.map(paper => (
               <Button
                 icon="print"

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -1,89 +1,115 @@
-import { map } from 'common/collections';
 import { useBackend } from '../backend';
-import { Button, Section } from '../components';
+import { Button, NoticeBox, Section } from '../components';
 import { NtosWindow } from '../layouts';
 
 export const NtosPaperworkPrinter = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     have_printer,
-    manifest = {},
   } = data;
-  return (
-    <NtosWindow
-      width={400}
-      height={480}
-      resizable>
-      <NtosWindow.Content scrollable>
-        <Section title="NTOS Paperwork Printer">
-          <Button
-            icon="print"
-            content="Print NT-010 General Request Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_GenReqForm')} />
-          <Button
-            icon="print"
-            content="Print NT-021 Complaint Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_ComplaintForm')} />
-          <Button
-            icon="print"
-            content="Print NT-400 Incident Report Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_IncidentRepForm')} />
-          <Button
-            icon="print"
-            content="Print NT-089 Item Request Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_ItemReqForm')} />
-          <Button
-            icon="print"
-            content="Print NT-203 Cyberization Consent Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_CyberConsentForm')} />
-          <Button
-            icon="print"
-            content="Print NT-022 HoP Access Request Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_HOPAccessForm')} />
-          <Button
-            icon="print"
-            content="Print NT-059 Job Reassignment Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_JobReassignForm')} />
-          <Button
-            icon="print"
-            content="Print SCI-3 R&D Request Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_RDReqForm')} />
-          <Button
-            icon="print"
-            content="Print SCI-9 Mech Request Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_MechReqForm')} />
-          <Button
-            icon="print"
-            content="Print Job Change Certificate"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_JobChangeCert')} />
-          <Button
-            icon="print"
-            content="Print SEC-030 Security Incident Report Form"
-            disabled={!have_printer}
-            width="100%"
-            onClick={() => act('PRG_print_SecRepForm')} />
-        </Section>
-      </NtosWindow.Content>
-    </NtosWindow>
-  );
+  if (have_printer) {
+    return (
+      <NtosWindow
+        width={400}
+        height={480}
+        resizable>
+        <NtosWindow.Content scrollable>
+          <Section title="NTOS Paperwork Printer">
+            <Button
+              icon="print"
+              content="Print NT-010 General Request Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "GeneralRequest",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-021 Complaint Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "ComplaintForm",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-400 Incident Report Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "IncidentForm",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-089 Item Request Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "ItemRequest",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-203 Cyberization Consent Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "CyberizationConsent",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-022 HoP Access Request Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "HOPAccessRequest",
+              })} />
+            <Button
+              icon="print"
+              content="Print NT-059 Job Reassignment Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "JobReassignment",
+              })} />
+            <Button
+              icon="print"
+              content="Print SCI-3 R&D Request Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "RDRequestForm",
+              })} />
+            <Button
+              icon="print"
+              content="Print SCI-9 Mech Request Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "MechRequest",
+              })} />
+            <Button
+              icon="print"
+              content="Print Job Change Certificate"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "JobChangeCertificate",
+              })} />
+            <Button
+              icon="print"
+              content="Print SEC-030 Security Incident Report Form"
+              width="100%"
+              onClick={() => act('PRG_print', {
+                whichpaperwork: "SecIncidentForm",
+              })} />
+          </Section>
+        </NtosWindow.Content>
+      </NtosWindow>
+    );
+  } else {
+    return (
+      <NtosWindow
+        width={400}
+        height={480}
+        resizable>
+        <NtosWindow.Content scrollable>
+          <Section title="NTOS Paperwork Printer" />
+          <NoticeBox>
+            There is no printer installed. Program halted.
+          </NoticeBox>
+        </NtosWindow.Content>
+      </NtosWindow>
+    );
+  }
+
 };

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -1,0 +1,80 @@
+import { map } from 'common/collections';
+import { useBackend } from '../backend';
+import { Button, Section } from '../components';
+import { NtosWindow } from '../layouts';
+
+export const NtosPaperworkPrinter = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    have_printer,
+    manifest = {},
+  } = data;
+  return (
+    <NtosWindow
+      width={400}
+      height={480}
+      resizable>
+      <NtosWindow.Content scrollable>
+        <Section
+          title="NTOS Paperwork Printer"
+          >
+            <Button
+              icon="print"
+              content="Print NT-010 General Request Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_GenReqForm')} />
+            <Button
+              icon="print"
+              content="Print NT-021 Complaint Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_ComplaintForm')} />
+            <Button
+              icon="print"
+              content="Print NT-400 Incident Report Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_IncidentRepForm')} />
+            <Button
+              icon="print"
+              content="Print NT-089 Item Request Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_ItemReqForm')} />
+            <Button
+              icon="print"
+              content="Print NT-203 Cyberization Consent Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_CyberConsentForm')} />
+            <Button
+              icon="print"
+              content="Print NT-022 HoP Access Request Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_HOPAccessForm')} />
+            <Button
+              icon="print"
+              content="Print NT-059 Job Reassignment Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_JobReassignForm')} />
+            <Button
+              icon="print"
+              content="Print SCI-3 R&D Request Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_RDReqForm')} />
+            <Button
+              icon="print"
+              content="Print SCI-9 Mech Request Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_MechReqForm')} />
+            <Button
+              icon="print"
+              content="Print Job Change Certificate"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_JobChangeCert')} />
+            <Button
+              icon="print"
+              content="Print SEC-030 Security Incident Report Form"
+              disabled={!have_printer}
+              onClick={() => act('PRG_print_SecRepForm')} />
+          </Section>
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+          }

--- a/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
+++ b/tgui/packages/tgui/interfaces/NtosPaperworkPrinter.js
@@ -18,6 +18,7 @@ export const NtosPaperworkPrinter = (props, context) => {
           <Section title="NTOS Paperwork Printer">
             {printable_papers.map(paper => (
               <Button
+                key={paper}
                 icon="print"
                 content={"Print " + paper.name}
                 width="100%"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2680,6 +2680,7 @@
 #include "code\modules\modular_computers\file_system\programs\ntmonitor.dm"
 #include "code\modules\modular_computers\file_system\programs\ntnrc_client.dm"
 #include "code\modules\modular_computers\file_system\programs\ntpda_msg.dm"
+#include "code\modules\modular_computers\file_system\programs\paperworkprinter.dm"
 #include "code\modules\modular_computers\file_system\programs\portrait_printer.dm"
 #include "code\modules\modular_computers\file_system\programs\radar.dm"
 #include "code\modules\modular_computers\file_system\programs\robotact.dm"
@@ -3885,5 +3886,4 @@
 #include "yogstation\code\modules\xenoarch\loot\gigadrill.dm"
 #include "yogstation\code\modules\xenoarch\loot\guns.dm"
 #include "yogstation\interface\interface.dm"
-#include "code\modules\modular_computers\file_system\programs\paperworkprinter.dm"
 // END_INCLUDE

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3885,4 +3885,5 @@
 #include "yogstation\code\modules\xenoarch\loot\gigadrill.dm"
 #include "yogstation\code\modules\xenoarch\loot\guns.dm"
 #include "yogstation\interface\interface.dm"
+#include "code\modules\modular_computers\file_system\programs\paperworkprinter.dm"
 // END_INCLUDE

--- a/yogstation/code/game/objects/items/premadepapers.dm
+++ b/yogstation/code/game/objects/items/premadepapers.dm
@@ -7,9 +7,13 @@
   * It's a subtype of paper, with written text already on it.
   *
   */
+/obj/item/paper/paperwork/
+	var/id = 0
+	var/printable = TRUE
 /obj/item/paper/paperwork/general_request_form
 	name = "General Requests Form (Form NT-010)"
-
+	id = 1
+	printable = FALSE
 
 /obj/item/paper/paperwork/general_request_form/Initialize()
 	. = ..()
@@ -34,6 +38,7 @@
   */
 /obj/item/paper/paperwork/complaint_form
 	name = "Complaint Form (Form NT-021)"
+	id = 2
 
 /obj/item/paper/paperwork/complaint_form/Initialize()
 	. = ..()
@@ -65,6 +70,7 @@
   */
 /obj/item/paper/paperwork/incident_report
 	name = "Incident Report (Form NT-400)"
+	id = 3
 
 /obj/item/paper/paperwork/incident_report/Initialize()
 	. = ..()
@@ -113,6 +119,7 @@
   */
 /obj/item/paper/paperwork/sec_incident_report
 	name = "Security Incident Report (Form SEC-030)"
+	id = 4
 
 /obj/item/paper/paperwork/sec_incident_report/Initialize()
 	. = ..()
@@ -180,6 +187,7 @@
   */
 /obj/item/paper/paperwork/item_form
 	name = "Item Request Form (Form NT-089)"
+	id = 5
 
 /obj/item/paper/paperwork/item_form/Initialize()
 	. = ..()
@@ -214,6 +222,7 @@
   */
 /obj/item/paper/paperwork/cyborg_request_form
 	name = "Cyborgization Consent Form (Form NT-203)"
+	id = 6
 
 /obj/item/paper/paperwork/cyborg_request_form/Initialize()
 	. = ..()
@@ -248,6 +257,7 @@
   */
 /obj/item/paper/paperwork/hopaccessrequestform
 	name = "HoP Access Request Form (Form NT-022)"
+	id = 7
 
 /obj/item/paper/paperwork/hopaccessrequestform/Initialize()
 	. = ..()
@@ -278,6 +288,7 @@
   */
 /obj/item/paper/paperwork/hop_job_change_form
 	name = "Job Reassignment Form (Form NT-059)"
+	id = 8
 
 /obj/item/paper/paperwork/hop_job_change_form/Initialize()
 	. = ..()
@@ -315,6 +326,7 @@
   */
 /obj/item/paper/paperwork/rd_form
 	name = "R&D Request Form (Form SCI-3)"
+	id = 9
 
 /obj/item/paper/paperwork/rd_form/Initialize()
 	. = ..()
@@ -344,6 +356,7 @@
   */
 /obj/item/paper/paperwork/mech_form
 	name = "R&D Mech Request Form (Form SCI-9)"
+	id = 10
 
 /obj/item/paper/paperwork/mech_form/Initialize()
 	. = ..()
@@ -373,6 +386,7 @@
   */
 /obj/item/paper/paperwork/jobchangecert
 	name = "Job Change Certificate"
+	id = 11
 
 /obj/item/paper/paperwork/jobchangecert/Initialize()
 	. = ..()

--- a/yogstation/code/game/objects/items/premadepapers.dm
+++ b/yogstation/code/game/objects/items/premadepapers.dm
@@ -13,7 +13,6 @@
 /obj/item/paper/paperwork/general_request_form
 	name = "General Requests Form (Form NT-010)"
 	id = 1
-	printable = FALSE
 
 /obj/item/paper/paperwork/general_request_form/Initialize()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Modular computers can now print paperwork. Gone are the days of clipboard and copier.

I DID TEST THIS, Special Thanks to Chubbygummibear, baimou, Bibby, and Chester
# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:ReddsNotDead
rscadd: Added paperwork printing to modular devices. To use, download the program.
/:cl:
