### PR TITLE
Removes several unused properties which had types that don't even exist, picked up by OpenDream

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -63,8 +63,12 @@
 #define MAX_BYOND_MAJOR 514
 #define MAX_BYOND_MINOR 1589
 
-///Uncomment to bypass the max version check. Note: This will likely break the game, only use if you know what you're doing
-//#define IGNORE_MAX_BYOND_VERSION
+// You can define IGNORE_MAX_BYOND_VERSION to bypass the max version check.
+// Note: This will likely break the game, especially any extools/auxtools linkage. Only use if you know what you're doing!
+#ifdef OPENDREAM // Thanks, Altoids!
+#define IGNORE_MAX_BYOND_VERSION
+#endif
+
 #if ((DM_VERSION > MAX_BYOND_MAJOR) || (DM_BUILD > MAX_BYOND_MINOR)) && !defined(IGNORE_MAX_BYOND_VERSION)
 #error Your version of BYOND is too new to compile this project. Download version 514.1589 at www.byond.com/download/build/514/514.1589_byond.exe
 #endif

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -52,7 +52,6 @@
 
 	var/cur_category = CAT_NONE
 	var/cur_subcategory = CAT_NONE
-	var/datum/action/innate/crafting/button
 	var/display_craftable_only = FALSE
 	var/display_compact = TRUE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -854,7 +854,6 @@
 	flags = HIGH_IMPACT_RULESET
 	minimum_players = 30
 	antag_cap = 3
-	var/datum/team/shadowling/shadowling
 
 /datum/dynamic_ruleset/roundstart/shadowling/ready(population, forced = FALSE)
 	required_candidates = get_antag_cap(population)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -106,9 +106,6 @@
 	///Used for limiting the rate of clicks sends by the client to avoid abuse
 	var/list/clicklimiter
 
-	///goonchat chatoutput of the client
-	var/datum/chatOutput/chatOutput
-
  	///lazy list of all credit object bound to this client
 	//var/list/credits
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -18,7 +18,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
 	var/can_reenter_corpse
-	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
 							//If you died in the game and are a ghsot - this will remain as null.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -120,8 +120,6 @@
 
 	var/list/implants = null
 
-	var/datum/riding/riding_datum
-
 	var/last_words	//used for database logging
 
 	var/list/obj/effect/proc_holder/abilities = list()

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -31,7 +31,6 @@
 	stat_attack = UNCONSCIOUS
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	var/combatant_state = SEEDLING_STATE_NEUTRAL
-	var/obj/seedling_weakpoint/weak_point
 	var/mob/living/beam_debuff_target
 	var/solar_beam_identifier = 0
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/29939414/203194328-7824d8bd-0952-4a44-b2c9-2b2a3177d1a1.png)

## Summary

Did another compile attempt with OpenDream, while fixing a bug in it where it would not compile-time on the following code:
```dm
// COMPILE ERROR
/datum/later
    var/datum/laterrr/aa = new(0)
/proc/RunTest()
    return
```
After doing that though, I tried it on Yogs and it discovered like a half-dozen unused variables in our code that reference types that don't exist anymore. Various HUD, gooncode, and component reworks have rendered them dead and useless.

So, might as well go ahead and fix it for you guys :^)

This PR also includes some tiny changes to ensure that Yogs does not `#error` against OpenDream as frequently. 

## Changelog
:cl:  Altoids
bugfix: Several random things in the game no longer store data that is not used for anything at all.
bugfix: Compatibility with OpenDream has been improved, very slightly.
/:cl:
