### PR TITLE
makes lavaland swarmer beacon drop seismic arm

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -55,12 +55,13 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	wander = FALSE
 	layer = BELOW_MOB_LAYER
 	AIStatus = AI_OFF
+	loot = list(/obj/item/bodypart/r_arm/robot/seismic)
+	deathmessage = "falls to pieces, leaving an odd prosthesis behind."
 	var/swarmer_spawn_cooldown = 0
 	var/swarmer_spawn_cooldown_amt = 150 //Deciseconds between the swarmers we spawn
 	var/call_help_cooldown = 0
 	var/call_help_cooldown_amt = 150 //Deciseconds between calling swarmers to help us when attacked
 	var/static/list/swarmer_caps
-
 
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/Initialize()
 	. = ..()
@@ -97,6 +98,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 	gpstag = "Hungry Signal"
 	desc = "Transmitted over the signal is a strange message repeated in every language you know of, and some you don't too..." //the message is "nom nom nom"
 	invisibility = 100
+
 
 //SWARMER AI
 //AI versions of the swarmer mini-antag


### PR DESCRIPTION
# Document the changes in your pull request

the swarmer ruin currently isn't worth interacting with because no amount of bluespace crystals is worth the nuisance of being lasered or cuffed/teleported somewhere that may or may not be gulag. Hopefully this makes the swarmer ruin in lavaland worth digging up on purpose by having the swarmer beacon drop the seismic arm when it dies.

# Wiki Documentation
Not too sure where to put this since in the 'crashed shuttle' part of the ruin list, there's no "loot" section of the chart. Maybe move it to the 'normal ruins' table where loot is a column there and mention the arm? 
https://wiki.yogstation.net/wiki/Ruins

# Changelog
:cl:  
rscadd: Added seismic arm to swarmer ruin
/:cl:
