### PR TITLE
Demon of Sin Envy buff

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -708,6 +708,7 @@
 /datum/mind/proc/AddSpell(obj/effect/proc_holder/spell/S)
 	spell_list += S
 	S.action.Grant(current)
+	S.on_gain(current)
 
 /datum/mind/proc/owns_soul()
 	return soulOwner == src
@@ -720,6 +721,7 @@
 		var/obj/effect/proc_holder/spell/S = X
 		if(istype(S, spell))
 			spell_list -= S
+			S.on_lose(current)
 			qdel(S)
 	current?.client << output(null, "statbrowser:check_spells")
 
@@ -755,6 +757,7 @@
 	for(var/X in spell_list)
 		var/obj/effect/proc_holder/spell/S = X
 		S.action.Grant(new_character)
+		S.on_gain(new_character)
 
 /datum/mind/proc/disrupt_spells(delay, list/exceptions = New())
 	for(var/X in spell_list)

--- a/code/modules/antagonists/demon/sins/envy.dm
+++ b/code/modules/antagonists/demon/sins/envy.dm
@@ -10,6 +10,16 @@
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "transform"
 	action_background_icon_state = "bg_demon"
+	var/list/stored_access
+
+/obj/effect/proc_holder/spell/targeted/touch/envy/on_gain(mob/living/user)
+	RegisterSignal(user, COMSIG_MOB_ALLOWED, .proc/envy_access)
+
+/obj/effect/proc_holder/spell/targeted/touch/envy/on_lose(mob/living/user)
+	UnregisterSignal(user, COMSIG_MOB_ALLOWED)
+
+/obj/effect/proc_holder/spell/targeted/touch/envy/proc/envy_access(datum/source, obj/O)
+	return O.check_access_list(stored_access)
 
 /obj/item/melee/touch_attack/envy
 	name = "Envious Hand"
@@ -31,7 +41,11 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(user.real_name != H.dna.real_name)
-			user.real_name = H.dna.real_name
+			if(attached_spell)
+				var/obj/effect/proc_holder/spell/targeted/touch/envy/E = attached_spell
+				var/obj/item/card/id/A = H.get_idcard()
+				E.stored_access = A?.access
+			user.fully_replace_character_name(user.real_name, H.dna.real_name)
 			H.dna.transfer_identity(user, transfer_SE=1)
 			user.updateappearance(mutcolor_update=1)
 			user.domutcheck()


### PR DESCRIPTION
# Document the changes in your pull request

Apparently on_gain and on_lose didn't work this whole time Very funny

Access does not "accumulate" but is wholly replaced whenever you copy someone, so copying a medic and then an engineer means you only have engineer access

Access is stored in the spell

Now uses fully_replace_character_name instead of changing real_name directly

# Changelog

:cl: 
tweak: Demon of Sin Envy now gets their ID renamed and copies access when copying someone
/:cl:
