### PR TITLE
bloodsucker coffin torpor is better

### DIFF
--- a/code/modules/antagonists/bloodsuckers/structures/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsuckers/structures/bloodsucker_life.dm
@@ -124,8 +124,8 @@
 			to_chat(user, span_warning("You will not heal while your Masquerade ability is active."))
 			return
 		fireheal = min(user.getFireLoss_nonProsthetic(), actual_regen)
-		mult *= 5 // Increase multiplier if we're sleeping in a coffin.
-		costMult /= 2 // Decrease cost if we're sleeping in a coffin.
+		mult *= 8 // Increase multiplier if we're sleeping in a coffin.
+		costMult *= 0 // No cost if we're sleeping in a coffin.
 		user.ExtinguishMob()
 		user.remove_all_embedded_objects() // Remove Embedded!
 		if(check_limbs(costMult))


### PR DESCRIPTION
# Document the changes in your pull request

Costs nothing, heals more
This way it can outheal frenzy damage instead of being a random roll that takes about five minutes to decide your fate while you are sleeplocked

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Bloodsuckers heal 1.6x faster in coffins and it doesn't cost them blood
/:cl: