### PR TITLE
Clockcult can now only convert up to 50% of the players in the game

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -88,8 +88,13 @@ Credit where due:
 			R.undeploy()
 			to_chat(AI, span_userdanger("Anomaly Detected. Returned to core!")) //The AI needs to be in its core to properly be converted
 
-	. = L.mind.add_antag_datum(C)
-
+	var/clockies_count = 0
+	for (var/datum/antagonist/clockcult/H in GLOB.antagonists)
+		clockies_count++
+	if (clockies_count <= (GLOB.player_list.len) / 2)
+		. = L.mind.add_antag_datum(C)
+	else
+		. = FALSE
 	if(.)
 		var/datum/antagonist/clockcult/servant = .
 		var/datum/team/clockcult/cult = servant.get_team()


### PR DESCRIPTION

# Document the changes in your pull request
Clockcult can now only convert up to 50% of the players in the game. A stomp is fun for nobody.
# Wiki Documentation
Clockcult can now only convert up to 50% of the players in the game

# Changelog

:cl:  
tweak: Clockcult can now only convert up to 50% of the players in the game
/:cl:
