### PR TITLE
makes miner pens not work on station

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -176,11 +176,19 @@
 
 /obj/item/reagent_containers/autoinjector/medipen/survival
 	name = "survival medipen"
-	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
+	desc = "A medipen for surviving in the harshest of environments, but won't work on a space station. heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "stimpen"
 	volume = 57
 	amount_per_transfer_from_this = 57
 	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/tricordrazine = 15, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/lavaland_extract = 2, /datum/reagent/medicine/omnizine = 5)
+
+/obj/item/reagent_containers/autoinjector/medipen/survival/attack(mob/living/M, mob/user)
+	var/turf/T = get_turf(user)
+	if(is_station_level(T.z))
+		to_chat(user, span_warning("The strong artificial gravity generator present nearby prevent this from working!")) //some flavor text
+		return
+	else
+		..()
 
 /obj/item/reagent_containers/autoinjector/medipen/species_mutator
 	name = "species mutator medipen"


### PR DESCRIPTION
technically this is an ided but i was working on this earlier so its ok
at this point the shaft miner coffin has to be the most structurally sound structure in the world with how many nails its got in it
now medbay has to put in an extra 0.35 seconds into making medicines instead of being handed a bag of holding full of survival pens, also makes it harder to validhunt because no more 1 click fullheals 🙂

# Changelog

:cl:  
tweak: miner survival pens dont work on the station anymore
/:cl:
