### PR TITLE
Removes research access block and replaces it with worse researching if you're not a scientist

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -28,8 +28,6 @@ Nothing else in the console has ID requirements.
 	var/obj/machinery/rnd/production/protolathe/linked_lathe				//Linked Protolathe
 	var/obj/machinery/rnd/production/circuit_imprinter/linked_imprinter	//Linked Circuit Imprinter
 
-	req_access = list(ACCESS_TOX)	//lA AND SETTING MANIPULATION REQUIRES SCIENTIST ACCESS.
-
 	//UI VARS
 	var/screen = RDSCREEN_MENU
 	var/back = RDSCREEN_MENU
@@ -159,11 +157,15 @@ Nothing else in the console has ID requirements.
 		say("Node unlock failed: Unknown error.")
 		return FALSE
 	var/list/price = TN.get_price(stored_research)
+	price = price.Copy()
+	if(!(user?.job in TN.approved_jobs) && !is_special_character(user))
+		for(var/L in price)
+			price[L] *= 1.25
 	if(stored_research.can_afford(price))
 		investigate_log("[key_name(user)] researched [id]([json_encode(price)]) on techweb id [stored_research.id].", INVESTIGATE_RESEARCH)
 		if(stored_research == SSresearch.science_tech)
 			SSblackbox.record_feedback("associative", "science_techweb_unlock", 1, list("id" = "[id]", "name" = TN.display_name, "price" = "[json_encode(price)]", "time" = SQLtime()))
-		if(stored_research.research_node_id(id))
+		if(stored_research.research_node_id(id, researcher = user))
 			say("Successfully researched [TN.display_name].")
 			var/logname = "Unknown"
 			if(isAI(user))

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -221,18 +221,23 @@
 /datum/techweb/proc/printout_points()
 	return techweb_point_display_generic(research_points)
 
-/datum/techweb/proc/research_node_id(id, force, auto_update_points)
-	return research_node(SSresearch.techweb_node_by_id(id), force, auto_update_points)
+/datum/techweb/proc/research_node_id(id, force, auto_update_points, mob/researcher)
+	return research_node(SSresearch.techweb_node_by_id(id), force, auto_update_points, researcher)
 
-/datum/techweb/proc/research_node(datum/techweb_node/node, force = FALSE, auto_adjust_cost = TRUE)
+/datum/techweb/proc/research_node(datum/techweb_node/node, force = FALSE, auto_adjust_cost = TRUE, mob/researcher)
 	if(!istype(node))
 		return FALSE
+	var/list/price = node.get_price(src)
+	price = price.Copy()
+	if(!(researcher?.job in node.approved_jobs) && !is_special_character(researcher))
+		for(var/L in price)
+			price[L] *= 1.25
 	update_node_status(node)
 	if(!force)
-		if(!available_nodes[node.id] || (auto_adjust_cost && (!can_afford(node.get_price(src)))))
+		if(!available_nodes[node.id] || (auto_adjust_cost && (!can_afford(price))))
 			return FALSE
 	if(auto_adjust_cost)
-		remove_point_list(node.get_price(src))
+		remove_point_list(price)
 	researched_nodes[node.id] = TRUE				//Add to our researched list
 	for(var/id in node.unlock_ids)
 		visible_nodes[id] = TRUE

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -17,6 +17,7 @@
 	var/category = "Misc"				//Category
 	var/ui_x = 805 // It's location - override this in techweb_layout.dm
 	var/ui_y = 805
+	var/list/approved_jobs = list("Scientist", "Roboticist", "Research Director", "Captain", "AI", "Cyborg")
 
 /datum/techweb_node/error_node
 	id = "ERROR"
@@ -93,4 +94,9 @@
 		return research_costs
 
 /datum/techweb_node/proc/price_display(datum/techweb/TN)
-	return techweb_point_display_generic(get_price(TN))
+	var/list/price = get_price(TN)
+	price = price.Copy()
+	if(!(usr?.job in approved_jobs) && !is_special_character(usr))
+		for(var/L in price)
+			price[L] *= 1.25
+	return techweb_point_display_generic(price)

--- a/yogstation/code/modules/research/rdconsole.dm
+++ b/yogstation/code/modules/research/rdconsole.dm
@@ -14,7 +14,12 @@
 		if(stored_research.researched_nodes[node_])
 			class = ""
 		else if(stored_research.available_nodes[node_])
-			if(stored_research.can_afford(node.get_price(stored_research)))
+			var/list/price = node.get_price(stored_research)
+			price = price.Copy()
+			if(!(usr?.job in node.approved_jobs) && !is_special_character(usr))
+				for(var/L in price)
+					price[L] *= 1.25
+			if(stored_research.can_afford(price))
 				class = "available"
 			else
 				class = "too-expensive"


### PR DESCRIPTION
# Document the changes in your pull request

SKILLS ARE REAL
<img src='https://user-images.githubusercontent.com/28408322/202875029-e0ed77bf-e4be-4193-9d70-738a57e855b2.png' width='100' height='50'>

This is several times better than complete lockout

Read changelog

# Changelog

:cl:  
tweak: You no longer require access to research things at an R&D console
tweak: Researching things are 1.25x more costly if you're not a member of science, silicon, special role, or captain
/:cl:
