### PR TITLE
mech strafe fix

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -618,7 +618,7 @@
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in))
 		move_result = mechsteprand()
-	else if(dir != direction && (!strafe || occupant.client.keys_held["Alt"]))
+	else if(dir != direction && (!strafe || occupant?.client?.prefs.bindings.isheld_key("Alt")))
 		move_result = mechturn(direction)
 	else
 		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in))


### PR DESCRIPTION
# Document the changes in your pull request

client var `keys_held` is non-functional, pressed keys are stored in /datum/keybindings

there are other things that are similarly broken but will need to be individually evaluated and atomized because they may break things or not be desired anymore

# Changelog

:cl:  
bugfix: fixed not being able to turn off strafing by holding the alt key
/:cl:
