### PR TITLE
Viruses now spread as advertised

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -18,8 +18,9 @@
 			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
 				continue
 
-			if((method == TOUCH || method == VAPOR) && (D.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
-				L.ContactContractDisease(D)
+			if((method == TOUCH || method == VAPOR))
+				if(D.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS)
+					L.ContactContractDisease(D)
 			else //ingest, patch or inject
 				L.ForceContractDisease(D)
 


### PR DESCRIPTION
# Document the changes in your pull request
Makes it so if the virus doesn't have a fluids spread flag and gets splashed on someone, it doesn't get treated like an injection.
Getting splashed by a high transmission viruses is properly blocked by armor.

# Changelog
:cl:  
bugfix: being splashed by low transmitability virus is no longer treated as an injection.
/:cl:
