### PR TITLE
Makes Firestacks examine actually work

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -94,11 +94,11 @@
 	switch(fire_stacks)
 		if(1 to INFINITY)
 			msg += "[t_He] [t_is] covered in something flammable.\n"
-		if(-1 to -2)
+		if(-5 to -1)
 			msg += "[t_He] look[p_s()] a little damp.\n"
-		if(-2 to -5)
+		if(-10 to -5)
 			msg += "[t_He] look[p_s()] a little soaked.\n"
-		if(-5 to -INFINITY)
+		if(-INFINITY to -10)
 			msg += "[t_He] look[p_s()] drenched.\n"
 
 	if(visible_tumors)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -219,11 +219,11 @@
 	switch(fire_stacks)
 		if(1 to INFINITY)
 			msg += "[t_He] [t_is] covered in something flammable.\n"
-		if(-1 to -2)
+		if(-5 to -1)
 			msg += "[t_He] look[p_s()] a little damp.\n"
-		if(-2 to -5)
+		if(-10 to -5)
 			msg += "[t_He] look[p_s()] a little soaked.\n"
-		if(-5 to -INFINITY)
+		if(-INFINITY to -10)
 			msg += "[t_He] look[p_s()] drenched.\n"
 
 	if(visible_tumors)


### PR DESCRIPTION
gotta put them in the "reverse" order because it's a negative number, not a positive

:cl:  
bugfix: negative fire_stacks now gets examined properly
/:cl:
