### PR TITLE
Ruin tech research bug fixes, and minor map change fixes

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -1,4 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bL" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
 "bN" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -32,8 +37,18 @@
 /obj/item/mining_scanner,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
+"dQ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/mecha_part_fabricator/ruin,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
 "fy" = (
 /turf/open/floor/carpet/exoticpurple,
+/area/ruin/powered/golem_ship)
+"gl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "gU" = (
 /obj/machinery/light{
@@ -112,6 +127,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
+"kX" = (
+/obj/machinery/computer/rdconsole/nolock/ruin,
+/turf/open/floor/pod,
 /area/ruin/powered/golem_ship)
 "lK" = (
 /turf/open/floor/plating/lavaland_baseturf,
@@ -218,12 +237,7 @@
 "ty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"tK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/computer/rdconsole/nolock/ruin,
+/obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "uc" = (
@@ -617,7 +631,6 @@
 "Pu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
-/obj/machinery/mecha_part_fabricator/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "Pz" = (
@@ -678,10 +691,6 @@
 /obj/machinery/door/airlock/survival_pod/glass,
 /turf/open/floor/pod,
 /area/ruin/powered/golem_ship)
-"Ue" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/pod/dark,
-/area/ruin/powered/golem_ship)
 "UB" = (
 /obj/structure/table/reinforced,
 /obj/item/circular_saw,
@@ -732,11 +741,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/ruin/powered/golem_ship)
-"Wk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "WR" = (
 /obj/machinery/light{
@@ -990,7 +994,7 @@ Ht
 yu
 Ht
 Ht
-tK
+XR
 Do
 YP
 YP
@@ -1011,9 +1015,9 @@ PC
 mY
 uB
 Hv
-Ue
+da
 xc
-ER
+gl
 xc
 pT
 yp
@@ -1032,9 +1036,9 @@ Ud
 Hp
 Jj
 Hv
-Wk
+YP
 xc
-Hp
+kX
 xc
 xc
 Hp
@@ -1055,7 +1059,7 @@ Ht
 Ht
 Pu
 xc
-LB
+bL
 xc
 ty
 Hp
@@ -1076,7 +1080,7 @@ pq
 Ht
 YA
 Hp
-ID
+dQ
 Hp
 ER
 Hp

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -220,6 +220,12 @@
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
+"tK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/computer/rdconsole/nolock/ruin,
+/turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
 "uc" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -455,13 +461,6 @@
 /obj/machinery/door/airlock/survival_pod/glass,
 /turf/open/floor/pod,
 /area/ruin/powered/golem_ship)
-"HB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/rdconsole/nolock/ruin{
-	dir = 1
-	},
-/turf/open/floor/pod,
-/area/ruin/powered/golem_ship)
 "HQ" = (
 /obj/machinery/computer/shuttle{
 	dir = 4
@@ -618,6 +617,7 @@
 "Pu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/greenglow,
+/obj/machinery/mecha_part_fabricator/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "Pz" = (
@@ -678,6 +678,10 @@
 /obj/machinery/door/airlock/survival_pod/glass,
 /turf/open/floor/pod,
 /area/ruin/powered/golem_ship)
+"Ue" = (
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/pod/dark,
+/area/ruin/powered/golem_ship)
 "UB" = (
 /obj/structure/table/reinforced,
 /obj/item/circular_saw,
@@ -728,6 +732,11 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
+/area/ruin/powered/golem_ship)
+"Wk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/pod/dark,
 /area/ruin/powered/golem_ship)
 "WR" = (
 /obj/machinery/light{
@@ -981,7 +990,7 @@ Ht
 yu
 Ht
 Ht
-XR
+tK
 Do
 YP
 YP
@@ -1002,7 +1011,7 @@ PC
 mY
 uB
 Hv
-da
+Ue
 xc
 ER
 xc
@@ -1023,11 +1032,11 @@ Ud
 Hp
 Jj
 Hv
-YP
+Wk
 xc
 Hp
 xc
-HB
+xc
 Hp
 YP
 MQ

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -6960,7 +6960,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Ku" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator/ruin,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "KA" = (

--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -28,18 +28,6 @@
 "bk" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"bx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "bI" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -164,6 +152,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "gD" = (
@@ -178,9 +169,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -219,20 +207,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "ir" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 7;
-	pixel_y = 7
-	},
+/obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "iN" = (
@@ -274,12 +249,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/shuttle/abandoned)
-"kt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/abandoned)
 "kL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/table,
@@ -290,10 +259,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
 	pixel_x = 32
 	},
@@ -431,9 +396,6 @@
 /area/shuttle/abandoned)
 "qe" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "qh" = (
@@ -644,6 +606,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"wt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "wu" = (
 /obj/structure/mecha_wreckage/clarke,
 /turf/open/floor/plasteel/recharge_floor,
@@ -727,6 +695,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"zR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "Ai" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -795,6 +772,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
+"BN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "BO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/window/shuttle,
@@ -821,11 +807,7 @@
 /area/shuttle/abandoned)
 "CM" = (
 /obj/machinery/light,
-/obj/machinery/rnd/production/circuit_imprinter/department/science{
-	categories = list("Exosuit Modules");
-	pixel_x = -2;
-	pixel_y = 2
-	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "DV" = (
@@ -839,9 +821,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
 "Es" = (
-/obj/machinery/mecha_part_fabricator/maint{
-	req_access = list(71)
-	},
+/obj/machinery/mecha_part_fabricator/ruin,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "EI" = (
@@ -879,9 +859,6 @@
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "FG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -31
 	},
@@ -1229,6 +1206,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Qy" = (
@@ -1346,7 +1327,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1465,9 +1446,6 @@
 "VZ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
 "Wd" = (
@@ -1529,6 +1507,23 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"YL" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/abandoned)
 "YM" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -1539,9 +1534,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/shuttle,
 /area/shuttle/abandoned)
@@ -1663,9 +1655,9 @@ bk
 Bw
 EI
 TX
-kt
-bx
-kt
+ih
+JW
+ih
 qe
 EI
 nZ
@@ -1679,7 +1671,7 @@ HB
 GW
 VY
 GW
-ih
+wt
 Nz
 qd
 sC
@@ -1696,7 +1688,7 @@ EI
 EI
 EI
 Ni
-ih
+wt
 Sd
 xK
 Mz
@@ -1730,7 +1722,7 @@ aY
 oE
 Iu
 bk
-JZ
+BN
 MP
 Ai
 qh
@@ -1784,7 +1776,7 @@ EI
 Ox
 ih
 JW
-ih
+YL
 ir
 EI
 Eq
@@ -1832,7 +1824,7 @@ EI
 zc
 EI
 EI
-JC
+zR
 ih
 Sg
 ih

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -642,7 +642,7 @@
 	if(issilicon(user))
 		return TRUE
 	id_card = user.get_idcard(hand_first = TRUE)
-	return ACCESS_HEADS in id_card.access
+	return ACCESS_HEADS in id_card?.access
 
 /obj/machinery/mecha_part_fabricator/ui_act(action, list/params)
 	. = ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -800,5 +800,5 @@
 	hacked = TRUE
 
 /obj/machinery/mecha_part_fabricator/ruin/Initialize(mapload)
+	. = ..()
 	stored_research = SSresearch.ruin_tech
-	return ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -793,3 +793,12 @@
 
 /obj/machinery/mecha_part_fabricator/maint
 	link_on_init = FALSE
+
+/obj/machinery/mecha_part_fabricator/ruin
+	link_on_init = FALSE
+	authorization_override = TRUE
+	hacked = TRUE
+
+/obj/machinery/mecha_part_fabricator/ruin/Initialize(mapload)
+	stored_research = SSresearch.ruin_tech
+	return ..()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -990,8 +990,8 @@ Nothing else in the console has ID requirements.
 			return
 		if(!research_control)
 			return				//honestly should call them out for href exploiting :^)
-		if(!SSresearch.science_tech.available_nodes[ls["research_node"]])
-			return			//Nope!
+		if(!stored_research.available_nodes[ls["research_node"]])
+			return 			//Nope!
 		research_node(ls["research_node"], usr)
 	if(ls["clear_tech"]) //Erase la on the technology disk.
 		if(QDELETED(t_disk))

--- a/tgui/packages/tgui/interfaces/ExosuitFabricator.js
+++ b/tgui/packages/tgui/interfaces/ExosuitFabricator.js
@@ -271,7 +271,7 @@ const Authorization = (props, context) => {
         <br />
         Combat ready designs {combat_parts_allowed ? "available" : "unavailable"}
         <br />
-        {auth_override ? "Authorization overriden by Head Personel\n" : ""}
+        {auth_override ? "Authorization overriden\n" : ""}
         {alert_level < 2 ? "" : "Credible threat to the station in effect\n"}
       </font>
     </Section>


### PR DESCRIPTION
- fixes #16520

# Document the changes in your pull request
Fixes unnable to research on rnd ruin console
Fixes unnable to sync ruin exosuit techfab
Fixes runtime spam in mech_fabricator.dm
Replaces and adds missing stuffs



# Wiki Documentation
Fix unnable to research on rnd ruin console
Fix unnable to sync ruin exosuit techfab
Fix runtime spam in mech_fabricator.dm
Replace and add missing stuffs

# Changelog



:cl:  

bugfix: Fixed unnable to research on rnd ruin console
bugfix: Fixed unnable to sync ruin exosuit techfab
bugfix: Fixed runtime spam in mech_fabricator.dm
mapping: Replaced and added missing stuffs

/:cl:
