### PR TITLE
Reverts IPC lungs, other tweaks included

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -115,11 +115,6 @@
 	desc = "You're not getting enough oxygen. Find some good air before you pass out! The box in your backpack has an oxygen tank and breath mask in it."
 	icon_state = "not_enough_oxy"
 
-/atom/movable/screen/alert/not_enough_oxy/ipc
-	name = "Overheating"
-	desc = "You're not able to disperse heat. Find some gas to cool back down!"
-	icon_state = "overheating"
-
 /atom/movable/screen/alert/too_much_oxy
 	name = "Choking (O2)"
 	desc = "There's too much oxygen in the air, and you're breathing it in! Find some good air before you pass out!"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -103,29 +103,25 @@
 	var/L = getorganslot(ORGAN_SLOT_LUNGS)
 
 	if(!L)
-		if(isipc(src))
-			throw_alert("not_enough_oxy", /atom/movable/screen/alert/not_enough_oxy/ipc)
-			adjust_bodytemperature(65, max_temp = 500)
-		else
-			if(health >= crit_threshold)
-				adjustOxyLoss(HUMAN_MAX_OXYLOSS + 1)
-			else if(!HAS_TRAIT(src, TRAIT_NOCRITDAMAGE))
-				adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
+		if(health >= crit_threshold)
+			adjustOxyLoss(HUMAN_MAX_OXYLOSS + 1)
+		else if(!HAS_TRAIT(src, TRAIT_NOCRITDAMAGE))
+			adjustOxyLoss(HUMAN_CRIT_MAX_OXYLOSS)
 
-			failed_last_breath = 1
+		failed_last_breath = 1
 
-			var/datum/species/S = dna.species
+		var/datum/species/S = dna.species
 
-			if(S.breathid == "o2")
-				throw_alert("not_enough_oxy", /atom/movable/screen/alert/not_enough_oxy)
-			else if(S.breathid == "tox")
-				throw_alert("not_enough_tox", /atom/movable/screen/alert/not_enough_tox)
-			else if(S.breathid == "co2")
-				throw_alert("not_enough_co2", /atom/movable/screen/alert/not_enough_co2)
-			else if(S.breathid == "n2")
-				throw_alert("not_enough_nitro", /atom/movable/screen/alert/not_enough_nitro)
+		if(S.breathid == "o2")
+			throw_alert("not_enough_oxy", /atom/movable/screen/alert/not_enough_oxy)
+		else if(S.breathid == "tox")
+			throw_alert("not_enough_tox", /atom/movable/screen/alert/not_enough_tox)
+		else if(S.breathid == "co2")
+			throw_alert("not_enough_co2", /atom/movable/screen/alert/not_enough_co2)
+		else if(S.breathid == "n2")
+			throw_alert("not_enough_nitro", /atom/movable/screen/alert/not_enough_nitro)
 
-			return FALSE
+		return FALSE
 	else
 		if(istype(L, /obj/item/organ/lungs))
 			var/obj/item/organ/lungs/lun = L

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -6,7 +6,7 @@
 	say_mod = "states" //inherited from a user's real species
 	sexes = FALSE
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,NOHUSK,AGENDER,NOBLOOD)
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE,TRAIT_GENELESS,TRAIT_MEDICALIGNORE,TRAIT_NOCLONE,TRAIT_TOXIMMUNE,TRAIT_EASILY_WOUNDED,TRAIT_NODEFIB)
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE,TRAIT_GENELESS,TRAIT_MEDICALIGNORE,TRAIT_NOCLONE,TRAIT_TOXIMMUNE,TRAIT_EASILY_WOUNDED,TRAIT_NODEFIB)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_brain = /obj/item/organ/brain/positron
 	mutant_heart = /obj/item/organ/heart/cybernetic/ipc
@@ -15,8 +15,7 @@
 	mutantliver = /obj/item/organ/liver/cybernetic/upgraded/ipc
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
-	mutantlungs = /obj/item/organ/lungs/ipc
-	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord, /obj/item/organ/cyberimp/mouth/breathing_tube)
+	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
 	meat = /obj/item/stack/sheet/plasteel{amount = 5}
@@ -25,12 +24,19 @@
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
 	payday_modifier = 0.6 //Mass producible labor
-	burnmod = 1.5
-	heatmod = 1
+
+	//stat mods
 	brutemod = 1
+	burnmod = 1.5
 	toxmod = 0
+	oxymod = 0
+	tempmod = 2 //they heat up and cool down faster because regular metal conducts heat quickly 
+	heatmod = 1.5 //machines don't like heat
+	coldmod = 0
 	clonemod = 0
+	acidmod = 1.5
 	staminamod = 0.8
+
 	siemens_coeff = 1.75
 	reagent_tag = PROCESS_SYNTHETIC
 	species_gibs = "robotic"
@@ -56,6 +62,10 @@
 	if(A)
 		A.Remove(C)
 		QDEL_NULL(A)
+	var/obj/item/organ/lungs/L = C.getorganslot(ORGAN_SLOT_LUNGS)
+	if(L)
+		L.Remove(C)
+		QDEL_NULL(L)
 	if(ishuman(C) && !change_screen)
 		change_screen = new
 		change_screen.Grant(C)
@@ -197,6 +207,12 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 
 /datum/species/ipc/spec_life(mob/living/carbon/human/H)
 	. = ..()
+
+	if(H.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT && !H.particles)//smokin hot
+		H.particles = new /particles/smoke()
+	if(H.particles && H.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)//remove if cool
+		QDEL_NULL(H.particles)
+
 	if(H.oxyloss)
 		H.setOxyLoss(0)
 		H.losebreath = 0
@@ -254,6 +270,10 @@ ipc martial arts stuff
 
 
 /datum/species/ipc/spec_emp_act(mob/living/carbon/human/H, severity)
+	H.hallucination += rand(50, 100)
+	H.dizziness += rand(10,20)
+	H.jitteriness += rand(10,20)	
+
 	if(H.mind.martial_art && H.mind.martial_art.id == "ultra violence")
 		if(H.in_throw_mode)//if countering the emp
 			add_empproof(H)


### PR DESCRIPTION
reverts #15682 
The idea was reasonable, but once playing it, it was clear that it just isn't ideal.
- It just felt like breathing, which removed one of the defining features of the species
- IPC took burn instead of oxy, which doesn't slowly heal back up after.
- Knowing which gases actually are effective requires significantly more knowledge than should be expected from something as fundamental as breathing
- The emergency oxygen tank everyone gets just doesn't work for them, giving them a plasmeme tank while fixing the problem doesn't feel right thematically
- Doesn't actually make for interesting gameplay, it's more frustrating than fun
- Doesn't solve the "problem" of people being able to just use a firesuit in space

So i've reverted it, instead i've made
- Getting emped gives hallucination, dizziness, and jittering
- Acid mod of 1.5
- Tempmod of 2 (they heat up and cool down by 2x the regular amount)
- Heatmod of 1.5
- They also give off smoke when too warm now (sorta like ai cores)

:cl:  
rscdel: IPC no longer have janky lungs
tweak: IPC now heat up faster, as well as take more damage from both heat and acid
/:cl:
