### PR TITLE
Gluttony Demon of Sin can now eat endlessly and faster

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -222,6 +222,7 @@
 #define TRAIT_NODEFIB			"nodefib" // No defibbing
 #define TRAIT_COLDBLOODED       "coldblooded" // Your body is literal room temperature. Does not make you immune to the temp
 #define TRAIT_EAT_MORE			"eat_more" //You get hungry three times as fast
+#define TRAIT_BOTTOMLESS_STOMACH "bottomless_stomach" // Can never be full
 #define TRAIT_MESONS			"mesons"
 /// This person is crying
 #define TRAIT_CRYING "crying"

--- a/code/modules/antagonists/demon/demons.dm
+++ b/code/modules/antagonists/demon/demons.dm
@@ -136,7 +136,9 @@
 		if(SIN_GLUTTONY)
 			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/demon/gluttony)
 			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/forcewall/gluttony)
-			ADD_TRAIT(owner.current, TRAIT_EAT_MORE, SINFULDEMON_TRAIT) //gluttonous demons hunger thrice as fast, unique to just them.
+			ADD_TRAIT(owner.current, TRAIT_EAT_MORE, SINFULDEMON_TRAIT) // 3x hunger rate
+			ADD_TRAIT(owner.current, TRAIT_BOTTOMLESS_STOMACH, SINFULDEMON_TRAIT) // nutrition is capped for infinite eating
+			ADD_TRAIT(owner.current, TRAIT_VORACIOUS, SINFULDEMON_TRAIT) // eat and drink faster & eat infinite snacks
 		if(SIN_GREED)
 			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/shapeshift/demon)
 			owner.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/summon_greedslots)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1325,7 +1325,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 		if(HAS_TRAIT(H, TRAIT_EAT_MORE))
 			hunger_rate *= 3 //hunger rate tripled
 		if(HAS_TRAIT(H, TRAIT_BOTTOMLESS_STOMACH))
-			nutrition = min(nutrition, NUTRITION_LEVEL_MOSTLY_FULL) //capped, can never be truly full
+			H.nutrition = min(H.nutrition, NUTRITION_LEVEL_MOSTLY_FULL) //capped, can never be truly full
 		// Whether we cap off our satiety or move it towards 0
 		if(H.satiety > MAX_SATIETY)
 			H.satiety = MAX_SATIETY

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1324,6 +1324,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 			hunger_rate *= 0.75 //hunger rate reduced by about 25%
 		if(HAS_TRAIT(H, TRAIT_EAT_MORE))
 			hunger_rate *= 3 //hunger rate tripled
+		if(HAS_TRAIT(H, TRAIT_BOTTOMLESS_STOMACH))
+			nutrition = min(nutrition, NUTRITION_LEVEL_MOSTLY_FULL) //capped, can never be truly full
 		// Whether we cap off our satiety or move it towards 0
 		if(H.satiety > MAX_SATIETY)
 			H.satiety = MAX_SATIETY

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -89,8 +89,10 @@
 
 /obj/effect/gluttony/Cross(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
 	. = ..()
-	if(is_sinfuldemon(mover))
-		return TRUE
+	if(ismob(mover))
+		var/mob/M = mover
+		if(is_sinfuldemon(M))
+			return TRUE
 	if(ishuman(mover))
 		var/mob/living/carbon/human/H = mover
 		if(H.nutrition >= NUTRITION_LEVEL_FAT)

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -89,6 +89,8 @@
 
 /obj/effect/gluttony/Cross(atom/movable/mover, turf/target)//So bullets will fly over and stuff.
 	. = ..()
+	if(is_sinfuldemon(mover))
+		return TRUE
 	if(ishuman(mover))
 		var/mob/living/carbon/human/H = mover
 		if(H.nutrition >= NUTRITION_LEVEL_FAT)


### PR DESCRIPTION
# Document the changes in your pull request

Gives Gluttony Demon of Sin `TRAIT_VORACIOUS` which lets them eat/drink faster and can eat infinite junk food

Adds `TRAIT_BOTTOMLESS_STOMACH` which caps your nutrition at `NUTRITION_LEVEL_MOSTLY_FULL` so you never get fat and never get full

Your objective is
"Devour as much food as possible. Do not devour or kill people unless they have gone out of their way to hunt you, or are intentionally stopping you."
and yet you have nothing to assist in actually eating food besides a 3x hunger rate so your entire niche devolves into taking a bite of something every 30 seconds because you're TOO GOD DAMN FAT

This fixes that

As a consequence of not being fat, you wouldn't be able to traverse gluttony walls, so I have changed it so that demons of sin can pass through them always.

# Changelog

:cl:  
rscadd: Made Gluttony Demon of Sin have a bottomless stomach and eat faster
tweak: Gluttony Demon of Sin can now pass through his forcewalls always
/:cl:
