### PR TITLE
Mail Changes - The Insane Rambling of a Man Cursed with Too Much Mail

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -2,7 +2,9 @@
 #define STARTING_PAYCHECKS_MIN 50 // Minimum roundstart money
 #define STARTING_PAYCHECKS_MAX 250 // Maximum roundstart money
 /// How much mail the Economy SS will create per minute, regardless of firing time.
-#define MAX_MAIL_PER_MINUTE 3
+#define MAX_MAIL_PER_MINUTE 6
+/// Chance to generate junk mail compared to generating nothing while packing mail crates.
+#define MAIL_JUNK_CHANCE 45 
 /// Probability of using letters of envelope sprites on all letters.
 #define FULL_CRATE_LETTER_ODDS 70
 

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -110,7 +110,7 @@ SUBSYSTEM_DEF(economy)
 				B.payday(c.paymodifier, TRUE)
 		B.payday(1)	
 	var/effective_mailcount = living_player_count()
-	mail_waiting += clamp(effective_mailcount, 1, MAX_MAIL_PER_MINUTE * 5 * delta_time)
+	mail_waiting += clamp(effective_mailcount, 1, MAX_MAIL_PER_MINUTE * delta_time)
 
 /datum/controller/subsystem/economy/proc/get_dep_account(dep_id)
 	for(var/datum/bank_account/department/D in generated_accounts)

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -17,11 +17,17 @@
 	/// How many goodies this mail contains.
 	var/goodie_count = 1
 	/// Goodies which can be given to anyone. The base weight for cash is 56. For there to be a 50/50 chance of getting a department item, they need 56 weight as well.
-	var/list/generic_goodies = list(
-		/obj/item/stack/spacecash/c50 = 10,
-		/obj/item/stack/spacecash/c100 = 25,
-		/obj/item/stack/spacecash/c200 = 15,
-		/obj/item/stack/spacecash/c500 = 5,
+	var/list/generic_goodies = list( //yogs, add coins, sorted least valuable to most valuable
+		/obj/item/coin/iron = 2,
+		/obj/item/coin/silver = 2,
+		/obj/item/coin/gold = 2,
+		/obj/item/coin/plasma = 2,
+		/obj/item/stack/spacecash/c50 = 5,
+		/obj/item/stack/spacecash/c100 = 20,
+		/obj/item/coin/diamond = 10,
+		/obj/item/stack/spacecash/c200 = 6,
+		/obj/item/coin/bananium = 4,
+		/obj/item/stack/spacecash/c500 = 2,
 		/obj/item/stack/spacecash/c1000 = 1,
 	)
 	// Overlays (pure fluff)
@@ -210,7 +216,7 @@
 	else
 		icon_state = "[initial(icon_state)]sealed"
 
-/// Fills this mail crate with N pieces of mail, where N is the lower of the amount var passed, and the maximum capacity of this crate. If N is larger than the number of alive human players, the excess will be junkmail.
+/// Fills this mail crate with N pieces of mail, where N is the lower of the amount var passed, and the maximum capacity of this crate. If N is larger than the number of alive human players, it will be padded by a proportional amount of junkmail.
 /obj/structure/closet/crate/mail/proc/populate(amount)
 	var/mail_count = min(amount, storage_capacity)
 	// Fills the
@@ -236,7 +242,7 @@
 		var/datum/mind/recipient = pick_n_take(mail_recipients)
 		if(recipient)
 			new_mail.initialize_for_recipient(recipient)
-		else
+		else if(prob(MAIL_JUNK_CHANCE))
 			new_mail.junk_mail()
 
 	update_icon()

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/autolathe, //same
 		/obj/item/projectile/beam/wormhole,
 		/obj/effect/portal,
-		/obj/item/mail,
 		/obj/item/shared_storage,
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,


### PR DESCRIPTION
# Document the changes in your pull request

We use a define of MAX_MAIL_PER_MINUTE (3) but then when figuring out the waiting mail we multiply that value by 5 so there's actually 15 mail a minute. This is a lot. I have removed the multiplication by 5 and set the MAX_MAIL_PER_MINUTE to 9, which is lower.

I also added the ABILITY TO SEND THE MAIL BACK IF YOU DON'T WANT IT.
What if a Cargo Tech doesn't want to deliver mail? It goes IN THE TRASH!!!!!!!!!!!!!!!!!!!!!!!!!! This way, you don't have to keep going back and forth between the damn trash. 
Clockies knocking on your door and you're panic ordering Energy Gun crates? I HOPE YOU LIKE TAKING OUT THE MAIL!!!!!!!!!!!!!!!!!!!! OH YOU'RE TRYING TO BUY NULL CRATES? THE BOTANIST'S BIRTHDAY CARD FROM THEIR GRANDMA IS STUCK IN THE SPACE BRAKES, THIS SHIT AINT FLYING!

I also adjusted the normal loot pool to include some coins because coins are cool, they are slightly less chance than the equivalent spacecash because you can recycle the coins into materials.

Last thing is I made it so that if there's 3 people on the station you don't get 50000 junk mail, you get 22500 instead (55% less)

# Changelog

:cl:  
tweak: The station gets 9 mail a minute instead of 15
tweak: You can send mail back on the cargo shuttle
tweak: generic mail loot includes various coins
tweak: the chance of filling an empty space in the mail crate with junkmail was reduced from 100% to 45%
/:cl:
