### PR TITLE
fix railing rod exploit

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -66,6 +66,8 @@
 	return TRUE
 
 /obj/structure/railing/CanAllowThrough(atom/movable/mover, turf/target)
+	if (istype(mover, /obj/effect/immovablerod))
+		return TRUE
 	. = ..()
 	var/attempted_dir = get_dir(loc, target)
 	if(attempted_dir == dir)
@@ -73,11 +75,14 @@
 	if(attempted_dir != dir)
 		return TRUE
 
+
 /obj/structure/railing/corner/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
 	return TRUE
 
 /obj/structure/railing/CheckExit(atom/movable/O, turf/target)
+	if (istype(mover, /obj/effect/immovablerod))
+		return TRUE
 	if(get_dir(O.loc, target) == dir)
 		return FALSE
 	return TRUE

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -81,7 +81,7 @@
 	return TRUE
 
 /obj/structure/railing/CheckExit(atom/movable/O, turf/target)
-	if (istype(mover, /obj/effect/immovablerod))
+	if (istype(O, /obj/effect/immovablerod))
 		return TRUE
 	if(get_dir(O.loc, target) == dir)
 		return FALSE

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -66,8 +66,6 @@
 	return TRUE
 
 /obj/structure/railing/CanAllowThrough(atom/movable/mover, turf/target)
-	if (istype(mover, /obj/effect/immovablerod))
-		return TRUE
 	. = ..()
 	var/attempted_dir = get_dir(loc, target)
 	if(attempted_dir == dir)
@@ -75,14 +73,11 @@
 	if(attempted_dir != dir)
 		return TRUE
 
-
 /obj/structure/railing/corner/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
 	return TRUE
 
 /obj/structure/railing/CheckExit(atom/movable/O, turf/target)
-	if (istype(O, /obj/effect/immovablerod))
-		return TRUE
 	if(get_dir(O.loc, target) == dir)
 		return FALSE
 	return TRUE

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -56,6 +56,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/notify = TRUE
 	var/atom/special_target
 	var/notdebris = FALSE
+	movement_type = UNSTOPPABLE
 
 /obj/effect/immovablerod/New(atom/start, atom/end, aimed_at)
 	..()


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->
![image](https://user-images.githubusercontent.com/101573582/202960492-ec8fbdca-e620-42ba-b4e5-a55d6abd5e9d.png)

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Immovable rod is now immovable again, according to leading railing experts
/:cl:
