### PR TITLE
Fix lights being broken (not updating) when smoke dissipates

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -23,11 +23,17 @@
 		return
 	if(frames == 0)
 		frames = 1 //We will just assume that by 0 frames, the coder meant "during one frame".
+	var/lighting_updated = FALSE
 	var/step = alpha / frames
 	for(var/i = 0, i < frames, i++)
 		alpha -= step
 		if(alpha < 160)
 			set_opacity(0) //if we were blocking view, we aren't now because we're fading out
+			if(!lighting_updated) // Only update lights around me once we have sufficiently faded, and only do it once
+				lighting_updated = TRUE
+				for(var/atom/L in view(15, src)) // Floodlights reach 15 tiles max, this should be sufficient
+					L.light?.force_update()
+					CHECK_TICK
 		stoplag()
 
 /obj/effect/particle_effect/smoke/Initialize()


### PR DESCRIPTION
# Document the changes in your pull request

Tested with 4 clusterbuster smoke nades on my slow laptop and it had no performance impact

Two areas of impact: scanning atoms in view(15,src) and settings lights to be updated on next lighting tick
See https://github.com/yogstation13/Yogstation/blob/master/code/modules/lighting/lighting_source.dm#L66

Explanation:

`set_opacity(0)` is supposed to update lighting on every turf it's updated on, but it only considers lights that are "affecting" that turf. In the case of smoke, it blocks light entirely from hitting that turf, and therefore there are no lights "affecting" that turf, so it doesn't update any. This updates all lights that are in view of 15 tiles (max floodlight range) when smoke sets itself to no longer be opaque.

Fixes #15913 
Fixes #15875

# Changelog

:cl:  
bugfix: fixed smoke grenades breaking lights
/:cl:
