### PR TITLE
Bodies copy damage to chairs

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1888,7 +1888,6 @@ GLOBAL_LIST_EMPTY(mentor_races)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * hit_percent * H.physiology.brain_mod)
 	
 	if(H.buckled && istype(H.buckled, /obj/structure))//prevent buckling corpses to chairs to make indestructible projectile walls
-		to_chat(world, "[H] is buckled to [H.buckled]")
 		var/obj/structure/sitter = H.buckled
 		sitter.take_damage(damage, damagetype)
 	return 1

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1886,6 +1886,11 @@ GLOBAL_LIST_EMPTY(mentor_races)
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)
 		if(BRAIN)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * hit_percent * H.physiology.brain_mod)
+	
+	if(H.buckled && istype(H.buckled, /obj/structure))//prevent buckling corpses to chairs to make indestructible projectile walls
+		to_chat(world, "[H] is buckled to [H.buckled]")
+		var/obj/structure/sitter = H.buckled
+		sitter.take_damage(damage, damagetype)
 	return 1
 
 /datum/species/proc/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)


### PR DESCRIPTION
This removes the wonky strat of using corpses buckled to chairs as invincible walls against projectiles.
It still works, the chair just eventually breaks.

:cl:  
tweak: dealing damage to a corpse buckled to a chair also damages the chair
/:cl:
