### PR TITLE
Make containment field stops singularity pull

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -312,6 +312,9 @@
 			if(isturf(loc) && thing != src)
 				var/atom/movable/X = thing
 				if(get_dist(X, src) > consume_range)
+					var/obj/machinery/field/containment/C = locate() in T
+					if(src in range(grav_pull, C))
+						return
 					X.singularity_pull(src, current_size)
 				else
 					consume(X)


### PR DESCRIPTION
this sucks and should be contained, you hate getting pulled and getting hit by an obj while working around singularity

# Document the changes in your pull request
Make containment field stops singularity pull below stage5

# Spriting


# Wiki Documentation

Make containment field stops singularity pull below stage5

# Changelog



:cl:  
rscadd: Make containment field stops singularity pull below stage5

/:cl:
