### PR TITLE
Makes Crusher Lavaproof

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -21,6 +21,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
 	sharpness = SHARP_EDGED
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15


### PR DESCRIPTION
# Document the changes in your pull request

Makes the Kinetic Crusher lava proof, and fireproof, because I'm tired of it getting knocked into lava and losing an hours worth of megafauna trophies.

I mean... its a super tough mining tool? makes sense to me.

# Wiki Documentation

idk if it needs to be, but potentially add a note reflecting this?

# Changelog


:cl:  
tweak: Makes the Kinetic Crusher immune to fire/lava
/:cl:
