### PR TITLE
Wirecutters now take 0.5 seconds to cut a wire

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -142,6 +142,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(W.tool_behaviour == TOOL_WIRECUTTER)
 		if (shock(user, 50))
 			return
+		if (!do_after(user, 0.5 SECONDS, src))
+			return
 		user.visible_message("[user] cuts the cable.", span_notice("You cut the cable."))
 		investigate_log("was cut by [key_name(usr)] in [AREACOORD(src)]", INVESTIGATE_WIRES)
 		add_fingerprint(user)


### PR DESCRIPTION
# Document the changes in your pull request
Wirecutters now take 0.5 seconds to cut a wire. It takes like 15 seconds to wire something up and 0 seconds to cut it. Why?

# Changelog


:cl:  
tweak: Wirecutters now take 0.5 seconds to cut a wire. 
/:cl:
