### PR TITLE
Minebots no longer passively die on jungleland

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -15,6 +15,7 @@
 	faction = list("neutral")
 	a_intent = INTENT_HARM
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	unsuitable_atmos_damage = 0
 	minbodytemp = 0
 	move_to_delay = 10
 	speed = -1 //YOGS - minebot //Buffed to not be a fucking god damn piece of slug matter writhing on the fucking floor pt2

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -90,10 +90,6 @@
 
 /mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/I)
 	. = TRUE
-	if(mode == MINEDRONE_ATTACK)
-		to_chat(user, span_info("[src] can't be repaired while in attack mode!"))
-		return
-
 	if(maxHealth == health)
 		to_chat(user, span_info("[src] is at full integrity."))
 		return


### PR DESCRIPTION
They just kinda randomly slowly took damage while on jungle land

closes #16530 

:cl:  
tweak: minebots no longer take atmospheric damage
tweak: minebots can be repaired while in combat mode
/:cl:
