### PR TITLE
[META] Removes the scientist spawn in the server room that they DO NOT HAVE ACCESS TO (who the fuck added that)

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -22738,11 +22738,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"bcv" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "bcz" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Station Entrance";
@@ -64955,6 +64950,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"ngA" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "ngF" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -113531,7 +113530,7 @@ cEr
 cEr
 cIg
 cIb
-bcv
+ngA
 cJS
 cIg
 bGP


### PR DESCRIPTION

# Document the changes in your pull request

Hey guys it's probably not smart to spawn someone in a room they do not have access to

# Spriting

# Wiki Documentation


# Changelog



:cl:  
mapping: removes a scientist spawn in meta server room 
/:cl:
