### PR TITLE
[ASTEROID] Adds a third pump to asteroid toxins

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -4825,6 +4825,14 @@
 "aLR" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
+"aLS" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "aLW" = (
 /mob/living/simple_animal/opossum,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -63980,13 +63988,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"uHk" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "uHm" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -65473,6 +65474,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vmu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "vmz" = (
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/beartrap,
@@ -65697,14 +65705,6 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
-"vrV" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "vrZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -113069,8 +113069,8 @@ oHB
 wUw
 fpC
 rhV
-uHk
-vrV
+aLS
+vmu
 asI
 amT
 jfX

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -4825,14 +4825,6 @@
 "aLR" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
-"aLS" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "aLW" = (
 /mob/living/simple_animal/opossum,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -35249,6 +35241,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
+"lfd" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "lfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -65474,13 +65474,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vmu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "vmz" = (
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/beartrap,
@@ -67809,6 +67802,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wcP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "wcV" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -113069,8 +113069,8 @@ oHB
 wUw
 fpC
 rhV
-aLS
-vmu
+lfd
+wcP
 asI
 amT
 jfX


### PR DESCRIPTION

# Document the changes in your pull request

Toxins meta is 3 pumps, this one only has two. Removed one of the stupid empty cans that serve zero purpose to toxins.

# Spriting

# Wiki Documentation



# Changelog


:cl:  
mapping: removes an empty can in favor of a third pump in asteroid toxins
/:cl:
