### PR TITLE
Station bounce radio QoL changes and tweaks

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -1,19 +1,3 @@
-// Used for translating channels to tokens on examination
-GLOBAL_LIST_INIT(channel_tokens, list(
-	RADIO_CHANNEL_COMMON = RADIO_KEY_COMMON,
-	RADIO_CHANNEL_SCIENCE = RADIO_TOKEN_SCIENCE,
-	RADIO_CHANNEL_COMMAND = RADIO_TOKEN_COMMAND,
-	RADIO_CHANNEL_MEDICAL = RADIO_TOKEN_MEDICAL,
-	RADIO_CHANNEL_ENGINEERING = RADIO_TOKEN_ENGINEERING,
-	RADIO_CHANNEL_SECURITY = RADIO_TOKEN_SECURITY,
-	RADIO_CHANNEL_CENTCOM = RADIO_TOKEN_CENTCOM,
-	RADIO_CHANNEL_SYNDICATE = RADIO_TOKEN_SYNDICATE,
-	RADIO_CHANNEL_SUPPLY = RADIO_TOKEN_SUPPLY,
-	RADIO_CHANNEL_SERVICE = RADIO_TOKEN_SERVICE,
-	MODE_BINARY = MODE_TOKEN_BINARY,
-	RADIO_CHANNEL_AI_PRIVATE = RADIO_TOKEN_AI_PRIVATE
-))
-
 /obj/item/radio/headset
 	name = "radio headset"
 	desc = "An updated, modular intercom that fits over the head. Takes encryption keys."
@@ -24,41 +8,15 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	canhear_range = 0 // can't hear headsets from very far away
 
 	slot_flags = ITEM_SLOT_EARS
-	var/obj/item/encryptionkey/keyslot2 = null
 	dog_fashion = null
 
 /obj/item/radio/headset/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins putting \the [src]'s antenna up [user.p_their()] nose! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer!"))
 	return TOXLOSS
 
-/obj/item/radio/headset/examine(mob/user)
-	. = ..()
-
-	if(item_flags & IN_INVENTORY && loc == user)
-		// construction of frequency description
-		var/list/avail_chans = list("Use [RADIO_KEY_COMMON] for the currently tuned frequency")
-		if(translate_binary)
-			avail_chans += "use [MODE_TOKEN_BINARY] for [MODE_BINARY]"
-		if(length(channels))
-			for(var/i in 1 to length(channels))
-				if(i == 1)
-					avail_chans += "use [MODE_TOKEN_DEPARTMENT] or [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
-				else
-					avail_chans += "use [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
-		. += span_notice("A small screen on the headset displays the following available frequencies:\n[english_list(avail_chans)].")
-
-		if(command)
-			. += span_info("Alt-click to toggle the high-volume mode.")
-	else
-		. += span_notice("A small screen on the headset flashes, it's too small to read without holding or wearing the headset.")
-
 /obj/item/radio/headset/Initialize()
 	. = ..()
 	recalculateChannels()
-
-/obj/item/radio/headset/Destroy()
-	QDEL_NULL(keyslot2)
-	return ..()
 
 /obj/item/radio/headset/talk_into(mob/living/M, message, channel, list/spans, datum/language/language, list/message_mods)
 	if (!listening)
@@ -336,24 +294,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		recalculateChannels()
 	else
 		return ..()
-
-
-/obj/item/radio/headset/recalculateChannels()
-	..()
-	if(keyslot2)
-		for(var/ch_name in keyslot2.channels)
-			if(!(ch_name in src.channels))
-				channels[ch_name] = keyslot2.channels[ch_name]
-
-		if(keyslot2.translate_binary)
-			translate_binary = TRUE
-		if(keyslot2.syndie)
-			syndie = TRUE
-		if (keyslot2.independent)
-			independent = TRUE
-
-	for(var/ch_name in channels)
-		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
 /obj/item/radio/headset/AltClick(mob/living/user)
 	if(!istype(user) || !Adjacent(user) || user.incapacitated())

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -14,6 +14,7 @@
 
 /obj/item/radio/intercom/unscrewed
 	unfastened = TRUE
+	unscrewed = TRUE
 
 /obj/item/radio/intercom/ratvar
 	name = "hierophant intercom"
@@ -62,11 +63,13 @@
 			if(I.use_tool(src, user, 30, volume=50))
 				user.visible_message(span_notice("[user] tightens [src]'s screws!"), span_notice("You tighten [src]'s screws."))
 				unfastened = FALSE
+				unscrewed = FALSE
 		else
 			user.visible_message(span_notice("[user] starts loosening [src]'s screws..."), span_notice("You start unscrewing [src]..."))
 			if(I.use_tool(src, user, 40, volume=50))
 				user.visible_message(span_notice("[user] loosens [src]'s screws!"), span_notice("You unscrew [src], loosening it from the wall."))
 				unfastened = TRUE
+				unscrewed = TRUE
 		return
 	else if(I.tool_behaviour == TOOL_WRENCH)
 		if(!unfastened)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -429,6 +429,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 	else
 		to_chat(user, span_warning("You have to unscrew the panel to do this!"))
+		return
 		
 
 /obj/item/radio/emp_act(severity)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -384,7 +384,30 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			to_chat(user, span_notice("The radio can now be attached and modified!"))
 		else
 			to_chat(user, span_notice("The radio can no longer be modified or attached!"))
-	if(W.tool_behaviour == TOOL_MULTITOOL)
+
+	else if(istype(W, /obj/item/encryptionkey/) && unscrewed)
+		if(keyslot && keyslot2)
+			to_chat(user, span_warning("The radio can't hold another key!"))
+			return
+
+		if(!keyslot)
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot = W
+
+		else
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot2 = W
+
+		recalculateChannels()
+	else
+		to_chat(user, span_warning("You cannot put anything in when [src]'s panel is closed!"))
+		return
+
+/obj/item/radio/AltClick(mob/user)
+	. = ..()
+	if(unscrewed)
 		if(keyslot || keyslot2)
 			for(var/ch_name in channels)
 				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
@@ -404,24 +427,9 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		else
 			to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
 
-	else if(istype(W, /obj/item/encryptionkey/))
-		if(keyslot && keyslot2)
-			to_chat(user, span_warning("The radio can't hold another key!"))
-			return
-
-		if(!keyslot)
-			if(!user.transferItemToLoc(W, src))
-				return
-			keyslot = W
-
-		else
-			if(!user.transferItemToLoc(W, src))
-				return
-			keyslot2 = W
-
-		recalculateChannels()
 	else
-		return ..()
+		to_chat(user, span_warning("You have to unscrew the panel to do this!"))
+		
 
 /obj/item/radio/emp_act(severity)
 	. = ..()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "station bounced radio"
 	icon_state = "walkietalkie"
 	item_state = "walkietalkie"
-	desc = "A basic handheld radio that communicates with local telecommunication networks."
+	desc = "A basic handheld radio that communicates with local telecommunication networks. Altclick to remove encryption key if panel is open."
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1 | HEAR_1
@@ -354,7 +354,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if (frequency && in_range(src, user))
 		. += span_notice("It is set to broadcast over the [frequency/10] frequency.")
 	if (unscrewed)
-		. += span_notice("It can be attached and modified.")
+		. += span_notice("It can be attached and modified. [(keyslot || keyslot2)? "Altclick to remove encryption key." : ""]")
 	else
 		. += span_notice("It cannot be modified or attached.")
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -1,3 +1,19 @@
+// Used for translating channels to tokens on examination
+GLOBAL_LIST_INIT(channel_tokens, list(
+	RADIO_CHANNEL_COMMON = RADIO_KEY_COMMON,
+	RADIO_CHANNEL_SCIENCE = RADIO_TOKEN_SCIENCE,
+	RADIO_CHANNEL_COMMAND = RADIO_TOKEN_COMMAND,
+	RADIO_CHANNEL_MEDICAL = RADIO_TOKEN_MEDICAL,
+	RADIO_CHANNEL_ENGINEERING = RADIO_TOKEN_ENGINEERING,
+	RADIO_CHANNEL_SECURITY = RADIO_TOKEN_SECURITY,
+	RADIO_CHANNEL_CENTCOM = RADIO_TOKEN_CENTCOM,
+	RADIO_CHANNEL_SYNDICATE = RADIO_TOKEN_SYNDICATE,
+	RADIO_CHANNEL_SUPPLY = RADIO_TOKEN_SUPPLY,
+	RADIO_CHANNEL_SERVICE = RADIO_TOKEN_SERVICE,
+	MODE_BINARY = MODE_TOKEN_BINARY,
+	RADIO_CHANNEL_AI_PRIVATE = RADIO_TOKEN_AI_PRIVATE
+))
+
 /obj/item/radio
 	icon = 'icons/obj/radio.dmi'
 	name = "station bounced radio"
@@ -32,6 +48,7 @@
 
 	// Encryption key handling
 	var/obj/item/encryptionkey/keyslot
+	var/obj/item/encryptionkey/keyslot2
 	var/translate_binary = FALSE  // If true, can hear the special binary channel.
 	var/independent = FALSE  // If true, can say/hear on the special CentCom channel.
 	var/syndie = FALSE  // If true, hears all well-known channels automatically, and can say/hear on the Syndicate channel.
@@ -67,6 +84,18 @@
 		if(keyslot.independent)
 			independent = TRUE
 
+	if(keyslot2)
+		for(var/ch_name in keyslot2.channels)
+			if(!(ch_name in channels))
+				channels[ch_name] = keyslot2.channels[ch_name]
+
+		if(keyslot2.translate_binary)
+			translate_binary = TRUE
+		if(keyslot2.syndie)
+			syndie = TRUE
+		if(keyslot2.independent)
+			independent = TRUE
+
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])
 
@@ -87,6 +116,7 @@
 	remove_radio_all(src) //Just to be sure
 	QDEL_NULL(wires)
 	QDEL_NULL(keyslot)
+	QDEL_NULL(keyslot2)
 	return ..()
 
 /obj/item/radio/Initialize()
@@ -283,7 +313,7 @@
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
 
-	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND)
+	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND || message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || message_mods[RADIO_EXTENSION] == MODE_HEADSET)
 		// try to avoid being heard double
 		if (loc == speaker && ismob(speaker))
 			var/mob/M = speaker
@@ -328,6 +358,24 @@
 	else
 		. += span_notice("It cannot be modified or attached.")
 
+	if((item_flags & IN_INVENTORY && loc == user) || (src in view(1, user)))
+		// construction of frequency description
+		var/list/avail_chans = list("Use [RADIO_KEY_COMMON] for the currently tuned frequency")
+		if(translate_binary)
+			avail_chans += "use [MODE_TOKEN_BINARY] for [MODE_BINARY]"
+		if(length(channels))
+			for(var/i in 1 to length(channels))
+				if(i == 1)
+					avail_chans += "use [MODE_TOKEN_DEPARTMENT] or [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
+				else
+					avail_chans += "use [GLOB.channel_tokens[channels[i]]] for [lowertext(channels[i])]"
+		. += span_notice("A small screen on the headset displays the following available frequencies:\n[english_list(avail_chans)].")
+
+		if(command)
+			. += span_info("Alt-click to toggle the high-volume mode.")
+	else
+		. += span_notice("A small screen on the [src] flashes, it's too small to read without going near the [src].")
+
 /obj/item/radio/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
@@ -336,6 +384,42 @@
 			to_chat(user, span_notice("The radio can now be attached and modified!"))
 		else
 			to_chat(user, span_notice("The radio can no longer be modified or attached!"))
+	if(W.tool_behaviour == TOOL_MULTITOOL)
+		if(keyslot || keyslot2)
+			for(var/ch_name in channels)
+				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
+				secure_radio_connections[ch_name] = null
+
+
+			if(keyslot)
+				user.put_in_hands(keyslot)
+				keyslot = null
+			if(keyslot2)
+				user.put_in_hands(keyslot2)
+				keyslot2 = null
+
+			recalculateChannels()
+			to_chat(user, span_notice("You pop out the encryption key in the radio."))
+
+		else
+			to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
+
+	else if(istype(W, /obj/item/encryptionkey/))
+		if(keyslot && keyslot2)
+			to_chat(user, span_warning("The radio can't hold another key!"))
+			return
+
+		if(!keyslot)
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot = W
+
+		else
+			if(!user.transferItemToLoc(W, src))
+				return
+			keyslot2 = W
+
+		recalculateChannels()
 	else
 		return ..()
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -66,7 +66,7 @@
 
 	if(message_mods[MODE_HEADSET])
 		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
 			radio.talk_into(src, message, , spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 		if(ears)
@@ -78,7 +78,7 @@
 				return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
 		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
 			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 		if(ears)
@@ -90,7 +90,7 @@
 				return ITALICS | REDUCE_RANGE
 	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
 		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
 			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 		if(ears)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -69,11 +69,6 @@
 		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
 			radio.talk_into(src, message, , spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-		var/obj/item/storage/storage = locate() in src
-		if(get_item_by_slot(SLOT_BELT) == storage)
-			if(locate(radio) in storage)
-				storage.talk_into(src, message, , spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
@@ -86,11 +81,6 @@
 		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
 			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-		var/obj/item/storage/storage = locate() in src
-		if(get_item_by_slot(SLOT_BELT) == storage)
-			if(locate(radio) in storage)
-				storage.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
@@ -102,11 +92,6 @@
 		var/obj/item/radio/radio = locate() in src
 		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
 			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
-		var/obj/item/storage/storage = locate() in src
-		if(get_item_by_slot(SLOT_BELT) == storage)
-			if(locate(radio) in storage)
-				storage.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -65,17 +65,56 @@
 		return .
 
 	if(message_mods[MODE_HEADSET])
+		var/obj/item/radio/radio = locate() in src
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+			radio.talk_into(src, message, , spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		var/obj/item/storage/storage = locate() in src
+		if(get_item_by_slot(SLOT_BELT) == storage)
+			if(locate(radio) in storage)
+				storage.talk_into(src, message, , spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
-		return ITALICS | REDUCE_RANGE
+			return ITALICS | REDUCE_RANGE
+		for (var/obj/item/radio/intercom/I in view(1, null))
+			if(I)
+				I.talk_into(src, message, , spans, language, message_mods)
+				return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
-		if(ears)
-			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-		return ITALICS | REDUCE_RANGE
-	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
+		var/obj/item/radio/radio = locate() in src
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		var/obj/item/storage/storage = locate() in src
+		if(get_item_by_slot(SLOT_BELT) == storage)
+			if(locate(radio) in storage)
+				storage.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
+		for (var/obj/item/radio/intercom/I in view(1, null))
+			if(I)
+				I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+				return ITALICS | REDUCE_RANGE
+	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
+		var/obj/item/radio/radio = locate() in src
+		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio))	
+			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		var/obj/item/storage/storage = locate() in src
+		if(get_item_by_slot(SLOT_BELT) == storage)
+			if(locate(radio) in storage)
+				storage.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		if(ears)
+			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		for (var/obj/item/radio/intercom/I in view(1, null))
+			if(I)
+				I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+				return ITALICS | REDUCE_RANGE
 
 	return 0
 


### PR DESCRIPTION
Bounce radio extension pack: Encryption key

# Document the changes in your pull request
- You can now add encryption key to station bounce radio and remove it by altclicking on it after its panel is opened
- You can use prefix ";" , as well as ":(channel_prefix)" to send comms message while the bounce radio is in your pocket, belt or in hands.



# Wiki Documentation
- You can now add encryption key to station bounce radio and remove it by altclicking on it after its panel is opened
- You can use prefix ";" , as well as ":(channel_prefix)" to send comms message while the bounce radio is in your pocket, belt or in hands.
# Changelog



:cl:  
rscadd: You can now add encryption key to station bounce radio and remove it by altclicking on it after its panel is opened
tweak: You can now use prefix ";" , as well as ":(channel_prefix)" to send comms message while the bounce radio is in your pocket, belt or in hands.
/:cl:
