### PR TITLE
[Meta] Adds insuls and engi goggles to tesla template

### DIFF
--- a/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
@@ -206,27 +206,6 @@
 /obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"jV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access_txt = "10"
-	},
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kb" = (
 /obj/structure/grille,
 /obj/structure/cable/orange{
@@ -342,6 +321,16 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"sb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "sm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -470,6 +459,20 @@
 "wg" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating/airless,
+/area/engine/engineering)
+"wr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "xa" = (
 /obj/machinery/door/airlock/external{
@@ -667,6 +670,17 @@
 	dir = 5
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"Kb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "Ks" = (
 /obj/machinery/button/door{
@@ -1036,7 +1050,7 @@ aO
 Lj
 ul
 Lj
-jV
+wr
 Lj
 zG
 Lj
@@ -1068,7 +1082,7 @@ vP
 sZ
 Gp
 Xa
-Uj
+sb
 pN
 RA
 SN
@@ -1094,7 +1108,7 @@ cR
 vP
 tW
 Xa
-Uj
+Kb
 pN
 gD
 SN

--- a/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
@@ -206,6 +206,27 @@
 /obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "10"
+	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kb" = (
 /obj/structure/grille,
 /obj/structure/cable/orange{
@@ -238,26 +259,6 @@
 	name = "Radiation Chamber Shutters"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"ls" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	pixel_y = 0;
-	req_access_txt = "10"
-	},
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "my" = (
 /obj/structure/grille,
@@ -1035,7 +1036,7 @@ aO
 Lj
 ul
 Lj
-ls
+jV
 Lj
 zG
 Lj

--- a/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/MetaStation/meta_singulo_tesla.dmm
@@ -239,6 +239,26 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"ls" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = 24;
+	pixel_y = 0;
+	req_access_txt = "10"
+	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "my" = (
 /obj/structure/grille,
 /obj/structure/cable/orange{
@@ -269,20 +289,6 @@
 	name = "Radiation Shutters Control";
 	pixel_x = 0;
 	pixel_y = -24;
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"of" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel,
@@ -1029,7 +1035,7 @@ aO
 Lj
 ul
 Lj
-of
+ls
 Lj
 zG
 Lj


### PR DESCRIPTION
# Document the changes in your pull request

testmerge n3d6s changes next t ime

adds a rack with insuls and engi scanner goggles to meta tesla template

# Spriting
If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob.

# Wiki Documentation

Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. 

# Changelog


:cl:  
mapping: meta tesla template has a new rack with insuls and scanner goggles
/:cl:
