### PR TITLE
Makes splashing reagents on someone respect their permeability protection

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -634,7 +634,7 @@
 				if(!check)
 					continue
 				var/touch_protection = 0
-				if(method == VAPOR)
+				if(method == TOUCH || method == VAPOR)
 					var/mob/living/L = A
 					touch_protection = L.get_permeability_protection()
 				R.reaction_mob(A, method, R.volume * volume_modifier, show_message, touch_protection)


### PR DESCRIPTION
# Document the changes in your pull request
Reagents upon being splashed on someone now respect their permeability values like being in a vapor does, so you can't just heal to full by splashing yourself with styptic powder if you have loads of armor.

# Changelog
:cl:  
bugfix: splashing requires contact with skin, so heavy duty armor will protect from it
/:cl:
