### PR TITLE
Telecomms machine now have a chance to turn themselves off if it gets EMPed

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -190,7 +190,8 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 		stat |= EMPED
 		var/duration = (300 * 10)/severity
 		addtimer(CALLBACK(src, .proc/de_emp), rand(duration - 20, duration + 20))
-
+		if (prob(10))
+			on = FALSE
 /obj/machinery/telecomms/proc/de_emp()
 	stat &= ~EMPED
 


### PR DESCRIPTION
# Document the changes in your pull request
Telecomms machine now have a chance to turn themselves off if it gets EMPed. This gives the telecomms admin more content to interact with as well as an excuse for malf AIs to keep it off for extended periods of time, "I was finding the ones that got turned off."
# Wiki Documentation
Telecomms machine now have a chance to turn themselves off if it gets EMPed. 
# Changelog
:cl:  
rscadd: Telecomms machine now have a chance to turn themselves off if it gets EMPed. 
/:cl:
