### PR TITLE
Plasmeme eyes no longer get roasted when welding

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -242,6 +242,10 @@
 /obj/item/weldingtool/tool_start_check(mob/living/user, amount=0)
 	. = tool_use_check(user, amount)
 	if(. && user)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H
+			if(istype(H.head,/obj/item/clothing/head/helmet/space/plasmaman))
+				return
 		user.flash_act(light_intensity)
 
 // Flash the user during welding progress
@@ -249,6 +253,10 @@
 	. = ..()
 	if(. && user)
 		if (progress_flash_divisor == 0)
+			if(ishuman(user))
+				var/mob/living/carbon/human/H
+				if(istype(H.head,/obj/item/clothing/head/helmet/space/plasmaman))
+					return
 			user.flash_act(min(light_intensity,1))
 			progress_flash_divisor = initial(progress_flash_divisor)
 		else

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -243,7 +243,7 @@
 	. = tool_use_check(user, amount)
 	if(. && user)
 		if(ishuman(user))
-			var/mob/living/carbon/human/H
+			var/mob/living/carbon/human/H = user
 			if(istype(H.head,/obj/item/clothing/head/helmet/space/plasmaman))
 				return
 		user.flash_act(light_intensity)
@@ -254,7 +254,7 @@
 	if(. && user)
 		if (progress_flash_divisor == 0)
 			if(ishuman(user))
-				var/mob/living/carbon/human/H
+				var/mob/living/carbon/human/H = user
 				if(istype(H.head,/obj/item/clothing/head/helmet/space/plasmaman))
 					return
 			user.flash_act(min(light_intensity,1))


### PR DESCRIPTION
Adds a snowflake check to welding tools that lets people wearing a plasmeme helmet weld without blinding themselves.
Doesn't help with flashes or other forms of blinding, just welding

Now plasmeme engineers don't get screwed over for simply existing

:cl:  
tweak: Plasmeme can now weld again
/:cl:
