### PR TITLE
Redd nerfs surgery (oh no)

### DIFF
--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -69,7 +69,7 @@
 			span_warning("[user] screws up, causing blood to spurt out of [H]'s chest!"))
 		var/obj/item/bodypart/BP = H.get_bodypart(target_zone)
 		BP.generic_bleedstacks += 10
-		H.adjustOrganLoss(ORGAN_SLOT_HEART, 10)
+		H.adjustOrganLoss(ORGAN_SLOT_HEART, 15)
 		H.adjustBruteLoss(10)
 
 //grafts a coronary bypass onto the individual's heart, success chance is 90% base again
@@ -80,7 +80,7 @@
 	preop_sound = 'sound/surgery/hemostat1.ogg'
 	success_sound = 'sound/surgery/hemostat1.ogg'
 	failure_sound = 'sound/surgery/organ2.ogg'
-	fuckup_damage = 20
+	fuckup_damage = 25
 
 /datum/surgery_step/coronary_bypass/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to graft a bypass onto [target]'s heart..."),

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -31,7 +31,6 @@
 			if(BP)
 				BP.generic_bleedstacks += bleeding
 	return TRUE
-
 /datum/surgery_step/incise/nobleed
 	fuckup_damage = 0
 	bleeding = 0
@@ -47,6 +46,7 @@
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_WIRECUTTER = 60, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 2.4 SECONDS
 	preop_sound = 'sound/surgery/hemostat1.ogg'
+	fuckup_damage = 20 //because you're clamping bleeders. You miss and accidentally stab the bleeder instead? Should deal damage
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]..."),
@@ -71,6 +71,7 @@
 	time = 2.4 SECONDS
 	preop_sound = 'sound/surgery/retractor1.ogg'
 	success_sound = 'sound/surgery/retractor2.ogg'
+	//no fuckup here under anesthesia because like, retracting skin isn't necessarily painful in real world
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to retract the skin in [target]'s [parse_zone(target_zone)]..."),
@@ -131,7 +132,7 @@
 		/obj/item = 'sound/surgery/scalpel1.ogg',
 	) 
 	success_sound = 'sound/surgery/bone3.ogg'
-	fuckup_damage = 20
+	fuckup_damage = 40 //this should REALLY fucking hurt if it fails
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, span_notice("You begin to saw through the bone in [target]'s [parse_zone(target_zone)]..."),
@@ -150,7 +151,7 @@
 	name = "drill bone"
 	implements = list(TOOL_DRILL = 100, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 3 SECONDS
-	fuckup_damage = 15
+	fuckup_damage = 20 //this should ALSO really fucking hurt if it fails
 	preop_sound = 'sound/weapons/circsawhit.ogg'
 	success_sound = 'sound/surgery/bone3.ogg'
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -21,7 +21,7 @@
 	/// Chems that will modify the chance for fuckups while operating on conscious patients, stacks.
 	var/list/ouchie_modifying_chems = list(/datum/reagent/consumable/ethanol/painkiller = 0.5, /datum/reagent/consumable/ethanol/inocybeshine = 0.5, /datum/reagent/medicine/morphine = 0.5) 
 	/// Base damage dealt on a surgery being done without anesthetics on SURGERY_FUCKUP_CHANCE percent chance
-	var/fuckup_damage = 10			
+	var/fuckup_damage = 15			
 	/// Damage type fuckup_damage is dealt as
 	var/fuckup_damage_type = BRUTE
 	/// If silicons have to deal with success chance


### PR DESCRIPTION
# Document the changes in your pull request
Increases fuckup damage from 10 to 15 across the board. Increases fuckup damage from 15 to 20 for bleeders, 15 to 40 for saw operations (makes sense given it's a saw and you're sawing through bone), and 15 to 20 for drill bone. All of this damage is counteracted by using anesthetic, putting someone under with morphine (ONLY 5U, DON'T USE MORE THAN THIS IT WILL OD THEM), or getting a patient drunk enough.

# Wiki Documentation
Fuckup damage is increased across the board. There appears to be nothing mentioning fuckup damage on the wiki, so no change should be needed.

# Changelog

:cl:TheReddDragon  
tweak: surgery is now more dangerous without proper preparation (read: morphine or anesthetic)  
/:cl:
