### PR TITLE
Nerfs the Syndicate L6 Squad Automatic Weapon (or god please I hope there isn't an ongoing nukies round right now or this PR will look even worse)

### DIFF
--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -25,21 +25,21 @@
 
 /obj/item/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
-	damage = 40
+	damage = 30
 	armour_penetration = 5
 	wound_bonus = -40				//hurt a lot but still mostly pointy
 	wound_falloff_tile = 0
 
 /obj/item/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
-	damage = 35
+	damage = 25
 	wound_bonus = -45				//they go straight through with little damage to surrounding tissue
 	armour_penetration = 60
 	bare_wound_bonus = -10			//flesh wont stop these very effectively but armor might make it tumble a bit before it enters
 
 /obj/item/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
-	damage = 55
+	damage = 40
 	armour_penetration = -35		//bulletproof armor almost totally stops these, but you're still getting hit in the chest by a supersonic nugget of lead
 	sharpness = SHARP_EDGED
 	wound_bonus = -35				//odds are you'll be shooting at someone with armor so you don't have a great chance for wounds
@@ -47,5 +47,5 @@
 
 /obj/item/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
-	damage = 27
+	damage = 25
 	fire_stacks = 2


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the damage of 7.12x82mm bullets (Will be called LMG rounds below) across the board.

Changed LMG Normal rounds from 40 to 30. (3 hits crit to 4 hits crit).
Changed LMG Armor Penetrating rounds from 35 to 25 (3 hits crit to 4 hits crit).
Changed LMG Hollow Point rounds from 55 to 40. (2 hits crit to 3 hits crit).
Changed LMG Incendiary rounds from  27 to 25. (4 hits crit to 4 hits crit).

## Justification

It was a little insane that a very accurate and low-recoil weapon did this amount of damage in a single burst, especially compared to other equipment. While it is only used by nuclear operatives and worth 20c, it still did more damage on a single hit (hit as in bullet impact) than an esword. Now, it does the same amount of damage on hit like an esword.

# Wiki Documentation

[Change this.](https://wiki.yogstation.net/wiki/Guide_to_Combat)


# Changelog

:cl:  BurgerBB
tweak: Nerfs the L6 Squad Automatic Weapon to crit on 4 hits (2 bursts) instead of 2 or 3 (1 burst)
/:cl:
