### PR TITLE
reduces the validhunting capabilities of syringe guns by making piercing syringes not fit into most syringe guns

### DIFF
--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -61,6 +61,9 @@
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
 		if(syringes.len < max_syringes)
+			if(istype(A, /obj/item/reagent_containers/syringe/piercing) && !istype(src, /obj/item/gun/syringe/syndicate))
+				to_chat(user, "<span class='notice'>[A] is designed to not be able to fit into [src].</span>")
+				return TRUE
 			if(!user.transferItemToLoc(A, src))
 				return FALSE
 			to_chat(user, span_notice("You load [A] into \the [src]."))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -61,7 +61,7 @@
 	var/mob/living/L
 	if(isliving(target))
 		L = target
-		if(!L.can_inject(user, 1))
+		if(!L.can_inject(null, TRUE, BODY_ZONE_CHEST, proj_piercing))
 			return
 
 	// chance of monkey retaliation
@@ -83,7 +83,7 @@
 					target.visible_message(span_danger("[user] is trying to take a blood sample from [target]!"), \
 									span_userdanger("[user] is trying to take a blood sample from [target]!"))
 					busy = TRUE
-					if(!do_mob(user, target, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, target, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, null, TRUE, BODY_ZONE_CHEST, proj_piercing)))
 						busy = FALSE
 						return
 					if(reagents.total_volume >= reagents.maximum_volume)
@@ -128,12 +128,12 @@
 				return
 
 			if(L) //living mob
-				if(!L.can_inject(user, TRUE))
+				if(!L.can_inject(null, TRUE, BODY_ZONE_CHEST, proj_piercing))
 					return
 				if(L != user)
 					L.visible_message(span_danger("[user] is trying to inject [L]!"), \
 											span_userdanger("[user] is trying to inject [L]!"))
-					if(!do_mob(user, L, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, L, extra_checks=CALLBACK(L, /mob/living/proc/can_inject, null, FALSE, BODY_ZONE_CHEST, proj_piercing)))
 						return
 					if(!reagents.total_volume)
 						return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -285,8 +285,7 @@
 
 /obj/item/reagent_containers/syringe/piercing
 	name = "piercing syringe"
-	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
-	volume = 10
+	desc = "A diamond-tipped syringe that can safely inject its contents into those wearing bulky clothing, it's been designed to be unable to fit into a syringe gun. It can hold up to 15 units."
 	proj_piercing = 1
 /obj/item/reagent_containers/syringe/crude
 	name = "crude syringe"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -618,7 +618,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_weapons/dart_pistol
 	name = "Dart Pistol"
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
-			space a small item can."
+			space a small item can, and it features a modified reciever capable of chambering piercing syringes."
 	item = /obj/item/gun/syringe/syndicate
 	cost = 4
 	surplus = 50


### PR DESCRIPTION
wow its fun to have the counter to something and it still means nothing and you get clicked once and die instantly
dart pistol can still load the piercing syringes because currently its fucking awful and there's no reason for it to exist
piercing syringes not removed because its actually helpful to be able to inject stuff into dead/dying people wearing hardsuits in space or whatever, also piercing syringe capacity changed to 15u to make it better for actually being a syringe and not a projectile

# Changelog
:cl:  
tweak: all syringe guns except the dart pistol can no longer fire piercing syringes
tweak: piercing syringes now hold 15u from 10u
tweak: bonus: syringes that are supposed to pierce armor now do so in melee
/:cl:
