### PR TITLE
Gives holoparasites base human speed

### DIFF
--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	icon_state = "magicOrange"
 	icon_living = "magicOrange"
 	icon_dead = "magicOrange"
-	speed = 1
+	speed = -1
 	a_intent = INTENT_HARM
 	stop_automated_movement = TRUE
 	movement_type = FLYING // Immunity to chasms and landmines, etc.

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	icon_state = "magicOrange"
 	icon_living = "magicOrange"
 	icon_dead = "magicOrange"
-	speed = 0
+	speed = 1
 	a_intent = INTENT_HARM
 	stop_automated_movement = TRUE
 	movement_type = FLYING // Immunity to chasms and landmines, etc.


### PR DESCRIPTION
# Document the changes in your pull request

See title

## Rationale

Holoparasites as a combat utility are nearly dead fucking useless. You NEED to pair it with something or else it's a 12TC sink (which is why i usually take it with esword).

The only thing carrying Holoparasites as a reasonable purchase are some of the better abilities like:
- Time Erasure (the meta)
- Frenzy (Incredibly dangerous and thusly never used)
- Teleport pad (Please merge #16643)

The issue is that, when you give holoparasites any points in the range stat, it will walk up to someone, hit them once, deal 5-25 damage (depending on armor and damage stat), and the person runs the fuck away and the holoparasite has to chase at SNAILS PACE. Congratulations you have paid 12TC for a single fucking hit on your target, guess you should've bought the miniature energy crossbow for a free win instead.

It is for this reason that people commonly ditch the range stat completely and have the holoparasite sit on their back permanently because they can actually keep up with whomever they're trying to kill, which removes pretty much all autonomy from the holoparasite player and makes hitting players a shit ton harder because they have to predict their master's movement as well as the enemy's.

This is slightly remedied by the ranged ability that lets you spend 3 points to turn your guardian into a living gun. I have yet to test this out effectively and I think it could be reasonably strong, however if it's on your back it SHOOTS YOU and if it's not it can STILL MISS AND SHOOT YOU IF IT ISN'T CAREFUL, which betrays the precedent set by the guardian not being able to punch you.

##

I am aware of the balance implications of this change, this **will** make holoparasites stronger, but even if other things need to be toned down for this, this still makes playing as and having holoparasites LOADS more consistent, interactive, fun.

TL;DR holoparasites are weak and melee is useless but if they can at least keep up with base human speed it'll be at least simulating human CQC which will make things a lot nicer for the holoparasite.

# Changelog

:cl:  
tweak: Holoparasites can now keep up with humans
/:cl:
