### PR TITLE
[ASTEROID] Adds third pump to toxins part 2

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -15640,6 +15640,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eqh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "eqq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -63027,6 +63034,14 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
+"usj" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "usq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
@@ -63980,13 +63995,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"uHk" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "uHm" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -65697,14 +65705,6 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
-"vrV" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "vrZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -113069,8 +113069,8 @@ oHB
 wUw
 fpC
 rhV
-uHk
-vrV
+usj
+eqh
 asI
 amT
 jfX


### PR DESCRIPTION
# Document the changes in your pull request

Toxins meta is 3 pumps, this one only has two. Removed one of the stupid empty cans that serve zero purpose to toxins.

# Spriting

# Wiki Documentation



# Changelog


:cl:  
mapping: removes an empty can in favor of a third pump in asteroid toxins
/:cl:
