### PR TITLE
Makes message monitor work with NTOS PDAs

### DIFF
--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -137,8 +137,9 @@
 		signal.logged = M
 	else if(istype(signal, /datum/signal/subspace/messaging/ntospda))
 		var/datum/computer_file/program/pdamessager/recipient = signal.data["targets"][1]
-		GLOB.NTPDAMessages += list(list(signal.data["program"].username, recipient.username, signal.data["message"]))
-		var/datum/data_pda_msg/M = new(recipient.username, signal.data["program"].username, signal.data["message"])
+		var/datum/computer_file/program/pdamessager/sender = signal.data["program"]
+		GLOB.NTPDAMessages += list(list(sender.username, recipient.username, signal.data["message"]))
+		var/datum/data_pda_msg/M = new(recipient.username, sender.username, signal.data["message"])
 		pda_msgs += M
 		signal.logged = TRUE
 		var/datum/signal/subspace/current = signal

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -137,7 +137,9 @@
 		signal.logged = M
 	else if(istype(signal, /datum/signal/subspace/messaging/ntospda))
 		var/datum/computer_file/program/pdamessager/recipient = signal.data["targets"][1]
-		GLOB.NTPDAMessages += list(list(signal.data["name"], recipient.username, signal.data["message"]))
+		GLOB.NTPDAMessages += list(list(signal.data["program"].username, recipient.username, signal.data["message"]))
+		var/datum/data_pda_msg/M = new(recipient.username, signal.data["program"].username, signal.data["message"])
+		pda_msgs += M
 		signal.logged = TRUE
 		var/datum/signal/subspace/current = signal
 		while (current) // Recursively mark logged so we know in the caller proc that it is logged and sent proper


### PR DESCRIPTION
# Document the changes in your pull request



# Changelog

:cl:  
bugfix: Message monitor now views NTOS PDA messages
bugfix: NTOS PDA Messages no longer log the user's name rather than the program's username
/:cl:
