### PR TITLE
Preternis charge the Vxtvul Hammer 1 second faster than other species

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1051,7 +1051,7 @@
 		to_chat(user, span_notice("You begin charging the weapon, concentration flowing into it..."))
 		user.visible_message(span_warning("[user] flicks the hammer on, tilting their head down as if in thought."))
 		spark_system.start() //Generates sparks when you charge
-		if(!do_mob(user, user, 6 SECONDS))
+		if(!do_mob(user, user, ispreternis(user)? 5 SECONDS : 6 SECONDS))
 			if(!charging) //So no duplicate messages
 				return
 			to_chat(user, span_notice("You flip the switch off as you lose your focus."))


### PR DESCRIPTION
With the rework, preternis attack slower than regular species, this also made their species specific hammer weaker for them than anyone else using it.
This buffs it without making it better at regular combat.

It goes from 6 seconds to 5 seconds in their hands

:cl:  
tweak: Preternis charge the Vxtvul hammer faster
/:cl:
