### PR TITLE
Fixes both arm implant dropping and conjure spells

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -298,7 +298,8 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE, silent = FALSE)
-	SEND_SIGNAL(I, COMSIG_ITEM_PREDROPPED, src)
+	if(I)//signals don't like null arguments
+		SEND_SIGNAL(I, COMSIG_ITEM_PREDROPPED, src)
 	. = doUnEquip(I, force, drop_location(), FALSE, silent = silent)
 	I.do_drop_animation(src)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -298,6 +298,7 @@
 //for when you want the item to end up on the ground
 //will force move the item to the ground and call the turf's Entered
 /mob/proc/dropItemToGround(obj/item/I, force = FALSE, silent = FALSE)
+	SEND_SIGNAL(I, COMSIG_ITEM_PREDROPPED, src)
 	. = doUnEquip(I, force, drop_location(), FALSE, silent = silent)
 	I.do_drop_animation(src)
 
@@ -324,7 +325,6 @@
 	if(HAS_TRAIT(I, TRAIT_NODROP) && !force)
 		return FALSE
 
-	SEND_SIGNAL(I, COMSIG_ITEM_PREDROPPED, src)
 	var/hand_index = get_held_index_of_item(I)
 	if(hand_index)
 		held_items[hand_index] = null

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -87,9 +87,8 @@
 		QDEL_NULL(item)
 	else
 		for(var/mob/living/carbon/C in targets)
-			if(C.get_active_held_item())
-				C.dropItemToGround(C.get_active_held_item())
-			C.put_in_hands(make_item(), TRUE)
+			if(C.dropItemToGround(C.get_active_held_item()))
+				C.put_in_hands(make_item(), TRUE)
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/Destroy()
 	if(item)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -87,8 +87,9 @@
 		QDEL_NULL(item)
 	else
 		for(var/mob/living/carbon/C in targets)
-			if(C.dropItemToGround(C.get_active_held_item()))
-				C.put_in_hands(make_item(), TRUE)
+			if(C.get_active_held_item())
+				C.dropItemToGround(C.get_active_held_item())
+			C.put_in_hands(make_item(), TRUE)
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/Destroy()
 	if(item)


### PR DESCRIPTION
actually does what #16393 says
turns out it was a problem with how the conjure item spell worked and not signals
so instead i just made it not call the signal if there is no item

closes #16508

:cl:  
bugfix: COMSIG_ITEM_PREDROPPED is only called if there is an item to drop
/:cl:
