### PR TITLE
Adds Backstab Knife to uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -35,16 +35,14 @@
 			new /obj/item/grenade/syndieminibomb/concussion/frag(src) //See above
 			new /obj/item/flashlight/emp(src) //2 TC
 
-		if("bloodyspai") //31 TCish
+		if("bloodyspai") //32 TCish
 			new /obj/item/clothing/under/chameleon/syndicate(src) //1 TC, has only two parts of the massive kit
 			new /obj/item/clothing/mask/chameleon/syndicate(src) //See above
 			new /obj/item/card/id/syndicate(src) //2 TC
-			new /obj/item/clothing/shoes/chameleon/noslip/syndicate(src) //2 TC
-			new /obj/item/camera_bug(src) //1 TC
 			new /obj/item/multitool/ai_detect(src) //1 TC
 			new /obj/item/encryptionkey/syndicate(src) //2 TC
 			new /obj/item/reagent_containers/syringe/mulligan(src) //4 TC
-			new /obj/item/switchblade(src) //1 TC, if even. 20 force melee is good but it's no edagger
+			new /obj/item/switchblade/backstab(src) //5 TC
 			new /obj/item/storage/box/fancy/cigarettes/cigpack_syndicate (src) //2 TC (for now)
 			new /obj/item/flashlight/emp(src) //2 TC
 			new /obj/item/chameleon(src) //7 TC

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -430,6 +430,20 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] own throat with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return (BRUTELOSS)
 
+/obj/item/switchblade/backstab
+	var/nt = FALSE
+
+/obj/item/switchblade/backstab/nt
+	nt = TRUE
+
+/obj/item/switchblade/backstab/examine(mob/user)
+	. = ..()
+	. += span_danger("\The [src] has a [nt ? "Nanotrasen" : "Syndicate"] marking on the blade.")
+
+/obj/item/switchblade/backstab/Initialize()
+	. = ..()
+	AddComponent(/datum/component/backstabs, 1.75) // 35 damage
+
 /obj/item/phone
 	name = "red phone"
 	desc = "Should anything ever go wrong..."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -413,6 +413,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 
+/datum/uplink_item/dangerous/backstab
+	name = "Backstabbing Switchblade"
+	desc = "This switchblade has a unique shape that makes it especially lethal when lodged in someone's backside. \
+			Still does a moderate amount of damage when applied from the front."
+	item = /obj/item/switchblade/backstab
+	cost = 5
+	// backstabs are pretty funny, clown ops can have this one
+
 /datum/uplink_item/dangerous/bostaff
 	name = "Bo Staff"
 	desc = "A wielded wooden staff that can be used to incapacitate opponents if intending to disarm."

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3383,6 +3383,7 @@
 #include "yogstation\code\datums\world_topic.dm"
 #include "yogstation\code\datums\actions\ninja.dm"
 #include "yogstation\code\datums\antagonists\vampire.dm"
+#include "yogstation\code\datums\components\backstabs.dm"
 #include "yogstation\code\datums\components\crawl.dm"
 #include "yogstation\code\datums\components\daniel.dm"
 #include "yogstation\code\datums\components\fishable.dm"

--- a/yogstation/code/datums/components/backstabs.dm
+++ b/yogstation/code/datums/components/backstabs.dm
@@ -1,0 +1,24 @@
+/datum/component/backstabs
+	var/backstab_multiplier = 2 // 2x damage by default
+
+/datum/component/backstabs/Initialize(mult)
+	backstab_multiplier = mult
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/on_attack)
+
+/datum/component/backstabs/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
+	// No bypassing pacifism nerd
+	if(source.force > 0 && HAS_TRAIT(user, TRAIT_PACIFISM) && (source.damtype != STAMINA))
+		return
+	// Same calculation that kinetic crusher uses
+	var/backstab_dir = get_dir(user, target)
+	// No backstabbing people if they're already in crit
+	if(!target.stat && (user.dir & backstab_dir) && (target.dir & backstab_dir))
+		var/multi = backstab_multiplier - 1
+		var/dmg = source.force * multi
+		if(dmg) // Truthy because backstabs can heal lol
+			target.apply_damage(dmg, source.damtype, BODY_ZONE_CHEST, 0, source.wound_bonus*multi, source.bare_wound_bonus*multi, source.sharpness*multi)
+			log_combat(user, target, "scored a backstab", source.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(source.damtype)])")
+			if(iscarbon(target))
+				target.emote("scream") // SPY AROUND HERE


### PR DESCRIPTION
# Document the changes in your pull request

Backstabbing Switchblade

Metashielded until examined since switchblade is obtainable in other ways, but security should be confiscating these anyways because it's a dangerous weapon

Same as regular switchblade (20 force) but on backstabs does 1.75x more damage (for a total of 35) when backstabbing, associated with an audible scream by the victim

![](https://thumbs.gfycat.com/ElementaryLeafyLeopard-max-1mb.gif)

Uses same backstab detection as kinetic crusher

5TC and also now in the bloodyspai traitor kit as described in changelog

# Changelog

:cl:  
rscadd: Added the backstabbing switchblade to the uplink for 5TC
rscdel: Removed noslips and camera bug from the bloodspai traitor kit
tweak: Replaced the switchblade with the backstabbing switchblade in the bloodyspai traitor kit
/:cl:
