### PR TITLE
removes maint access from security officers outside of engie guards and skeleton crew

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(available_depts_sec, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICA
 			accessory = /obj/item/clothing/accessory/armband/cargo
 		if(SEC_DEPT_ENGINEERING)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/engi
-			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ATMOSPHERICS)
+			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ATMOSPHERICS, ACCESS_MAINT_TUNNELS)
 			destination = /area/security/checkpoint/engineering
 			spawn_point = locate(/obj/effect/landmark/start/depsec/engineering) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/engine

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -364,7 +364,7 @@ MINIMAL_ACCESS_THRESHOLD 18
 #ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you dectivate JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
-SECURITY_HAS_MAINT_ACCESS
+#SECURITY_HAS_MAINT_ACCESS
 
 ## Uncomment to give everyone maint access.
 #EVERYONE_HAS_MAINT_ACCESS


### PR DESCRIPTION
makes the 'roll around maintenance roundstart searching for a valid' technique less common or fast, it's not fun for anyone when there's 6 security officers running around maintenance roundstart and killing all the valids in like 5 minutes which ruins the game for everyone. they can of course get access added to their ID but that requires cooperation between players and at the very least will slow down the maintenance rollout
engie guard gets maintenance access because maintenance is part of engineering (technically) so it makes sense
# Changelog

:cl:  
tweak: maintenance access is now restricted to engineering security or lowpop security, otherwise they dont have it
/:cl:
