### PR TITLE
Security record and radio hot fix

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -785,7 +785,7 @@
 					else
 						changed_rank = input("Select a rank", "Rank Selection") as null|anything in get_all_jobs()
 
-					if(active_general_record)
+					if(active_general_record && changed_rank)
 						active_general_record.fields["rank"] = strip_html(changed_rank)
 						if(changed_rank in get_all_jobs())
 							active_general_record.fields["real_rank"] = changed_rank

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -385,7 +385,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 		else
 			to_chat(user, span_notice("The radio can no longer be modified or attached!"))
 
-	else if(istype(W, /obj/item/encryptionkey/) && unscrewed)
+	else if(istype(W, /obj/item/encryptionkey/))
 		if(keyslot && keyslot2)
 			to_chat(user, span_warning("The radio can't hold another key!"))
 			return
@@ -401,35 +401,30 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			keyslot2 = W
 
 		recalculateChannels()
+	
 	else
-		to_chat(user, span_warning("You cannot put anything in when [src]'s panel is closed!"))
-		return
+		return ..()
 
 /obj/item/radio/AltClick(mob/user)
 	. = ..()
-	if(unscrewed)
-		if(keyslot || keyslot2)
-			for(var/ch_name in channels)
-				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
-				secure_radio_connections[ch_name] = null
+	if(keyslot || keyslot2)
+		for(var/ch_name in channels)
+			SSradio.remove_object(src, GLOB.radiochannels[ch_name])
+			secure_radio_connections[ch_name] = null
 
 
-			if(keyslot)
-				user.put_in_hands(keyslot)
-				keyslot = null
-			if(keyslot2)
-				user.put_in_hands(keyslot2)
-				keyslot2 = null
+		if(keyslot)
+			user.put_in_hands(keyslot)
+			keyslot = null
+		if(keyslot2)
+			user.put_in_hands(keyslot2)
+			keyslot2 = null
 
-			recalculateChannels()
-			to_chat(user, span_notice("You pop out the encryption key in the radio."))
-
-		else
-			to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
+		recalculateChannels()
+		to_chat(user, span_notice("You pop out the encryption key in the radio."))
 
 	else
-		to_chat(user, span_warning("You have to unscrew the panel to do this!"))
-		return
+		to_chat(user, span_warning("This radio doesn't have any encryption keys!"))
 		
 
 /obj/item/radio/emp_act(severity)


### PR DESCRIPTION
fixes #16650 
# Document the changes in your pull request
Fix changing rank button in record console disappear when pressing cancel button
Fix radio being funky when switching radio and unnable to put TC into radio uplink



# Wiki Documentation

Fix changing rank button in record console disappear when pressing cancel button
Fix radio being funky when switching radio and unnable to put TC into radio uplink

# Changelog



:cl:  
bugfix: Fix changing rank button in record console disappear when pressing cancel button
bugfix: Fix radio being funky when switching radio and unnable to put TC into radio uplink
/:cl:
