### PR TITLE
Gives Blood Brothers a good way to communicate (Port from BeeStation)

### DIFF
--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -1,0 +1,63 @@
+/obj/item/implant/bloodbrother
+	name = "communication implant"
+	desc = "Use this to communicate with your fellow blood brother(s)."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "cypherkey"
+	var/list/linked_implants // All other implants that this communicates to
+
+/obj/item/implant/bloodbrother/Initialize()
+	. = ..()
+	linked_implants = list()
+
+/obj/item/implant/bloodbrother/activate()
+	. = ..()
+	if(linked_implants.len)
+		var/input = stripped_input(imp_in, "Enter a message to communicate to your blood brother(s).", "Radio Implant", "")
+		if(!input || imp_in.stat == DEAD)
+			return
+		if(isnotpretty(input))
+			to_chat(imp_in, "<span class='warning'>The message contains prohibited words!</span>")
+			return
+
+		var/my_message = "<font color=\"#ff0000\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
+		var/ghost_message = "<font color=\"#ff0000\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"
+
+		to_chat(imp_in, my_message) // Sends message to the user
+		for(var/obj/item/implant/bloodbrother/i in linked_implants) // Sends message to all linked implnats
+			var/M = i.imp_in
+			to_chat(M, my_message)
+		for(var/M in GLOB.dead_mob_list) // Sends message to ghosts
+			var/link = FOLLOW_LINK(M, imp_in)
+			to_chat(M, "[link] [ghost_message]")
+
+		imp_in.log_talk(input, LOG_SAY, tag="Blood Brother Implant")
+	else
+		to_chat(imp_in, "<span class='bold'>There are no linked implants!</span>")
+
+/obj/item/implant/bloodbrother/Destroy()
+	. = ..()
+	for(var/obj/item/implant/bloodbrother/i in linked_implants) // Removes this implant from the list of implants
+		i.linked_implants -= src
+
+/obj/item/implant/bloodbrother/proc/link_implant(var/obj/item/implant/bloodbrother/BB)
+	if(BB)
+		if(BB == src) // Don't want to put this implant into itself
+			return
+		linked_implants |= BB
+		BB.linked_implants |= src
+
+/obj/item/implant/bloodbrother/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Donk Corp(tm) Initiate Communication Implant<BR>
+				<b>Life:</b> Indefinite.<BR>
+				<b>Important Notes: <font color='red'>Illegal</font></B><BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a small, directly linked radio device along with a small speaker and microphone. Allows communication between two similar implants.<BR>"}
+	return dat
+
+/obj/item/implanter/bloodbrother
+	name = "implanter (communication)"
+	imp_type = /obj/item/implant/bloodbrother
+
+

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -64,11 +64,16 @@
 /datum/antagonist/brother/greet()
 	var/brother_text = get_brother_names()
 	to_chat(owner.current, span_alertsyndie("You are the [owner.special_role] of [brother_text]."))
-	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together!")
+	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together! You and your team are outfitted with communication implants allowing for direct, encrypted communication.")
 	owner.announce_objectives()
 	give_meeting_area()
 
 /datum/antagonist/brother/proc/finalize_brother()
+	var/obj/item/implant/bloodbrother/I = new /obj/item/implant/bloodbrother()
+	I.implant(owner.current, null, TRUE, TRUE)
+	for(var/datum/mind/M in team.members) // Link the implants of all team members
+		var/obj/item/implant/bloodbrother/T = locate() in M.current.implants
+		I.link_implant(T)
 	SSticker.mode.update_brother_icons_added(owner)
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE)
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1096,6 +1096,7 @@
 #include "code\game\objects\items\grenades\syndieminibomb.dm"
 #include "code\game\objects\items\implants\implant.dm"
 #include "code\game\objects\items\implants\implant_abductor.dm"
+#include "code\game\objects\items\implants\implant_bb.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
 #include "code\game\objects\items\implants\implant_exile.dm"


### PR DESCRIPTION
# Document the changes in your pull request

> ## About The Pull Request
> Adds a communication implant that can be linked to another implant of the same type to communicate secretly. Implants blood brothers with this implant roundstart. Updates BB instruction text to explain the implant.
> 
> ## Why It's Good For The Game
> Blood brothers have always been very underpowered as antags, as they have no good way to communicate that won't get them caught instantly if the AI decides to look at message logs. This is extremely bad for a team antag, and this change works to fix it rather than just giving them TC or some other fix.
> 
> ## Changelog
> add: Adds a communication implant
> add: Blood brothers get a communication implant to their team roundstart



Ports https://github.com/BeeStation/BeeStation-Hornet/pull/3023

Requested by Ultra#8599

I think blood brothers as a gamemode could be a lot more interactive and better suited with a direct comm line between brothers

Finally something unique for BB

#

Pros: Blood brothers will practically be forced to interact with each other, greatly improving teamwork and coordination

Cons: No more PDA funnies between BBs

# Changelog

:cl:  
rscadd: Adds a communication implant
rscadd: Blood brothers get a communication implant to their team roundstart
/:cl:
