### PR TITLE
Remove chat client program from basic pda to get more space and give atmos pda supermatter monitor

### DIFF
--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -81,7 +81,8 @@
 /obj/item/modular_computer/tablet/pda/preset/basic/atmos/Initialize()
 	starting_files |= list(
 		new /datum/computer_file/program/atmosscan,
-		new /datum/computer_file/program/alarm_monitor
+		new /datum/computer_file/program/alarm_monitor,
+		new /datum/computer_file/program/supermatter_monitor
 	)	
 	. = ..()
 

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -183,7 +183,7 @@
 	store_file(new/datum/computer_file/program/ntnetdownload/emagged(src))
 	store_file(new/datum/computer_file/program/filemanager(src))
 
-/// For PDAs, comes pre-equipped with PDA messaging & chat client
+/// For PDAs, comes pre-equipped with PDA messaging
 /obj/item/computer_hardware/hard_drive/small/pda
 /obj/item/computer_hardware/hard_drive/small/pda/install_default_programs()
 	..()

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -189,7 +189,6 @@
 	..()
 	store_file(new/datum/computer_file/program/themeify(src))
 	store_file(new/datum/computer_file/program/pdamessager(src))
-	store_file(new/datum/computer_file/program/chatclient(src))
 
 /// For tablets given to nuke ops
 /obj/item/computer_hardware/hard_drive/small/nukeops


### PR DESCRIPTION
Remove chat client program from basic pda to get more space, chat client is rarely get used because most of the time people use pda messenger program.

Give atmos pda supermatter monitor because sm requires atmos

# Document the changes in your pull request
Remove chat client program from basic pda
give atmos pda supermatter monitor


# Wiki Documentation

Remove chat client program from basic pda
give atmos pda supermatter monitor
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscdel: Remove chat client program from basic pda
rscadd: give atmos pda supermatter monitor
/:cl:
