### PR TITLE
Lets alt click toggle T scanners and mining scanners

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -44,7 +44,7 @@ GENE SCANNER
 /obj/item/t_scanner/attack_self(mob/user)
 	toggle_on()
 	
-/obj/item/t_scanner/CtrlClick(mob/user)
+/obj/item/t_scanner/AltClick(mob/user)
 	toggle_on()
 
 /obj/item/t_scanner/cyborg_unequip(mob/user)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -43,6 +43,9 @@ GENE SCANNER
 
 /obj/item/t_scanner/attack_self(mob/user)
 	toggle_on()
+	
+/obj/item/t_scanner/CtrlClick(mob/user)
+	toggle_on()
 
 /obj/item/t_scanner/cyborg_unequip(mob/user)
 	if(!on)


### PR DESCRIPTION
Huge QoL for jungleland where the constant scanner blinds you

:cl:  
tweak: alt click now toggles T scanners and mining scanners
/:cl:
