### PR TITLE
fix ruin tech research console switching to station tech when reconstructing the console

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -345,6 +345,11 @@
 	icon_state = "science"
 	build_path = /obj/machinery/computer/rdconsole/core
 
+/obj/item/circuitboard/computer/rdconsole/ruin
+	name = "Experimental R&D Console (Computer Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/computer/rdconsole/nolock/ruin
+
 /obj/item/circuitboard/computer/rdconsole/production
 	name = "R&D Console Production Only (Computer Board)"
 	build_path = /obj/machinery/computer/rdconsole/production

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1195,7 +1195,7 @@
 	new /obj/item/circuitboard/machine/protolathe(src)
 	new /obj/item/circuitboard/machine/destructive_analyzer(src)
 	new /obj/item/circuitboard/machine/circuit_imprinter(src)
-	new /obj/item/circuitboard/computer/rdconsole(src)
+	new /obj/item/circuitboard/computer/rdconsole/ruin(src)
 
 /obj/item/storage/box/silver_sulf
 	name = "box of silver sulfadiazine patches"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1178,6 +1178,7 @@ Nothing else in the console has ID requirements.
 /obj/machinery/computer/rdconsole/nolock/ruin
 	name = "R&D Console"
 	desc = "A console used to interface with R&D tools. This one seems to run on different research tech and does not have access requirement."
+	circuit = /obj/item/circuitboard/computer/rdconsole/ruin
 
 /obj/machinery/computer/rdconsole/nolock/ruin/Initialize()
     . = ..()


### PR DESCRIPTION
fix fix fix

# Document the changes in your pull request
fix ruin tech research console switching to station tech when reconstructing the console
free miner vendor R&D kit has been replaced with ruin reserch console circuit



# Wiki Documentation

fix ruin tech research console switching to station tech when reconstructing the console
free miner vendor R&D kit has been replaced with ruin reserch console circuit

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fix ruin tech research console switching to station tech when reconstructing the console
tweak: free miner vendor R&D kit has been replaced with ruin reserch console circuit
/:cl:
