### PR TITLE
Revert "Disables TEG from engine rotation, new engine rotation is 50/50 SM:Sing/Tesla"

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 50, "Engine TEG" = 0)
+	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 30, "Engine TEG" = 20)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -137,7 +137,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Transfer 1", "Transfer 2", "Transfer 3", "Transfer 4", "Transfer 5", "Transfer 6", "Transfer 7", "Transfer 8", "Transfer 9", "Transfer 10")
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta Singulo And Tesla" = 50, "Meta SM" = 50, "Meta TEG" = 0)
+	template_names = list("Meta Singulo And Tesla" = 30, "Meta SM" = 50, "Meta TEG" = 20)
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16300
Improve, don't remove.
TEG is also the easiest engine to setup since all you need is a fire and a space loop. People have difficulties getting the machine to actually exist, so it should come pre-setup in the map instead.