### PR TITLE
ACTUALLY makes vial boxes fit on the medical belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -219,7 +219,8 @@
 		/obj/item/pinpointer/crew,
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/holosign_creator/medical,
-		/obj/item/holosign_creator/firstaid
+		/obj/item/holosign_creator/firstaid,
+		/obj/item/storage/lockbox/vialbox
 		))
 
 /obj/item/storage/belt/medical/chief


### PR DESCRIPTION
# Document the changes in your pull request

Our coders are liars

# Wiki Documentation

No I changed the wiki already for this PR because I possess massive prophetic ability

# Changelog

:cl:  
tweak: Vial boxes now ACTUALLY go on medibelts
/:cl:
