### PR TITLE
Xenomorphs mini rework

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -157,6 +157,18 @@
 
 /obj/item/restraints/handcuffs/alien
 	icon_state = "handcuffAlien"
+	
+/obj/item/restraints/handcuffs/alien/beno
+	name = "resin handcuffs"
+	desc = "Extremely weak cuffs made to restrict movement."
+	icon_state = "cuff" // Needs sprite
+	breakouttime = 10 //Deciseconds = 1s
+	break_strength = 1
+	item_flags = DROPDEL
+
+/obj/item/restraints/handcuffs/alien/beno/dropped(mob/user)	
+	user.visible_message(span_danger("[user]'s [name] falls apart"))
+	. = ..()
 
 /obj/item/restraints/handcuffs/fake
 	name = "fake handcuffs"

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -60,7 +60,10 @@
 	if(has_buckled_mobs())
 		unbuckle_all_mobs()
 
+	var/mob/living/carbon/human/alienprisoner = M
 	if(buckle_mob(M))
+		alienprisoner.handcuffed = new /obj/item/restraints/handcuffs/alien/beno(alienprisoner)
+		alienprisoner.update_handcuffed()
 		M.visible_message(\
 			"[user.name] secretes a thick vile goo, securing [M.name] into [src]!",\
 			span_danger("[user.name] drenches you in a foul-smelling resin, trapping you in [src]!"),\

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -21,7 +21,14 @@
 	bodyparts = list(/obj/item/bodypart/chest/alien, /obj/item/bodypart/head/alien, /obj/item/bodypart/l_arm/alien,
 					 /obj/item/bodypart/r_arm/alien, /obj/item/bodypart/r_leg/alien, /obj/item/bodypart/l_leg/alien)
 
-
+/mob/living/carbon/alien/humanoid/stripPanelEquip(obj/item/what, mob/who, where)
+	to_chat(src, span_warning("Your sharp claws fumble as you attempt to put the [what] on [who]."))
+	return FALSE
+	
+/mob/living/carbon/alien/humanoid/stripPanelUnequip(obj/item/what, mob/who, where)
+	to_chat(src, span_warning("Your sharp claws fumble as you attempt to remove [who]'s [what]."))
+	return FALSE
+	
 /mob/living/carbon/alien/humanoid/restrained(ignore_grab)
 	return handcuffed
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -9,7 +9,7 @@
 	/// Are we bursting out of the poor sucker who's the xeno mom?
 	var/bursting = FALSE
 	/// How long does it take to advance one stage? Growth time * 5 = how long till we make a Larva!
-	var/growth_time = 60 SECONDS
+	var/growth_time = 40 SECONDS
 
 /obj/item/organ/body_egg/alien_embryo/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -64,7 +64,9 @@
 
 /obj/item/clothing/mask/facehugger/attack(mob/living/M, mob/user)
 	..()
-	if(user.transferItemToLoc(src, get_turf(M)))
+	if(isalien(user) && do_after_mob(user, M, 2 SECONDS))
+		Leap(M, TRUE)
+	else if(user.transferItemToLoc(src, get_turf(M)))
 		Leap(M)
 
 /obj/item/clothing/mask/facehugger/examine(mob/user)
@@ -142,7 +144,7 @@
 
 	return FALSE
 
-/obj/item/clothing/mask/facehugger/proc/Leap(mob/living/M)
+/obj/item/clothing/mask/facehugger/proc/Leap(mob/living/M, force = FALSE)
 	if(!valid_to_attach(M))
 		return FALSE
 	if(iscarbon(M))
@@ -160,10 +162,16 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.is_mouth_covered(head_only = 1))
-				H.visible_message(span_danger("[src] smashes against [H]'s [H.head]!"), \
-									span_userdanger("[src] smashes against [H]'s [H.head]!"))
-				Die()
-				return FALSE
+				if(force)//if they are wearing a helmet to remove and this is a manual application
+					var/obj/item/clothing/helmet = target.head
+					if(target.dropItemToGround(helmet))
+						target.visible_message(span_danger("[src] wedges it's limbs under [helmet] and tears it off of [target]'s head!"), \
+											span_userdanger("[src] wedges it's limbs under [helmet] and tears it off of [target]'s head!"))
+				else
+					H.visible_message(span_danger("[src] smashes against [H]'s [H.head]!"), \
+										span_userdanger("[src] smashes against [H]'s [H.head]!"))
+					Die()
+					return FALSE
 
 		if(target.wear_mask)
 			var/obj/item/clothing/W = target.wear_mask

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -293,7 +293,7 @@
 		loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
 
 /mob/living/carbon/is_muzzled()
-	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
+	return istype(src.wear_mask, /obj/item/clothing/mask/muzzle) || istype(src.wear_mask, /obj/item/clothing/mask/facehugger)
 
 /mob/living/carbon/hallucinating()
 	if(hallucination)


### PR DESCRIPTION
Xenomorphs full stripping is boring, it makes recovering people from xeno nests pointless unless all xenos are dead.
This removes their ability to strip, but also lets them manually apply facehuggers to forcefully remove the target's helmet. (so they can still facehug people with hardsuits)

This should make it at least possible for those that escape to survive as they still have most of their gear.
This also helps people locate victims by not letting xenos from just removing suit sensors.

I am receptive to other buffs to xenos that will make sure this isn't a crippling nerf

**Current buff ideas are**
- Xeno embryo take less time to burst out of a body (it currently takes 5 whopping minutes)(this has been changed to 3:20)
- Facehugger implants quicker
- Give stat buffs to xenos

Hopefully with them being easier to notice, but stronger it'll make xeno antag triggers less binary
As they are currently either found instantly and demolished, or not found until it's too late to even have a chance of doing anything

:cl:  
tweak: Xenos can no longer strip people
tweak: Xenos can now apply facehuggers by hand, removing any helmets in the way
tweak: Xenos beds now bucklecuff
tweak: Facehuggers now act like muzzles
tweak: Alien Embryos now burst in 3:20 instead of 5:00
/:cl:
