### PR TITLE
fixes some bugs with digitigrade leg swapping

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -196,7 +196,7 @@
 	if(spot == user && !user.get_inactive_held_item())
 		user.put_in_inactive_hand(prosthetic)
 	else
-		prosthetic.loc = get_turf(user)
+		prosthetic.forceMove(get_turf(user))
 	qdel(src)
 	
 /obj/item/bodypart/r_leg/robot/attackby(obj/item/W, mob/user, params)
@@ -222,7 +222,7 @@
 	if(spot == user && !user.get_inactive_held_item())
 		user.put_in_inactive_hand(prosthetic)
 	else
-		prosthetic.loc = get_turf(user)
+		prosthetic.forceMove(get_turf(user))
 	qdel(src)
 	
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -191,8 +191,12 @@
 	if(!prosthetic)
 		return
 	
+	var/spot = src.loc
 	moveToNullspace()
-	prosthetic.loc = get_turf(user)
+	if(spot == user && !user.get_inactive_held_item())
+		user.put_in_inactive_hand(prosthetic)
+	else
+		prosthetic.loc = get_turf(user)
 	qdel(src)
 	
 /obj/item/bodypart/r_leg/robot/attackby(obj/item/W, mob/user, params)
@@ -213,8 +217,12 @@
 	if(!prosthetic)
 		return
 
+	var/spot = src.loc
 	moveToNullspace()
-	prosthetic.loc = get_turf(user)
+	if(spot == user && !user.get_inactive_held_item())
+		user.put_in_inactive_hand(prosthetic)
+	else
+		prosthetic.loc = get_turf(user)
 	qdel(src)
 	
 

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -174,7 +174,7 @@
 	
 //make them swappable
 /obj/item/bodypart/l_leg/robot/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/screwdriver))
+	if(W.tool_behaviour != TOOL_SCREWDRIVER)
 		return ..()
 	var/obj/item/bodypart/l_leg/robot/prosthetic
 	to_chat(user, span_notice("You configure [src] into [use_digitigrade != FULL_DIGITIGRADE ? "digitigrade" : "plantigrade"] mode."))
@@ -191,16 +191,12 @@
 	if(!prosthetic)
 		return
 	
-	var/spot = src.loc
 	moveToNullspace()
-	if(spot == user)
-		user.put_in_inactive_hand(prosthetic)
-	else
-		prosthetic.loc = spot
+	prosthetic.loc = get_turf(user)
 	qdel(src)
 	
 /obj/item/bodypart/r_leg/robot/attackby(obj/item/W, mob/user, params)
-	if(!istype(W, /obj/item/screwdriver))
+	if(W.tool_behaviour != TOOL_SCREWDRIVER)
 		return ..()
 	var/obj/item/bodypart/r_leg/robot/prosthetic
 	to_chat(user, span_notice("You configure [src] into [use_digitigrade != FULL_DIGITIGRADE ? "digitigrade" : "plantigrade"] mode."))
@@ -217,12 +213,8 @@
 	if(!prosthetic)
 		return
 
-	var/spot = src.loc
 	moveToNullspace()
-	if(spot == user)
-		user.put_in_inactive_hand(prosthetic)
-	else
-		prosthetic.loc = spot
+	prosthetic.loc = get_turf(user)
 	qdel(src)
 	
 


### PR DESCRIPTION
Can use any screwdriver like tool to swap between prosthetic leg types rather than just specifically the screwdriver item
fixes swapping them while they're in pockets or backpack making things buggy

:cl:  
bugfix: fixes some bugs with robotic digitigrade leg swapping
/:cl:
