### PR TITLE
Mecha no more EMP armor

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -2,7 +2,7 @@
 	force = 30
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
 	internal_damage_threshold = 50
-	armor = list(MELEE = 30, BULLET = 30, LASER = 15, ENERGY = 20, BOMB = 20, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 15, ENERGY = 0, BOMB = 20, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
 	destruction_sleep_duration = 40
 	exit_delay = 40

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 400
 	deflect_chance = 20
-	armor = list(MELEE = 40, BULLET = 35, LASER = 15, ENERGY = 10, BOMB = 20, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 35, LASER = 15, ENERGY = 0, BOMB = 20, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
 	max_temperature = 30000
 	infra_luminosity = 8
 	force = 40

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 250
 	deflect_chance = 5
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 40, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 6
 	wreckage = /obj/structure/mecha_wreckage/gygax

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -5,7 +5,7 @@
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25
-	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 50, BULLET = 55, LASER = 40, ENERGY = 0, BOMB = 30, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_temperature = 60000
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -7,7 +7,7 @@
 	step_energy_drain = 3
 	max_integrity = 200
 	deflect_chance = 30
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 0, BOMB = 30, BIO = 100, RAD = 50, FIRE = 100, ACID = 100)
 	max_temperature = 25000
 	infra_luminosity = 3
 	wreckage = /obj/structure/mecha_wreckage/phazon

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -6,7 +6,7 @@
 	dir_in = 1 //Facing North.
 	max_integrity = 100
 	deflect_chance = 3
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	max_temperature = 15000
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -617,19 +617,15 @@
 	var/move_result = 0
 	var/oldloc = loc
 
-	// Damage slowdown
-	// Slowdown starts at below 75% integrity
-	// Builds based on how damaged you are below 75%
-	// Max slowdown (2.5x slower) at 30% integrity
-	var/slowdown = clamp(0.75 / (obj_integrity/max_integrity), 1, 2.5)
-	
+
+
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
-		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) * slowdown ))
+		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) ))
 		move_result = mechsteprand()
 	else if(dir != direction && (!strafe || occupant?.client?.prefs.bindings.isheld_key("Alt")))
 		move_result = mechturn(direction)
 	else
-		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) * slowdown ))
+		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) ))
 		move_result = mechstep(direction)
 	if(move_result || loc != oldloc)// halfway done diagonal move still returns false
 		use_power(step_energy_drain)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -616,13 +616,20 @@
 
 	var/move_result = 0
 	var/oldloc = loc
+
+	// Damage slowdown
+	// Slowdown starts at below 75% integrity
+	// Builds based on how damaged you are below 75%
+	// Max slowdown (2.5x slower) at 30% integrity
+	var/slowdown = clamp(0.75 / (obj_integrity/max_integrity), 1, 2.5)
+	
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
-		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in * (check_eva() ? EVA_MODIFIER : 1)))
+		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) * slowdown ))
 		move_result = mechsteprand()
 	else if(dir != direction && (!strafe || occupant?.client?.prefs.bindings.isheld_key("Alt")))
 		move_result = mechturn(direction)
 	else
-		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in * (check_eva() ? EVA_MODIFIER : 1)))
+		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) * slowdown ))
 		move_result = mechstep(direction)
 	if(move_result || loc != oldloc)// halfway done diagonal move still returns false
 		use_power(step_energy_drain)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -616,16 +616,13 @@
 
 	var/move_result = 0
 	var/oldloc = loc
-
-
-
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
-		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) ))
+		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in * (check_eva() ? EVA_MODIFIER : 1)))
 		move_result = mechsteprand()
 	else if(dir != direction && (!strafe || occupant?.client?.prefs.bindings.isheld_key("Alt")))
 		move_result = mechturn(direction)
 	else
-		set_glide_size(DELAY_TO_GLIDE_SIZE( step_in * (check_eva() ? EVA_MODIFIER : 1) ))
+		set_glide_size(DELAY_TO_GLIDE_SIZE(step_in * (check_eva() ? EVA_MODIFIER : 1)))
 		move_result = mechstep(direction)
 	if(move_result || loc != oldloc)// halfway done diagonal move still returns false
 		use_power(step_energy_drain)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -162,7 +162,7 @@
 		return
 	if(get_charge())
 		use_power((cell.charge/3)/(severity*2))
-		take_damage(30 / severity, BURN, ENERGY, 1)
+		take_damage(40 / severity, BURN, ENERGY, 1)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	if(istype(src, /obj/mecha/combat))

--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -12,7 +12,7 @@
 	lights_power = 7
 	deflect_chance = 10
 	step_energy_drain = 15 //slightly higher energy drain since you movin those wheels FAST
-	armor = list(MELEE = 20, BULLET = 10, LASER = 20, ENERGY = 10, BOMB = 60, BIO = 0, RAD = 70, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 20, BULLET = 10, LASER = 20, ENERGY = 0, BOMB = 60, BIO = 0, RAD = 70, FIRE = 100, ACID = 100)
 	max_equip = 7
 	wreckage = /obj/structure/mecha_wreckage/clarke
 	enter_delay = 40

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -8,7 +8,7 @@
 	max_integrity = 200
 	lights_power = 7
 	deflect_chance = 15
-	armor = list(MELEE = 40, BULLET = 20, LASER = 10, ENERGY = 20, BOMB = 40, BIO = 0, RAD = 20, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 40, BULLET = 20, LASER = 10, ENERGY = 0, BOMB = 40, BIO = 0, RAD = 20, FIRE = 100, ACID = 100)
 	max_equip = 6
 	wreckage = /obj/structure/mecha_wreckage/ripley
 	internals_req_access = list(ACCESS_MECH_ENGINE, ACCESS_MECH_SCIENCE, ACCESS_MECH_MINING, ACCESS_MECH_FREEMINER)


### PR DESCRIPTION
# Document the changes in your pull request

## EMP changes

The ion rifle tends to feel like a wet noodle against mechs damage-wise. This is largely in part due to the `ENERGY` armor most mechs possess, which affects nothing but EMPs due to mechs not respecting stamina damage.

All energy armor has been stripped from mechs and EMP damage has been boosted by 5/10 damage (light/heavy)

# Changelog

:cl:  
tweak: Stripped all mechs of EMP armor and slightly buffed EMP damage to mechs
/:cl:
