### PR TITLE
SHADOWLING REBALANCE 2022

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -52,7 +52,7 @@
 	name = "Glare"
 	desc = "Disrupts the target's motor and speech abilities. Much more effective within two meters."
 	panel = "Shadowling Abilities"
-	charge_max = 300
+	charge_max = 30 SECONDS
 	human_req = TRUE
 	clothes_req = FALSE
 	action_icon_state = "glare"
@@ -61,7 +61,19 @@
 /obj/effect/proc_holder/spell/targeted/sling/glare/InterceptClickOn(mob/living/caller, params, atom/t)
 	. = ..()
 	if(!target)
-		return
+		//Pick the closest mob in 3 tiles.
+		var/mob/living/carbon/human/closest
+		var/dist = 10
+		for (var/mob/living/carbon/human/M in view(3))
+			if (get_dist(M, usr) < dist)
+				closest = M
+				dist = get_dist(M, usr)
+		if (!closest)
+			revert_cast()
+			return
+		else
+			target = closest
+
 	if(!caller.getorganslot(ORGAN_SLOT_EYES))
 		to_chat(user, span_warning("You need eyes to glare!"))
 		revert_cast()
@@ -277,6 +289,8 @@
 			return
 		if(!target.client)
 			to_chat(user, span_warning("[target]'s mind is vacant of activity."))
+			revert_cast()
+			return
 		enthralling = TRUE
 		for(var/progress = 0, progress <= 3, progress++)
 			switch(progress)
@@ -509,7 +523,7 @@
 	desc = "Deafens, stuns, and confuses nearby people. Also shatters windows."
 	panel = "Shadowling Abilities"
 	range = 7
-	charge_max = 300
+	charge_max = 30 SECONDS
 	human_req = TRUE
 	clothes_req = FALSE
 	action_icon_state = "screech"
@@ -549,7 +563,7 @@
 	desc = "Empowers a thrall. You can only have 3 empowered thralls at a time. Empowered thralls become lesser versions of yourself, gaining a small selection of your abilities as well as your healing in the dark and aversion to light."
 	panel = "Shadowling Abilities"
 	range = 1
-	charge_max = 600
+	charge_max = 60 SECONDS
 	human_req = TRUE
 	clothes_req = FALSE
 	include_user = FALSE

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -101,7 +101,7 @@
 	name = "Veil"
 	desc = "Extinguishes most nearby light sources."
 	panel = "Shadowling Abilities"
-	charge_max = 120 //Short cooldown because people can just turn the lights back on
+	charge_max = 8 SECONDS //Short cooldown because people can just turn the lights back on
 	human_req = TRUE
 	clothes_req = FALSE
 	range = 5
@@ -198,7 +198,7 @@
 	desc = "Instantly freezes the blood of nearby people, stunning them and causing burn damage while hampering their movement."
 	panel = "Shadowling Abilities"
 	range = 3
-	charge_max = 1 MINUTES
+	charge_max = 40 SECONDS
 	human_req = TRUE
 	clothes_req = FALSE
 	action_icon = 'yogstation/icons/mob/actions.dmi'
@@ -667,7 +667,7 @@
 				thrallToRevive.Unconscious(500)
 				thrallToRevive.visible_message(span_boldannounce("[thrallToRevive] collapses in exhaustion."), \
 				   span_warning("<b><i>You collapse in exhaustion... nap..... dark.</b></i>"))
-
+GLOBAL_VAR_INIT(shadowlings_engines_destroyed, FALSE)
 /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle
 	name = "Destroy Engines"
 	desc = "Sacrifice a thrall to extend the time of the emergency shuttle's arrival by fifteen minutes. This can only be used once."
@@ -682,6 +682,9 @@
 /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle/cast(list/targets, mob/living/carbon/human/user = usr)
 	if(!shadowling_check(user))
 		revert_cast()
+		return
+	if (GLOB.shadowlings_engines_destroyed)
+		to_chat(user, "span class='warning'>Can't destroy a destroyed engine.</span>")
 		return
 	for(var/mob/living/carbon/human/target in targets)
 		if(target.stat)
@@ -716,9 +719,7 @@
 			priority_announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes...", "System Failure", 'sound/misc/notice1.ogg')
 			SSshuttle.emergency.setTimer(timer)
 			SSshuttle.emergencyNoRecall = TRUE
-		user.mind.spell_list.Remove(src) //Can only be used once!
-		qdel(src)
-
+			shadowlings_engines_destroyed = TRUE
 //Loosely adapted from the Nightmare's Shadow Walk, but different enough that
 //inheriting would have been more hacky code.
 //Unlike Shadow Walk, jaunting shadowlings can move through lit areas unmolested,

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -289,24 +289,8 @@
 					to_chat(target, span_danger("A terrible red light floods your mind. You collapse as conscious thought is wiped away."))
 					target.Knockdown(120)
 					if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
-						if(ispreternis(target))
-							to_chat(user, span_notice("Your servant's mind has been corrupted by other machinery. You begin to shut down the implant preventing your command - this will take some time..."))
-							user.visible_message(span_warning("[user] growls in frustration, then dips their head with determination!"))
-						else
-							to_chat(user, span_notice("They are protected by an implant. You begin to shut down the nanobots in their brain - this will take some time..."))
-							user.visible_message(span_warning("[user] pauses, then dips their head in concentration!"))
-						to_chat(target, span_boldannounce("You feel your mental protection faltering!"))
-						if(!do_mob(user, target, 650)) //65 seconds to remove a loyalty implant. yikes!
-							to_chat(user, span_warning("The enthralling has been interrupted - your target's mind returns to its previous state."))
-							to_chat(target, span_userdanger("You wrest yourself away from [user]'s hands and compose yourself!"))
-							enthralling = FALSE
-							return
-						to_chat(user, span_notice("The nanobots composing the mindshield implant have been rendered inert. Now to continue."))
-						user.visible_message(span_warning("[user] relaxes again."))
-						for(var/obj/item/implant/mindshield/L in target)
-							if(L)
-								qdel(L)
-						to_chat(target, span_boldannounce("Your mental protection unexpectedly falters, dims, dies."))
+						to_chat(user, span_notice("They are protected by an implant. It is too strong to break through! You marvel at the ingenuity of Nanotrasen's engineers."))
+						return
 				if(3)
 					to_chat(user, span_notice("You begin planting the tumor that will control the new thrall..."))
 					user.visible_message(span_warning("A strange energy passes from [user]'s hands into [target]'s head!"))

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -733,7 +733,7 @@ GLOBAL_VAR_INIT(shadowlings_engines_destroyed, FALSE)
 			priority_announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes...", "System Failure", 'sound/misc/notice1.ogg')
 			SSshuttle.emergency.setTimer(timer)
 			SSshuttle.emergencyNoRecall = TRUE
-			shadowlings_engines_destroyed = TRUE
+			GLOB.shadowlings_engines_destroyed = TRUE
 //Loosely adapted from the Nightmare's Shadow Walk, but different enough that
 //inheriting would have been more hacky code.
 //Unlike Shadow Walk, jaunting shadowlings can move through lit areas unmolested,

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -304,6 +304,7 @@
 					target.Knockdown(120)
 					if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 						to_chat(user, span_notice("They are protected by an implant. It is too strong to break through! You marvel at the ingenuity of Nanotrasen's engineers."))
+						target.say(pick(";TAMPER ATTEMPT DETECTED.", ";TAMPERING OF NANOTRASEN PROPERTY IS PROHIBITED.", ";Error detected in protection routines. Please contact your local NanoTrasen representative."), spans = list(SPAN_ROBOT))
 						return
 				if(3)
 					to_chat(user, span_notice("You begin planting the tumor that will control the new thrall..."))

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -86,6 +86,10 @@
 		to_chat(usr, span_warning("You cannot glare at allies!"))
 		revert_cast()
 		return
+	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		to_chat(user, span_notice("They are protected by a mindshield! We cannot glare or convert [target]."))
+		target.say(pick(";TAMPER ATTEMPT DETECTED.", ";TAMPERING OF NANOTRASEN PROPERTY IS PROHIBITED.", ";Error detected in protection routines. Please contact your local NanoTrasen representative."), spans = list(SPAN_ROBOT))
+		return
 	var/mob/living/carbon/human/M = target
 	usr.visible_message(span_warning("<b>[usr]'s eyes flash a purpleish-red!</b>"))
 	var/distance = get_dist(target, usr)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

## It is WAY TOO EASY for competent shadowlings to win.
## However, it is too HARD for new shadowlings to win.
I have taken this into account and designed a balance PR methodically that is to make it easier for newer shadowlings to win, as well as making it harder for competent shadowlings to steamroll.

1. Shadowlings can no longer enthrall mindshielded people. This is because I noticed that competent shadowlings would rush security officers or heads and convert them at round start instead of normal people, which was a guaranteed win if you got the Captain. Additionally, mindshields are completely useless in this gamemode because of the aforementioned issue. This makes it so they are a worthwhile buy.
2. I have decreased the cooldown on Icy Veins and Veil. This is to make escape easier, which noticeably helps newer players learn the basics, as well as letting them live for longer against a competent security force. I have seen new shadowlings die solo to an assistant in maintenance.
3. I have made "glare" auto select a target that is closest to you if you miss your shot. This is to make it easier for newer players as they may not always have the best aim, so it is equalizing aim skill. This makes it easier for newer players to get going because it has a very hefty cooldown if you miss, and if you miss the entire stealth portion of the gamemode is now over, which makes it almost impossible for newer groups to win.
4. Glare no longer works on mindshielded humans since it is a conversion tool. 
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->
Can't enthrall mindshielded people
Glare no longer works on mindshielded humans since it is a conversion tool. 
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Glare now can auto-target if you miss in a radius
tweak: Shadowlings can't thrall mindshielded people
tweak: Veil and icy veins cooldown reduced
tweak: Glare no longer works on mindshielded humans since it is a conversion tool. 
bugfix: Fixed Destroy Engines being able to be used multiple times by different shadowlings
/:cl:
