### PR TITLE
Makes the bomb immune trait actually do what it says

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -417,7 +417,7 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
-	if(TRAIT_BOMBIMMUNE in dna.species.species_traits)
+	if(HAS_TRAIT(src, TRAIT_BOMBIMMUNE))
 		return
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
 		return


### PR DESCRIPTION
With all the bomb stuff going around i saw that bomb immunity is actually a trait
However, for some reason it only cared about species specific bomb immunity
This meant that granting it with ADD_TRAIT did not have it function

Literally the only thing this changes currently is ascended ash heretics

:cl:  
bugfix: makes the bomb immune trait actually give bomb immunity
/:cl:
