### PR TITLE
Lower power cost of weapons and moving on nukie mechs

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -28,11 +28,13 @@
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 4
 	destruction_sleep_duration = 20
+	step_energy_drain = 0.5
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
 	ME.attach(src)
+	ME.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -32,9 +32,11 @@
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
 	. = ..()
+	var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/MW = null
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
 	ME.attach(src)
-	ME.projectile_energy_cost = 20
+	MW = ME
+	MW.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -82,15 +82,19 @@
 
 /obj/mecha/combat/marauder/mauler/loaded/Initialize()
 	. = ..()
+	var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/MW = null
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg(src)
 	ME.attach(src)
-	ME.projectile_energy_cost = 20
+	MW = ME
+	MW.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
 	ME.attach(src)
-	ME.projectile_energy_cost = 20
+	MW = ME
+	MW.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
 	ME.attach(src)
-	ME.projectile_energy_cost = 20
+	MW = ME
+	MW.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -78,15 +78,19 @@
 	wreckage = /obj/structure/mecha_wreckage/mauler
 	max_equip = 5
 	destruction_sleep_duration = 20
+	step_energy_drain = 0.5
 
 /obj/mecha/combat/marauder/mauler/loaded/Initialize()
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg(src)
 	ME.attach(src)
+	ME.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
 	ME.attach(src)
+	ME.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
 	ME.attach(src)
+	ME.projectile_energy_cost = 20
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)


### PR DESCRIPTION
# Document the changes in your pull request
Alternate nukie mech buff to cutting the TC in half, a major problem with nukie mechs is the incredibly high power usage and no place to recharge. This PR aims to solve that by reducing the power cost of basic actions massively.


# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:    
tweak: Lowered power cost of weapons and moving on nukie mechs
/:cl:
