### PR TITLE
Improves and doesnt remove antinobilium

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1706,7 +1706,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Ensures a storm of EMP waves that blacks out the entire station and eventually the full delamination of the crystal. \
 			Comes with a secure radiation shielded containment box, special tweezers and usage instructions."
 	item = /obj/item/storage/box/syndie_kit/supermatter_delaminator
-	cost = 10
+	cost = 3
 	manufacturer = /datum/corporation/traitor/waffleco
 	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr, /datum/objective/nuclear) //yogs
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration


### PR DESCRIPTION
# Document the changes in your pull request
Changed the TC price of antinobilium from 10 to 3. I have determined this is a fair value seeing as how it takes 1 C4 to destroy the SM, and a revolver does the same. and both have INFINITELY more utility and value. Frankly this should be a free item since it's more likely to get you killed than it is to give you a benefit which is just a station wide EMP.

# Wiki Documentation
Changed the TC price of antinobilium from 10 to 3.
# Changelog
:cl:  
tweak: Changed the TC price of antinobilium from 10 to 3.
/:cl:
