### PR TITLE
POWER CONSUMPTION now depends on the PLAYTIME OF ENGINEERS 

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -18,3 +18,5 @@ GLOBAL_LIST_EMPTY(powernets)
 GLOBAL_VAR_INIT(bsa_unlock, FALSE)	//BSA unlocked by head ID swipes
 
 GLOBAL_LIST_EMPTY(player_details)	// ckey -> /datum/player_details
+
+GLOBAL_VAR_INIT(power_mod, 1)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -611,7 +611,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   * Add a power value amount to the stored used_x variables
   */
 /area/proc/use_power(amount, chan)
-
+	amount *= GLOB.power_mod
 	switch(chan)
 		if(EQUIP)
 			used_equip += amount

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -94,6 +94,27 @@ GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, E
 	else
 		to_chat(M, "<b>You have not been assigned to any department. Patrol the halls and help where needed.</b>")
 
+	var/most_hours_played = 0
+	for (var/mob/M in GLOB.player_list)
+		var/mob/living/carbon/human/H = M
+		if (istype(H))
+			var/datum/job/J = SSjob.GetJob(H.job)
+			if (J && J.department_flag == ENGSEC)
+				if ((H.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60) > most_hours_played)
+					most_hours_played = (H.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60)
+	
+	//Time to balance
+
+	var/x1 = 10
+	var/x2 = most_hours_played
+	var/x3 = 1000
+	var/y1 = 0.5
+	var/y3 = 120
+
+	var/a1 = (((x2 - x1) * (y3 - y1)) / (x3 - x1)) + y1
+
+	GLOB.power_mod = clamp(a1, 0.5, 100)
+
 /datum/outfit/job/engineer
 	name = "Station Engineer"
 	jobtype = /datum/job/engineer

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -95,13 +95,13 @@ GLOBAL_LIST_INIT(available_depts_eng, list(ENG_DEPT_MEDICAL, ENG_DEPT_SCIENCE, E
 		to_chat(M, "<b>You have not been assigned to any department. Patrol the halls and help where needed.</b>")
 
 	var/most_hours_played = 0
-	for (var/mob/M in GLOB.player_list)
-		var/mob/living/carbon/human/H = M
-		if (istype(H))
-			var/datum/job/J = SSjob.GetJob(H.job)
+	for (var/mob/plr in GLOB.player_list)
+		var/mob/living/carbon/human/hm = plr
+		if (istype(hm))
+			var/datum/job/J = SSjob.GetJob(hm.job)
 			if (J && J.department_flag == ENGSEC)
-				if ((H.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60) > most_hours_played)
-					most_hours_played = (H.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60)
+				if ((hm.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60) > most_hours_played)
+					most_hours_played = (hm.client.prefs.exp[EXP_TYPE_ENGINEERING] / 60)
 	
 	//Time to balance
 


### PR DESCRIPTION
# Document the changes in your pull request
To make it easier to balance around having two different kinds of engineers, noob and pro, I have decided to make it easier for noob engineers to power the station and harder for pro engineers to power the station, which means the hours you learn how to make a 1000 TW supermatter are actually useful.

# Wiki Documentation
Engineering gets HARDER NOW

# Changelog

:cl:  
rscadd: POWER CONSUMPTION now depends on the PLAYTIME OF ENGINEERS 
/:cl:
