### PR TITLE
Revert "Let Snellie play the game again"

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -128,7 +128,7 @@
 
 /datum/map_template/shuttle/arrival
 	port_id = "arrival"
-	movement_force = list("KNOCKDOWN" = 2, "THROW" = 2)
+
 /datum/map_template/shuttle/infiltrator
 	port_id = "infiltrator"
 


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16499

> tweak: Arrivals shuttle now has slower engines so they don't throw everything back and lag connection-challenged people out

ok what, currently the arrival shuttle still throws shit around and i get 12 brutes everytime i arrive at station due to 3 toolboxes hitting me
# Changelog:
:cl:
tweak: Arrival shuttle no longer throw shits around
/:cl: