### PR TITLE
Buff radioactive goat, radiation anomaly now spawns radioactive goat!

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -383,6 +383,7 @@
 
 /obj/effect/anomaly/radiation/detonate()
 	INVOKE_ASYNC(src, .proc/makegoat)
+	radiation_pulse(src, 1000, 2)
 	var/turf/T = get_turf(src)
 	for(var/i = 1 to 72)
 		var/angle = i * 10

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -371,9 +371,20 @@
 		fire_nuclear_particle_wimpy()
 	radiation_pulse(src, 100, 2)
 
+/obj/effect/anomaly/radiation/proc/makegoat()
+	var/turf/open/T = get_turf(src)
+	var/mob/living/simple_animal/hostile/retaliate/goat/radioactive/S = new(T)
+
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a radioactive goat?", ROLE_SENTIENCE, null, null, 100, S, POLL_IGNORE_PYROSLIME)
+	if(LAZYLEN(candidates))
+		var/mob/dead/observer/chosen = pick(candidates)
+		S.key = chosen.key
+		log_game("[key_name(S.key)] was made into a radioactive goat by radiation anomaly at [AREACOORD(T)].")
+
 /obj/effect/anomaly/radiation/detonate()
-    var/turf/T = get_turf(src)
-    for(var/i = 1 to 72)
-        var/angle = i * 10
-        T.fire_nuclear_particle_wimpy(angle)
-        sleep(1)
+	INVOKE_ASYNC(src, .proc/makegoat)
+	var/turf/T = get_turf(src)
+	for(var/i = 1 to 72)
+		var/angle = i * 10
+		T.fire_nuclear_particle_wimpy(angle)
+		sleep(1)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -383,7 +383,7 @@
 
 /obj/effect/anomaly/radiation/detonate()
 	INVOKE_ASYNC(src, .proc/makegoat)
-	radiation_pulse(src, 1000, 2)
+	radiation_pulse(src, 3000, 5)
 	var/turf/T = get_turf(src)
 	for(var/i = 1 to 72)
 		var/angle = i * 10

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -168,9 +168,25 @@
 	light_power = 5
 	light_range = 4
 	light_color = LIGHT_COLOR_GREEN
+	melee_damage_lower = 25
+	melee_damage_upper = 50
+	speed = -0.5
+	robust_searching = 1
+	stat_attack = UNCONSCIOUS
+
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
+	. = ..()
+	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+		// abosrbs nuclear particle to heal
+		P.damage = 0
+		adjustBruteLoss(-10)
+		adjustFireLoss(-10)
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	radiation_pulse(src, 600) // It gets stronker as time passes
+	adjustBruteLoss(-1)
+	adjustFireLoss(-1) //gets healed over time
+	ADD_TRAIT(src, TRAIT_RADIMMUNE, src)
 
 /mob/living/simple_animal/hostile/retaliate/goat/rainbow
 	name = "Rainbow Goat"

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -186,7 +186,7 @@
 	radiation_pulse(src, 600) // It gets stronker as time passes
 	adjustBruteLoss(-1)
 	adjustFireLoss(-1) //gets healed over time
-	ADD_TRAIT(src, TRAIT_RADIMMUNE, src)
+	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
 
 /mob/living/simple_animal/hostile/retaliate/goat/rainbow
 	name = "Rainbow Goat"


### PR DESCRIPTION
Add more shit to round for entertainment even tho radioactive goat is very hostile and very dangerous by close range, but if you have strong armor, and a fucking toolbox, you can kill it. 
# Document the changes in your pull request
Radiation anomaly now spawns radioactive goat that can be controlled by ghost
Radioactive goat buffs: more damage, higher speed, gets healed by nuclear particle and overtime
# Spriting


# Wiki Documentation
Radiation anomaly now spawns radioactive goat that can be controlled by ghost
Radioactive goat buffs: more damage, higher speed, gets healed by nuclear particle and overtime

# Changelog



:cl:  
tweak: Radiation anomaly now spawns radioactive goat that can be controlled by ghost
tweak: Radioactive goat buffs: more damage, higher speed, gets healed by nuclear particle and overtime
/:cl:
