### PR TITLE
Remove mediborg pinpointer due to having access to the Lifeline modular computer program

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -853,15 +853,6 @@
 		for(var/obj/item/gun/energy/plasmacutter/adv/cyborg/PC in R.module.modules)
 			R.module.remove_module(PC, TRUE)
 
-/obj/item/borg/upgrade/pinpointer
-	name = "medical cyborg crew pinpointer"
-	desc = "A crew pinpointer module for the medical cyborg."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "pinpointer_crew"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/medical
-	module_flags = BORG_MODULE_MEDICAL
-
 /obj/item/borg/upgrade/transform
 	name = "borg module picker (Standard)"
 	desc = "Allows you to turn a cyborg into a standard cyborg."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -862,25 +862,6 @@
 	module_type = /obj/item/robot_module/medical
 	module_flags = BORG_MODULE_MEDICAL
 
-/obj/item/borg/upgrade/pinpointer/action(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-
-		var/obj/item/pinpointer/crew/PP = locate() in R.module.modules
-		if(PP)
-			to_chat(user, span_warning("This unit is already equipped with a pinpointer module."))
-			return FALSE
-
-		PP = new(R.module)
-		R.module.basic_modules += PP
-		R.module.add_module(PP, FALSE, TRUE)
-
-/obj/item/borg/upgrade/pinpointer/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (.)
-		for(var/obj/item/pinpointer/crew/PP in R.module.modules)
-			R.module.remove_module(PP, TRUE)
-
 /obj/item/borg/upgrade/transform
 	name = "borg module picker (Standard)"
 	desc = "Allows you to turn a cyborg into a standard cyborg."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -845,15 +845,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_pinpointer
-	name = "Cyborg Upgrade (Crew pinpointer)"
-	id = "borg_upgrade_pinpointer"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/pinpointer
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracker (Exosuit Tracking Beacon)"


### PR DESCRIPTION
# Document the changes in your pull request
Mediborgs no longer need the medical pinpointer due to having access to the Modular Computers Lifeline program. They can download it at round start and it seems to function better than crew pinpointer.

# Wiki Documentation
@missatessatessy if crew pinpointer is listed as an available module on cyborg wiki stuff, I'll give you cheese to update it to mention the Lifeline program
# Changelog
:cl:  
rscdel: Removed Medical Cyborg pinpointer in favor of modular computer Lifeline program
/:cl:
