### PR TITLE
Buffs Beds and Holobeds for surgery

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -23,7 +23,7 @@
 	var/bolts = TRUE
 
 /obj/structure/bed/ComponentInitialize()
-	AddComponent(/datum/component/surgery_bed, 0.85)
+	AddComponent(/datum/component/surgery_bed, 0.8)
 
 /obj/structure/bed/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -23,7 +23,7 @@
 	var/bolts = TRUE
 
 /obj/structure/bed/ComponentInitialize()
-	AddComponent(/datum/component/surgery_bed, 0.7)
+	AddComponent(/datum/component/surgery_bed, 0.85)
 
 /obj/structure/bed/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -192,7 +192,7 @@
 	return ..()
 
 /obj/structure/holobed/ComponentInitialize()
-	AddComponent(/datum/component/surgery_bed, 0.7)
+	AddComponent(/datum/component/surgery_bed, 0.85)
 
 /obj/structure/holobed/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -192,7 +192,7 @@
 	return ..()
 
 /obj/structure/holobed/ComponentInitialize()
-	AddComponent(/datum/component/surgery_bed, 0.85)
+	AddComponent(/datum/component/surgery_bed, 0.8)
 
 /obj/structure/holobed/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
For some reason they were literally worse(0.7) than using any generic table (0.8) or a generic surgical mat (also 0.8)
This brings them to 0.85 which is in-line with the goliath surgical mat
This makes holobeds not terrible, considering they require research and the CMO specifically starts with one, it's weird that they're just bad.

:cl:  
tweak: buffs beds and holobeds to be better at surgeries
/:cl:
