### PR TITLE
7.62mm

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -1,27 +1,27 @@
 // 7.62 (Nagant Rifle)
 
 /obj/item/ammo_casing/a762
-	name = "7.62 bullet casing"
-	desc = "A 7.62 bullet casing."
+	name = "7.62mm bullet casing"
+	desc = "A 7.62mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/raze
-	name = "7.62 Raze bullet casing"
-	desc = "A 7.62 Raze bullet casing."
+	name = "7.62mm Raze bullet casing"
+	desc = "A 7.62mm Raze bullet casing."
 	icon_state = "762R-casing"
 	projectile_type = /obj/item/projectile/bullet/a762/raze
 
 /obj/item/ammo_casing/a762/pen
-	name = "7.62 anti-material bullet casing"
-	desc = "A 7.62 anti-material bullet casing."
+	name = "7.62mm anti-material bullet casing"
+	desc = "A 7.62mm anti-material bullet casing."
 	icon_state = "762P-casing"
 	projectile_type = /obj/item/projectile/bullet/a762/pen
 
 /obj/item/ammo_casing/a762/vulcan
-	name = "7.62 Vulcan bullet casing"
-	desc = "A 7.62 Vulcan bullet casing."
+	name = "7.62mm Vulcan bullet casing"
+	desc = "A 7.62mm Vulcan bullet casing."
 	icon_state = "762I-casing"
 	projectile_type = /obj/item/projectile/bullet/a762/vulcan
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -107,7 +107,7 @@
 
 /obj/item/ammo_box/a762
 	name = "stripper clip (7.62mm)"
-	desc = "A stripper clip."
+	desc = "A stripper clip holding 7.62mm rounds."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
 	max_ammo = 5

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -123,8 +123,8 @@
 	return
 
 /obj/item/ammo_box/magazine/ks762
-	name = "rifle magazine (7.62)"
-	desc = "A standard 11-round magazine for the K-41s DMR. Filled with 7.62 rounds."
+	name = "rifle magazine (7.62mm)"
+	desc = "A standard 11-round magazine for the K-41s DMR. Filled with 7.62mm rounds."
 	icon_state = "ks762"
 	ammo_type = /obj/item/ammo_casing/a762
 	caliber = "a762"
@@ -138,24 +138,24 @@
 		icon_state = "ks762[sprite_designation]_empty"
 
 /obj/item/ammo_box/magazine/ks762/raze
-	name = "rifle magazine (Raze 7.62)"
-	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with Raze 7.62 rounds. \
+	name = "rifle magazine (Raze 7.62mm)"
+	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with Raze 7.62mm rounds. \
 			These rounds do notably less damage, but release radium dust in targets that severely damages their DNA structure."
 	icon_state = "ks762R"
 	ammo_type = /obj/item/ammo_casing/a762/raze
 	sprite_designation = "R"
 
 /obj/item/ammo_box/magazine/ks762/pen
-	name = "rifle magazine (Anti-Material 7.62)"
-	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with anti-material 7.62 rounds. \
+	name = "rifle magazine (Anti-Material 7.62mm)"
+	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with anti-material 7.62mm rounds. \
 			These rounds offer less stopping power, but pierce through a couple of objects before stopping."
 	icon_state = "ks762P"
 	ammo_type = /obj/item/ammo_casing/a762/pen
 	sprite_designation = "P"
 
 /obj/item/ammo_box/magazine/ks762/vulcan
-	name = "rifle magazine (Vulcan 7.62)"
-	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with Vulcan 7.62 rounds. \
+	name = "rifle magazine (Vulcan 7.62mm)"
+	desc = "An alternative 11-round magazine for the K-41s DMR. Filled with Vulcan 7.62mm rounds. \
 			These rounds are loaded with an incendiary payload that causes fire to erupt out upon impact."
 	icon_state = "ks762I"
 	ammo_type = /obj/item/ammo_casing/a762/vulcan

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -318,7 +318,7 @@
 
 /obj/item/gun/ballistic/automatic/k41s
 	name = "\improper K-41s DMR"
-	desc = "A sleek, urban camouflage rifle that fires powerful 7.62 rounds. Comes with a mid-range scope."
+	desc = "A sleek, urban camouflage rifle that fires powerful 7.62mm rounds. Comes with a mid-range scope."
 	icon_state = "dmr"
 	item_state = "dmr"
 	fire_sound = "sound/weapons/dmrshot.ogg"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -38,14 +38,14 @@
 // 7.62 (Nagant Rifle + K-41s DMR)
 
 /obj/item/projectile/bullet/a762
-	name = "7.62 bullet"
+	name = "7.62mm bullet"
 	speed = 0.3
 	damage = 60
 	wound_bonus = -35
 	wound_falloff_tile = 0
 
 /obj/item/projectile/bullet/a762/raze
-	name = "7.62 Raze bullet"
+	name = "7.62mm Raze bullet"
 	damage = 40
 	irradiate = 300
 
@@ -56,7 +56,7 @@
 	return ..()
 
 /obj/item/projectile/bullet/a762/pen
-	name = "7.62 anti-material bullet"
+	name = "7.62mm anti-material bullet"
 	damage = 52
 	armour_penetration = 40
 	penetrating = TRUE //Passes through two objects, stops on a mob or on a third object
@@ -64,7 +64,7 @@
 	penetration_type = 1
 
 /obj/item/projectile/bullet/a762/vulcan
-	name = "7.62 Vulcan bullet"
+	name = "7.62mm Vulcan bullet"
 	damage = 47
 
 /obj/item/projectile/bullet/a762/vulcan/on_hit(atom/target, blocked = FALSE) //God-forsaken mutant of explosion and incendiary code that makes it so it does an explosion basically without the throwing around
@@ -80,7 +80,7 @@
 	return BULLET_ACT_HIT
 
 /obj/item/projectile/bullet/a762_enchanted
-	name = "enchanted 7.62 bullet"
+	name = "enchanted 7.62mm bullet"
 	damage = 20
 	stamina = 80
 


### PR DESCRIPTION
# Document the changes in your pull request

So hilariously going through it the one instance where 7.62mm was used properly was in the name of the stripper clip

Nowhere else was it right because I love to perpetuate mistakes by repeating what coders before me did wrong

# Wiki Documentation

Technically Syndicate Items will need the same treatment but NOT Guide to Combat since it was right on there

# Changelog

:cl:  
spellcheck: Rectifies gun measurements so America can prosper
/:cl:
