### PR TITLE
Shuttle catastrophe can now get ANY shuttle

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -25,7 +25,7 @@
 	var/list/valid_shuttle_templates = list()
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
-		if(!template.emag_buy && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+		if(template.credit_cost < INFINITY) //if we could get it from the emagged communications console, it's cool for us to get it here
 			valid_shuttle_templates += template
 	new_shuttle = pick(valid_shuttle_templates)
 

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -13,7 +13,8 @@
 
 /datum/round_event/shuttle_catastrophe
 	var/datum/map_template/shuttle/new_shuttle
-
+	var/list/datum/map_template/shuttle/blacklisted_shuttles = list(/datum/map_template/shuttle/emergency/arena, /datum/map_template/shuttle/emergency/construction,
+	/datum/map_template/shuttle/emergency/construction/small, /datum/map_template/shuttle/emergency/discoinferno)
 /datum/round_event/shuttle_catastrophe/announce(fake)
 	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
 		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "fell into a black hole",
@@ -26,7 +27,8 @@
 	for(var/shuttle_id in SSmapping.shuttle_templates)
 		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
 		if(template.credit_cost < INFINITY) //if we could get it from the emagged communications console, it's cool for us to get it here
-			valid_shuttle_templates += template
+			if (!(template in blacklisted_shuttles))
+				valid_shuttle_templates += template
 	new_shuttle = pick(valid_shuttle_templates)
 
 /datum/round_event/shuttle_catastrophe/start()

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -14,7 +14,7 @@
 /datum/round_event/shuttle_catastrophe
 	var/datum/map_template/shuttle/new_shuttle
 	var/list/datum/map_template/shuttle/blacklisted_shuttles = list(/datum/map_template/shuttle/emergency/arena, /datum/map_template/shuttle/emergency/construction,
-	/datum/map_template/shuttle/emergency/construction/small, /datum/map_template/shuttle/emergency/discoinferno)
+	/datum/map_template/shuttle/emergency/construction/small, /datum/map_template/shuttle/emergency/discoinferno, /datum/map_template/shuttle/emergency/meteor)
 /datum/round_event/shuttle_catastrophe/announce(fake)
 	var/cause = pick("was attacked by [syndicate_name()] Operatives", "mysteriously teleported away", "had its refuelling crew mutiny",
 		"was found with its engines stolen", "\[REDACTED\]", "flew into the sunset, and melted", "fell into a black hole",


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

What's the point of this event if all it does is give you some random shuttle any bozo can buy from the comms console? This introduces some variety into the event as well as seen shuttles, since emagged shuttles rarely happen due to the nature and rules of the server.
Blacklisted BYOS, Disco Inferno, Arena for being too griefy

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Shuttle catastrophe can now get ANY shuttle aside BYOS, Disco Inferno, Arena
/:cl:
