### PR TITLE
Chair buckling only transfers damage from standing corpses

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1887,9 +1887,10 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(BRAIN)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * hit_percent * H.physiology.brain_mod)
 	
-	if(H.buckled && istype(H.buckled, /obj/structure))//prevent buckling corpses to chairs to make indestructible projectile walls
-		var/obj/structure/sitter = H.buckled
-		sitter.take_damage(damage, damagetype)
+	if(H.stat == DEAD && (H.mobility_flags & MOBILITY_STAND))
+		if(H.buckled && istype(H.buckled, /obj/structure))//prevent buckling corpses to chairs to make indestructible projectile walls
+			var/obj/structure/sitter = H.buckled
+			sitter.take_damage(damage, damagetype)
 	return 1
 
 /datum/species/proc/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)


### PR DESCRIPTION
This allows for buckleable surgery beds to not get damaged
It also lets living people not transfer damage

:cl:  
tweak: Only standing corpses transfer damage to chairs
/:cl:
