### PR TITLE
Fix Holoparasite Teleportation Pad lacking an icon

### DIFF
--- a/yogstation/code/modules/guardian/abilities/minor/teleport.dm
+++ b/yogstation/code/modules/guardian/abilities/minor/teleport.dm
@@ -67,7 +67,7 @@
 	if (ability.beacon)
 		ability.beacon.disappear()
 		ability.beacon = null
-	ability.beacon = new(beacon_loc, src)
+	ability.beacon = new(beacon_loc, user)
 	to_chat(user, span_bolddanger("Beacon placed! You may now warp targets and objects to it, including your user, via the Teleport ability."))
 
 // the pad

--- a/yogstation/code/modules/guardian/abilities/minor/teleport.dm
+++ b/yogstation/code/modules/guardian/abilities/minor/teleport.dm
@@ -57,6 +57,7 @@
 /datum/action/guardian/place_beacon
 	name = "Place Bluespace Beacon"
 	desc = "Mark a floor as your beacon point, allowing you to warp targets to it. Your beacon will not work at extreme distances."
+	button_icon_state = "omae_wa_shinderu"
 
 /datum/action/guardian/place_beacon/on_use(mob/living/simple_animal/hostile/guardian/user)
 	var/turf/beacon_loc = get_turf(user)


### PR DESCRIPTION
# Document the changes in your pull request

No sprite = no button to press

I think someone just forgot to set this

Also fixes a runtime

# Changelog

:cl:  
bugfix: Fixed the Holoparasite Teleportation Pad being unusable
/:cl:
