### PR TITLE
Can no longer wrap items with nodrop

### DIFF
--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -69,6 +69,9 @@
 		return
 	if(target.anchored)
 		return
+	if(HAS_TRAIT(target, TRAIT_NODROP))
+		to_chat(user, span_warning("You can't seem to figure out a way to wrap this."))
+		return
 
 	if(isitem(target))
 		var/obj/item/I = target


### PR DESCRIPTION
This both lets people trick people into picking up an item they can't drop
and lets people drop items they shouldn't be able to drop

:cl:  
bugfix: Can no longer wrap items with nodrop
/:cl:
