### PR TITLE
Increases wounding chances when doing surgery without anesthetic

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -273,8 +273,8 @@
 		return
 	user.visible_message(span_boldwarning("[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!"), span_boldwarning("[target] flinches, bumping your [tool ? tool.name : "hand"] into something important!"))
 	var/obj/item/bodypart/BP = get_bodypart(target_zone)
-	if(BP?.mangled_state = MANGLED_FLESH)
-		final_wound_bonus = 0 //'ate bone wounds
+	if(BP?.get_mangled_state() = MANGLED_FLESH)
+		final_wound_bonus = -80 they are already quite fucked up, we don't want to KILL them do we? that would make it easy on them.
 	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone, wound_bonus = final_wound_bonus)
 
 ///Deal damage if the user moved during the op

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -259,6 +259,7 @@
 ///Attempts to deal damage if the patient isn't sedated or under painkillers
 /datum/surgery_step/proc/cause_ouchie(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, success)
 	var/ouchie_mod = 1
+	var/final_wound_bonus = 15 //I SURE hope you like BLEEDING
 	for(var/datum/reagent/R in ouchie_modifying_chems)
 		if(target.reagents?.has_reagent(R))
 			ouchie_mod *= ouchie_modifying_chems[R]
@@ -271,7 +272,10 @@
 	if(!prob(final_ouchie_chance))
 		return
 	user.visible_message(span_boldwarning("[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!"), span_boldwarning("[target] flinches, bumping your [tool ? tool.name : "hand"] into something important!"))
-	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone)
+	var/obj/item/bodypart/BP = get_bodypart(target_zone)
+	if(BP?.mangled_state = MANGLED_FLESH)
+		final_wound_bonus = 0 //'ate bone wounds
+	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone, wound_bonus = final_wound_bonus)
 
 ///Deal damage if the user moved during the op
 /datum/surgery_step/proc/move_ouchie(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, success)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -272,7 +272,7 @@
 	if(!prob(final_ouchie_chance))
 		return
 	user.visible_message(span_boldwarning("[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!"), span_boldwarning("[target] flinches, bumping your [tool ? tool.name : "hand"] into something important!"))
-	var/obj/item/bodypart/BP = get_bodypart(target_zone)
+	var/obj/item/bodypart/BP = target.get_bodypart(target_zone)
 	if(BP?.get_mangled_state() = MANGLED_FLESH)
 		final_wound_bonus = -80 they are already quite fucked up, we don't want to KILL them do we? that would make it easy on them.
 	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone, wound_bonus = final_wound_bonus)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -273,8 +273,8 @@
 		return
 	user.visible_message(span_boldwarning("[target] flinches, bumping [user]'s [tool ? tool.name : "hand"] into something important!"), span_boldwarning("[target] flinches, bumping your [tool ? tool.name : "hand"] into something important!"))
 	var/obj/item/bodypart/BP = target.get_bodypart(target_zone)
-	if(BP?.get_mangled_state() = MANGLED_FLESH)
-		final_wound_bonus = -80 they are already quite fucked up, we don't want to KILL them do we? that would make it easy on them.
+	if(BP?.get_mangled_state() <= MANGLED_FLESH )
+		final_wound_bonus = CANT_WOUND //they are already quite fucked up, we don't want to KILL them do we? that would make it easy on them.
 	target.apply_damage(fuckup_damage, fuckup_damage_type, target_zone, wound_bonus = final_wound_bonus)
 
 ///Deal damage if the user moved during the op


### PR DESCRIPTION
# Document the changes in your pull request

I want people to suffer. That is all.

# Wiki Documentation

Surgeries done without anesthetic have a much higher chance to cause wounds if they roll to deal damage

# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
tweak: Surgeries done without anesthetic have a much higher chance to cause wounds if they roll to deal damage
/:cl:
