### PR TITLE
Changes hierophant crusher trophy's effect and makes colossus a bit more approachable.

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -430,25 +430,14 @@
 	denied_type = /obj/item/crusher_trophy/vortex_talisman
 
 /obj/item/crusher_trophy/vortex_talisman/effect_desc()
-	return "mark detonation to create a barrier you can pass"
+	return "mark detonation to create a homing hierophant chaser" //Wall was way too cheesy and allowed miners to be nearly invincible while dumb mob AI just rubbed its face on the wall.
 
 /obj/item/crusher_trophy/vortex_talisman/on_mark_detonation(mob/living/target, mob/living/user)
-	var/turf/current_location = get_turf(user)//yogs added a current location check that was totally ripped from the hand tele code honk
-	var/area/current_area = current_location.loc //yogs more location check stuff
-	if(current_area.noteleport) //yogs added noteleport
-		to_chat(user, "[src] fizzles uselessly.")
-		return
-	var/turf/T = get_turf(user)
-	new /obj/effect/temp_visual/hierophant/wall/crusher(T, user) //a wall only you can pass!
-	var/turf/otherT = get_step(T, turn(user.dir, 90))
-	if(otherT)
-		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
-	otherT = get_step(T, turn(user.dir, -90))
-	if(otherT)
-		new /obj/effect/temp_visual/hierophant/wall/crusher(otherT, user)
-
-/obj/effect/temp_visual/hierophant/wall/crusher
-	duration = 75
+	if(isliving(target))
+		var/obj/effect/temp_visual/hierophant/chaser/C = new(get_turf(user), user, target, 3, TRUE)
+		C.damage = 10 // Weaker because there is no cooldown
+		C.monster_damage_boost = FALSE
+		log_combat(user, target, "fired a chaser at", src)
 
 //Legion (Megafauna)
 /obj/item/crusher_trophy/malformed_bone

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -214,6 +214,7 @@ Difficulty: Very Hard
 	for(var/mob/M in range(10,src))
 		if(M.client)
 			flash_color(M.client, "#C80000", 1)
+			sleep( 0.5 SECONDS)
 			shake_camera(M, 4, 3)
 	playsound(src, 'sound/magic/clockwork/narsie_attack.ogg', 200, 1)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -214,7 +214,7 @@ Difficulty: Very Hard
 	for(var/mob/M in range(10,src))
 		if(M.client)
 			flash_color(M.client, "#C80000", 1)
-			sleep( 0.5 SECONDS)
+			sleep(0.5 SECONDS)
 			shake_camera(M, 4, 3)
 	playsound(src, 'sound/magic/clockwork/narsie_attack.ogg', 200, 1)
 


### PR DESCRIPTION
# Document the changes in your pull request

Don't like the vortex talisman walls because it turns crusher gameplay more into ka gameplay, so now it shoots out a hierophant chaser on mark detonation aimed at the target. Also colossus is a bit more approachable with the crusher with a half second delay on some of its attacks. (initially this was gonna be a port of the beestation change but i realized i didnt like most of it).

![dreamseeker_PxIfVkgrNJ](https://user-images.githubusercontent.com/58535870/202781276-6688f26c-786d-4804-b9c1-f7dc816945e2.gif)

Thanks to beestation's Rukofamicom for making the original pr i based this one off of.

# Wiki Documentation
https://wiki.yogstation.net/wiki/Shaft_Miner#Crusher_Trophies
For the vortex talisman bit, change the description to like 'sends out a hierophant chaser on mark detonation which does 10 damage on crossing a target.'


# Changelog

:cl:  @LazennG @Rukofamicom
tweak: tweaked vortex talisman and colossus
/:cl:
