### PR TITLE
Makes red brig tiles craftable

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -349,6 +349,7 @@ GLOBAL_LIST_INIT(titanium_recipes, list ( \
 
 GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	new/datum/stack_recipe("plastitanium tile", /obj/item/stack/tile/mineral/plastitanium, 1, 4, 20), \
+	new/datum/stack_recipe("red plastitanium tile", /obj/item/stack/tile/mineral/plastitanium/red/brig, 1, 4, 20), \
 	))
 
 /obj/item/stack/sheet/mineral/plastitanium/Initialize(mapload, new_amount, merge = TRUE)

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -88,6 +88,16 @@
 	mineralType = "plastitanium"
 	materials = list(/datum/material/titanium=250, /datum/material/plasma=250)
 
+/obj/item/stack/tile/mineral/plastitanium/red/brig
+	name = "brig plastitanium tile"
+	singular_name = "brig plastitanium floor tile"
+	desc = "A tile made of plastitanium, used for shuttle brig."
+	icon_state = "tile_darkshuttle"
+	item_state = "tile-darkshuttle"
+	turf_type = /turf/open/floor/mineral/plastitanium/red/brig
+	mineralType = "plastitanium"
+	materials = list(/datum/material/titanium=250, /datum/material/plasma=500)
+
 /obj/item/stack/tile/mineral/snow
 	name = "snow tile"
 	singular_name = "snow tile"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

Makes red brig tiles craftable so if they get removed you can replace them, or if your shuttle doesn't have them
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Makes red brig tiles craftable
/:cl:
