### PR TITLE
removes undocumented change that completely blocks use of the mech fabricator to EVERYONE who doesn't have robotics access

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -555,9 +555,6 @@
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/ui_interact(mob/user, datum/tgui/ui)
-	if(!allowed(user) && !combat_parts_allowed && !isobserver(user) && !hacked)
-		to_chat(user, span_warning("You do not have the proper credentials to operate this device!"))
-		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ExosuitFabricator")


### PR DESCRIPTION
# Document the changes in your pull request

This change was introduced in #15114 which exists specifically to prevent people from busting into robotics and building combat mechs without proper authorization

![image](https://user-images.githubusercontent.com/24857008/201109507-bfb0eb30-2326-4126-8a08-08733b2ee4a7.png)
![image](https://user-images.githubusercontent.com/24857008/201109486-7029b8f2-d97b-44b3-a81d-d1d61fbdc6cd.png)

No mention is made of preventing non-roboticists from using the mech fabricator in the changelog or title, it's just to prevent people from building combat mechs, which works fine without the piece of code I am excising.

All this does is allow non-roboticists to build things like utility mechs, cyborg parts and implants when lacking specifically a roboticist/RD

# Wiki Documentation

This is likely undocumented on the wiki the same way it was undocumented in the changelog, but mech fabricators will no longer completely block people from using them if they don't have specifically robotics access

# Changelog

:cl:  
rscdel: no more hard access lock on the exosuit fabricator, which was undocumented but apparently in the game anyways.
/:cl:
