### PR TITLE
Fixes book description for how to make the ashen blade

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -1,6 +1,6 @@
 /datum/eldritch_knowledge/base_ash
 	name = "Nightwatcher's Secret"
-	desc = "Opens up the path of ash to you. Allows you to transmute a match with a knife or its derivatives into an ashen blade. Additionally empowers your mansus grasp to throw away enemies."
+	desc = "Opens up the path of ash to you. Allows you to transmute a pile of ash with a knife or its derivatives into an ashen blade. Additionally empowers your mansus grasp to throw away enemies."
 	gain_text = "The City Guard knows their watch. If you ask them past dusk they may tell you tales of the Ashy Lantern."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ash_knife)


### PR DESCRIPTION
# Document the changes in your pull request

NO YOU DON'T NEED A MATCHBOX TO MAKE THE CITRUS BLADE

# Changelog

:cl:  
spellcheck: Ash blade flavor text ritual thingy fixed to proper recipe
/:cl:
