### PR TITLE
Microwaving a bomb core now causes it to explode

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -270,6 +270,10 @@
 /obj/item/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
 	detonate()
 
+/obj/item/bombcore/microwave_act(obj/machinery/microwave/M)
+	detonate()
+	. = ..()
+	
 
 /obj/item/bombcore/burn()
 	detonate()


### PR DESCRIPTION
# Document the changes in your pull request

Microwaving a bomb core now causes it to explode for consistency

# Wiki Documentation
Microwaving a bomb core now causes it to explode
# Changelog

:cl:  
rscadd: Microwaving a bomb core now causes it to explode
/:cl:
