### PR TITLE
Uplinked ERT report now shows what they bought

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -581,9 +581,10 @@
 				ERTOperative.mind.assigned_role = ert_antag.name
 
 				// Equip uplink
-				var/obj/item/upl = new ertemplate.uplinktype
+				var/obj/item/ntuplink/upl = new ertemplate.uplinktype(ERTOperative, ERTOperative.key)
 				if(istype(upl))
 					ERTOperative.equip_to_slot_or_del(upl, SLOT_IN_BACKPACK)
+					ert_team.uplink_type = ertemplate.uplinktype // Type path
 
 				//Logging and cleanup
 				//log_game("[key_name(ERTOperative)] has been selected as an [ert_antag.name]") | yogs - redundant

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -2,6 +2,51 @@
 /datum/team/ert
 	name = "Emergency Response Team"
 	var/datum/objective/mission //main mission
+	var/obj/item/ntuplink/uplink_type
+
+/datum/team/ert/roundend_report()
+	if(!show_roundend_report)
+		return
+
+	var/list/report = list()
+
+	report += span_header("[name]:")
+	report += "The [member_name]s were:"
+	report += printplayerlist(members)
+
+	var/win = FALSE
+	if(objectives.len)
+		report += span_header("ERT had following objectives:")
+		win = TRUE
+		var/objective_count = 1
+		for(var/datum/objective/objective in objectives)
+			if(objective.check_completion())
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [span_greentext("Success!")]"
+			else
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] [span_redtext("Fail.")]"
+				win = FALSE
+			objective_count++
+		if(win)
+			report += span_greentext("The [name] was successful!")
+		else
+			report += span_redtext("The [name] have failed!")
+
+	if(uplink_type)
+		var/purchases = ""
+		var/TC_uses = 0
+		LAZYINITLIST(GLOB.uplink_purchase_logs_by_key)
+		for(var/I in members)
+			var/datum/mind/ertmember = I
+			var/datum/uplink_purchase_log/H = GLOB.uplink_purchase_logs_by_key[ertmember.key]
+			if(H)
+				TC_uses += H.total_spent
+				purchases += H.generate_render(show_key = FALSE)
+		report += "<br>"
+		report += "(ERT was equipped with [initial(uplink_type.name)]s and used [TC_uses] WC) [purchases]"
+		if(TC_uses == 0 && win)
+			report += "<BIG>[icon2html('icons/badass.dmi', world, "badass")]</BIG>"
+
+	return "<div class='panel redborder'>[report.Join("<br>")]</div>"
 
 /datum/antagonist/ert
 	name = "Emergency Response Officer"

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -40,7 +40,7 @@
 			var/datum/uplink_purchase_log/H = GLOB.uplink_purchase_logs_by_key[ertmember.key]
 			if(H)
 				TC_uses += H.total_spent
-				purchases += H.generate_render(show_key = FALSE)
+				purchases += H.generate_render(show_key = FALSE, currency = "WC")
 		report += "<br>"
 		report += "(ERT was equipped with [initial(uplink_type.name)]s and used [TC_uses] WC) [purchases]"
 		if(TC_uses == 0 && win)

--- a/code/modules/uplink/uplink_purchase_log.dm
+++ b/code/modules/uplink/uplink_purchase_log.dm
@@ -39,11 +39,11 @@ GLOBAL_LIST(uplink_purchase_logs_by_key)	//assoc key = /datum/uplink_purchase_lo
 /datum/uplink_purchase_log/proc/TotalTelecrystalsSpent()
 	. = total_spent
 
-/datum/uplink_purchase_log/proc/generate_render(show_key = TRUE)
+/datum/uplink_purchase_log/proc/generate_render(show_key = TRUE, currency = "TC")
 	. = ""
 	for(var/hash in purchase_log)
 		var/datum/uplink_purchase_entry/UPE = purchase_log[hash]
-		. += span_tooltip_container("\[[UPE.icon_b64][show_key?"([owner])":""]<span class='tooltip_hover'><b>[UPE.name]</b><br>[UPE.spent_cost ? "[UPE.spent_cost] TC" : "[UPE.base_cost] TC<br>(Surplus)"]<br>[UPE.desc]</span>[(UPE.amount_purchased > 1) ? "x[UPE.amount_purchased]" : ""]\]")
+		. += span_tooltip_container("\[[UPE.icon_b64][show_key?"([owner])":""]<span class='tooltip_hover'><b>[UPE.name]</b><br>[UPE.spent_cost ? "[UPE.spent_cost] [currency]" : "[UPE.base_cost] [currency]<br>(Surplus)"]<br>[UPE.desc]</span>[(UPE.amount_purchased > 1) ? "x[UPE.amount_purchased]" : ""]\]")
 
 /datum/uplink_purchase_log/proc/LogPurchase(atom/A, datum/uplink_item/uplink_item, spent_cost)
 	var/datum/uplink_purchase_entry/UPE


### PR DESCRIPTION
# Document the changes in your pull request

![](https://i.imgur.com/LimXh52.png)

Says WC instead of TC on buy log https://github.com/yogstation13/Yogstation/pull/16517/commits/fe47bd3e344dbb8ef9dd03848baabd4c5d6d13a3

Purchase log only shows up if they had uplinks

# Changelog

:cl:  
tweak: Round-end report now includes what Uplinked ERTs bought
/:cl:
