### PR TITLE
Ports https://github.com/tgstation/tgstation/pull/66299

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -145,6 +145,7 @@
 // Subsystem fire priority, from lowest to highest priority
 // If the subsystem isn't listed here it's either DEFAULT or PROCESS (if it's a processing subsystem child)
 
+#define FIRE_PRIORITY_PING 			10
 #define FIRE_PRIORITY_IDLE_NPC		10
 #define FIRE_PRIORITY_SERVER_MAINT	10
 #define FIRE_PRIORITY_RESEARCH		10

--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) 2022 Aleksej Komarov
+ * SPDX-License-Identifier: MIT
+ */
+
+SUBSYSTEM_DEF(ping)
+	name = "Ping"
+	priority = FIRE_PRIORITY_PING
+	wait = 4 SECONDS
+	flags = SS_NO_INIT
+	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+
+	var/list/currentrun = list()
+
+/datum/controller/subsystem/ping/stat_entry()
+	..("P:[GLOB.clients.len]")
+
+/datum/controller/subsystem/ping/fire(resumed = FALSE)
+	// Prepare the new batch of clients
+	if (!resumed)
+		src.currentrun = GLOB.clients.Copy()
+
+	// De-reference the list for sanic speeds
+	var/list/currentrun = src.currentrun
+
+	while (currentrun.len)
+		var/client/client = currentrun[currentrun.len]
+		currentrun.len--
+
+		if (client?.tgui_panel?.is_ready())
+			// Send a soft ping
+			client.tgui_panel.window.send_message("ping/soft", list(
+				// Slightly less than the subsystem timer (somewhat arbitrary)
+				// to prevent incoming pings from resetting the afk state
+				"afk" = client.is_afk(3.5 SECONDS),
+			))
+
+		if (MC_TICK_CHECK)
+			return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -525,7 +525,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.ahelp_tickets.ClientLogout(src)
 	GLOB.directory -= ckey
 	GLOB.clients -= src
-
+	SSping.currentrun -= src
+	
 	var/datum/connection_log/CL = GLOB.connection_logs[ckey]
 	if(CL)
 		CL.logout(mob)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -297,7 +297,7 @@
 	switch(type)
 		if("ready")
 			initialized = TRUE
-		if("pingReply")
+		if("ping/Reply")
 			initialized = TRUE
 		if("suspend")
 			close(can_be_suspended = TRUE)

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -307,7 +307,7 @@
 	// If not locked, handle these message types
 	switch(type)
 		if("ping")
-			send_message("pingReply", payload)
+			send_message("ping/Reply", payload)
 		if("suspend")
 			close(can_be_suspended = TRUE)
 		if("close")

--- a/tgui/packages/tgui-panel/game/constants.js
+++ b/tgui/packages/tgui-panel/game/constants.js
@@ -4,4 +4,4 @@
  * @license MIT
  */
 
-export const CONNECTION_LOST_AFTER = 15000;
+export const CONNECTION_LOST_AFTER = 20000;

--- a/tgui/packages/tgui-panel/game/middleware.js
+++ b/tgui/packages/tgui-panel/game/middleware.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { pingSuccess } from '../ping/actions';
+import { pingSoft, pingSuccess } from '../ping/actions';
 import { connectionLost, connectionRestored, roundRestarted } from './actions';
 import { selectGame } from './selectors';
 import { CONNECTION_LOST_AFTER } from './constants';
@@ -35,9 +35,10 @@ export const gameMiddleware = store => {
     }
   }, 1000);
   return next => action => {
-    const { type, payload, meta } = action;
-    if (type === pingSuccess.type) {
-      lastPingedAt = meta.now;
+    const { type } = action;
+
+    if (type === pingSuccess.type || type === pingSoft.type) {
+      lastPingedAt = Date.now();
       return next(action);
     }
     if (type === roundRestarted.type) {

--- a/tgui/packages/tgui-panel/ping/actions.js
+++ b/tgui/packages/tgui-panel/ping/actions.js
@@ -6,20 +6,20 @@
 
 import { createAction } from 'common/redux';
 
-export const pingSuccess = createAction(
-  'ping/success',
-  ping => {
-    const now = Date.now();
-    const roundtrip = (now - ping.sentAt) * 0.5;
-    return {
-      payload: {
-        lastId: ping.id,
-        roundtrip,
-      },
-      meta: { now },
-    };
-  }
-);
+export const pingReply = createAction('ping/reply');
+
+/**
+ * Soft ping from the server.
+ * It's intended to send periodic server-side metadata about the client,
+ * e.g. its AFK status.
+ */
+export const pingSoft = createAction('ping/soft');
+
+export const pingSuccess = createAction('ping/success', (ping) => ({
+  payload: {
+    lastId: ping.id,
+    roundtrip: (Date.now() - ping.sentAt) * 0.5,
+  },
+}));
 
 export const pingFail = createAction('ping/fail');
-export const pingReply = createAction('ping/reply');

--- a/tgui/packages/tgui-panel/ping/constants.js
+++ b/tgui/packages/tgui-panel/ping/constants.js
@@ -4,7 +4,6 @@
  * @license MIT
  */
 
-export const PING_INTERVAL = 2500;
 export const PING_TIMEOUT = 2000;
 export const PING_MAX_FAILS = 3;
 export const PING_QUEUE_SIZE = 8;

--- a/tgui/packages/tgui-panel/ping/middleware.js
+++ b/tgui/packages/tgui-panel/ping/middleware.js
@@ -5,8 +5,8 @@
  */
 
 import { sendMessage } from 'tgui/backend';
-import { pingFail, pingSuccess } from './actions';
-import { PING_INTERVAL, PING_QUEUE_SIZE, PING_TIMEOUT } from './constants';
+import { pingFail, pingReply, pingSoft, pingSuccess } from './actions';
+import { PING_QUEUE_SIZE, PING_TIMEOUT } from './constants';
 
 export const pingMiddleware = store => {
   let initialized = false;
@@ -32,10 +32,18 @@ export const pingMiddleware = store => {
     const { type, payload } = action;
     if (!initialized) {
       initialized = true;
-      setInterval(sendPing, PING_INTERVAL);
       sendPing();
     }
-    if (type === 'pingReply') {
+    if (type === pingSoft.type) {
+      const { afk } = payload;
+      // On each soft ping where client is not flagged as afk,
+      // initiate a new ping.
+      if (!afk) {
+        sendPing();
+      }
+      return next(action);
+    }
+    if (type === pingReply.type) {
       const { index } = payload;
       const ping = pings[index];
       // Received a timed out ping

--- a/tgui/packages/tgui/backend.js
+++ b/tgui/packages/tgui/backend.js
@@ -144,7 +144,7 @@ export const backendMiddleware = store => {
 
     if (type === 'ping') {
       sendMessage({
-        type: 'pingReply',
+        type: 'ping/Reply',
       });
       return;
     }

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -306,6 +306,7 @@
 #include "code\controllers\subsystem\parallax.dm"
 #include "code\controllers\subsystem\pathfinder.dm"
 #include "code\controllers\subsystem\persistence.dm"
+#include "code\controllers\subsystem\ping.dm"
 #include "code\controllers\subsystem\profiler.dm"
 #include "code\controllers\subsystem\radiation.dm"
 #include "code\controllers\subsystem\radio.dm"


### PR DESCRIPTION
About The Pull Request

Implements soft pings, as it was previously done in Goonchat.

Before: Pings were initiated by tgui-panel and sent continuously in a 2.5 second loop.

Connection quality is based on how many pings were lost, and alert is shown if 3 pings consecutively timed out.

After: Pings are no longer initiated by tgui-panel, and instead are initiated by the ping subsystem in DM. It runs every 4 seconds and sends a "soft" ping, which isn't really a ping, but more of a status update about the client, with information on how long they have been inactive since the last soft ping cycle. If client is active, ping is sent by tgui-panel. That's the only time when the ping number changes, and all other time it will remain the same.

Connection quality is still calculated based on how many pings were lost, but alert is shown only if soft-pings were not received in 10 or so seconds.
Why It's Good For The Game

Inactive and deadminned players will now be properly kicked out of the game, because pings will not be sent by inactive players and will not reset the AFK code.

Both manual reconnect and automatic reconnect now work 100% of the time, because previously pings interfered with the reconnect message sent by Dreamseeker (it's a BYOND bug, blame Lummox for not fixing it for years).

This might also reduce some stress on the server, because AFK players will get kicked, semi-AFK players will not send pings, and frequency of pings is generally much slower now (but it does add a subsystem for sending extra soft pings, so ¯\_(ツ)_/¯)
# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  stylemistake
rscadd: Ping system of tgui-panel has been reworked, which fixes things mentioned below.
bugfix: AFK players now get properly detected and kicked
bugfix: Automatic reconnect should now work 100% of the time
bugfix: Manual reconnect should now work 100% of the time
/:cl:
