### PR TITLE
no more ipc zombies

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -62,6 +62,8 @@
 		return
 	if(!owner.getorgan(/obj/item/organ/brain))
 		return
+	if(isipc(owner))
+		return
 	if(!iszombie(owner))
 		to_chat(owner, "<span class='cultlarge'>You can feel your heart stopping, but something isn't right... \
 		life has not abandoned your broken form. You can only feel a deep and immutable hunger that \


### PR DESCRIPTION
closes #16551

:cl:  
bugfix: ipcs can no longer become zombies if someone manually implants the tumor
/:cl:
