### PR TITLE
Revert "Increases throw force & knockdown of most shuttles"

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -241,7 +241,7 @@
 	description = "A hollowed out asteroid with engines strapped to it, the hollowing procedure makes it very difficult to hijack but is very expensive. Due to its size and difficulty in steering it, this shuttle may damage the docking area."
 	admin_notes = "This shuttle will likely crush escape, killing anyone there."
 	credit_cost = 15000
-	movement_force = list("KNOCKDOWN" = 6, "THROW" = 10)
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/luxury
@@ -327,7 +327,7 @@
 	credit_cost = -1000
 	description = "Due to a lack of functional emergency shuttles, we bought this second hand from a scrapyard and pressed it into service. Please do not lean too heavily on the exterior windows, they are fragile."
 	admin_notes = "An abomination with no functional medbay, sections missing, and some very fragile windows. Surprisingly airtight."
-	movement_force = list("KNOCKDOWN" = 6, "THROW" = 20)
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 	emag_buy = TRUE
 
 /datum/map_template/shuttle/emergency/narnar
@@ -375,7 +375,7 @@
 	admin_notes = "Tiny, with a single airlock and wooden walls. What could go wrong?"
 	credit_cost = 7500
 	emag_buy = TRUE
-	movement_force = list("KNOCKDOWN" = 6, "THROW" = 20)
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 2)
 
 /datum/map_template/shuttle/emergency/goon
 	suffix = "goon"

--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -11,7 +11,7 @@
 	callTime = INFINITY
 	ignitionTime = 50
 
-	movement_force = list("KNOCKDOWN" = 6, "THROW" = 10)
+	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
 	var/sound_played
 	var/damaged	//too damaged to undock?

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -167,7 +167,7 @@
 	log_game("[key_name(user)] has emagged the emergency shuttle in [COORD(src)] [time] seconds before launch.")
 
 	ENABLE_BITFIELD(obj_flags, EMAGGED)
-	SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 60, "THROW" = 40)//YOUR PUNY SEATBELTS can SAVE YOU NOW, MORTAL
+	SSshuttle.emergency.movement_force = list("KNOCKDOWN" = 60, "THROW" = 20)//YOUR PUNY SEATBELTS can SAVE YOU NOW, MORTAL
 	var/datum/species/S = new
 	for(var/i in 1 to 10)
 		// the shuttle system doesn't know who these people are, but they

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -283,7 +283,7 @@
 	var/launch_status = NOLAUNCH
 
 	///Whether or not you want your ship to knock people down, and also whether it will throw them several tiles upon launching.
-	var/list/movement_force = list("KNOCKDOWN" = 6, "THROW" = 10)
+	var/list/movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
 	var/list/ripples = list()
 	var/engine_coeff = 1


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16375

This was a terrible change and just causes hell for anyone on the shuttle. It doesn't just fling people it flings items. All items. You can't buckle items.