### PR TITLE
Makes bomb armour more effective

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -441,7 +441,8 @@
 				gib()
 				return
 			else
-				brute_loss = 500
+				brute_loss = 200*(2 - round(bomb_armor/60, 0.05))	//0-83% damage reduction
+				burn_loss = brute_loss/2 //don't wanna husk people	
 				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(throw_target, 200, 4)
 				damage_clothes(400 - bomb_armor, BRUTE, BOMB)
@@ -450,7 +451,7 @@
 			brute_loss = 60
 			burn_loss = 60
 			if(bomb_armor)
-				brute_loss = 30*(2 - round(bomb_armor/75, 0.05))	//0-66% damage reduction
+				brute_loss = 30*(2 - round(bomb_armor/60, 0.05))	//0-83% damage reduction
 				burn_loss = brute_loss					//40-120 total combined brute + burn
 			damage_clothes(200 - bomb_armor, BRUTE, BOMB)
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
@@ -462,7 +463,7 @@
 		if (EXPLODE_LIGHT)
 			brute_loss = 24
 			if(bomb_armor)
-				brute_loss = 12*(2 - round(bomb_armor/75, 0.05))	//8-24 damage total depending on bomb armor
+				brute_loss = 12*(2 - round(bomb_armor/60, 0.05))	//4-24 damage total depending on bomb armor
 			damage_clothes(max(40 - bomb_armor, 0), BRUTE, BOMB)
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
 				adjustEarDamage(15,60)


### PR DESCRIPTION
### Mutually exclusive with #16577

Currently bomb armour is a meme at best, even 100% bomb armour feels terrible for it's intended purpose because you still instantly die.

**Now bomb armour is slightly more effective**
instead of being 0-66% damage reduction
it is now 0-83% damage reduction

**Bomb armour now applies to devastation range explosions damage**
50% bomb armour is still the cutoff point for gib protection
however, the damage taken from a devastation range explosion is now
233 brute and 116 burn with 50% bomb armour (still an instant kill, but less than the 500 brute of before)
66 brute and 33 burn with 100% bomb armour (just barely not in crit, but with the strong throw, of nearby objects and yourself, you'll still probably get put into crit)

closes #16577

:cl:  
tweak: Bomb armour is now more effective
/:cl:
