### PR TITLE
Add a new hack wire for advanced airlock controller that can toggle cycle by pulsing

### DIFF
--- a/code/datums/wires/airlock_cycle.dm
+++ b/code/datums/wires/airlock_cycle.dm
@@ -41,10 +41,17 @@
 			for(var/obj/machinery/door/airlock/airlock in A.airlocks)
 				if(airlock.operating || (airlock.obj_flags & EMAGGED))
 					return
-				if(airlock.density)
+				var/is_allowed = TRUE
+				if(!airlock.allowed(usr))
+					if(is_allowed)
+						is_allowed = FALSE
+						to_chat(usr, span_danger("Access denied."))
+					if(airlock.density)
+						spawn()
+							airlock.do_animate("deny")
+				if(is_allowed && airlock.density)
 					if(airlock.locked || airlock.aac)
 						A.request_from_door(airlock)
-						return
 
 /datum/wires/advanced_airlock_controller/on_cut(wire, mend)
 	var/obj/machinery/advanced_airlock_controller/A = holder

--- a/code/datums/wires/airlock_cycle.dm
+++ b/code/datums/wires/airlock_cycle.dm
@@ -43,7 +43,7 @@
 					return
 				if(airlock.density)
 					if(airlock.locked || airlock.aac)
-						A.request_from_door(src)
+						A.request_from_door(airlock)
 						return
 
 /datum/wires/advanced_airlock_controller/on_cut(wire, mend)

--- a/code/datums/wires/airlock_cycle.dm
+++ b/code/datums/wires/airlock_cycle.dm
@@ -4,10 +4,10 @@
 
 /datum/wires/advanced_airlock_controller/New(atom/holder)
 	wires = list(
-		WIRE_POWER,
+		WIRE_POWER, WIRE_ACTIVATE,
 		WIRE_IDSCAN, WIRE_AI
 	)
-	add_duds(3)
+	add_duds(1)
 	..()
 
 /datum/wires/advanced_airlock_controller/interactable(mob/user)
@@ -37,6 +37,14 @@
 			if(!A.aidisabled)
 				A.aidisabled = TRUE
 			addtimer(CALLBACK(A, /obj/machinery/advanced_airlock_controller.proc/reset, wire), 100)
+		if(WIRE_ACTIVATE) // Toggle airlock cycles
+			for(var/obj/machinery/door/airlock/airlock in A.airlocks)
+				if(airlock.operating || (airlock.obj_flags & EMAGGED))
+					return
+				if(airlock.density)
+					if(airlock.locked || airlock.aac)
+						A.request_from_door(src)
+						return
 
 /datum/wires/advanced_airlock_controller/on_cut(wire, mend)
 	var/obj/machinery/advanced_airlock_controller/A = holder


### PR DESCRIPTION
## Why you may ask?
This is just for remotely control from distance that's it. 
# Document the changes in your pull request
Add a new hack wire for advanced airlock controller that can toggle cycle by pulsing
Reduced dumb wire to 1

# Wiki Documentation
Add a new hack wire for advanced airlock controller that can toggle cycle by pulsing
Reduced dumb wire to 1
# Changelog

Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name.

:cl:  
rscadd: Add a new hack wire for advanced airlock controller that can toggle cycle by pulsing
tweak: Reduced dumb wire to 1
/:cl:
