### PR TITLE
Zombies can no longer pull objects

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -64,6 +64,8 @@
 				iter_wound.remove_wound()
 	if(!C.InCritical() && prob(4))
 		playsound(C, pick(spooks), 50, TRUE, 10)
+	if (C.pulling)
+		C.stop_pulling()
 
 //Congrats you somehow died so hard you stopped being a zombie
 /datum/species/zombie/infectious/spec_death(mob/living/carbon/C)


### PR DESCRIPTION
# Document the changes in your pull request
Can't balance zombies if they can stun people with water tanks.

# Changelog

:cl:  
tweak: Zombies can no longer pull objects
/:cl:
