### PR TITLE
Makes atmos holofan barriers fireproof

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -100,6 +100,7 @@
 	density = FALSE
 	anchored = TRUE
 	CanAtmosPass = ATMOS_PASS_NO
+	resistance_flags = FIRE_PROOF
 	alpha = 150
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	rad_insulation = RAD_LIGHT_INSULATION


### PR DESCRIPTION
# Document the changes in your pull request

Holofan barriers will no longer get destroyed by fire, which makes sense because it's meant to contain fire

# Changelog

:cl:  
tweak: atmos holofan barriers are now fireproof
/:cl:
