### PR TITLE
bolapocolapse: the great ided bola nerf

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -327,6 +327,7 @@
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
 	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
+	slowdown = 4
 
 /obj/item/restraints/legcuffs/bola
 	name = "bola"
@@ -338,7 +339,9 @@
 	breakouttime = 35//easy to apply, easy to break out of
 	gender = NEUTER
 	break_strength = 3
+	slowdown = 2
 	var/immobilize = 0
+	var/autoremovetime = 10 SECONDS //seconds until the bola falls off by itself
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, quickstart = TRUE)
 	if(!..())
@@ -364,6 +367,14 @@
 	to_chat(hit_carbon, span_userdanger("\The [src] ensnares you!"))
 	hit_carbon.Immobilize(immobilize)
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
+	if(autoremovetime != -1)
+		addtimer(CALLBACK(src, .proc/slideoff, hit_carbon), autoremovetime)
+
+
+/obj/item/restraints/legcuffs/bola/proc/slideoff(mob/living/carbon/mobtoremove)
+	visible_message(span_danger("\The [src] loses tension, and falls to the ground."))
+	mobtoremove.legcuffed = null
+	forceMove(get_turf(src))
 
 /obj/item/restraints/legcuffs/bola/proc/impactAnimal(mob/living/simple_animal/hit_animal, datum/thrownthing/throwingdatum)
 	return // Does nothing by default
@@ -376,6 +387,8 @@
 	breakouttime = 70
 	immobilize = 20
 	break_strength = 4
+	slowdown = 5.25
+	autoremovetime = 20 SECONDS
 
 /obj/item/restraints/legcuffs/bola/watcher //tribal bola for tribal lizards
 	name = "watcher Bola"
@@ -393,6 +406,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 6 SECONDS
 	break_strength = 2
+	autoremovetime = -1
 
 /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(iscarbon(hit_atom))

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -408,6 +408,10 @@
 	break_strength = 2
 	autoremovetime = -1
 
+/obj/item/restraints/legcuffs/bola/energy/emp_act()
+	visible_message(span_danger("\The [src] fizzles out!"))
+	qdel(src)
+	
 /obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(iscarbon(hit_atom))
 		var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(hit_atom))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -269,6 +269,7 @@
 	item_state = "bola_cult"
 	breakouttime = 60
 	immobilize = 20
+	autoremovetime = -1
 
 /obj/item/restraints/legcuffs/bola/cult/pickup(mob/living/user)
 	. = ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -269,7 +269,7 @@
 	item_state = "bola_cult"
 	breakouttime = 60
 	immobilize = 20
-	autoremovetime = -1
+	autoremovetime = 20 SECONDS
 
 /obj/item/restraints/legcuffs/bola/cult/pickup(mob/living/user)
 	. = ..()

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -13,8 +13,7 @@
 					/obj/item/assembly/flash/handheld = 5,
 					/obj/item/reagent_containers/food/snacks/donut = 12,
 					/obj/item/storage/box/evidence = 6,
-					/obj/item/flashlight/seclite = 4,
-					/obj/item/restraints/legcuffs/bola/energy = 7)
+					/obj/item/flashlight/seclite = 4)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,
 					  /obj/item/storage/box/fancy/donut_box = 2)
 	premium = list(/obj/item/storage/belt/security/webbing = 5,


### PR DESCRIPTION
all bola slowdowns have been reduced so that they actually reflect how easy they are to hit someone with, with normal crafted bola being hit the hardest since it's literally 6 pieces of iron and 15 cablecoil to make. bolas will now automatically fall off too excluding security and cult bolas, with normal bolas taking 10 seconds to fall off and reinforced ones taking 20 seconds to fall off.
energy bolas also delete themselves now when emped (but not if they're already attached to someone 🙂) 
roundstart sectech ebolas are gone too because the meta rollout of carrying 2-3 ebolas at once fills me with bitter hatred, note that you can still print them with research lol

# Changelog

:cl:  
rscdel: roundstart ebolas are gone, wait until research is done to print them
tweak: all bola slowdown has been reduced by a substantial margin
tweak: all bolas except energy ones will now fall off after a period of time
tweak: energy bolas will now delete themselves when emped
/:cl:
