### PR TITLE
Stock parts level now affect the power consumption of the machine it is installed in.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -61,6 +61,7 @@
 			continue
 		available_treatments |= treatments[i]
 	stasis = (I >= 4)
+	. = ..()
 
 /obj/machinery/sleeper/update_icon()
 	if(state_open)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -69,8 +69,6 @@ Class Procs:
       contained in the component_parts list. (example: glass and material amounts for
       the autolathe)
 
-      Default definition does nothing.
-
    process()                  'game/machinery/machine.dm'
       Called by the 'machinery subsystem' once per machinery tick for each machine that is listed in its 'machines' list.
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -353,6 +353,8 @@ Class Procs:
 
 /obj/machinery/proc/RefreshParts() //Placeholder proc for machines that are built using frames.
 	avgrating = 1
+	if (length(component_parts) <= 0)
+		return
 	for (var/obj/item/stock_parts/part in component_parts)
 		avgrating += part.rating
 	avgrating /= length(component_parts)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -131,6 +131,8 @@ Class Procs:
 	var/climb_stun = 20
 	var/mob/living/machineclimber
 
+	var/avgrating
+
 /obj/machinery/Initialize()
 	if(!armor)
 		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 70)
@@ -352,6 +354,10 @@ Class Procs:
 	RefreshParts()
 
 /obj/machinery/proc/RefreshParts() //Placeholder proc for machines that are built using frames.
+	avgrating = 1
+	for (var/obj/item/stock_parts/part in component_parts)
+		avgrating += part.rating
+	avgrating /= length(component_parts)
 	return
 
 /obj/machinery/proc/default_pry_open(obj/item/I)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -235,6 +235,7 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		T -= M.rating*0.2
 	prod_coeff = min(1,max(0,T)) // Coeff going 1 -> 0,8 -> 0,6 -> 0,4
+	. = ..()
 
 /obj/machinery/autolathe/examine(mob/user)
 	. += ..()

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -119,6 +119,7 @@
 	charge_rate = 500
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		charge_rate *= C.rating
+	. = ..()
 
 /obj/machinery/cell_charger/process()
 	if(!charging || !anchored || (stat & (BROKEN|NOPOWER)))

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -90,6 +90,7 @@ GLOBAL_VAR_INIT(clones, 0)
 		heal_level = MINIMUM_HEAL_LEVEL
 	if(heal_level > 100)
 		heal_level = 100
+	. = ..()
 
 /obj/machinery/clonepod/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -79,7 +79,8 @@
 	if(board)
 		suction_enabled = board.suction
 		transmit_enabled = board.transmit
-
+	. = ..()
+	
 /obj/machinery/dish_drive/process()
 	if(time_since_dishes <= world.time && transmit_enabled)
 		do_the_dishes()

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -111,6 +111,7 @@
 	workingPower = lasers / 2 //used in the amount of moles processed
 
 	efficiency = (cap + 1) * 0.5 //used in the amount of charge in power cell uses
+	. = ..()
 
 /obj/machinery/electrolyzer/attackby(obj/item/I, mob/user, params)
 	add_fingerprint(user)

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -39,6 +39,7 @@
 		rating += L.rating
 	bite_size = initial(bite_size) + rating * 5
 	nutrient_to_meat = initial(nutrient_to_meat) - rating * 5
+	. = ..()
 
 /obj/machinery/fat_sucker/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -26,6 +26,7 @@
 	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
 		max_time -= L.rating
 	interval = max(max_time,1)
+	. = ..()
 
 /obj/machinery/harvester/update_icon(warming_up)
 	if(warming_up)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -177,6 +177,7 @@ obj/machinery/holopad/secure/Initialize()
 	for(var/obj/item/stock_parts/capacitor/B in component_parts)
 		holograph_range += 1 * B.rating
 	holo_range = holograph_range
+	. = ..()
 
 /obj/machinery/holopad/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -25,6 +25,7 @@
 		E += M.rating
 	range = initial(range)
 	range *= E
+	. = ..()
 
 /obj/machinery/launchpad/Initialize()
 	. = ..()

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -282,6 +282,7 @@
 	for(var/obj/item/stock_parts/manipulator/our_manipulator in component_parts)
 		production_coefficient -= our_manipulator.rating * 0.25
 	production_coefficient = clamp(production_coefficient, 0, 1) // coefficient goes from 1 -> 0.75 -> 0.5 -> 0.25
+	. = ..()
 
 /obj/machinery/limbgrower/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -85,7 +85,7 @@
 	var/obj/item/circuitboard/machine/medical_kiosk/board = circuit
 	if(board)
 		active_price = board.custom_cost
-	return
+	. = ..()
 
 /obj/machinery/medical_kiosk/attackby(obj/item/O, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "kiosk_open", "kiosk", O))

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -49,6 +49,7 @@
 	teleport_speed -= (E*10)
 	teleport_cooldown = initial(teleport_cooldown)
 	teleport_cooldown -= (E * 100)
+	. = ..()
 
 /obj/machinery/quantumpad/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "pad-idle-o", "qpad-idle", I))

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -42,6 +42,7 @@
 		if(charging)
 			var/obj/item/stock_parts/cell/C = charging.get_cell()
 			. += "<span class='notice'>- \The [charging]'s cell is at <b>[C.percent()]%</b>.<span>"
+	. = ..()
 
 
 /obj/machinery/recharger/proc/setCharging(new_charging)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -27,6 +27,7 @@
 		repairs += M.rating - 1
 	for(var/obj/item/stock_parts/cell/C in component_parts)
 		recharge_speed *= C.maxcharge / 10000
+	. = ..()
 
 /obj/machinery/recharge_station/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -38,6 +38,7 @@
 	var/datum/component/butchering/butchering = GetComponent(/datum/component/butchering)
 	butchering.effectiveness = amount_produced
 	butchering.bonus_modifier = amount_produced/5
+	. = ..()
 
 /obj/machinery/recycler/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -130,6 +130,7 @@
 	targetTemperature = clamp(targetTemperature,
 		max(settableTemperatureMedian - settableTemperatureRange, TCMB),
 		settableTemperatureMedian + settableTemperatureRange)
+	. = ..()
 
 /obj/machinery/space_heater/emp_act(severity)
 	. = ..()

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -58,6 +58,7 @@
 	if(occupant)
 		thaw_them(occupant)
 		chill_out(occupant)
+	. = ..()
 	
 
 /obj/machinery/stasis/ComponentInitialize()

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -30,6 +30,7 @@
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		A += M.rating
 	accuracy = A
+	. = ..()
 
 /obj/machinery/teleport/hub/examine(mob/user)
 	. = ..()
@@ -127,6 +128,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		E += C.rating
 	efficiency = E - 1
+	. = ..()
 
 /obj/machinery/teleport/station/examine(mob/user)
 	. = ..()

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -46,6 +46,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		MC += C.rating
 	max_charge = MC * 25
+	. = ..()
 
 /obj/machinery/mech_bay_recharge_port/examine(mob/user)
 	. = ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -123,6 +123,7 @@
 		build_finish = world.time + new_build_time
 
 	update_static_data(usr)
+	. = ..()
 
 /obj/machinery/mecha_part_fabricator/examine(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -69,6 +69,7 @@
 	unconscious_factor = initial(unconscious_factor) * C
 	heat_capacity = initial(heat_capacity) / C
 	conduction_coefficient = initial(conduction_coefficient) * C
+	. = ..()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/examine(mob/user) //this is leaving out everything but efficiency since they follow the same idea of "better beaker, better results"
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -38,6 +38,7 @@
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		B += M.rating
 	heat_capacity = 5000 * ((B - 1) ** 2)
+	. = ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon()
 	cut_overlays()
@@ -209,6 +210,7 @@
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		L += M.rating
 	min_temperature = max(T0C - (initial(min_temperature) + L * 15), TCMB) //73.15K with T1 stock parts
+	. = ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
@@ -235,6 +237,7 @@
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		L += M.rating
 	max_temperature = T20C + (initial(max_temperature) * L) //573.15K with T1 stock parts
+	. = ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/AltClick(mob/living/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -69,6 +69,7 @@ God bless America.
 		oil_efficiency += M.rating
 	oil_use = initial(oil_use) - (oil_efficiency * 0.0095)
 	fry_speed = oil_efficiency
+	. = ..()
 
 /obj/machinery/deepfryer/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -29,6 +29,7 @@
 		gibtime -= 5 * M.rating
 		if(M.rating >= 2)
 			ignore_clothing = TRUE
+	. = ..()
 
 /obj/machinery/gibber/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -51,6 +51,7 @@
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		max_n_of_items = 10 * M.rating
 		break
+	. = ..()
 
 /obj/machinery/microwave/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 		cube_production += B.rating * 0.1
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		cube_production += M.rating * 0.1
+	. = ..()
 
 /obj/machinery/monkey_recycler/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -20,6 +20,7 @@
 		rating_amount = B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		rating_speed = M.rating
+	. = ..()
 
 /obj/machinery/processor/examine(mob/user)
 	. = ..()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -61,6 +61,7 @@
 /obj/machinery/smartfridge/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_n_of_items = initial(max_n_of_items) * B.rating
+	. = ..()
 
 /obj/machinery/smartfridge/examine(mob/user)
 	. = ..()
@@ -616,6 +617,7 @@
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_n_of_items = 20 * B.rating
 		repair_rate = max(0, STANDARD_ORGAN_HEALING * (B.rating - 1))
+	. = ..()
 
 /obj/machinery/smartfridge/organ/Destroy()
 	for(var/organ in src)

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -56,6 +56,7 @@
 	efficiency = E
 	productivity = P
 	max_items = max_storage
+	. = ..()
 
 /obj/machinery/biogenerator/examine(mob/user)
 	. = ..()

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -54,6 +54,7 @@
 			max_endurance = 100
 			min_wchance = 0
 			min_wrate = 0
+	. = ..()
 
 /obj/machinery/plantgenes/update_icon()
 	..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -45,6 +45,7 @@
 		rating = M.rating
 	maxwater = tmp_capacity * 50 // Up to 300
 	maxnutri = tmp_capacity * 5 // Up to 30
+	. = ..()
 
 /obj/machinery/hydroponics/constructable/examine(mob/user)
 	. = ..()

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -75,6 +75,7 @@
 		max_seeds = staring_max_seeds * B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		seed_multiplier = staring_seed_multiplier * M.rating
+	. = ..()
 
 /obj/machinery/seed_extractor/examine(mob/user)
 	. = ..()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -47,6 +47,7 @@
 	ore_pickup_rate = ore_pickup_rate_temp
 	point_upgrade = point_upgrade_temp
 	sheet_per_ore = round(sheet_per_ore_temp, 0.01)
+	. = ..()
 
 /obj/machinery/mineral/ore_redemption/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/ai_data_core.dm
@@ -49,6 +49,7 @@ GLOBAL_VAR_INIT(primary_data_core, null)
 	heat_modifier = new_heat_mod
 	power_modifier = new_power_mod
 	active_power_usage = AI_DATA_CORE_POWER_USAGE * power_modifier
+	. = ..()
 
 /obj/machinery/ai/data_core/process_atmos()
 	calculate_validity()

--- a/code/modules/mob/living/silicon/ai/decentralized/server_cabinet.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/server_cabinet.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_EMPTY(server_cabinets)
 	power_modifier = new_power_mod
 
 	idle_power_usage = initial(idle_power_usage) * power_modifier
+	. = ..()
 
 /obj/machinery/ai/server_cabinet/process_atmos()
 	valid_ticks = clamp(valid_ticks, 0, MAX_AI_EXPANSION_TICKS)

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -39,7 +39,6 @@
 		efficiency_coeff = INFINITY
 	else
 		efficiency_coeff = 1/total_rating
-	. = ..()
 
 
 /obj/machinery/rack_creator/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -39,6 +39,7 @@
 		efficiency_coeff = INFINITY
 	else
 		efficiency_coeff = 1/total_rating
+	. = ..()
 
 
 /obj/machinery/rack_creator/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -112,6 +112,7 @@
 			consumption_coeff += SP.rating
 	power_gen = round(initial(power_gen) * temp_rating * 2)
 	consumption = consumption_coeff
+	. = ..()
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -93,12 +93,7 @@
 		return
 	if(chan == -1)
 		chan = power_channel
-	var/avgrating = 1
-	for (var/obj/item/stock_parts/part in component_parts)
-		avgrating += part.rating
-	avgrating /= length(component_parts)
-	amount = amount ** avgrating;
-	A.use_power(amount, chan)
+	A.use_power(amount ** (avgrating * 0.5), chan)
 
 /obj/machinery/proc/addStaticPower(value, powerchannel)
 	var/area/A = get_area(src)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -93,6 +93,11 @@
 		return
 	if(chan == -1)
 		chan = power_channel
+	var/avgrating = 1
+	for (var/obj/item/stock_parts/part in component_parts)
+		avgrating += part.rating
+	avgrating /= length(component_parts)
+	amount = amount ** avgrating;
 	A.use_power(amount, chan)
 
 /obj/machinery/proc/addStaticPower(value, powerchannel)

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -35,6 +35,7 @@
 		part_level += SP.rating
 
 	power_gen = initial(power_gen) * part_level
+	. = ..()
 
 /obj/machinery/power/rtg/examine(mob/user)
 	. = ..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -98,6 +98,7 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		power_usage -= 50 * M.rating
 	active_power_usage = power_usage
+	. = ..()
 
 /obj/machinery/power/emitter/examine(mob/user)
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -77,6 +77,7 @@
 	capacity = MC / (15000) * 2e7
 	if(!initial(charge) && !charge)
 		charge = C / 15000 * 2e7
+	. = ..()
 
 /obj/machinery/power/smes/attackby(obj/item/I, mob/user, params)
 	//opening using screwdriver

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -40,6 +40,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		input_power_multiplier += C.rating // Each level increases power gain by 100%
 		zap_cooldown -= (C.rating * 20) // Each level decreases cooldown by 2 seconds
+	. = ..()
 
 /obj/machinery/power/tesla_coil/examine(mob/user)
 	. = ..()

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -104,6 +104,7 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		E += M.rating
 	efficiency = E / 6
+	. = ..()
 
 /obj/machinery/power/compressor/examine(mob/user)
 	. = ..()
@@ -193,6 +194,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
 		P += C.rating
 	productivity = P / 6
+	. = ..()
 
 /obj/machinery/power/turbine/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -424,6 +424,7 @@
 		if (M.rating > 3) // T4+
 			dispensable_reagents |= t4_upgrade_reagents
 	powerefficiency = round(newpowereff, 0.01)
+	. = ..()
 
 /obj/machinery/chem_dispenser/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -54,6 +54,7 @@
 	heater_coefficient = initial(heater_coefficient)
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		heater_coefficient *= M.rating
+	. = ..()
 
 /obj/machinery/chem_heater/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -45,6 +45,7 @@
 	reagents.maximum_volume = 0
 	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
 		reagents.maximum_volume += B.reagents.maximum_volume
+	. = ..()
 
 /obj/machinery/chem_master/ex_act(severity, target)
 	if(severity < 3)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -59,6 +59,7 @@
 	speed = 1
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		speed = M.rating
+	. = ..()
 
 /obj/machinery/reagentgrinder/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -61,6 +61,7 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		max_range += M.rating
 	max_range = max(3, max_range)
+	. = ..()
 
 /obj/machinery/smoke_machine/process()
 	..()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -19,6 +19,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	for(var/obj/item/stock_parts/S in component_parts)
 		T += S.rating
 	decon_mod = T
+	. = ..()
 
 
 /obj/machinery/rnd/destructive_analyzer/proc/ConvertReqString2List(list/source_list)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -99,6 +99,7 @@
 		new_badThingCoeff += M.rating
 	resetTime = min(resetTime, new_resetTime)
 	badThingCoeff = max(badThingCoeff, new_badThingCoeff)
+	. = ..()
 
 /obj/machinery/rnd/experimentor/examine(mob/user)
 	. = ..()

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -49,6 +49,7 @@
 
 /obj/machinery/rnd/production/RefreshParts()
 	calculate_efficiency()
+	. = ..()
 
 /obj/machinery/rnd/production/ui_interact(mob/user)
 	user.set_machine(src)

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -28,6 +28,7 @@
 	scan_level = 0
 	for(var/obj/item/stock_parts/scanning_module/P in component_parts)
 		scan_level += P.rating
+	. = ..()
 
 /obj/machinery/nanite_chamber/examine(mob/user)
 	. = ..()

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -26,6 +26,7 @@
 	var/obj/item/circuitboard/machine/public_nanite_chamber/board = circuit
 	if(board)
 		cloud_id = board.cloud_id
+	. = ..()
 
 /obj/machinery/public_nanite_chamber/proc/set_busy(status, working_icon)
 	busy = status

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -38,6 +38,7 @@
 	for(var/obj/item/stock_parts/SP in src)
 		tot_rating += SP.rating
 	heat_gen /= max(1, tot_rating)
+	. = ..()
 
 /obj/machinery/rnd/server/update_icon()
 	if(panel_open)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -234,6 +234,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	build_inventory(premium, coin_records, start_empty = TRUE)
 	for(var/obj/item/vending_refill/VR in component_parts)
 		restock(VR)
+	. = ..()
 
 /obj/machinery/vending/deconstruct(disassembled = TRUE)
 	if(!refill_canister) //the non constructable vendors drop metal instead of a machine frame.


### PR DESCRIPTION
# Document the changes in your pull request
Now you can't upgrade every machine from your robotics console without being in lockstep with engineering, and you get to pick and choose what machines are more important, and it has increasing difficulty for engineers generating power as the round goes on, which makes power generation more interesting overall and the choice of what stock parts to put in what machine.

# Wiki Documentation
Stock parts level now affect the power consumption of the machine it is installed in.
# Changelog

:cl:  
tweak: Stock parts level now affect the power consumption of the machine it is installed in.
/:cl:
