### PR TITLE
[Meta] Adds a third pump and a space injector to toxins

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -52930,17 +52930,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"fcv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -54019,6 +54008,18 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"fTc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "fTh" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -58065,18 +58066,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"iNq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "iNs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -73331,6 +73320,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sIp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "sJK" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -111505,8 +111505,8 @@ nHk
 bPe
 bPF
 cta
-fcv
-iNq
+sIp
+fTc
 cFh
 cFh
 cKH

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -43956,16 +43956,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cyD" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cyE" = (
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
@@ -43994,19 +43984,6 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cyH" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyI" = (
@@ -44535,14 +44512,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"cAG" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cAH" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
@@ -62037,6 +62006,19 @@
 	dir = 1
 	},
 /area/crew_quarters/kitchen)
+"lhm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "lij" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -71804,6 +71786,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"rHC" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "rHE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -78921,6 +78913,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wuv" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "wuF" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -114291,7 +114291,7 @@ cuQ
 cdJ
 cwT
 crQ
-cyD
+rHC
 mom
 crB
 cBv
@@ -115319,7 +115319,7 @@ euk
 vsa
 rrV
 crR
-cyH
+lhm
 czx
 crG
 cBs
@@ -115835,7 +115835,7 @@ cqD
 crR
 cyJ
 czB
-cAG
+wuv
 crO
 cCC
 cDp

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -2773,6 +2773,10 @@
 "ahc" = (
 /turf/open/floor/plasteel,
 /area/security/range)
+"ahf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "ahg" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -42582,17 +42586,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cum" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "cun" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -42615,18 +42608,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cuB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "cuD" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -44773,35 +44754,6 @@
 "cCs" = (
 /turf/template_noop,
 /area/template_noop)
-"cCt" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cCu" = (
-/obj/item/assembly/signaler{
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cCv" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -52978,6 +52930,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"fcv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -55393,6 +55356,12 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"gNB" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "gOO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -57104,6 +57073,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"hZS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 1;
+	name = "toxins space injector"
+	},
+/turf/open/space,
+/area/science/mixing/chamber)
 "ibb" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -57363,6 +57340,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"ike" = (
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/pump/on,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "ikT" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -58081,6 +58065,18 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"iNq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "iNs" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -59787,6 +59783,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jPA" = (
+/obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "jPG" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
@@ -61478,6 +61479,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"kTi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "kTm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -68267,6 +68277,28 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"psi" = (
+/obj/item/assembly/signaler{
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "psG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -111473,8 +111505,8 @@ nHk
 bPe
 bPF
 cta
-cum
-cuB
+fcv
+iNq
 cFh
 cFh
 cKH
@@ -113266,10 +113298,10 @@ crQ
 cyz
 cFr
 crA
-cFr
-cCt
-wQA
-cEq
+kTi
+ike
+ahf
+hZS
 cEq
 cEq
 cIg
@@ -113523,8 +113555,8 @@ crQ
 cyA
 cBs
 crB
-cBs
-cCt
+gNB
+jPA
 wQA
 cEr
 cEr
@@ -113781,7 +113813,7 @@ crj
 fIp
 crB
 cBt
-cCu
+psi
 wQA
 cEs
 cFn


### PR DESCRIPTION
# Document the changes in your pull request

Current toxins meta involves 3 pumps, and meta only has two, making it very inconvenient to produce toxin bombs on meta

Also adds a space injector, removes one of the bomb closets because there's like 3 and only one on box

Removes a spare yellow can in favor of an extra oxygen can (since toxins storage only has 3), and moves the scrubber to make way for the new pump
# Spriting


# Wiki Documentation

Screenshot of meta toxins

# Changelog



:cl:  
mapping: removes a spare can in toxins in favor of a new air pump
mapping: removes a bomb closet in favor of a space injector
/:cl:
