### PR TITLE
Inorganic synthesis lets viruses infect ipc

### DIFF
--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -30,3 +30,4 @@
 	if(!.)
 		return
 	A.infectable_biotypes |= MOB_INORGANIC
+	A.infectable_biotypes |= MOB_ROBOTIC


### PR DESCRIPTION
Metal is inorganic
Why not, this could be interesting
also a buff to sentient viruses

:cl:  
rscadd: Inorganic synthesis lets viruses infect robotic species
/:cl:
