### PR TITLE
Touches up AsteroidStation Engineering

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -55,6 +55,9 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"aav" = (
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "aaw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -92,17 +95,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aaB" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "aaJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window{
@@ -942,6 +934,15 @@
 "ahe" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
+"ahh" = (
+/obj/machinery/suit_storage_unit/ce,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "ahm" = (
 /obj/item/twohanded/required/pool/pool_noodle,
 /turf/open/indestructible/sound/pool,
@@ -992,6 +993,20 @@
 "ahN" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
+"ahO" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/heads/chief)
 "ahR" = (
 /obj/structure/window{
 	dir = 8
@@ -1183,11 +1198,6 @@
 "ajz" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"ajC" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "ajF" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -1238,18 +1248,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
-"akc" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "akf" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -1420,10 +1418,6 @@
 "aly" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
-"alA" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "alB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/cryopod{
@@ -2115,12 +2109,6 @@
 "aqZ" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"arb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/chief)
 "arc" = (
 /obj/effect/landmark/stationroom/box/dorm_edoor,
 /turf/template_noop,
@@ -2488,13 +2476,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"atD" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "atG" = (
 /obj/machinery/telecomms/message_server/preset,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -2536,14 +2517,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"atU" = (
-/obj/structure/closet/secure_closet/security/engine,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "atX" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/camera,
@@ -2574,6 +2547,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"auf" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aui" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -2852,12 +2834,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"awz" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "awB" = (
 /turf/closed/wall/rust,
 /area/maintenance/port/aft)
@@ -3150,18 +3126,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"azv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "azw" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -3369,16 +3333,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"aAJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aAN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -3802,10 +3756,6 @@
 /obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"aDu" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aDv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4033,10 +3983,6 @@
 "aFu" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aFv" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "aFy" = (
 /obj/item/book/random,
 /obj/structure/table/glass,
@@ -4133,16 +4079,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"aGk" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "aGo" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/electrical";
@@ -4519,10 +4455,6 @@
 "aID" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"aIE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "aIH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -4610,10 +4542,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"aJC" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "aJD" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine,
@@ -4796,6 +4724,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"aLz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/heads/chief)
 "aLB" = (
 /obj/effect/landmark/stationroom/box/testingsite,
 /turf/open/space/basic,
@@ -4819,6 +4770,16 @@
 "aLR" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
+"aLS" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aLW" = (
 /mob/living/simple_animal/opossum,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5022,15 +4983,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"aNX" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aNY" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -6047,20 +5999,6 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
-"aXh" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "aXl" = (
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/yellowsiding{
@@ -6486,12 +6424,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"baA" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "baF" = (
 /obj/effect/turf_decal/pool,
 /obj/structure/chair/stool/bamboo{
@@ -6556,15 +6488,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bco" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "bcH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 2
@@ -6704,6 +6627,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"bfV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bgi" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -6727,6 +6657,18 @@
 	dir = 8
 	},
 /area/ruin/powered)
+"bgx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -6956,22 +6898,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
-"bjH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bjM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7081,6 +7007,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"blh" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bll" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7102,14 +7038,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"bly" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "blJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "AI Upload Access"
@@ -7165,10 +7093,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"bnm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bnq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7231,12 +7155,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"boH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "bpd" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -7904,6 +7822,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"bzC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bzU" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -7929,21 +7856,6 @@
 /obj/item/drone_shell,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"bAk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "bAo" = (
 /obj/machinery/light{
 	dir = 4
@@ -8132,6 +8044,13 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/plasteel,
 /area/clerk)
+"bEB" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "bEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -8566,25 +8485,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"bNW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/crew_quarters/heads/chief)
 "bOk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8857,16 +8757,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/vacant_room)
-"bSj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bSy" = (
 /obj/machinery/light,
 /obj/machinery/door/firedoor/border_only{
@@ -9004,6 +8894,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"bWZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "bXj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "EVA Maintenance";
@@ -9050,6 +8945,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bXD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -9153,13 +9057,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"bZq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "bZK" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -9227,6 +9124,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"caJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "caU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -9389,6 +9301,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ccS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "atmospherics sorting disposal pipe";
+	sortType = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "cdc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -9406,12 +9335,6 @@
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos_distro)
-"cdm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "cdt" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -9462,6 +9385,18 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"cdU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "cev" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -9950,6 +9885,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ckU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ckX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -10034,12 +9975,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
-"cma" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cmB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10122,6 +10057,14 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
+"cpf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "cpm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10151,19 +10094,6 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
-"cqg" = (
-/obj/structure/table,
-/obj/item/electronics/apc,
-/obj/item/electronics/firealarm{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/electronics/firelock,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cqi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -10217,6 +10147,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"crk" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "crm" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office/dark,
@@ -10240,15 +10174,6 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"cse" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "csn" = (
 /obj/structure/chair{
 	dir = 8
@@ -10261,24 +10186,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"csp" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 1;
-	name = "CE Office APC";
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "csy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -10298,6 +10205,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cte" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Engineering Delivery";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ctm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -10548,12 +10467,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"cyj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "cyl" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
@@ -10652,6 +10565,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"czV" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "czY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -10816,21 +10749,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cBJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cCg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -11134,14 +11052,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"cHX" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "cIa" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11182,10 +11092,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cID" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/engine/foyer)
 "cIE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -11313,6 +11219,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cLV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cLY" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -11624,13 +11540,12 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
-"cQR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"cQX" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -11645,6 +11560,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"cRg" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cRN" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -11674,6 +11595,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"cSe" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cSt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/stand_clear/white,
@@ -11712,6 +11648,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/starboard/aft)
+"cSZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cTi" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -11926,6 +11870,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cWR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cWU" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
@@ -12051,19 +12002,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"cYN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cZb" = (
 /obj/machinery/light{
 	dir = 1
@@ -12242,15 +12180,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
-"dcD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "dcK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armoury";
@@ -12283,12 +12212,35 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"ddd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "ddn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ddz" = (
+/mob/living/simple_animal/cockroach,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ddB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -12372,12 +12324,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dfm" = (
-/obj/structure/disposalpipe/segment{
+"dfg" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dfp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -12422,6 +12385,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"dfI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dgv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -12534,28 +12510,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"dhY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"die" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dix" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -12642,21 +12596,17 @@
 "dki" = (
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"dkB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"dkm" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/crew_quarters/heads/chief)
 "dkJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -12806,6 +12756,20 @@
 /obj/item/pen,
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
+"dnP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dnZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -13322,28 +13286,11 @@
 	dir = 8
 	},
 /area/crew_quarters/heads/chief)
-"dzM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dzR" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/reagent_containers/food/snacks/egg,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
-"dAa" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dAc" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor/border_only{
@@ -13371,26 +13318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"dAy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Medical";
-	location = "Engineering";
-	name = "engineering navigation beacon"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dAN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13432,15 +13359,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"dCb" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dCg" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -13576,6 +13494,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dFn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dFu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -13635,16 +13559,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dGD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "dGM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13660,6 +13574,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"dGO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "dHk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13839,6 +13769,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"dKp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dKB" = (
 /obj/machinery/power/smes/engineering{
 	charge = 6e+007
@@ -14096,24 +14035,6 @@
 /area/security/prison)
 "dPn" = (
 /obj/item/flashlight/flare/signal,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"dPt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Engineering Delivery";
-	req_access_txt = "10"
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dPy" = (
@@ -14904,6 +14825,18 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
+"edx" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "edA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14940,6 +14873,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"eeg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eem" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15062,6 +15002,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ega" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ego" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/showroomfloor,
@@ -15382,6 +15329,23 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
+"elN" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"elQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "emc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -15967,6 +15931,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ewa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ewc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
@@ -16277,20 +16259,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"eCj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "eCo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -16339,6 +16307,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"eCU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/modular_computer/console/preset/command/ce{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "eCV" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -16404,29 +16381,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"eEz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/heads/chief)
 "eEH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -16437,21 +16391,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"eFa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "eFb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16694,6 +16633,19 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eJd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eJp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -16938,6 +16890,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eMo" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eMs" = (
 /obj/machinery/papershredder,
 /obj/machinery/camera{
@@ -16975,18 +16935,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"eMP" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "eMS" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -17029,6 +16977,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"eOt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eOS" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17338,6 +17296,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"eUj" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eUk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17603,6 +17571,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"fav" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "faH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -17690,20 +17668,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"fcF" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -7;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 7;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fcG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17917,6 +17881,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"feQ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "feZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -17940,6 +17912,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ffy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ffE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18018,6 +17997,23 @@
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/space/nearstation)
+"fgx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 4;
+	name = "CE Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/heads/chief)
 "fgM" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -18230,6 +18226,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"fjq" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "fjL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18310,14 +18313,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fle" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "flf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -18545,12 +18540,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fpZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fqa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18565,6 +18554,27 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"fqt" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 1;
+	freq = 1400;
+	location = "Engineering"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "fqz" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -18630,6 +18640,17 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
+"frJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fsd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -18642,6 +18663,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"fso" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fsA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -18751,16 +18778,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fva" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fvf" = (
 /obj/item/bikehorn/rubberducky,
 /obj/machinery/light/small{
@@ -18868,6 +18885,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"fxs" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fxw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -18958,13 +18985,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fyX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "fzb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -19321,6 +19341,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fFO" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "fFP" = (
 /turf/closed/wall,
 /area/maintenance/central)
@@ -19397,18 +19424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fHr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "fHD" = (
 /obj/machinery/light{
 	dir = 1
@@ -19453,13 +19468,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fIs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fIS" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/plasteel/freezer,
@@ -19563,16 +19571,6 @@
 "fLl" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"fLo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering West";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fLC" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -19734,20 +19732,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fOJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/item/clipboard,
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "fOX" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -19896,17 +19880,6 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"fQZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Engineering Access";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fRn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20083,6 +20056,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"fTt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fTy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20125,19 +20108,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"fTX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "fUb" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office A";
@@ -20151,6 +20121,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/vacant_room)
+"fUi" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/closet/secure_closet/engineering_chief,
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "fUp" = (
 /obj/structure/chair{
 	dir = 8;
@@ -20244,6 +20230,14 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"fWk" = (
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -20605,15 +20599,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
-"gct" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "gcC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
@@ -20642,6 +20627,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gdg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gdp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -20690,13 +20682,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"gdX" = (
-/obj/machinery/computer/station_alert,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -20743,6 +20728,14 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"geE" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "geG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -20763,6 +20756,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"gfj" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/crew_quarters/heads/chief)
 "gfx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21178,19 +21187,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
-"gmW" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gng" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -21398,16 +21394,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"grt" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gry" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -21446,6 +21432,12 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"gsw" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "gsy" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -21626,6 +21618,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"gwx" = (
+/obj/machinery/computer/station_alert,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gwC" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/cardhand{
@@ -21854,13 +21850,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"gzH" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/glass/plasma,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gzN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -21978,18 +21967,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gBr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "gBu" = (
 /obj/machinery/light{
 	dir = 1
@@ -22337,10 +22314,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"gHr" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "gHV" = (
 /obj/machinery/camera{
 	c_tag = "Patient Room 1";
@@ -22361,6 +22334,28 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
+"gIi" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gIn" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -23005,21 +23000,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"gSW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "gTd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23176,6 +23156,17 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"gWY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "gXg" = (
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plasteel,
@@ -23672,6 +23663,13 @@
 	},
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
+"hgU" = (
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hhi" = (
 /obj/structure/table/wood,
 /obj/item/seeds/tower{
@@ -23867,6 +23865,17 @@
 /obj/item/deskbell/preset/kitchen,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"hjm" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/stack/rods/fifty,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hjo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/gloves,
@@ -24182,6 +24191,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"hnZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hoj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -24248,6 +24270,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"hoQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "hoR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -24284,6 +24310,12 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/secondary/exit)
+"hpa" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hpr" = (
 /turf/closed/indestructible/riveted,
 /area/ruin/space/has_grav/listeningstation)
@@ -24501,6 +24533,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/explab)
+"hsl" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hsp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -24545,31 +24583,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hsw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hsL" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt2";
@@ -24705,25 +24718,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"hvl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "hvA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25060,6 +25054,18 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
+"hAW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"hBt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hBu" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -25425,6 +25431,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hHg" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "hHn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25579,12 +25591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hKu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hKz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -25945,19 +25951,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hQP" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hRk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -26045,14 +26038,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"hSz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hSC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -26074,6 +26059,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"hSL" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hTa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -26125,13 +26116,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"hTN" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "hTV" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/service";
@@ -26184,13 +26168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hUL" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hUM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -26331,40 +26308,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
-"hYl" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"hYt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hYM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -26410,6 +26353,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"hZl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "hZo" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -27072,6 +27021,18 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"ilp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "ilt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27094,6 +27055,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ilG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Vacant Office Maint";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/vacant_room)
 "imc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27144,6 +27127,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"imW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "imY" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -27355,23 +27350,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"irS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "isf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -27470,21 +27448,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/science/mixing)
+"itH" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "iua" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"iuh" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iul" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -27707,6 +27684,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"ixk" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "ixo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -27839,6 +27831,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iAi" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "iAo" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -27933,6 +27936,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"iCi" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "iCn" = (
 /obj/effect/turf_decal/tile/black{
 	dir = 4
@@ -28039,16 +28055,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"iFM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iFS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -28068,6 +28074,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iGy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/firstsingularity{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iGC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -28103,6 +28127,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iHv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "iHx" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West 2";
@@ -28206,15 +28243,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"iJh" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "iJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -28499,11 +28527,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"iOJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iPe" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel{
@@ -28916,6 +28939,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iWK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "iWR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -29079,24 +29114,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"iZv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "iZD" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -29177,16 +29194,6 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"jaf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jag" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -29534,18 +29541,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
-"jdA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jdG" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -29823,6 +29818,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jhs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jhw" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -30040,6 +30039,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"jkx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "jky" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -30098,6 +30109,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"jkS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jkV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -30274,15 +30296,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"joq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "joF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
@@ -30297,17 +30310,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"jpa" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jpg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30360,10 +30362,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
-"jqs" = (
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jqA" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos_distro)
@@ -30572,6 +30570,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"juM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "juN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -31046,6 +31051,47 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"jDp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -8;
+	pixel_y = 39;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = -8;
+	pixel_y = 26;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 7;
+	pixel_y = 26;
+	req_access_txt = "24"
+	},
+/obj/machinery/button/door{
+	id = "ceprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "jDw" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -31058,6 +31104,10 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jDC" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/foyer)
 "jDJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -31210,16 +31260,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"jFD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "jFM" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -31229,6 +31269,13 @@
 "jGe" = (
 /turf/template_noop,
 /area/maintenance/starboard)
+"jGn" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "jGN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -31351,10 +31398,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"jIO" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jIR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31442,12 +31485,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"jKI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "jKV" = (
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
@@ -31458,17 +31495,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"jLc" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jLj" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
-"jLp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jLz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/royalblack,
@@ -31514,19 +31550,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"jMp" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/item/twohanded/rcl/pre_loaded,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "jMt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31542,19 +31565,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"jMR" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jNi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -31612,13 +31622,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"jOs" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jOv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/sheep,
@@ -31769,12 +31772,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
-"jQR" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "jQV" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/cockroach,
@@ -31843,6 +31840,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"jRJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jRR" = (
 /obj/structure/showcase/machinery/tv,
 /obj/structure/table/wood,
@@ -31911,6 +31917,13 @@
 /obj/item/toy/spinningtoy,
 /turf/open/floor/fakespace,
 /area/maintenance/port/fore)
+"jTg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jTt" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31980,6 +31993,21 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"jUp" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jUr" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -32004,15 +32032,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jVe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jVp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light,
@@ -32105,11 +32124,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jWA" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "jWJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/fancy/donut_box,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"jWK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jXg" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -32166,10 +32207,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jXR" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jXS" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
@@ -32508,6 +32545,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"kfQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kfX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -32668,19 +32711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"khf" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_one_access_txt = "10;61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "khq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32795,6 +32825,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"kkX" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "klf" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /obj/structure/table,
@@ -32916,25 +32959,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"knn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kns" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -33022,6 +33046,16 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"kok" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "koH" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -33118,20 +33152,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kpV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kqr" = (
 /obj/item/radio/off,
 /turf/open/floor/plasteel/dark,
@@ -33190,18 +33210,6 @@
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"krp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/modular_computer/console/preset/command/ce{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "krq" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -33444,6 +33452,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kvl" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "kvo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -33471,15 +33487,6 @@
 /mob/living/simple_animal/hostile/glockroach,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"kvW" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "kwj" = (
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
@@ -33721,6 +33728,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos_distro)
+"kBn" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/camera{
+	c_tag = "Engineering North"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "kBW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34044,13 +34062,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kGZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kHg" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -34112,6 +34123,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"kIa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kIj" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -34143,15 +34161,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kIv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "kIA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -34341,6 +34350,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"kMY" = (
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "kNk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -34457,6 +34477,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"kQC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "kQI" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -34552,23 +34576,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kSc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	name = "Engineering Security APC";
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "kSF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -34678,6 +34685,10 @@
 /obj/item/soap,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"kUo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/foyer)
 "kUp" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -34789,15 +34800,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"kWo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kWz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -34856,6 +34858,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"kXu" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kXE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -35564,6 +35573,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"loK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "loY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35665,18 +35681,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"lrr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lrM" = (
 /obj/machinery/light{
 	dir = 4
@@ -35754,6 +35758,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ltf" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "ltl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -35801,6 +35817,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"ltQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ltS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35836,12 +35864,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lur" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "luy" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -36110,18 +36132,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"lyK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36474,6 +36484,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"lHk" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "lIp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -36679,17 +36699,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"lLz" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "lLR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36919,6 +36928,22 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lOb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "lOu" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/royalblack,
@@ -36965,10 +36990,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"lPh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lPj" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -37260,17 +37281,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/grass,
 /area/quartermaster/office)
-"lTU" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lUc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
@@ -37322,12 +37332,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lUZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/engine/engineering)
 "lVv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -37476,6 +37480,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lYs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "lYD" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -37522,6 +37534,16 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"lZt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lZC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -37661,21 +37683,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"maT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -38329,6 +38336,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mmN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mmV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -38996,19 +39007,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"myA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "myR" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
@@ -39057,15 +39055,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"mzz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mzH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -39203,6 +39192,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"mBW" = (
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "mCf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -39494,6 +39490,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mHp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mHs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -39572,13 +39578,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"mIn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "mIo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/showroomfloor,
@@ -39620,6 +39619,20 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"mJj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
 /area/engine/engineering)
 "mJq" = (
 /obj/structure/cable{
@@ -40056,6 +40069,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"mQb" = (
+/mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/glass/plasma,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mQc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40238,6 +40256,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mSi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mTb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -40380,13 +40420,6 @@
 /obj/effect/turf_decal/pool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"mVl" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "mVu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40539,10 +40572,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mXg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mXo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -41073,16 +41102,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"ndZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "neg" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5
@@ -41105,12 +41124,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"neQ" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "neY" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -41186,6 +41199,24 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
+"ngB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ngM" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/plasteel,
@@ -41232,19 +41263,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nhS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nik" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"niA" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "niB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41398,15 +41424,6 @@
 "nks" = (
 /turf/closed/wall,
 /area/storage/primary)
-"nkM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nkP" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -41484,6 +41501,10 @@
 /obj/machinery/vending/fishing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"nlK" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "nlP" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -41576,22 +41597,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nnB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nnF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -41711,6 +41716,13 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
+"npV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nqc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41823,6 +41835,12 @@
 "nru" = (
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
+"nrA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nrL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -41919,14 +41937,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nsi" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "nst" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -42012,6 +42022,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nuM" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "nuQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -42160,18 +42187,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"nwN" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nwZ" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -42342,12 +42357,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered)
-"nzP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "nzW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42820,6 +42829,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nHR" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nIi" = (
 /obj/structure/table/reinforced,
 /obj/item/coin/iron{
@@ -42858,6 +42878,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nIT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nJl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -42975,6 +43007,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"nLB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "nLG" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel/dark,
@@ -43105,18 +43141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nOg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nOn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43277,20 +43301,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"nRa" = (
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = 32;
-	pixel_y = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "nRs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43648,13 +43658,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"nVU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/field/generator,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nVY" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -43821,6 +43824,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"nZo" = (
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = 32;
+	pixel_y = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "nZw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -43937,6 +43957,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"obt" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "obx" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/window/reinforced{
@@ -43961,27 +43985,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"obF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/firstsingularity{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "obQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -44095,6 +44098,24 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"odw" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "odK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44369,6 +44390,26 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"ojg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "ojt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Research Division";
@@ -44388,6 +44429,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ojB" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "ojF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -44538,39 +44583,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"omj" = (
+"omg" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/crew_quarters/heads/chief)
+/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "omv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"omJ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glass/plasma,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "omW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -44739,12 +44769,33 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
+"oqe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "oqD" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"oqJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "oqQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44909,10 +44960,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/starboard)
-"ots" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ott" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44973,6 +45020,27 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
+"ouO" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "ouR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -45342,6 +45410,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oCy" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oCN" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck"
@@ -45732,26 +45811,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"oIA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "oIE" = (
 /obj/machinery/light{
 	dir = 8
@@ -45792,6 +45851,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"oJw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oJQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45898,6 +45969,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oMd" = (
+/obj/machinery/power/smes/engineering{
+	output_attempt = 0
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oMh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/lapvend,
@@ -46039,6 +46122,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"oOf" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "oOl" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/light,
@@ -46098,26 +46185,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oQc" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "oQd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -46372,6 +46439,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"oTz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "oTC" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -46546,6 +46631,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"oWK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "oWS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46624,13 +46715,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"oZh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "oZi" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -46806,6 +46890,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"pbB" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pbC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47020,31 +47113,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"peF" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "peP" = (
 /mob/living/simple_animal/hostile/retaliate/dolphin/manatee,
 /turf/open/space/basic,
@@ -47074,16 +47142,6 @@
 "pfc" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"pfg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/obj/machinery/camera{
-	c_tag = "Engineering North"
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "pfh" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -47183,6 +47241,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"phh" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "phj" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -47487,6 +47557,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pnh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "pnm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47722,21 +47802,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ppQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ppT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -47773,15 +47838,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"pqA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "pqX" = (
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -47982,6 +48038,23 @@
 /obj/item/chair/stool,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
+"puj" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "pul" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -48156,6 +48229,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"pxA" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pxD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48420,24 +48497,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"pAZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "pBl" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -48650,15 +48709,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
-"pFQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pFT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -48859,20 +48909,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pIs" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/rods/fifty,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "pIz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48907,6 +48943,24 @@
 /mob/living/simple_animal/hostile/russian,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"pIT" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Storage";
+	name = "engineering camera";
+	network = list("ss13","engine")
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engine/engineering";
+	dir = 1;
+	name = "Engineering APC";
+	pixel_y = 23
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pJh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -48974,16 +49028,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"pJZ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "pKa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -49494,13 +49538,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pRm" = (
-/obj/structure/chair/office/light,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "pRM" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -49521,6 +49558,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"pSm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "pSo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49740,6 +49788,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"pUU" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "pVb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -49814,24 +49870,6 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"pVW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pWj" = (
 /obj/machinery/light{
 	dir = 4
@@ -50030,14 +50068,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"pYp" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "pYC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -50082,6 +50112,12 @@
 "pZo" = (
 /turf/closed/wall/rust,
 /area/space/nearstation)
+"pZu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pZL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -50093,21 +50129,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pZN" = (
-/obj/machinery/power/smes/engineering{
-	output_attempt = 0
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pZT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
@@ -50189,30 +50210,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/secondarydatacore)
-"qbe" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = -27
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
-"qbj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qbl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -50282,13 +50279,12 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"qcV" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+"qcO" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/engine/engineering)
 "qcX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -50501,6 +50497,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"qgc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "qgi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -50544,16 +50555,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"qhl" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "qhs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -50782,13 +50783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"qmj" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qmk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50808,6 +50802,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qmt" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"qmB" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qmF" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -50902,6 +50917,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"qnO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "qnV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
@@ -51207,13 +51240,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"qtt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "qtF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -51294,25 +51320,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"quE" = (
-/obj/machinery/computer/apc_control{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "quG" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"quP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "quS" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -51795,16 +51816,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"qDT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qDZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -51927,6 +51938,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qFQ" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "qGm" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -52102,6 +52119,26 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"qIB" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"qID" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qIJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -52337,12 +52374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"qNR" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qNW" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -52438,6 +52469,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"qPb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/light,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qPl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -52664,18 +52701,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qTL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qTR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -52717,13 +52742,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qVg" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "qVm" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -52738,6 +52756,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qVt" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "qVG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52763,6 +52788,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"qVI" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "qVL" = (
 /turf/closed/mineral/random/low_chance_air,
 /area/maintenance/port)
@@ -53293,28 +53327,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rdK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Vacant Office Maint";
-	req_access_txt = "32"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/vacant_room)
 "rdW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -53470,6 +53482,15 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"rgj" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rgq" = (
 /obj/machinery/light{
 	dir = 8
@@ -53696,30 +53717,6 @@
 /obj/structure/displaycase/cmo,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"rkJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 1;
-	freq = 1400;
-	location = "Engineering"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rkL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54006,6 +54003,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"roJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "roK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -54076,44 +54079,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"rpS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -8;
-	pixel_y = 39;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -8;
-	pixel_y = 26;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 7;
-	pixel_y = 26;
-	req_access_txt = "24"
-	},
-/obj/machinery/button/door{
-	id = "ceprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 7;
-	pixel_y = 39
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "rqp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -54143,6 +54108,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rqG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "rqK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -54204,6 +54190,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"rrS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rsh" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -54409,6 +54405,21 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
+"ruL" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ruM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/grille/broken,
@@ -54839,6 +54850,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"rBO" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rBT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54863,6 +54884,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"rCK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "rDe" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -54888,30 +54927,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"rDv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"rDw" = (
-/obj/effect/decal/cleanable/glass/plasma,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"rDJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rDM" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -55202,6 +55217,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rHq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rHu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55217,16 +55241,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"rHy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rHK" = (
 /obj/structure/chair{
 	dir = 4
@@ -55267,16 +55281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"rJw" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "rJC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -55324,6 +55328,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"rKN" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rLv" = (
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -55437,6 +55447,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"rNw" = (
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rNE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -55446,38 +55467,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"rNV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"rNW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"rOe" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/starboard)
 "rOt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -55529,11 +55533,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"rPf" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/foyer)
 "rPh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/pool{
@@ -55725,23 +55724,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"rRA" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
-	name = "engineering camera";
-	network = list("ss13","engine")
-	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rRV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -55832,15 +55814,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"rTI" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "rTM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -55852,12 +55825,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rTX" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rUg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"rUl" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rUv" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -55893,25 +55882,6 @@
 /obj/item/toy/figure/captain,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"rUV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/item/cartridge/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 8
-	},
-/obj/item/cartridge/atmos,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "rVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -55985,6 +55955,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"rVT" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/stack/cable_coil,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"rVU" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rVZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -56274,10 +56264,6 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/secondary/exit)
-"rZz" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "rZG" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating/airless{
@@ -56327,6 +56313,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"saP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "saZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -56413,6 +56411,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"scj" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "sck" = (
 /obj/machinery/light{
 	dir = 1
@@ -56459,22 +56465,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"scv" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"scw" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "scx" = (
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8;
@@ -56554,6 +56544,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"sdE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sdO" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 17
@@ -56562,22 +56570,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"sdR" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sdZ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56589,6 +56581,16 @@
 	},
 /turf/closed/mineral/random/low_chance_air,
 /area/space/nearstation)
+"sej" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "sek" = (
 /obj/machinery/door/window/westright,
 /obj/structure/table/reinforced,
@@ -56845,6 +56847,10 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
+"slg" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -56968,10 +56974,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"sod" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "son" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -57160,6 +57162,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"srK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "srR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -57516,6 +57530,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sxN" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sxT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -57587,13 +57605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"szs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "szt" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/bait/apprentice,
@@ -57637,6 +57648,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
+"sAK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sAV" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel{
@@ -57908,18 +57929,6 @@
 	dir = 8
 	},
 /area/science/xenobiology)
-"sFQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sFR" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -57989,6 +57998,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sHd" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "sHg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -58260,13 +58277,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/clerk)
-"sLf" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sLu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -58572,6 +58582,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"sPy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sPG" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
@@ -58585,6 +58602,22 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"sPS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
+	},
+/obj/item/clipboard,
+/obj/item/paper/monitorkey,
+/turf/open/floor/plasteel/white/corner,
+/area/crew_quarters/heads/chief)
 "sPZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58743,17 +58776,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
-"sSu" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58906,18 +58928,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"sVk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sVr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
@@ -58945,6 +58955,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"sVC" = (
+/obj/structure/filingcabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
+"sVU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sWf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59127,12 +59158,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
-"sZg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sZi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -59261,13 +59286,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"tbh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tbk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59282,13 +59300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"tbv" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/foyer)
 "tbM" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -59319,24 +59330,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"tcg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "tct" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"tcz" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "tcG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -59436,6 +59448,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tef" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "tej" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59559,6 +59584,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"tge" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tgg" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/assistant,
@@ -59602,6 +59634,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"tgT" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tgX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
@@ -59706,37 +59750,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tit" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"tiu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/foyer)
 "tiz" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -59763,24 +59776,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"tiK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/foyer";
-	dir = 8;
-	name = "Engineering Foyer APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "tjc" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -59798,6 +59793,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"tjX" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "tkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -59809,13 +59813,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"tkw" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "tkI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -60060,18 +60057,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"toS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office"
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "toT" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -60246,11 +60231,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"ttp" = (
-/obj/structure/filingcabinet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "ttD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -60319,11 +60299,6 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"tuG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tuJ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60611,6 +60586,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"tzi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tzn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -61199,13 +61181,6 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"tJJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "tJN" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plasteel{
@@ -61569,6 +61544,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"tRe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "tRA" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -62058,6 +62042,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ubq" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ubw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -62065,6 +62062,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"ubI" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ubJ" = (
 /mob/living/carbon/monkey,
 /obj/item/reagent_containers/food/snacks/grown/banana{
@@ -62216,6 +62221,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"uek" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uer" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62326,13 +62340,6 @@
 "ufK" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
-"ufN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
-	},
-/mob/living/simple_animal/cockroach,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ufS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -62365,15 +62372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"uhk" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uhv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
@@ -62396,16 +62394,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"uhS" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uhV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62464,38 +62452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"uiI" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/siding/wideplating/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "uiU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -62992,23 +62948,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"urH" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "urY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -63088,6 +63027,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"utp" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uty" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -63154,6 +63103,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uuj" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "uun" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/hydroponicsguide{
@@ -63189,6 +63155,18 @@
 /obj/item/pickaxe/mini,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"uuy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uuB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -63206,6 +63184,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"uvA" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uvM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -63248,20 +63233,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"uxM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "uxS" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -63350,21 +63321,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted/shutter,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"uyV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -63780,20 +63736,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"uDr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/mob/living/simple_animal/cockroach,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uDy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63831,6 +63773,19 @@
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
+"uEO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Engineering Desk";
+	req_access_txt = "10"
+	},
+/obj/item/deskbell/preset/engi{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/engine/foyer)
 "uFl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -63899,24 +63854,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uGg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uGh" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -64223,12 +64160,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"uMl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uMm" = (
 /obj/structure/rack,
 /obj/item/latexballon,
@@ -64276,6 +64207,16 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"uNt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uNI" = (
 /obj/structure/toilet_bong{
 	flags_1 = 128
@@ -64463,6 +64404,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"uRe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uRg" = (
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -64538,6 +64485,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uTw" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uTB" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -64556,20 +64509,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"uUB" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "uVl" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -64703,6 +64642,13 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"uXf" = (
+/obj/machinery/computer/atmos_alert,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uXo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64724,14 +64670,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"uXx" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "uXQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65001,6 +64939,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"vcq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vct" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -65374,14 +65319,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"vkj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "vkl" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
@@ -65431,6 +65368,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vli" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "vlm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -65489,6 +65437,19 @@
 /obj/item/toy/figure/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
+"vmW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "vmX" = (
 /obj/machinery/light{
 	dir = 4
@@ -65567,13 +65528,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"vpj" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 6
+"vpv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "vpN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -65599,16 +65568,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vql" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/crew_quarters/heads/chief)
 "vqC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65750,24 +65709,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"vsN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "vsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66113,21 +66054,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"vxW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vyc" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -66294,10 +66220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"vCu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "vCI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -66365,6 +66287,24 @@
 	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
+"vEg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	name = "Engineering Security APC";
+	pixel_y = -23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "vEi" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -66549,13 +66489,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vHx" = (
-/obj/machinery/computer/atmos_alert,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "vHF" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
@@ -66567,12 +66500,6 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"vId" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "vIG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66587,24 +66514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vIH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_one_access_txt = "10;61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vIX" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
@@ -66986,12 +66895,39 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"vND" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vNJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vNU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vNX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67057,6 +66993,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vPg" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/poster/firstsingularity,
+/obj/item/poster/random_official{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/flashlight,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vPC" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -67079,6 +67033,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"vPO" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vPP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -67489,15 +67450,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vXp" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+"vXl" = (
+/obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vXF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -67596,6 +67557,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"vZy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Engineering Access";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vZC" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
@@ -67703,6 +67675,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"wbk" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wbq" = (
 /obj/structure/table/wood,
 /obj/item/toy/toygrenade{
@@ -67889,6 +67870,14 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"wew" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = 32
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wey" = (
 /obj/structure/statue/silver/secborg,
 /obj/structure/window/reinforced{
@@ -68084,17 +68073,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"whl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 5
+"whx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/security/checkpoint/engineering)
 "whA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -68257,6 +68261,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wkT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wkY" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -68799,10 +68814,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"wuG" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wuJ" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
@@ -68964,21 +68975,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"wzi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wzw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -69179,22 +69175,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"wBx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wBL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -69292,16 +69272,6 @@
 "wCY" = (
 /turf/closed/wall,
 /area/maintenance/department/tcoms)
-"wDa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/foyer)
 "wDs" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
@@ -69494,13 +69464,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"wFY" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wGs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -69522,12 +69485,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wHu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
+"wHc" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "wHG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -69693,15 +69658,6 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
-"wJA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wJE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -69986,6 +69942,13 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"wOt" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "wOz" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -70046,24 +70009,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wPL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "atmospherics sorting disposal pipe";
-	sortType = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wPR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -70193,14 +70138,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
-"wSk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wSF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -70747,28 +70684,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xaE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access_txt = "63"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "xaT" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
@@ -70814,19 +70729,23 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"xbE" = (
+"xbU" = (
 /obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/head/welding{
-	pixel_x = 4;
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/item/clothing/glasses/meson{
 	pixel_y = 4
 	},
-/obj/item/poster/firstsingularity,
-/obj/effect/turf_decal/siding/wideplating{
+/obj/item/reagent_containers/pill/patch/silver_sulf,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
+/area/crew_quarters/heads/chief)
 "xcx" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -71057,23 +70976,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"xfS" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/poster/firstsingularity,
-/obj/item/poster/random_official{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/item/flashlight,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "xfT" = (
 /mob/living/simple_animal/hostile/bear/russian,
 /turf/open/floor/grass/snow/safe,
@@ -71109,6 +71011,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"xgC" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xgD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -71147,6 +71056,29 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"xhy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Medical";
+	location = "Engineering";
+	name = "engineering navigation beacon"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xhF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -71784,6 +71716,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xuJ" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/foyer";
+	dir = 8;
+	name = "Engineering Foyer APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xuL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -72423,17 +72370,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"xGC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = 32
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xGF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -72655,14 +72591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"xKl" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xKy" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -72754,6 +72682,19 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"xLj" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "xLp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72907,6 +72848,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xNx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xNz" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -73051,14 +73004,16 @@
 /turf/open/floor/carpet,
 /area/library)
 "xQN" = (
-/obj/structure/cable{
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "xQV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -73142,22 +73097,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xRY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xSa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -73267,6 +73206,18 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xUZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_middle,
+/area/engine/engineering)
 "xVq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -73474,15 +73425,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"xXN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xYb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -73544,6 +73486,21 @@
 /obj/item/cartridge/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"xZc" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering West";
+	dir = 4
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "xZB" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -73963,18 +73920,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"yhR" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "yia" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -74112,6 +74057,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ylj" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ylM" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -113313,7 +113266,7 @@ aZH
 amx
 amx
 amx
-rdK
+ilG
 amx
 amx
 amx
@@ -113863,10 +113816,10 @@ aiZ
 aiZ
 jJp
 aiZ
-dAy
-vCu
-qop
-aHh
+xhy
+cWR
+ubq
+hpa
 wgj
 agn
 aAA
@@ -114117,13 +114070,13 @@ bJJ
 bOv
 bOv
 bOv
-uyV
+iWK
 pyH
-bOv
-qbj
-uhS
+nIT
+frJ
+loK
 afp
-aHh
+ckU
 aoJ
 agn
 agn
@@ -114371,25 +114324,25 @@ aJq
 aJq
 aJq
 aJq
-tiu
 aJq
-aJq
-aJq
-aJq
-tbv
-uiI
-rPf
-ahe
-aHh
-aHh
-gct
-gct
-gct
-gct
-gct
-jQR
-aHh
-eMv
+ojB
+nlK
+lYs
+aav
+jTg
+caJ
+rUl
+afp
+cRg
+lUD
+rTX
+rTX
+rTX
+rTX
+rTX
+vXl
+lUD
+ega
 aoJ
 aHh
 aHh
@@ -114625,18 +114578,18 @@ aXb
 oBq
 oBq
 ahe
-xKl
-cHX
-lLz
-xQN
-hsw
-tiK
-qcV
-hYl
-sLf
-pAZ
-qbe
-ahe
+fWk
+omg
+vli
+aJq
+aJq
+aJq
+aJq
+aJq
+hsl
+caJ
+rUl
+afp
 hFp
 gMy
 aFk
@@ -114646,12 +114599,12 @@ aFk
 iRo
 aoJ
 aHh
-aHh
+ckU
 hFp
-aHh
-aHh
-iam
-bPc
+roJ
+lUD
+mHp
+ltQ
 pYX
 kxk
 pYX
@@ -114884,16 +114837,16 @@ mzH
 ahe
 xDb
 ayk
-sZg
-kIv
-dfm
-dGD
-dfm
-dfm
-dfm
-wPL
-xbE
-ahe
+oqJ
+oWK
+phh
+xuJ
+qVI
+kUo
+hsl
+caJ
+rUl
+afp
 aHh
 iwt
 aFk
@@ -114903,12 +114856,12 @@ aFk
 aFk
 aoJ
 ogK
-aHh
-aHh
-aHh
+cRg
+lUD
+rKN
 pNr
 aoJ
-bPc
+bzC
 aHh
 wYf
 aHh
@@ -115140,17 +115093,17 @@ xfC
 hif
 jYe
 pbm
-fHr
-dhY
-bco
-jKI
-scw
-ayk
-ayk
-ayk
-sdR
-qhl
-ahe
+rCK
+jkS
+tRe
+gWY
+ouO
+pnh
+nuM
+uuy
+rNW
+qPb
+afp
 wMo
 fdq
 aFk
@@ -115165,7 +115118,7 @@ aoJ
 aoJ
 aoJ
 aoJ
-gBr
+jRJ
 waS
 lDV
 rth
@@ -115397,17 +115350,17 @@ pbV
 vXZ
 ahe
 biV
-bAk
-wSk
-uXx
-fyX
-xRY
-eCj
-eCj
-eCj
-wBx
-qVg
-ahe
+lOb
+hSL
+qFQ
+hAW
+ccS
+mhV
+kUo
+hsl
+sxN
+kXu
+afp
 aJj
 aJj
 aJj
@@ -115416,13 +115369,13 @@ aJj
 aJj
 aJj
 aJj
-dkB
-cse
-cse
-cse
-cse
-tcg
-pqA
+oqe
+uRe
+uRe
+uRe
+oOf
+sej
+kfQ
 agn
 agn
 agn
@@ -115654,17 +115607,17 @@ kZw
 aOd
 aOd
 aOd
-xaE
+whx
 aOd
 rEs
-hKu
-fFj
-ayk
-ayk
-gHr
-mhV
-nsi
-ahe
+kQC
+iHv
+bWZ
+uEO
+hsl
+aiZ
+kXu
+afp
 tYf
 tYf
 iom
@@ -115673,7 +115626,7 @@ wrl
 xgJ
 ruw
 aJj
-rkJ
+fqt
 aJj
 pwX
 aJj
@@ -115909,19 +115862,19 @@ rqK
 qHV
 vgW
 aOd
-aXh
-aaB
-azv
+uuj
+tcz
+dGO
 drR
 sQf
 ayk
 fFj
-ayk
-aIE
-cdm
-lml
-pJZ
-ahe
+elN
+aJq
+jGn
+gsw
+fFO
+afp
 tYf
 tYf
 ozg
@@ -115929,13 +115882,13 @@ wRS
 ozg
 oAU
 ruw
-lur
-dPt
-lUZ
-xXN
-pVW
-lrr
-nOg
+aJj
+cte
+aJj
+dKp
+odw
+tgT
+imW
 aqp
 aqp
 aqp
@@ -116166,33 +116119,33 @@ ooL
 aJF
 aJF
 drR
-ajC
+itH
 abS
-azv
+vmW
 drR
 kiL
-mVl
+qFQ
 fFj
-ayk
 pXS
 gLw
-oIA
+ojg
 mfI
+aPn
 aPn
 aJj
 bZf
-gzH
-boH
-boH
-boH
-nVU
-awz
-peF
-irS
-bSj
-aAJ
-aAJ
-jMR
+oAU
+ozg
+ozg
+ozg
+ruw
+aJj
+gIi
+dnP
+lZt
+kok
+sAK
+eJd
 aqp
 aqp
 aqp
@@ -116423,31 +116376,31 @@ ljF
 abc
 abc
 drR
-aFv
+qVt
 aNR
-kSc
+vEg
 aOd
 drR
-joq
-iZv
-atD
-mIn
-hvl
-vql
-jMp
-lyK
-arb
-arb
-iJh
+fxs
+sdE
+mhV
+vpv
+sPS
+kvl
+lHk
+ahh
+aPn
+aPn
+aJj
 aMk
 aMk
 aJj
 aJj
 aJj
-obF
-fgX
+iGy
 asO
-pdN
+tsh
+ddz
 pfc
 aqp
 aqp
@@ -116680,31 +116633,31 @@ ljF
 aPx
 aPx
 drR
-ttp
+sVC
 tQo
-dcD
-aJC
+jkx
+fjq
 drR
-eMP
+tjX
 fFj
-ayk
 mhV
-eFa
-vId
-uxM
-bNW
-quE
-fTX
-pZN
-jpa
-alA
-fLo
-jXR
-uxT
-uGg
-asO
-jIO
-asO
+qnO
+jWA
+hHg
+aYF
+gfj
+kMY
+aPn
+oMd
+ubI
+xgC
+xZc
+feQ
+tzi
+ewa
+fso
+oCy
+auf
 aqp
 aqp
 aqp
@@ -116937,31 +116890,31 @@ ljF
 aPp
 acT
 aOd
-akc
-nRa
-uUB
-atU
+ixk
+nZo
+puj
+iAi
 drR
-hQP
-tit
-nzP
+tef
+rqG
 lml
 aPn
-aGk
-fOJ
-pRm
-krp
-fTX
-fIs
-rHy
+ltf
+aYF
+aYF
+crk
+eCU
+aPn
+pbB
+uNt
 xeC
-die
+mJj
 ctX
 gSw
-rOe
-asO
-asO
-cfQ
+vND
+sJB
+hBt
+tge
 aqp
 aqp
 aqp
@@ -117199,26 +117152,26 @@ aOd
 aOd
 aOd
 aOd
-cID
+jDC
 jVA
-khf
-wDa
+ahe
 aPn
-rpS
-rUV
+jDp
+nLB
+wOt
 aYF
 wIk
 aPn
-rRA
-qmj
-kvW
-rTI
-uhk
-uxT
+pIT
+aLS
+saP
+ilp
+cdU
+aJj
 jXk
 asO
 asO
-asO
+uTw
 aqp
 aqp
 aqp
@@ -117454,28 +117407,28 @@ aTU
 aTU
 aTU
 aJj
-scv
-vkj
-fQZ
+aJj
+quP
+vZy
 pQu
-vRX
 rQj
 aPn
-toS
-jFD
+fUi
 ule
-pIs
-fTX
+edx
+iVY
+dkm
+qgc
 pSy
-dzM
+rHq
 jkI
-rZz
+cpf
 mAG
 uxT
 eyq
 asO
 cua
-asO
+uTw
 aqp
 aqp
 aqp
@@ -117711,28 +117664,28 @@ aBu
 aBu
 aTU
 aJj
-tkw
-rDv
+aJj
+fTt
 dbQ
 rHj
-asO
 sud
 aPn
-csp
-vsN
-iVY
-urH
-aPn
-hUL
-asO
-rDw
-tJJ
-qtt
-uxT
-knn
-asO
-asO
-lPh
+wHc
+hoQ
+oTz
+ule
+czV
+ddd
+slg
+qcO
+rNw
+eOt
+rrS
+kIa
+mSi
+nrA
+fgX
+vPO
 aqp
 aqp
 aqp
@@ -117968,28 +117921,28 @@ aBu
 aBu
 aTU
 aJj
-wuG
-rJw
+aJj
+pSm
 uAV
 aqU
-wHu
 uAV
 aPn
 dzz
-eEz
-omj
-oQc
-fTX
+fgx
+aLz
+ahO
+xbU
+aPn
 wjt
-iuh
+rVT
 exT
 nBx
 gHd
 uxT
 ucs
-cma
+bXD
 bJr
-bnm
+eeg
 aqp
 aqp
 aqp
@@ -118229,8 +118182,8 @@ aJj
 aJj
 pVi
 oEg
-vIH
-gSW
+aJj
+aPn
 aPn
 aPn
 cYf
@@ -118244,9 +118197,9 @@ aJj
 hAQ
 aJj
 jzc
+oNt
 asO
-asO
-mXg
+ffy
 aqp
 aqp
 aqp
@@ -118482,28 +118435,28 @@ aKe
 dvm
 aTU
 aJj
-wuG
-bZq
-hSz
+aJj
+qmt
+npV
 uaF
-ndZ
-myA
-dqq
-lWz
+juM
+srK
+xNx
+scj
 qfe
 sSd
 sUr
 kJr
-cQR
+wkT
 lWz
 fdm
 cfJ
 dqq
 xBe
 eHO
-sod
+sPy
 vSX
-bnm
+eeg
 aqp
 aqp
 aqp
@@ -118739,28 +118692,28 @@ aOL
 vtF
 ahN
 aJj
-pfg
-jqs
+aJj
+kBn
 cfQ
 lXQ
 mXv
 uZc
 eyp
-eyp
+xUZ
 bDH
 gxt
 dMP
-uDr
+dfI
 btx
 eyp
 bYq
 eyp
-jdA
-bly
-ppQ
-asO
-asO
-iOJ
+fav
+nHR
+ngB
+jWK
+vNU
+ylj
 aqp
 aqp
 aqp
@@ -118996,14 +118949,14 @@ wHG
 kSR
 hiX
 aJj
-vpj
-pYp
-tuG
+hZl
+wbk
+wDS
 wDS
 wDS
 ssp
 pIm
-pIm
+iCi
 jCM
 nvE
 vKg
@@ -119011,13 +118964,13 @@ lGS
 qew
 gkG
 mUV
-kWo
-bjH
-whl
-wzi
-rDJ
-uMl
-bnm
+cLV
+cSZ
+uek
+qmB
+eMo
+jUp
+eeg
 aqp
 aqp
 aqp
@@ -119260,21 +119213,21 @@ aYa
 aYa
 aYa
 aYa
-aDu
+aJj
 aAy
 aIh
 cdG
 aAy
 aAy
-jOs
-jaf
-uMl
-qTL
-vXp
-ozg
-cyj
-gmW
-fpZ
+mBW
+utp
+qID
+qID
+eUj
+sHd
+qIB
+cSe
+rgj
 aqp
 aqp
 aqp
@@ -119525,13 +119478,13 @@ vGn
 aAy
 aAy
 aVM
-aNX
-rNV
-grt
-ozg
-hTN
-cqg
-asO
+rVU
+uxT
+uxT
+aVM
+dfg
+cSe
+uTw
 aqp
 aqp
 aqp
@@ -119781,14 +119734,14 @@ qEr
 aAy
 aAy
 aAy
-gdX
-oZh
-maT
-sSu
-ozg
-cyj
-nwN
+gwx
+obt
 asO
+bEB
+uxT
+xLj
+cSe
+uTw
 aqp
 aqp
 aqp
@@ -120039,13 +119992,13 @@ nLg
 cIE
 aAy
 aKN
-dAa
-maT
-niA
-ozg
-wFY
-yhR
-asO
+geE
+cfQ
+elQ
+uxT
+kkX
+cSe
+uTw
 aqp
 aqp
 aqp
@@ -120295,14 +120248,14 @@ pvD
 sMq
 nwg
 aAy
-vHx
-szs
-maT
-iFM
-omJ
-lTU
-kGZ
+uXf
+dFn
 asO
+hjm
+aVM
+xQN
+cSe
+uTw
 aqp
 aqp
 aqp
@@ -120553,13 +120506,13 @@ xWo
 nYv
 aAy
 aVM
-fcF
-cBJ
-qNR
-asO
-tsh
-asO
-asO
+jLc
+vRX
+fdm
+rBO
+cQX
+cSe
+uTw
 aqp
 aqp
 aqp
@@ -120809,15 +120762,15 @@ osl
 xhX
 qcd
 aAy
-ots
-qDT
-fle
-nnB
-hYt
-vxW
-sFQ
-sFQ
-sFQ
+pUU
+bfV
+asO
+cua
+nhS
+gdg
+sVU
+bgx
+oJw
 aqp
 aqp
 aqp
@@ -121066,13 +121019,13 @@ atj
 fgM
 eRU
 aAy
-xfS
-mzz
-wJA
-qNR
-jLp
-tsh
+vPg
+pZu
+pdN
 asO
+pxA
+tsh
+cSe
 asO
 asO
 aqp
@@ -121323,13 +121276,13 @@ jmq
 ldu
 fLl
 aAy
-neQ
-nkM
-wJA
-ufN
-jVe
-dCb
-pFQ
+uvA
+pZu
+asO
+mQb
+asO
+tsh
+ruL
 eFi
 coo
 aqp
@@ -121580,13 +121533,13 @@ aAy
 aAy
 aAy
 aAy
-baA
+hgU
 xNW
-aVu
-tbh
-sVk
-cYN
-kpV
+asO
+jhs
+mmN
+vcq
+hnZ
 ejt
 xNw
 gWo
@@ -121837,12 +121790,12 @@ phM
 fTh
 afF
 afF
-aJj
+aVM
 dLn
 sYl
 fzB
-xGC
-fva
+wew
+blh
 iLO
 mJf
 ufs

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -55,9 +55,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"aav" = (
-/turf/closed/wall,
-/area/hallway/primary/starboard)
 "aaw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -95,6 +92,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"aaB" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "aaJ" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window{
@@ -934,15 +942,6 @@
 "ahe" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
-"ahh" = (
-/obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "ahm" = (
 /obj/item/twohanded/required/pool/pool_noodle,
 /turf/open/indestructible/sound/pool,
@@ -993,20 +992,6 @@
 "ahN" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"ahO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/heads/chief)
 "ahR" = (
 /obj/structure/window{
 	dir = 8
@@ -1198,6 +1183,11 @@
 "ajz" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"ajC" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "ajF" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -1248,6 +1238,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"akc" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "akf" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -1418,6 +1420,10 @@
 "aly" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
+"alA" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "alB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/computer/cryopod{
@@ -2109,6 +2115,12 @@
 "aqZ" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"arb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/chief)
 "arc" = (
 /obj/effect/landmark/stationroom/box/dorm_edoor,
 /turf/template_noop,
@@ -2476,6 +2488,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"atD" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "atG" = (
 /obj/machinery/telecomms/message_server/preset,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -2517,6 +2536,14 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"atU" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "atX" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/camera,
@@ -2547,15 +2574,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"auf" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aui" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -2834,6 +2852,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"awz" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "awB" = (
 /turf/closed/wall/rust,
 /area/maintenance/port/aft)
@@ -3126,6 +3150,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"azv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "azw" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -3333,6 +3369,16 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"aAJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aAN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -3756,6 +3802,10 @@
 /obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"aDu" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aDv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -3983,6 +4033,10 @@
 "aFu" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"aFv" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "aFy" = (
 /obj/item/book/random,
 /obj/structure/table/glass,
@@ -4079,6 +4133,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"aGk" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "aGo" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/electrical";
@@ -4455,6 +4519,10 @@
 "aID" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"aIE" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "aIH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -4542,6 +4610,10 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"aJC" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "aJD" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine,
@@ -4724,29 +4796,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"aLz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/heads/chief)
 "aLB" = (
 /obj/effect/landmark/stationroom/box/testingsite,
 /turf/open/space/basic,
@@ -4770,16 +4819,6 @@
 "aLR" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
-"aLS" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aLW" = (
 /mob/living/simple_animal/opossum,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -4983,6 +5022,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"aNX" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aNY" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -5999,6 +6047,20 @@
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
+"aXh" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "aXl" = (
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/yellowsiding{
@@ -6424,6 +6486,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"baA" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "baF" = (
 /obj/effect/turf_decal/pool,
 /obj/structure/chair/stool/bamboo{
@@ -6488,6 +6556,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bco" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "bcH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 2
@@ -6627,13 +6704,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"bfV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bgi" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -6657,18 +6727,6 @@
 	dir = 8
 	},
 /area/ruin/powered)
-"bgx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -6898,6 +6956,22 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
+"bjH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bjM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7007,16 +7081,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"blh" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/closet/emcloset,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bll" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7038,6 +7102,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"bly" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "blJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "AI Upload Access"
@@ -7093,6 +7165,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bnm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bnq" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7155,6 +7231,12 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"boH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "bpd" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -7822,15 +7904,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"bzC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "bzU" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -7856,6 +7929,21 @@
 /obj/item/drone_shell,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"bAk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "bAo" = (
 /obj/machinery/light{
 	dir = 4
@@ -8044,13 +8132,6 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/plasteel,
 /area/clerk)
-"bEB" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "bEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -8485,6 +8566,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"bNW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/crew_quarters/heads/chief)
 "bOk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8757,6 +8857,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/vacant_room)
+"bSj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bSy" = (
 /obj/machinery/light,
 /obj/machinery/door/firedoor/border_only{
@@ -8894,11 +9004,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"bWZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "bXj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "EVA Maintenance";
@@ -8945,15 +9050,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"bXD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -9057,6 +9153,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"bZq" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "bZK" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -9124,21 +9227,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"caJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "caU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -9301,23 +9389,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ccS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "atmospherics sorting disposal pipe";
-	sortType = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "cdc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -9335,6 +9406,12 @@
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos_distro)
+"cdm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "cdt" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -9385,18 +9462,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"cdU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "cev" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -9885,12 +9950,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ckU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "ckX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -9975,6 +10034,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"cma" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cmB" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -10057,14 +10122,6 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
-"cpf" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "cpm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10094,6 +10151,19 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
+"cqg" = (
+/obj/structure/table,
+/obj/item/electronics/apc,
+/obj/item/electronics/firealarm{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/electronics/firelock,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cqi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -10147,10 +10217,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"crk" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "crm" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office/dark,
@@ -10174,6 +10240,15 @@
 /obj/machinery/vending/gifts,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cse" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "csn" = (
 /obj/structure/chair{
 	dir = 8
@@ -10186,6 +10261,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"csp" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 1;
+	name = "CE Office APC";
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "csy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -10205,18 +10298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cte" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Engineering Delivery";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ctm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -10467,6 +10548,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"cyj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "cyl" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
@@ -10565,26 +10652,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"czV" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "czY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -10749,6 +10816,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cBJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cCg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -11052,6 +11134,14 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"cHX" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "cIa" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11092,6 +11182,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cID" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/engine/foyer)
 "cIE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -11219,16 +11313,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cLV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cLY" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -11540,12 +11624,13 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
-"cQX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+"cQR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -11560,12 +11645,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"cRg" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cRN" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -11595,21 +11674,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"cSe" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cSt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/stand_clear/white,
@@ -11648,14 +11712,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/starboard/aft)
-"cSZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cTi" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8;
@@ -11870,13 +11926,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cWR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cWU" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
@@ -12002,6 +12051,19 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"cYN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cZb" = (
 /obj/machinery/light{
 	dir = 1
@@ -12180,6 +12242,15 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
+"dcD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "dcK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armoury";
@@ -12212,35 +12283,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"ddd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "ddn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ddz" = (
-/mob/living/simple_animal/cockroach,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ddB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -12324,23 +12372,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dfg" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/light{
+"dfm" = (
+/obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "dfp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -12385,19 +12422,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"dfI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dgv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -12510,6 +12534,28 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"dhY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"die" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dix" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -12596,17 +12642,21 @@
 "dki" = (
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"dkm" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
+"dkB" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/area/crew_quarters/heads/chief)
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dkJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -12756,20 +12806,6 @@
 /obj/item/pen,
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
-"dnP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dnZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -13286,11 +13322,28 @@
 	dir = 8
 	},
 /area/crew_quarters/heads/chief)
+"dzM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dzR" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/reagent_containers/food/snacks/egg,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
+"dAa" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dAc" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/firedoor/border_only{
@@ -13318,6 +13371,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"dAy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Medical";
+	location = "Engineering";
+	name = "engineering navigation beacon"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dAN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13359,6 +13432,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"dCb" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dCg" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -13494,12 +13576,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"dFn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dFu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -13559,6 +13635,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dGD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "dGM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13574,22 +13660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"dGO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "dHk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13769,15 +13839,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"dKp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dKB" = (
 /obj/machinery/power/smes/engineering{
 	charge = 6e+007
@@ -14035,6 +14096,24 @@
 /area/security/prison)
 "dPn" = (
 /obj/item/flashlight/flare/signal,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"dPt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Engineering Delivery";
+	req_access_txt = "10"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dPy" = (
@@ -14825,18 +14904,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
-"edx" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "edA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14873,13 +14940,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"eeg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eem" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15002,13 +15062,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ega" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "ego" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/showroomfloor,
@@ -15329,23 +15382,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"elN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"elQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "emc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -15931,24 +15967,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ewa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ewc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
@@ -16259,6 +16277,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"eCj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "eCo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -16307,15 +16339,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"eCU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/modular_computer/console/preset/command/ce{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/chief)
 "eCV" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -16381,6 +16404,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"eEz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/heads/chief)
 "eEH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -16391,6 +16437,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"eFa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "eFb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16633,19 +16694,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eJd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eJp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -16890,14 +16938,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eMo" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eMs" = (
 /obj/machinery/papershredder,
 /obj/machinery/camera{
@@ -16935,6 +16975,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"eMP" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "eMS" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -16977,16 +17029,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"eOt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "eOS" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17296,16 +17338,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"eUj" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "eUk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17571,16 +17603,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"fav" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "faH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -17668,6 +17690,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"fcF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -7;
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 7;
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fcG" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -17881,14 +17917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"feQ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "feZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -17912,13 +17940,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ffy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ffE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -17997,23 +18018,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/space/nearstation)
-"fgx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 4;
-	name = "CE Office APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/heads/chief)
 "fgM" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -18226,13 +18230,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"fjq" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "fjL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18313,6 +18310,14 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fle" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "flf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -18540,6 +18545,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fpZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fqa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18554,27 +18565,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"fqt" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 1;
-	freq = 1400;
-	location = "Engineering"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "fqz" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -18640,17 +18630,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
-"frJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "fsd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -18663,12 +18642,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"fso" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fsA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -18778,6 +18751,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fva" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fvf" = (
 /obj/item/bikehorn/rubberducky,
 /obj/machinery/light/small{
@@ -18885,16 +18868,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"fxs" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "fxw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -18985,6 +18958,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fyX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fzb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -19341,13 +19321,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fFO" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
 "fFP" = (
 /turf/closed/wall,
 /area/maintenance/central)
@@ -19424,6 +19397,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fHr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fHD" = (
 /obj/machinery/light{
 	dir = 1
@@ -19468,6 +19453,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fIs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fIS" = (
 /obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/plasteel/freezer,
@@ -19571,6 +19563,16 @@
 "fLl" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"fLo" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering West";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fLC" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -19732,6 +19734,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fOJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/clipboard,
+/obj/item/paper/monitorkey,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "fOX" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -19880,6 +19896,17 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
+"fQZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Engineering Access";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fRn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20056,16 +20083,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"fTt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fTy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20108,6 +20125,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"fTX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "fUb" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office A";
@@ -20121,22 +20151,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/vacant_room)
-"fUi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/closet/secure_closet/engineering_chief,
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "fUp" = (
 /obj/structure/chair{
 	dir = 8;
@@ -20230,14 +20244,6 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"fWk" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "fWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -20599,6 +20605,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
+"gct" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gcC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
@@ -20627,13 +20642,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gdg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gdp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -20682,6 +20690,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"gdX" = (
+/obj/machinery/computer/station_alert,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
@@ -20728,14 +20743,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"geE" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "geG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -20756,22 +20763,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"gfj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/crew_quarters/heads/chief)
 "gfx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21187,6 +21178,19 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
+"gmW" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gng" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -21394,6 +21398,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"grt" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gry" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -21432,12 +21446,6 @@
 	dir = 8
 	},
 /area/science/xenobiology)
-"gsw" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
 "gsy" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -21618,10 +21626,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"gwx" = (
-/obj/machinery/computer/station_alert,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gwC" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/cardhand{
@@ -21850,6 +21854,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"gzH" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/glass/plasma,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gzN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -21967,6 +21978,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gBr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gBu" = (
 /obj/machinery/light{
 	dir = 1
@@ -22314,6 +22337,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"gHr" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "gHV" = (
 /obj/machinery/camera{
 	c_tag = "Patient Room 1";
@@ -22334,28 +22361,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
-"gIi" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gIn" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -23000,6 +23005,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"gSW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gTd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -23156,17 +23176,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"gWY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "gXg" = (
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plasteel,
@@ -23663,13 +23672,6 @@
 	},
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
-"hgU" = (
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "hhi" = (
 /obj/structure/table/wood,
 /obj/item/seeds/tower{
@@ -23865,17 +23867,6 @@
 /obj/item/deskbell/preset/kitchen,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"hjm" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "hjo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/gloves,
@@ -24191,19 +24182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
-"hnZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hoj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -24270,10 +24248,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"hoQ" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "hoR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -24310,12 +24284,6 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/secondary/exit)
-"hpa" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "hpr" = (
 /turf/closed/indestructible/riveted,
 /area/ruin/space/has_grav/listeningstation)
@@ -24533,12 +24501,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/explab)
-"hsl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hsp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -24583,6 +24545,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hsw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hsL" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt2";
@@ -24718,6 +24705,25 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"hvl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "hvA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -25054,18 +25060,6 @@
 	name = "Ice Sheet"
 	},
 /area/space/nearstation)
-"hAW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"hBt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hBu" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -25431,12 +25425,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hHg" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "hHn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25591,6 +25579,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hKu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hKz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -25951,6 +25945,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hQP" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hRk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -26038,6 +26045,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"hSz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hSC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -26059,12 +26074,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"hSL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hTa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -26116,6 +26125,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"hTN" = (
+/obj/effect/decal/cleanable/glass,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hTV" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/service";
@@ -26168,6 +26184,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hUL" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hUM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -26308,6 +26331,40 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
+"hYl" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"hYt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hYM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -26353,12 +26410,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hZl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "hZo" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -27021,18 +27072,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"ilp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ilt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27055,28 +27094,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ilG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Vacant Office Maint";
-	req_access_txt = "32"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/vacant_room)
 "imc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27127,18 +27144,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"imW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "imY" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -27350,6 +27355,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"irS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "isf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -27448,20 +27470,21 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/science/mixing)
-"itH" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "iua" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iuh" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iul" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -27684,21 +27707,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
-"ixk" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "ixo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -27831,17 +27839,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iAi" = (
-/obj/structure/closet/secure_closet/security/engine,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "iAo" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -27936,19 +27933,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"iCi" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "iCn" = (
 /obj/effect/turf_decal/tile/black{
 	dir = 4
@@ -28055,6 +28039,16 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"iFM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iFS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -28074,24 +28068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"iGy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/firstsingularity{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iGC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -28127,19 +28103,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iHv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "iHx" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West 2";
@@ -28243,6 +28206,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"iJh" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "iJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -28527,6 +28499,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"iOJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iPe" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel{
@@ -28939,18 +28916,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"iWK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "iWR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -29114,6 +29079,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"iZv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "iZD" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -29194,6 +29177,16 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"jaf" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jag" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -29541,6 +29534,18 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"jdA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jdG" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -29818,10 +29823,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"jhs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jhw" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -30039,18 +30040,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"jkx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "jky" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -30109,17 +30098,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"jkS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "jkV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -30296,6 +30274,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"joq" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "joF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
@@ -30310,6 +30297,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"jpa" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jpg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30362,6 +30360,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"jqs" = (
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "jqA" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos_distro)
@@ -30570,13 +30572,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"juM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "juN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -31051,47 +31046,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"jDp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -8;
-	pixel_y = 39;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -8;
-	pixel_y = 26;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 7;
-	pixel_y = 26;
-	req_access_txt = "24"
-	},
-/obj/machinery/button/door{
-	id = "ceprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 7;
-	pixel_y = 39
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "jDw" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -31104,10 +31058,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jDC" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/engine/foyer)
 "jDJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -31260,6 +31210,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"jFD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "jFM" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -31269,13 +31229,6 @@
 "jGe" = (
 /turf/template_noop,
 /area/maintenance/starboard)
-"jGn" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/machinery/lapvend,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
 "jGN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -31398,6 +31351,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"jIO" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jIR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31485,6 +31442,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"jKI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jKV" = (
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
@@ -31495,16 +31458,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"jLc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jLj" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
+"jLp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jLz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/royalblack,
@@ -31550,6 +31514,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"jMp" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "jMt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31565,6 +31542,19 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"jMR" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jNi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -31622,6 +31612,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"jOs" = (
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jOv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/sheep,
@@ -31772,6 +31769,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"jQR" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jQV" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/cockroach,
@@ -31840,15 +31843,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"jRJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "jRR" = (
 /obj/structure/showcase/machinery/tv,
 /obj/structure/table/wood,
@@ -31917,13 +31911,6 @@
 /obj/item/toy/spinningtoy,
 /turf/open/floor/fakespace,
 /area/maintenance/port/fore)
-"jTg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "jTt" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31993,21 +31980,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"jUp" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jUr" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -32032,6 +32004,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jVe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jVp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light,
@@ -32124,33 +32105,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jWA" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "jWJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/fancy/donut_box,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"jWK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jXg" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -32207,6 +32166,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jXR" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jXS" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
@@ -32545,12 +32508,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"kfQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "kfX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -32711,6 +32668,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"khf" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_one_access_txt = "10;61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "khq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32825,19 +32795,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"kkX" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "klf" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
 /obj/structure/table,
@@ -32959,6 +32916,25 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"knn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kns" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -33046,16 +33022,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"kok" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "koH" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -33152,6 +33118,20 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kpV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kqr" = (
 /obj/item/radio/off,
 /turf/open/floor/plasteel/dark,
@@ -33210,6 +33190,18 @@
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"krp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/modular_computer/console/preset/command/ce{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "krq" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -33452,14 +33444,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kvl" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "kvo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -33487,6 +33471,15 @@
 /mob/living/simple_animal/hostile/glockroach,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"kvW" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "kwj" = (
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
@@ -33728,17 +33721,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos_distro)
-"kBn" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/machinery/camera{
-	c_tag = "Engineering North"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "kBW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34062,6 +34044,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kGZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kHg" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -34123,13 +34112,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"kIa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "kIj" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -34161,6 +34143,15 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kIv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "kIA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -34350,17 +34341,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"kMY" = (
-/obj/machinery/computer/apc_control{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "kNk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -34477,10 +34457,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"kQC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "kQI" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -34576,6 +34552,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"kSc" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	name = "Engineering Security APC";
+	pixel_y = -23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "kSF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -34685,10 +34678,6 @@
 /obj/item/soap,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"kUo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/foyer)
 "kUp" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -34800,6 +34789,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"kWo" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kWz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -34858,13 +34856,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"kXu" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "kXE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -35573,13 +35564,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"loK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "loY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35681,6 +35665,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"lrr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lrM" = (
 /obj/machinery/light{
 	dir = 4
@@ -35758,18 +35754,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ltf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "ltl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -35817,18 +35801,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
-"ltQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "ltS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35864,6 +35836,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lur" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "luy" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -36132,6 +36110,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"lyK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/suit_storage_unit/ce,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36484,16 +36474,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"lHk" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/item/twohanded/rcl/pre_loaded,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/heads/chief)
 "lIp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -36699,6 +36679,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lLz" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "lLR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36928,22 +36919,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"lOb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "lOu" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/royalblack,
@@ -36990,6 +36965,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"lPh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lPj" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -37281,6 +37260,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/grass,
 /area/quartermaster/office)
+"lTU" = (
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lUc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
@@ -37332,6 +37322,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lUZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall,
+/area/engine/engineering)
 "lVv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -37480,14 +37476,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lYs" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/wood,
-/area/hallway/primary/starboard)
 "lYD" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -37534,16 +37522,6 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
-"lZt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lZC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -37683,6 +37661,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"maT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -38336,10 +38329,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"mmN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mmV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -39007,6 +38996,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"myA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "myR" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
@@ -39055,6 +39057,15 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"mzz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mzH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -39192,13 +39203,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"mBW" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "mCf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -39490,16 +39494,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"mHp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "mHs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -39578,6 +39572,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"mIn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "mIo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/showroomfloor,
@@ -39619,20 +39620,6 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
-"mJj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 1
-	},
 /area/engine/engineering)
 "mJq" = (
 /obj/structure/cable{
@@ -40069,11 +40056,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"mQb" = (
-/mob/living/simple_animal/cockroach,
-/obj/effect/decal/cleanable/glass/plasma,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mQc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40256,28 +40238,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mSi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mTb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -40420,6 +40380,13 @@
 /obj/effect/turf_decal/pool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"mVl" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "mVu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40572,6 +40539,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mXg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mXo" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -41102,6 +41073,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ndZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "neg" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5
@@ -41124,6 +41105,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"neQ" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "neY" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -41199,24 +41186,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
-"ngB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ngM" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/plasteel,
@@ -41263,14 +41232,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"nhS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nik" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"niA" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "niB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41424,6 +41398,15 @@
 "nks" = (
 /turf/closed/wall,
 /area/storage/primary)
+"nkM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nkP" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -41501,10 +41484,6 @@
 /obj/machinery/vending/fishing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"nlK" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/wood,
-/area/hallway/primary/starboard)
 "nlP" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -41597,6 +41576,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nnB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nnF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -41716,13 +41711,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
-"npV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nqc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41835,12 +41823,6 @@
 "nru" = (
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
-"nrA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nrL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -41937,6 +41919,14 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nsi" = (
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
 "nst" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -42022,23 +42012,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nuM" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "nuQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -42187,6 +42160,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"nwN" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nwZ" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -42357,6 +42342,12 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered)
+"nzP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "nzW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42829,17 +42820,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nHR" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nIi" = (
 /obj/structure/table/reinforced,
 /obj/item/coin/iron{
@@ -42878,18 +42858,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nIT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "nJl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -43007,10 +42975,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"nLB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "nLG" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel/dark,
@@ -43141,6 +43105,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nOg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nOn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43301,6 +43277,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"nRa" = (
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = 32;
+	pixel_y = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "nRs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43658,6 +43648,13 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"nVU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/field/generator,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nVY" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -43824,23 +43821,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"nZo" = (
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = 32;
-	pixel_y = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "nZw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -43957,10 +43937,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"obt" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "obx" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/window/reinforced{
@@ -43985,6 +43961,27 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"obF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/firstsingularity{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "obQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -44098,24 +44095,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"odw" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "odK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44390,26 +44369,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"ojg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "ojt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Research Division";
@@ -44429,10 +44388,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ojB" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/hallway/primary/starboard)
 "ojF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -44583,24 +44538,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"omg" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+"omj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/crew_quarters/heads/chief)
 "omv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"omJ" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass/plasma,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "omW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -44769,33 +44739,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
-"oqe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "oqD" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"oqJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "oqQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44960,6 +44909,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/starboard)
+"ots" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "ott" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -45020,27 +44973,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
-"ouO" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "ouR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -45410,17 +45342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oCy" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oCN" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck"
@@ -45811,6 +45732,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"oIA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "oIE" = (
 /obj/machinery/light{
 	dir = 8
@@ -45851,18 +45792,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"oJw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oJQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45969,18 +45898,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oMd" = (
-/obj/machinery/power/smes/engineering{
-	output_attempt = 0
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oMh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/lapvend,
@@ -46122,10 +46039,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"oOf" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "oOl" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/light,
@@ -46185,6 +46098,26 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oQc" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/pill/patch/silver_sulf,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "oQd" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -46439,24 +46372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"oTz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "oTC" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -46631,12 +46546,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"oWK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "oWS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46715,6 +46624,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"oZh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "oZi" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -46890,15 +46806,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"pbB" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pbC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47113,6 +47020,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"peF" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "peP" = (
 /mob/living/simple_animal/hostile/retaliate/dolphin/manatee,
 /turf/open/space/basic,
@@ -47142,6 +47074,16 @@
 "pfc" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"pfg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/camera{
+	c_tag = "Engineering North"
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "pfh" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -47241,18 +47183,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"phh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "phj" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -47557,16 +47487,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"pnh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "pnm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47802,6 +47722,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ppQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ppT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -47838,6 +47773,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"pqA" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "pqX" = (
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -48038,23 +47982,6 @@
 /obj/item/chair/stool,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
-"puj" = (
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("engine");
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "pul" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -48229,10 +48156,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"pxA" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pxD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48497,6 +48420,24 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"pAZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "pBl" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -48709,6 +48650,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
+"pFQ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pFT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -48909,6 +48859,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"pIs" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/rods/fifty,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "pIz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48943,24 +48907,6 @@
 /mob/living/simple_animal/hostile/russian,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"pIT" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
-	name = "engineering camera";
-	network = list("ss13","engine")
-	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_y = 23
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pJh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -49028,6 +48974,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"pJZ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
 "pKa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -49538,6 +49494,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pRm" = (
+/obj/structure/chair/office/light,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "pRM" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -49558,17 +49521,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"pSm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "pSo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49788,14 +49740,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"pUU" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "pVb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -49870,6 +49814,24 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"pVW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pWj" = (
 /obj/machinery/light{
 	dir = 4
@@ -50068,6 +50030,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"pYp" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "pYC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -50112,12 +50082,6 @@
 "pZo" = (
 /turf/closed/wall/rust,
 /area/space/nearstation)
-"pZu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pZL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -50129,6 +50093,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pZN" = (
+/obj/machinery/power/smes/engineering{
+	output_attempt = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pZT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
@@ -50210,6 +50189,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/secondarydatacore)
+"qbe" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light_switch{
+	pixel_y = -27
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
+"qbj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qbl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -50279,12 +50282,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"qcO" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+"qcV" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/foyer)
 "qcX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -50497,21 +50501,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"qgc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "qgi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -50555,6 +50544,16 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"qhl" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
 "qhs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -50783,6 +50782,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"qmj" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qmk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50802,27 +50808,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qmt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"qmB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qmF" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -50917,24 +50902,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"qnO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "qnV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
@@ -51240,6 +51207,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"qtt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qtF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -51320,20 +51294,25 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"quE" = (
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/heads/chief)
 "quG" = (
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"quP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "quS" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -51816,6 +51795,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"qDT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qDZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -51938,12 +51927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qFQ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "qGm" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -52119,26 +52102,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"qIB" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"qID" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "qIJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -52374,6 +52337,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"qNR" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qNW" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -52469,12 +52438,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"qPb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qPl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -52701,6 +52664,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qTL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qTR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -52742,6 +52717,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qVg" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
 "qVm" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -52756,13 +52738,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qVt" = (
-/obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "qVG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52788,15 +52763,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"qVI" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "qVL" = (
 /turf/closed/mineral/random/low_chance_air,
 /area/maintenance/port)
@@ -53327,6 +53293,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rdK" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Vacant Office Maint";
+	req_access_txt = "32"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/vacant_room)
 "rdW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -53482,15 +53470,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"rgj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rgq" = (
 /obj/machinery/light{
 	dir = 8
@@ -53717,6 +53696,30 @@
 /obj/structure/displaycase/cmo,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"rkJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 1;
+	freq = 1400;
+	location = "Engineering"
+	},
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rkL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54003,12 +54006,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"roJ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "roK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -54079,6 +54076,44 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"rpS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -8;
+	pixel_y = 39;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = -8;
+	pixel_y = 26;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 7;
+	pixel_y = 26;
+	req_access_txt = "24"
+	},
+/obj/machinery/button/door{
+	id = "ceprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "rqp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -54108,27 +54143,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"rqG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "rqK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -54190,16 +54204,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"rrS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "rsh" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -54405,21 +54409,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"ruL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ruM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/grille/broken,
@@ -54850,16 +54839,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"rBO" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rBT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54884,24 +54863,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"rCK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "rDe" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -54927,6 +54888,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rDv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"rDw" = (
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"rDJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rDM" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -55217,15 +55202,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"rHq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rHu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55241,6 +55217,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rHy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rHK" = (
 /obj/structure/chair{
 	dir = 4
@@ -55281,6 +55267,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"rJw" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rJC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -55328,12 +55324,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"rKN" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "rLv" = (
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -55447,17 +55437,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"rNw" = (
-/obj/effect/decal/cleanable/glass/plasma,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "rNE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -55467,21 +55446,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"rNW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+"rNV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/engine/engineering)
+"rOe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rOt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -55533,6 +55529,11 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rPf" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/foyer)
 "rPh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/pool{
@@ -55724,6 +55725,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"rRA" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Storage";
+	name = "engineering camera";
+	network = list("ss13","engine")
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engine/engineering";
+	dir = 1;
+	name = "Engineering APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rRV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -55814,6 +55832,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"rTI" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rTM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -55825,28 +55852,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rTX" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "rUg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"rUl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rUv" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -55882,6 +55893,25 @@
 /obj/item/toy/figure/captain,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"rUV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/item/cartridge/engineering{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/cartridge/engineering{
+	pixel_x = 8
+	},
+/obj/item/cartridge/atmos,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "rVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -55955,26 +55985,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"rVT" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/twohanded/rcl/pre_loaded,
-/obj/item/stack/cable_coil,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"rVU" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rVZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -56264,6 +56274,10 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/secondary/exit)
+"rZz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rZG" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating/airless{
@@ -56313,18 +56327,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"saP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/machinery/computer/atmos_alert{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "saZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -56411,14 +56413,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"scj" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "sck" = (
 /obj/machinery/light{
 	dir = 1
@@ -56465,6 +56459,22 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"scv" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"scw" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "scx" = (
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8;
@@ -56544,24 +56554,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"sdE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sdO" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 17
@@ -56570,6 +56562,22 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"sdR" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sdZ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56581,16 +56589,6 @@
 	},
 /turf/closed/mineral/random/low_chance_air,
 /area/space/nearstation)
-"sej" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "sek" = (
 /obj/machinery/door/window/westright,
 /obj/structure/table/reinforced,
@@ -56847,10 +56845,6 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
-"slg" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -56974,6 +56968,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"sod" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "son" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -57162,18 +57160,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"srK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "srR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -57530,10 +57516,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"sxN" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sxT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -57605,6 +57587,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"szs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "szt" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/bait/apprentice,
@@ -57648,16 +57637,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"sAK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sAV" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel{
@@ -57929,6 +57908,18 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"sFQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sFR" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -57998,14 +57989,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sHd" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "sHg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -58277,6 +58260,13 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/clerk)
+"sLf" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sLu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -58582,13 +58572,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
-"sPy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sPG" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
@@ -58602,22 +58585,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"sPS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/obj/item/clipboard,
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel/white/corner,
-/area/crew_quarters/heads/chief)
 "sPZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58776,6 +58743,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"sSu" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58928,6 +58906,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"sVk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sVr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
@@ -58955,27 +58945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"sVC" = (
-/obj/structure/filingcabinet,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"sVU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sWf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59158,6 +59127,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"sZg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sZi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -59286,6 +59261,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tbh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tbk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59300,6 +59282,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"tbv" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/foyer)
 "tbM" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -59330,25 +59319,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"tcg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tct" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"tcz" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "tcG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -59448,19 +59436,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tef" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "tej" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59584,13 +59559,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"tge" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tgg" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/assistant,
@@ -59634,18 +59602,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"tgT" = (
-/obj/structure/sign/poster/official/work_for_a_future{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tgX" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
@@ -59750,6 +59706,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tit" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"tiu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/foyer)
 "tiz" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -59776,6 +59763,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"tiK" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/foyer";
+	dir = 8;
+	name = "Engineering Foyer APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "tjc" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -59793,15 +59798,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"tjX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "tkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -59813,6 +59809,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tkw" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tkI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -60057,6 +60060,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"toS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "toT" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -60231,6 +60246,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ttp" = (
+/obj/structure/filingcabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "ttD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -60299,6 +60319,11 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"tuG" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tuJ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60586,13 +60611,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"tzi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "tzn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -61181,6 +61199,13 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"tJJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tJN" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plasteel{
@@ -61544,15 +61569,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"tRe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "tRA" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -62042,19 +62058,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ubq" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "ubw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -62062,14 +62065,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"ubI" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ubJ" = (
 /mob/living/carbon/monkey,
 /obj/item/reagent_containers/food/snacks/grown/banana{
@@ -62221,15 +62216,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"uek" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uer" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62340,6 +62326,13 @@
 "ufK" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
+"ufN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ufS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -62372,6 +62365,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"uhk" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uhv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
@@ -62394,6 +62396,16 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"uhS" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uhV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -62452,6 +62464,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"uiI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/wideplating/corner,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "uiU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -62948,6 +62992,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"urH" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10;
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/chief)
 "urY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -63027,16 +63088,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"utp" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uty" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -63103,23 +63154,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uuj" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "uun" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/hydroponicsguide{
@@ -63155,18 +63189,6 @@
 /obj/item/pickaxe/mini,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"uuy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uuB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -63184,13 +63206,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"uvA" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uvM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -63233,6 +63248,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"uxM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "uxS" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -63321,6 +63350,21 @@
 /obj/effect/spawner/structure/window/reinforced/tinted/shutter,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"uyV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -63736,6 +63780,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
+"uDr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uDy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63773,19 +63831,6 @@
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
-"uEO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Engineering Desk";
-	req_access_txt = "10"
-	},
-/obj/item/deskbell/preset/engi{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/engine/foyer)
 "uFl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -63854,6 +63899,24 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uGg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uGh" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -64160,6 +64223,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uMl" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uMm" = (
 /obj/structure/rack,
 /obj/item/latexballon,
@@ -64207,16 +64276,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"uNt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uNI" = (
 /obj/structure/toilet_bong{
 	flags_1 = 128
@@ -64404,12 +64463,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"uRe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "uRg" = (
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -64485,12 +64538,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"uTw" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uTB" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -64509,6 +64556,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"uUB" = (
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("engine");
+	pixel_x = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "uVl" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -64642,13 +64703,6 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"uXf" = (
-/obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uXo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64670,6 +64724,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uXx" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "uXQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64939,13 +65001,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
-"vcq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vct" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -65319,6 +65374,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"vkj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vkl" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
@@ -65368,17 +65431,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vli" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "vlm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -65437,19 +65489,6 @@
 /obj/item/toy/figure/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
-"vmW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "vmX" = (
 /obj/machinery/light{
 	dir = 4
@@ -65528,21 +65567,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"vpv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"vpj" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vpN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -65568,6 +65599,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vql" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/crew_quarters/heads/chief)
 "vqC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65709,6 +65750,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"vsN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/chief)
 "vsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -66054,6 +66113,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"vxW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vyc" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -66220,6 +66294,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"vCu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vCI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -66287,24 +66365,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/ruin/powered)
-"vEg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	name = "Engineering Security APC";
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "vEi" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -66489,6 +66549,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vHx" = (
+/obj/machinery/computer/atmos_alert,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vHF" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
@@ -66500,6 +66567,12 @@
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"vId" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "vIG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66514,6 +66587,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"vIH" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_one_access_txt = "10;61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vIX" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
@@ -66895,39 +66986,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"vND" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vNJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vNU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vNX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66993,24 +67057,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"vPg" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/poster/firstsingularity,
-/obj/item/poster/random_official{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/item/flashlight,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "vPC" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -67033,13 +67079,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"vPO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vPP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -67450,15 +67489,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vXl" = (
-/obj/structure/window/reinforced/tinted{
+"vXp" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vXF" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -67557,17 +67596,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
-"vZy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Engineering Access";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vZC" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
@@ -67675,15 +67703,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wbk" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wbq" = (
 /obj/structure/table/wood,
 /obj/item/toy/toygrenade{
@@ -67870,14 +67889,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"wew" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = 32
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wey" = (
 /obj/structure/statue/silver/secborg,
 /obj/structure/window/reinforced{
@@ -68073,32 +68084,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"whx" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_access_txt = "63"
+"whl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/area/engine/engineering)
 "whA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -68261,17 +68257,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wkT" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wkY" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -68814,6 +68799,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"wuG" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wuJ" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
@@ -68975,6 +68964,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"wzi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wzw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -69175,6 +69179,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"wBx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wBL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -69272,6 +69292,16 @@
 "wCY" = (
 /turf/closed/wall,
 /area/maintenance/department/tcoms)
+"wDa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/foyer)
 "wDs" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
@@ -69464,6 +69494,13 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"wFY" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wGs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 1
@@ -69485,14 +69522,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wHc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+"wHu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wHG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -69658,6 +69693,15 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
+"wJA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wJE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -69942,13 +69986,6 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"wOt" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "wOz" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -70009,6 +70046,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wPL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "atmospherics sorting disposal pipe";
+	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wPR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -70138,6 +70193,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
+"wSk" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wSF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -70684,6 +70747,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xaE" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_access_txt = "63"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "xaT" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
@@ -70729,23 +70814,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"xbU" = (
+"xbE" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/item/clothing/glasses/meson{
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/head/welding{
+	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/white/corner{
+/obj/item/poster/firstsingularity,
+/obj/effect/turf_decal/siding/wideplating{
 	dir = 1
 	},
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel/dark,
+/area/engine/foyer)
 "xcx" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -70976,6 +71057,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xfS" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/poster/firstsingularity,
+/obj/item/poster/random_official{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/flashlight,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "xfT" = (
 /mob/living/simple_animal/hostile/bear/russian,
 /turf/open/floor/grass/snow/safe,
@@ -71011,13 +71109,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"xgC" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xgD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -71056,29 +71147,6 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"xhy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Medical";
-	location = "Engineering";
-	name = "engineering navigation beacon"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "xhF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -71716,21 +71784,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xuJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/foyer";
-	dir = 8;
-	name = "Engineering Foyer APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xuL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -72370,6 +72423,17 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"xGC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = 32
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xGF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -72591,6 +72655,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"xKl" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xKy" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -72682,19 +72754,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"xLj" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "xLp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72848,18 +72907,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xNx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xNz" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -73004,16 +73051,14 @@
 /turf/open/floor/carpet,
 /area/library)
 "xQN" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xQV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -73097,6 +73142,22 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xRY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xSa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -73206,18 +73267,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xUZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_middle,
-/area/engine/engineering)
 "xVq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -73425,6 +73474,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"xXN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xYb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -73486,21 +73544,6 @@
 /obj/item/cartridge/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"xZc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering West";
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "xZB" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -73920,6 +73963,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"yhR" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "yia" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -74057,14 +74112,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ylj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ylM" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -113266,7 +113313,7 @@ aZH
 amx
 amx
 amx
-ilG
+rdK
 amx
 amx
 amx
@@ -113816,10 +113863,10 @@ aiZ
 aiZ
 jJp
 aiZ
-xhy
-cWR
-ubq
-hpa
+dAy
+vCu
+qop
+aHh
 wgj
 agn
 aAA
@@ -114070,13 +114117,13 @@ bJJ
 bOv
 bOv
 bOv
-iWK
+uyV
 pyH
-nIT
-frJ
-loK
+bOv
+qbj
+uhS
 afp
-ckU
+aHh
 aoJ
 agn
 agn
@@ -114324,25 +114371,25 @@ aJq
 aJq
 aJq
 aJq
+tiu
 aJq
-ojB
-nlK
-lYs
-aav
-jTg
-caJ
-rUl
-afp
-cRg
-lUD
-rTX
-rTX
-rTX
-rTX
-rTX
-vXl
-lUD
-ega
+aJq
+aJq
+aJq
+tbv
+uiI
+rPf
+ahe
+aHh
+aHh
+gct
+gct
+gct
+gct
+gct
+jQR
+aHh
+eMv
 aoJ
 aHh
 aHh
@@ -114578,18 +114625,18 @@ aXb
 oBq
 oBq
 ahe
-fWk
-omg
-vli
-aJq
-aJq
-aJq
-aJq
-aJq
-hsl
-caJ
-rUl
-afp
+xKl
+cHX
+lLz
+xQN
+hsw
+tiK
+qcV
+hYl
+sLf
+pAZ
+qbe
+ahe
 hFp
 gMy
 aFk
@@ -114599,12 +114646,12 @@ aFk
 iRo
 aoJ
 aHh
-ckU
+aHh
 hFp
-roJ
-lUD
-mHp
-ltQ
+aHh
+aHh
+iam
+bPc
 pYX
 kxk
 pYX
@@ -114837,16 +114884,16 @@ mzH
 ahe
 xDb
 ayk
-oqJ
-oWK
-phh
-xuJ
-qVI
-kUo
-hsl
-caJ
-rUl
-afp
+sZg
+kIv
+dfm
+dGD
+dfm
+dfm
+dfm
+wPL
+xbE
+ahe
 aHh
 iwt
 aFk
@@ -114856,12 +114903,12 @@ aFk
 aFk
 aoJ
 ogK
-cRg
-lUD
-rKN
+aHh
+aHh
+aHh
 pNr
 aoJ
-bzC
+bPc
 aHh
 wYf
 aHh
@@ -115093,17 +115140,17 @@ xfC
 hif
 jYe
 pbm
-rCK
-jkS
-tRe
-gWY
-ouO
-pnh
-nuM
-uuy
-rNW
-qPb
-afp
+fHr
+dhY
+bco
+jKI
+scw
+ayk
+ayk
+ayk
+sdR
+qhl
+ahe
 wMo
 fdq
 aFk
@@ -115118,7 +115165,7 @@ aoJ
 aoJ
 aoJ
 aoJ
-jRJ
+gBr
 waS
 lDV
 rth
@@ -115350,17 +115397,17 @@ pbV
 vXZ
 ahe
 biV
-lOb
-hSL
-qFQ
-hAW
-ccS
-mhV
-kUo
-hsl
-sxN
-kXu
-afp
+bAk
+wSk
+uXx
+fyX
+xRY
+eCj
+eCj
+eCj
+wBx
+qVg
+ahe
 aJj
 aJj
 aJj
@@ -115369,13 +115416,13 @@ aJj
 aJj
 aJj
 aJj
-oqe
-uRe
-uRe
-uRe
-oOf
-sej
-kfQ
+dkB
+cse
+cse
+cse
+cse
+tcg
+pqA
 agn
 agn
 agn
@@ -115607,17 +115654,17 @@ kZw
 aOd
 aOd
 aOd
-whx
+xaE
 aOd
 rEs
-kQC
-iHv
-bWZ
-uEO
-hsl
-aiZ
-kXu
-afp
+hKu
+fFj
+ayk
+ayk
+gHr
+mhV
+nsi
+ahe
 tYf
 tYf
 iom
@@ -115626,7 +115673,7 @@ wrl
 xgJ
 ruw
 aJj
-fqt
+rkJ
 aJj
 pwX
 aJj
@@ -115862,19 +115909,19 @@ rqK
 qHV
 vgW
 aOd
-uuj
-tcz
-dGO
+aXh
+aaB
+azv
 drR
 sQf
 ayk
 fFj
-elN
-aJq
-jGn
-gsw
-fFO
-afp
+ayk
+aIE
+cdm
+lml
+pJZ
+ahe
 tYf
 tYf
 ozg
@@ -115882,13 +115929,13 @@ wRS
 ozg
 oAU
 ruw
-aJj
-cte
-aJj
-dKp
-odw
-tgT
-imW
+lur
+dPt
+lUZ
+xXN
+pVW
+lrr
+nOg
 aqp
 aqp
 aqp
@@ -116119,33 +116166,33 @@ ooL
 aJF
 aJF
 drR
-itH
+ajC
 abS
-vmW
+azv
 drR
 kiL
-qFQ
+mVl
 fFj
+ayk
 pXS
 gLw
-ojg
+oIA
 mfI
-aPn
 aPn
 aJj
 bZf
-oAU
-ozg
-ozg
-ozg
-ruw
-aJj
-gIi
-dnP
-lZt
-kok
-sAK
-eJd
+gzH
+boH
+boH
+boH
+nVU
+awz
+peF
+irS
+bSj
+aAJ
+aAJ
+jMR
 aqp
 aqp
 aqp
@@ -116376,31 +116423,31 @@ ljF
 abc
 abc
 drR
-qVt
+aFv
 aNR
-vEg
+kSc
 aOd
 drR
-fxs
-sdE
-mhV
-vpv
-sPS
-kvl
-lHk
-ahh
-aPn
-aPn
-aJj
+joq
+iZv
+atD
+mIn
+hvl
+vql
+jMp
+lyK
+arb
+arb
+iJh
 aMk
 aMk
 aJj
 aJj
 aJj
-iGy
+obF
+fgX
 asO
-tsh
-ddz
+pdN
 pfc
 aqp
 aqp
@@ -116633,31 +116680,31 @@ ljF
 aPx
 aPx
 drR
-sVC
+ttp
 tQo
-jkx
-fjq
+dcD
+aJC
 drR
-tjX
+eMP
 fFj
+ayk
 mhV
-qnO
-jWA
-hHg
-aYF
-gfj
-kMY
-aPn
-oMd
-ubI
-xgC
-xZc
-feQ
-tzi
-ewa
-fso
-oCy
-auf
+eFa
+vId
+uxM
+bNW
+quE
+fTX
+pZN
+jpa
+alA
+fLo
+jXR
+uxT
+uGg
+asO
+jIO
+asO
 aqp
 aqp
 aqp
@@ -116890,31 +116937,31 @@ ljF
 aPp
 acT
 aOd
-ixk
-nZo
-puj
-iAi
+akc
+nRa
+uUB
+atU
 drR
-tef
-rqG
+hQP
+tit
+nzP
 lml
 aPn
-ltf
-aYF
-aYF
-crk
-eCU
-aPn
-pbB
-uNt
+aGk
+fOJ
+pRm
+krp
+fTX
+fIs
+rHy
 xeC
-mJj
+die
 ctX
 gSw
-vND
-sJB
-hBt
-tge
+rOe
+asO
+asO
+cfQ
 aqp
 aqp
 aqp
@@ -117152,26 +117199,26 @@ aOd
 aOd
 aOd
 aOd
-jDC
+cID
 jVA
-ahe
+khf
+wDa
 aPn
-jDp
-nLB
-wOt
+rpS
+rUV
 aYF
 wIk
 aPn
-pIT
-aLS
-saP
-ilp
-cdU
-aJj
+rRA
+qmj
+kvW
+rTI
+uhk
+uxT
 jXk
 asO
 asO
-uTw
+asO
 aqp
 aqp
 aqp
@@ -117407,28 +117454,28 @@ aTU
 aTU
 aTU
 aJj
-aJj
-quP
-vZy
+scv
+vkj
+fQZ
 pQu
+vRX
 rQj
 aPn
-fUi
+toS
+jFD
 ule
-edx
-iVY
-dkm
-qgc
+pIs
+fTX
 pSy
-rHq
+dzM
 jkI
-cpf
+rZz
 mAG
 uxT
 eyq
 asO
 cua
-uTw
+asO
 aqp
 aqp
 aqp
@@ -117664,28 +117711,28 @@ aBu
 aBu
 aTU
 aJj
-aJj
-fTt
+tkw
+rDv
 dbQ
 rHj
+asO
 sud
 aPn
-wHc
-hoQ
-oTz
-ule
-czV
-ddd
-slg
-qcO
-rNw
-eOt
-rrS
-kIa
-mSi
-nrA
-fgX
-vPO
+csp
+vsN
+iVY
+urH
+aPn
+hUL
+asO
+rDw
+tJJ
+qtt
+uxT
+knn
+asO
+asO
+lPh
 aqp
 aqp
 aqp
@@ -117921,28 +117968,28 @@ aBu
 aBu
 aTU
 aJj
-aJj
-pSm
+wuG
+rJw
 uAV
 aqU
+wHu
 uAV
 aPn
 dzz
-fgx
-aLz
-ahO
-xbU
-aPn
+eEz
+omj
+oQc
+fTX
 wjt
-rVT
+iuh
 exT
 nBx
 gHd
 uxT
 ucs
-bXD
+cma
 bJr
-eeg
+bnm
 aqp
 aqp
 aqp
@@ -118182,8 +118229,8 @@ aJj
 aJj
 pVi
 oEg
-aJj
-aPn
+vIH
+gSW
 aPn
 aPn
 cYf
@@ -118197,9 +118244,9 @@ aJj
 hAQ
 aJj
 jzc
-oNt
 asO
-ffy
+asO
+mXg
 aqp
 aqp
 aqp
@@ -118435,28 +118482,28 @@ aKe
 dvm
 aTU
 aJj
-aJj
-qmt
-npV
+wuG
+bZq
+hSz
 uaF
-juM
-srK
-xNx
-scj
+ndZ
+myA
+dqq
+lWz
 qfe
 sSd
 sUr
 kJr
-wkT
+cQR
 lWz
 fdm
 cfJ
 dqq
 xBe
 eHO
-sPy
+sod
 vSX
-eeg
+bnm
 aqp
 aqp
 aqp
@@ -118692,28 +118739,28 @@ aOL
 vtF
 ahN
 aJj
-aJj
-kBn
+pfg
+jqs
 cfQ
 lXQ
 mXv
 uZc
 eyp
-xUZ
+eyp
 bDH
 gxt
 dMP
-dfI
+uDr
 btx
 eyp
 bYq
 eyp
-fav
-nHR
-ngB
-jWK
-vNU
-ylj
+jdA
+bly
+ppQ
+asO
+asO
+iOJ
 aqp
 aqp
 aqp
@@ -118949,14 +118996,14 @@ wHG
 kSR
 hiX
 aJj
-hZl
-wbk
-wDS
+vpj
+pYp
+tuG
 wDS
 wDS
 ssp
 pIm
-iCi
+pIm
 jCM
 nvE
 vKg
@@ -118964,13 +119011,13 @@ lGS
 qew
 gkG
 mUV
-cLV
-cSZ
-uek
-qmB
-eMo
-jUp
-eeg
+kWo
+bjH
+whl
+wzi
+rDJ
+uMl
+bnm
 aqp
 aqp
 aqp
@@ -119213,21 +119260,21 @@ aYa
 aYa
 aYa
 aYa
-aJj
+aDu
 aAy
 aIh
 cdG
 aAy
 aAy
-mBW
-utp
-qID
-qID
-eUj
-sHd
-qIB
-cSe
-rgj
+jOs
+jaf
+uMl
+qTL
+vXp
+ozg
+cyj
+gmW
+fpZ
 aqp
 aqp
 aqp
@@ -119478,13 +119525,13 @@ vGn
 aAy
 aAy
 aVM
-rVU
-uxT
-uxT
-aVM
-dfg
-cSe
-uTw
+aNX
+rNV
+grt
+ozg
+hTN
+cqg
+asO
 aqp
 aqp
 aqp
@@ -119734,14 +119781,14 @@ qEr
 aAy
 aAy
 aAy
-gwx
-obt
+gdX
+oZh
+maT
+sSu
+ozg
+cyj
+nwN
 asO
-bEB
-uxT
-xLj
-cSe
-uTw
 aqp
 aqp
 aqp
@@ -119992,13 +120039,13 @@ nLg
 cIE
 aAy
 aKN
-geE
-cfQ
-elQ
-uxT
-kkX
-cSe
-uTw
+dAa
+maT
+niA
+ozg
+wFY
+yhR
+asO
 aqp
 aqp
 aqp
@@ -120248,14 +120295,14 @@ pvD
 sMq
 nwg
 aAy
-uXf
-dFn
+vHx
+szs
+maT
+iFM
+omJ
+lTU
+kGZ
 asO
-hjm
-aVM
-xQN
-cSe
-uTw
 aqp
 aqp
 aqp
@@ -120506,13 +120553,13 @@ xWo
 nYv
 aAy
 aVM
-jLc
-vRX
-fdm
-rBO
-cQX
-cSe
-uTw
+fcF
+cBJ
+qNR
+asO
+tsh
+asO
+asO
 aqp
 aqp
 aqp
@@ -120762,15 +120809,15 @@ osl
 xhX
 qcd
 aAy
-pUU
-bfV
-asO
-cua
-nhS
-gdg
-sVU
-bgx
-oJw
+ots
+qDT
+fle
+nnB
+hYt
+vxW
+sFQ
+sFQ
+sFQ
 aqp
 aqp
 aqp
@@ -121019,13 +121066,13 @@ atj
 fgM
 eRU
 aAy
-vPg
-pZu
-pdN
-asO
-pxA
+xfS
+mzz
+wJA
+qNR
+jLp
 tsh
-cSe
+asO
 asO
 asO
 aqp
@@ -121276,13 +121323,13 @@ jmq
 ldu
 fLl
 aAy
-uvA
-pZu
-asO
-mQb
-asO
-tsh
-ruL
+neQ
+nkM
+wJA
+ufN
+jVe
+dCb
+pFQ
 eFi
 coo
 aqp
@@ -121533,13 +121580,13 @@ aAy
 aAy
 aAy
 aAy
-hgU
+baA
 xNW
-asO
-jhs
-mmN
-vcq
-hnZ
+aVu
+tbh
+sVk
+cYN
+kpV
 ejt
 xNw
 gWo
@@ -121790,12 +121837,12 @@ phM
 fTh
 afF
 afF
-aVM
+aJj
 dLn
 sYl
 fzB
-wew
-blh
+xGC
+fva
 iLO
 mJf
 ufs

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -11458,6 +11458,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cNM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "cNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -12838,13 +12844,6 @@
 	},
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
-"dnb" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "dnH" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -13157,14 +13156,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dvX" = (
-/obj/structure/tank_dispenser,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dwf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -13445,6 +13436,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dAD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/camera{
+	c_tag = "Atmospherics South West";
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos_distro)
 "dAN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13763,6 +13771,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dHK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "dIa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -15876,6 +15893,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
+"etx" = (
+/obj/machinery/computer/station_alert{
+	dir = 1;
+	name = "Station Alert Console"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "etS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17083,15 +17108,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"ePl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "ePs" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -18450,6 +18466,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"fnI" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/ten,
+/obj/item/toy/figure/atmos,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fnN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -19215,13 +19245,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/morgue)
 "fDI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "fDQ" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -20460,8 +20493,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fZZ" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -26616,6 +26647,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Engine"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "ida" = (
@@ -27936,6 +27971,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"iBJ" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iBN" = (
 /obj/effect/overlay/palmtree_l{
 	pixel_y = 29
@@ -30426,6 +30478,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jrn" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "jrt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -30653,15 +30715,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jvV" = (
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -31608,14 +31666,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "jND" = (
-/obj/machinery/computer/station_alert{
-	dir = 1;
-	name = "Station Alert Console"
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jNN" = (
@@ -32414,14 +32467,8 @@
 /turf/open/floor/plating,
 /area/science/nanite)
 "kbK" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
@@ -33414,6 +33461,16 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"kty" = (
+/obj/machinery/computer/atmos_control{
+	dir = 1;
+	name = "Tank Monitor"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ktA" = (
 /obj/structure/window{
 	dir = 1
@@ -34607,20 +34664,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
-"kSR" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/camera{
-	c_tag = "Atmospherics South West";
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
 "kSV" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -34787,15 +34830,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/starboard/aft)
-"kVW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "kWb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
@@ -41739,6 +41773,13 @@
 	icon_state = "platingdmg2"
 	},
 /area/ruin/powered)
+"npS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "npT" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/bluespace,
@@ -42048,15 +42089,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"nuT" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "nuX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal/incinerator";
@@ -42573,6 +42605,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"nCY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "nDf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44422,6 +44461,15 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"ojJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "ojY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/sign/painting{
@@ -48470,26 +48518,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"pCg" = (
-/obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pCL" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel{
@@ -51543,23 +51571,6 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
-"qAW" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/ten,
-/obj/item/toy/figure/atmos,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qAX" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -53640,16 +53651,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"rjS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "rjT" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
@@ -55395,9 +55396,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "rNE" = (
@@ -55477,6 +55476,20 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rOU" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	name = "Atmospheric Alert Console"
+	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rPf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
@@ -56782,20 +56795,11 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "skT" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "skV" = (
@@ -56805,6 +56809,9 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "skY" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
@@ -56993,6 +57000,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"soA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "soS" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -62925,13 +62941,14 @@
 /turf/open/floor/wood,
 /area/vacant_room)
 "uqy" = (
-/obj/effect/turf_decal/siding/thinplating{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	layer = 2.4;
-	name = "Mix Outlet Pump"
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
@@ -63663,9 +63680,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "uBL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/engine/atmos_distro)
 "uCb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -68575,6 +68597,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"woS" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "woT" = (
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
@@ -68860,6 +68887,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wuj" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	layer = 2.4;
+	name = "Mix Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "wur" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -71325,17 +71366,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"xlq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "xlv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -117186,10 +117216,10 @@ aXb
 aXb
 ibo
 aXb
-oBq
+ojJ
 aXb
-aOd
-aOd
+aXb
+aXb
 aOd
 aOd
 aOd
@@ -117444,13 +117474,13 @@ rVc
 rcz
 tkI
 jvV
+kty
 aXb
 aTU
 aTU
 aTU
 aTU
 aTU
-aJj
 aJj
 vkj
 fQZ
@@ -117701,13 +117731,13 @@ xvy
 byo
 fZZ
 skT
+rOU
 aXb
 aTU
 aBu
 aBu
 aBu
 aTU
-aJj
 aJj
 rDv
 dbQ
@@ -117958,13 +117988,13 @@ wFA
 fOl
 aCQ
 jND
+etx
 aXb
 aTU
 aBu
 aBu
 aBu
 aTU
-aJj
 aJj
 rJw
 uAV
@@ -118214,14 +118244,14 @@ aXb
 fDQ
 hCJ
 qEC
-pCg
+jND
+iBJ
 aXb
 aTU
 aox
 aBu
 qui
 aTU
-aJj
 aJj
 aJj
 pVi
@@ -118471,14 +118501,14 @@ aXb
 dJx
 dyv
 wXG
-dvX
+jND
+woS
 aXb
 aTU
 lDF
 aKe
 dvm
 aTU
-aJj
 aJj
 bZq
 hSz
@@ -118728,14 +118758,14 @@ aXb
 jLV
 ceW
 nEQ
-qAW
+dfp
+fnI
 aXb
 ahN
 mTX
 aOL
 vtF
 ahN
-aJj
 aJj
 jqs
 cfQ
@@ -118987,12 +119017,12 @@ dUD
 wJw
 skY
 ahJ
+ahJ
 hiX
 kHQ
 wHG
-kSR
+dAD
 hiX
-aJj
 vpj
 pYp
 wDS
@@ -119246,8 +119276,8 @@ iNj
 wJE
 kbK
 uqy
+wuj
 gkw
-xlq
 fDI
 uBL
 rjr
@@ -119501,11 +119531,11 @@ fbB
 mzk
 iQP
 agi
+sEj
 agi
 nyh
 iMH
-nuT
-kVW
+tgX
 kBm
 aYa
 aVi
@@ -119759,10 +119789,10 @@ sou
 rvE
 oLb
 oLb
+nCY
 wAt
-ePl
-hto
-kZQ
+dHK
+jrn
 vUk
 aYa
 vsQ
@@ -120015,10 +120045,10 @@ eQb
 iap
 eZK
 nZm
-dnb
+nZm
+tAQ
 eaS
-iMH
-nOx
+soA
 tgX
 sAW
 aYa
@@ -120273,8 +120303,8 @@ dzg
 xfD
 pqo
 pqo
+cNM
 gwE
-rjS
 icR
 kZQ
 thR
@@ -120530,7 +120560,7 @@ ttI
 sss
 vKE
 vKE
-asM
+npS
 asM
 rNl
 xXi

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -101,6 +101,9 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "aaJ" = (
@@ -1186,6 +1189,9 @@
 "ajC" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ajF" = (
@@ -1247,6 +1253,9 @@
 	dir = 4;
 	name = "Station Intercom (General)";
 	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -1422,6 +1431,9 @@
 /area/crew_quarters/fitness)
 "alA" = (
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "alB" = (
@@ -2115,12 +2127,6 @@
 "aqZ" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"arb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/chief)
 "arc" = (
 /obj/effect/landmark/stationroom/box/dorm_edoor,
 /turf/template_noop,
@@ -2488,13 +2494,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"atD" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "atG" = (
 /obj/machinery/telecomms/message_server/preset,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -2541,6 +2540,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -2852,12 +2854,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"awz" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "awB" = (
 /turf/closed/wall/rust,
 /area/maintenance/port/aft)
@@ -3160,6 +3156,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "azw" = (
@@ -3374,8 +3374,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/cable/orange{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -3802,10 +3802,6 @@
 /obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"aDu" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aDv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4035,6 +4031,9 @@
 /area/science/xenobiology)
 "aFv" = (
 /obj/machinery/computer/secure_data,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "aFy" = (
@@ -4133,16 +4132,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"aGk" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "aGo" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/electrical";
@@ -4519,10 +4508,6 @@
 "aID" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"aIE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "aIH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -4612,6 +4597,9 @@
 /area/library)
 "aJC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "aJD" = (
@@ -5026,10 +5014,8 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aNY" = (
 /turf/closed/wall,
@@ -6059,6 +6045,9 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "aXl" = (
@@ -6487,9 +6476,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "baA" = (
-/obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "baF" = (
@@ -6560,9 +6550,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bcH" = (
@@ -6960,15 +6950,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -7108,6 +7093,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "blJ" = (
@@ -7167,6 +7155,9 @@
 /area/engine/atmos_distro)
 "bnm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bnq" = (
@@ -7190,6 +7181,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bnP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "bob" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -7231,12 +7238,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"boH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "bpd" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -7933,15 +7934,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bAo" = (
@@ -8570,9 +8572,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
@@ -8863,7 +8862,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -9158,6 +9157,7 @@
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bZK" = (
@@ -9407,11 +9407,12 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos_distro)
 "cdm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/obj/machinery/lapvend,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "cdt" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -10038,6 +10039,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmB" = (
@@ -10151,19 +10155,6 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
-"cqg" = (
-/obj/structure/table,
-/obj/item/electronics/apc,
-/obj/item/electronics/firealarm{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/electronics/firelock,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cqi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -10186,6 +10177,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cqB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cqN" = (
 /obj/structure/table/wood,
 /obj/item/folder/documents,
@@ -10241,9 +10239,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "cse" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -10262,22 +10257,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "csp" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 1;
-	name = "CE Office APC";
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white/side,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "csy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -10457,6 +10438,13 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"cwc" = (
+/mob/living/simple_animal/cockroach,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cwd" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/white{
@@ -10549,9 +10537,17 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cyj" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cyl" = (
@@ -10816,21 +10812,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cBJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cCg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -11140,6 +11121,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "cIa" = (
@@ -11184,7 +11169,7 @@
 /area/hallway/primary/starboard)
 "cID" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/foyer)
 "cIE" = (
 /obj/structure/cable/yellow{
@@ -11238,6 +11223,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cJQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "cKy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -11632,6 +11630,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cRb" = (
@@ -11863,6 +11862,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"cWh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cWi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -12052,13 +12061,7 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "cYN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -12249,6 +12252,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "dcK" = (
@@ -12289,6 +12295,18 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ddv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ddB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -12363,6 +12381,18 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"deC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "deR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -12373,8 +12403,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dfm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -12471,6 +12507,15 @@
 /obj/effect/spawner/lootdrop/techstorage/AI,
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"dgK" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "dhf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12538,9 +12583,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "die" = (
@@ -12553,8 +12600,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
 /area/engine/engineering)
 "dix" = (
 /obj/structure/table/wood,
@@ -12643,9 +12691,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "dkB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -12920,6 +12965,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"drg" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "drq" = (
 /obj/structure/dresser,
 /turf/open/floor/plasteel/white,
@@ -13326,6 +13378,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dzR" = (
@@ -13338,10 +13393,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dAc" = (
@@ -13389,6 +13440,9 @@
 	location = "Engineering";
 	name = "engineering navigation beacon"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dAN" = (
@@ -13432,15 +13486,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"dCb" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dCg" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -13636,12 +13681,17 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dGD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	areastring = "/area/engine/foyer";
+	dir = 8;
+	name = "Engineering Foyer APC";
+	pixel_x = -25
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -14099,12 +14149,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dPt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -16277,20 +16321,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"eCj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "eCo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -16417,11 +16447,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -16438,19 +16468,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "eFa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white/side,
 /area/crew_quarters/heads/chief)
 "eFb" = (
 /obj/structure/cable{
@@ -16604,6 +16631,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"eHq" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "eHs" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -16976,15 +17009,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "eMP" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 2;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "eMS" = (
@@ -17691,16 +17721,8 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "fcF" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -7;
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 7;
-	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18310,14 +18332,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fle" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "flf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -18415,6 +18429,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/server)
+"fnh" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "fnA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -18548,6 +18566,9 @@
 "fpZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
+	},
+/obj/structure/cable/orange{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -18755,10 +18776,10 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
+/obj/structure/closet/emcloset,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fvf" = (
@@ -18959,10 +18980,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fyX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "fzb" = (
@@ -19407,6 +19427,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "fHD" = (
@@ -19454,10 +19480,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fIs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fIS" = (
@@ -19571,7 +19599,12 @@
 	c_tag = "Engineering West";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
 /area/engine/engineering)
 "fLC" = (
 /obj/structure/sign/poster/official/random{
@@ -19734,20 +19767,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fOJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/item/clipboard,
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "fOX" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -19902,7 +19921,7 @@
 	c_tag = "Engineering Access";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20127,14 +20146,16 @@
 /area/medical/sleeper)
 "fTX" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
@@ -20612,6 +20633,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gcC" = (
@@ -20692,9 +20716,6 @@
 /area/ai_monitored/security/armory)
 "gdX" = (
 /obj/machinery/computer/station_alert,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gef" = (
@@ -21076,7 +21097,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -21179,13 +21200,18 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
 "gmW" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
 	},
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/clothing/glasses/meson,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -21252,6 +21278,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"gok" = (
+/turf/closed/wall,
+/area/hallway/primary/starboard)
 "gon" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -21398,16 +21427,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"grt" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gry" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -21854,13 +21873,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"gzH" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/glass/plasma,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gzN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -21979,14 +21991,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gBr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -22058,6 +22067,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"gCe" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "gCy" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -22337,10 +22359,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"gHr" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "gHV" = (
 /obj/machinery/camera{
 	c_tag = "Patient Room 1";
@@ -22386,6 +22404,19 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
+"gID" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gIL" = (
 /obj/structure/toilet{
 	dir = 1
@@ -22437,6 +22468,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"gJm" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
@@ -22878,6 +22917,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gRr" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gRu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -23005,27 +23051,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"gSW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "gTd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gTs" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gTH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -24545,31 +24582,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hsw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hsL" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt2";
@@ -24706,23 +24718,20 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "hvl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
+/obj/item/clipboard,
+/obj/item/paper/monitorkey,
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/heads/chief)
 "hvA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25544,6 +25553,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hJu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hJG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -25580,9 +25601,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hKu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hKz" = (
@@ -25946,16 +25965,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hQP" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hRk" = (
@@ -26047,8 +26066,7 @@
 /area/medical/genetics)
 "hSz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26126,7 +26144,17 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "hTN" = (
-/obj/effect/decal/cleanable/glass,
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -26185,9 +26213,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hUL" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -26331,38 +26356,8 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
-"hYl" = (
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "hYt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hYM" = (
@@ -27100,6 +27095,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"imi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "imk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -27315,6 +27319,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"iqQ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "irb" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -27359,9 +27369,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -27483,6 +27490,10 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/twohanded/rcl/pre_loaded,
 /obj/item/stack/cable_coil,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iul" = (
@@ -28040,14 +28051,15 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iFM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iFS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -28206,15 +28218,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"iJh" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "iJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -28502,6 +28505,9 @@
 "iOJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iPe" = (
@@ -29083,13 +29089,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -29182,10 +29188,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jag" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -29535,15 +29541,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "jdA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jdG" = (
@@ -30275,11 +30279,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "joq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -30298,14 +30303,11 @@
 /turf/open/space/basic,
 /area/space)
 "jpa" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jpg" = (
@@ -30362,6 +30364,13 @@
 /area/hallway/secondary/service)
 "jqs" = (
 /obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/camera{
+	c_tag = "Engineering North"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jqA" = (
@@ -31210,13 +31219,32 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"jFp" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	req_access_txt = "32"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jFD" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
@@ -31353,6 +31381,13 @@
 /area/ai_monitored/security/armory)
 "jIO" = (
 /obj/effect/decal/cleanable/glass,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jIR" = (
@@ -31446,6 +31481,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "jKV" = (
@@ -31463,9 +31503,6 @@
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
 "jLp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -31515,9 +31552,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "jMp" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -31543,16 +31577,16 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
 "jMR" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jNi" = (
@@ -31614,10 +31648,10 @@
 /area/crew_quarters/bar)
 "jOs" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jOv" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -31772,6 +31806,9 @@
 "jQR" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -32004,15 +32041,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jVe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jVp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/light,
@@ -32168,6 +32196,10 @@
 /area/medical/medbay/central)
 "jXR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jXS" = (
@@ -32264,6 +32296,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jZh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jZu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -32668,19 +32710,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"khf" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_one_access_txt = "10;61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "khq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32933,6 +32962,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kns" = (
@@ -33119,16 +33151,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kpV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -33192,9 +33223,6 @@
 /area/medical/virology)
 "krp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1
 	},
@@ -33472,11 +33500,14 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "kvW" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -34044,13 +34075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kGZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kHg" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -34144,11 +34168,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kIv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -34567,6 +34588,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "kSF" = (
@@ -34796,6 +34818,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "kWz" = (
@@ -35666,14 +35692,14 @@
 /turf/open/space/basic,
 /area/space)
 "lrr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -35836,12 +35862,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lur" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "luy" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/decal/cleanable/dirt,
@@ -36111,9 +36131,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lyK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -36682,11 +36699,11 @@
 "lLz" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
-/obj/machinery/light{
-	dir = 8
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -36967,8 +36984,21 @@
 /area/hallway/primary/aft)
 "lPh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lPi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "lPj" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -37262,14 +37292,14 @@
 /area/quartermaster/office)
 "lTU" = (
 /obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "lUc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37322,12 +37352,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lUZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall,
-/area/engine/engineering)
 "lVv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -37662,19 +37686,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "maT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -37937,6 +37950,22 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"mgd" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Chief Engineer's Office"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/closet/secure_closet/engineering_chief,
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "mgs" = (
 /obj/machinery/smartfridge,
 /turf/open/floor/plasteel,
@@ -37982,6 +38011,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mgM" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "mgX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -38662,6 +38699,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"mrp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mrX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -39003,7 +39050,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -39058,9 +39104,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mzz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -39573,12 +39616,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "mIn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "mIo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel/showroomfloor,
@@ -39949,6 +40000,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mNZ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mOu" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -40341,6 +40402,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mUZ" = (
@@ -40380,13 +40444,6 @@
 /obj/effect/turf_decal/pool,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"mVl" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "mVu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40541,6 +40598,9 @@
 /area/security/brig)
 "mXg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mXo" = (
@@ -41078,9 +41138,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "neg" = (
@@ -41109,6 +41166,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "neY" = (
@@ -41157,6 +41215,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"nfx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/foyer)
 "nfH" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -41237,13 +41299,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "niA" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "niB" = (
 /obj/structure/cable{
@@ -41398,15 +41455,6 @@
 "nks" = (
 /turf/closed/wall,
 /area/storage/primary)
-"nkM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nkP" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -41576,22 +41624,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nnB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nnF" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -41919,14 +41951,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nsi" = (
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "nst" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -42160,18 +42184,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"nwN" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nwZ" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -42342,12 +42354,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered)
-"nzP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "nzW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42451,6 +42457,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nBt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "nBv" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -42845,6 +42857,18 @@
 /obj/item/coin/iron,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/meeting_room)
+"nIv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "nIB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -43106,14 +43130,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nOg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -43288,6 +43312,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -43648,13 +43675,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"nVU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/field/generator,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nVY" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -43967,9 +43987,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -44545,9 +44562,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
@@ -44561,16 +44575,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"omJ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glass/plasma,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "omW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -44705,6 +44709,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"opo" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "opp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -44910,7 +44920,11 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/starboard)
 "ots" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ott" = (
@@ -45732,26 +45746,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"oIA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "oIE" = (
 /obj/machinery/light{
 	dir = 8
@@ -46107,9 +46101,6 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/pill/patch/silver_sulf,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26
@@ -46624,13 +46615,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"oZh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "oZi" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -47025,9 +47009,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -47074,16 +47055,6 @@
 "pfc" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"pfg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/obj/machinery/camera{
-	c_tag = "Engineering North"
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "pfh" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -47445,6 +47416,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pmk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "pmr" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -47729,11 +47710,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47774,9 +47758,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "pqA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -48420,24 +48401,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"pAZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "pBl" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -48652,10 +48615,16 @@
 /area/maintenance/department/tcoms)
 "pFQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 1
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48866,9 +48835,6 @@
 	amount = 30
 	},
 /obj/item/stack/rods/fifty,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -48975,15 +48941,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "pJZ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/siding/wideplating{
-	dir = 1
+	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/engine/foyer)
+/area/hallway/primary/starboard)
 "pKa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -49496,9 +49459,6 @@
 /area/maintenance/starboard/aft)
 "pRm" = (
 /obj/structure/chair/office/light,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "pRM" = (
@@ -49815,9 +49775,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "pVW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -49829,6 +49786,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50036,6 +49996,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "pYC" = (
@@ -50097,14 +50058,11 @@
 /obj/machinery/power/smes/engineering{
 	output_attempt = 0
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50189,16 +50147,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/secondarydatacore)
-"qbe" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = -27
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "qbj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50206,9 +50154,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50224,6 +50169,14 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
+"qbz" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qbC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50282,13 +50235,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"qcV" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "qcX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -50545,15 +50491,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "qhl" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/light,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qhs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -50690,6 +50632,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"qkm" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qkr" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -50786,6 +50746,9 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -51212,6 +51175,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qtF" = (
@@ -51276,6 +51242,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"quu" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "quB" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -51300,9 +51272,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
@@ -51797,9 +51766,6 @@
 /area/clerk)
 "qDT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -51987,6 +51953,26 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"qHk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "qHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -52337,12 +52323,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"qNR" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qNW" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -52664,18 +52644,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qTL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qTR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -52718,12 +52686,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qVg" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/siding/wideplating{
+/obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qVm" = (
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -53313,7 +53281,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/vacant_room)
 "rdW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -53697,9 +53665,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
 "rkJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -53829,6 +53794,15 @@
 "rlJ" = (
 /turf/open/floor/mineral/silver,
 /area/crew_quarters/heads/captain)
+"rmj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rml" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -54077,42 +54051,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "rpS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -8;
-	pixel_y = 39;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -8;
-	pixel_y = 26;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 7;
-	pixel_y = 26;
-	req_access_txt = "24"
-	},
-/obj/machinery/button/door{
-	id = "ceprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 7;
-	pixel_y = 39
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "rqp" = (
 /obj/structure/closet/firecloset,
@@ -54446,6 +54386,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"rva" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rvc" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
@@ -54893,6 +54837,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rDw" = (
@@ -54901,14 +54848,19 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rDJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55134,6 +55086,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rGi" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/hallway/primary/starboard)
 "rGp" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -55223,7 +55179,7 @@
 	dir = 6
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55275,6 +55231,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rJC" = (
@@ -55410,6 +55367,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rMG" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rMV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -55446,25 +55409,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"rNV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rOe" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
@@ -55475,6 +55420,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55530,10 +55478,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "rPf" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/foyer)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rPh" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/pool{
@@ -55737,8 +55684,9 @@
 	name = "Engineering APC";
 	pixel_y = 23
 	},
+/obj/machinery/portable_atmospherics/pump,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55833,11 +55781,14 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "rTI" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -55894,22 +55845,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "rUV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/structure/table/reinforced,
-/obj/item/cartridge/engineering{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/cartridge/engineering{
-	pixel_x = 8
-	},
-/obj/item/cartridge/atmos,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "rVb" = (
@@ -56030,6 +55969,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"rWw" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "rWz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4;
@@ -56252,6 +56197,18 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"rZp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rZw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -56276,6 +56233,10 @@
 /area/hallway/secondary/exit)
 "rZz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rZG" = (
@@ -56459,10 +56420,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"scv" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "scw" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56470,8 +56427,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -56563,21 +56529,20 @@
 	},
 /area/crew_quarters/kitchen)
 "sdR" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/hallway/primary/starboard)
 "sdZ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -56970,6 +56935,9 @@
 /area/hallway/primary/port)
 "sod" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "son" = (
@@ -57437,6 +57405,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"swq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_middle,
+/area/engine/engineering)
 "swD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -57589,9 +57569,8 @@
 /area/quartermaster/sorting)
 "szs" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "szt" = (
@@ -57802,6 +57781,24 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"sDl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sDn" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/sign/painting{
@@ -57883,6 +57880,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"sFn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "sFw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57909,14 +57924,15 @@
 	},
 /area/science/xenobiology)
 "sFQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -58261,12 +58277,11 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "sLf" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/hallway/primary/starboard)
 "sLu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -58744,15 +58759,8 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "sSu" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "sTh" = (
 /obj/structure/cable{
@@ -58779,6 +58787,47 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"sTv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = -8;
+	pixel_y = 39;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = -8;
+	pixel_y = 26;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 7;
+	pixel_y = 26;
+	req_access_txt = "24"
+	},
+/obj/machinery/button/door{
+	id = "ceprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side,
+/area/crew_quarters/heads/chief)
 "sTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -58907,15 +58956,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "sVk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sVr" = (
@@ -59128,8 +59169,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "sZg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -59262,10 +59306,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tbh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tbk" = (
@@ -59283,12 +59324,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "tbv" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/foyer)
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tbM" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -59320,9 +59361,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "tcg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
@@ -59722,20 +59760,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
-"tiu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/foyer)
 "tiz" = (
 /obj/effect/spawner/structure/window,
@@ -59763,24 +59791,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"tiK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/foyer";
-	dir = 8;
-	name = "Engineering Foyer APC";
-	pixel_x = -25
+"tiX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tjc" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -59809,13 +59826,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"tkw" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "tkI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -60060,18 +60070,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"toS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office"
-	},
-/turf/open/floor/plasteel/white/side,
-/area/crew_quarters/heads/chief)
 "toT" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -60249,6 +60247,9 @@
 "ttp" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ttD" = (
@@ -60319,11 +60320,6 @@
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"tuG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tuJ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -61204,6 +61200,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "tJN" = (
@@ -62327,10 +62326,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ufN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
-	},
 /mob/living/simple_animal/cockroach,
+/obj/effect/decal/cleanable/glass/plasma,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ufS" = (
@@ -62344,6 +62341,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"ugz" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "ugM" = (
 /obj/structure/table,
 /obj/effect/landmark/event_spawn,
@@ -62366,11 +62371,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uhk" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/computer/station_alert{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -62397,13 +62405,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhS" = (
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uhV" = (
@@ -62439,6 +62444,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uik" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uiu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -62465,37 +62482,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uiI" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering";
-	req_access_txt = "32"
-	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/hallway/primary/starboard)
 "uiU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -62963,6 +62963,19 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"urj" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uro" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/disposalpipe/segment{
@@ -63004,6 +63017,9 @@
 /obj/item/stack/sheet/glass/fifty{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
@@ -63248,20 +63264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"uxM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/chief)
 "uxS" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -63356,9 +63358,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -63791,7 +63790,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uDy" = (
@@ -63831,6 +63829,19 @@
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
+"uFc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Engineering Desk";
+	req_access_txt = "10"
+	},
+/obj/item/deskbell/preset/engi{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/open/floor/plating,
+/area/engine/foyer)
 "uFl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -63906,14 +63917,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -64097,6 +64108,18 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"uIC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uIW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -64224,10 +64247,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uMl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uMm" = (
 /obj/structure/rack,
@@ -64304,6 +64327,23 @@
 "uOl" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uOD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 4;
+	name = "CE Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/heads/chief)
 "uOO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -64556,6 +64596,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"uUo" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uUB" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engine.";
@@ -64567,6 +64613,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -64728,8 +64777,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uXQ" = (
@@ -65044,6 +65091,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vdG" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vdI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -65096,6 +65158,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"veL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "veR" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -65380,6 +65455,7 @@
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/siding/wideplating,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vkl" = (
@@ -65571,8 +65647,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 6
 	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "vpN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -65600,14 +65675,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vql" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/heads/chief)
 "vqC" = (
 /obj/structure/cable{
@@ -65754,17 +65827,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
@@ -66114,15 +66187,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "vxW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -66296,6 +66361,9 @@
 /area/hallway/primary/port)
 "vCu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vCI" = (
@@ -66551,8 +66619,8 @@
 /area/crew_quarters/bar)
 "vHx" = (
 /obj/machinery/computer/atmos_alert,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -66568,10 +66636,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "vId" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "vIG" = (
 /obj/structure/cable{
@@ -66587,24 +66655,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vIH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room";
-	req_one_access_txt = "10;61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vIX" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Reception";
@@ -67200,12 +67250,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vRX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vRY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/closed/mineral/random/low_chance_air,
@@ -67490,13 +67534,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vXp" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 4
-	},
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vXF" = (
 /obj/structure/table,
@@ -67984,6 +68029,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wfy" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wfA" = (
 /obj/machinery/light{
 	dir = 4
@@ -68085,14 +68136,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "whl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "whA" = (
@@ -68451,6 +68503,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"wnH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wnM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68597,6 +68655,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wqz" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wqC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -68799,10 +68866,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"wuG" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wuJ" = (
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
@@ -68965,17 +69028,18 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "wzi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -69180,21 +69244,9 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "wBx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/hallway/primary/starboard)
 "wBL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -69292,16 +69344,6 @@
 "wCY" = (
 /turf/closed/wall,
 /area/maintenance/department/tcoms)
-"wDa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/foyer)
 "wDs" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
@@ -69495,7 +69537,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "wFY" = (
-/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -69522,12 +69570,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wHu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wHG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -69641,6 +69683,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"wIF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wIK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -69693,15 +69745,6 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos)
-"wJA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wJE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -70046,24 +70089,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wPL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "atmospherics sorting disposal pipe";
-	sortType = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wPR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -70197,8 +70222,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "wSF" = (
@@ -70767,6 +70790,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "xaT" = (
@@ -70814,19 +70841,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"xbE" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/head/welding{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/poster/firstsingularity,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/foyer)
 "xcx" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -71072,6 +71086,7 @@
 	pixel_y = 32
 	},
 /obj/item/flashlight,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xfT" = (
@@ -72424,9 +72439,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "xGC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
 /obj/structure/sign/painting{
 	persistence_id = "public";
 	pixel_x = 32
@@ -72657,10 +72669,10 @@
 /area/quartermaster/office)
 "xKl" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/item/radio/off,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "xKy" = (
@@ -72839,6 +72851,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"xMN" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/chair/office/light,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xNb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -73050,15 +73067,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"xQN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xQV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -73146,16 +73154,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "atmospherics sorting disposal pipe";
+	sortType = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "xSa" = (
@@ -73475,11 +73484,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "xXN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -73963,18 +73972,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"yhR" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "yia" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -113865,8 +113862,8 @@ jJp
 aiZ
 dAy
 vCu
-qop
-aHh
+gID
+opo
 wgj
 agn
 aAA
@@ -114119,11 +114116,11 @@ bOv
 bOv
 uyV
 pyH
-bOv
+uik
 qbj
 uhS
 afp
-aHh
+nBt
 aoJ
 agn
 agn
@@ -114371,25 +114368,25 @@ aJq
 aJq
 aJq
 aJq
-tiu
 aJq
-aJq
-aJq
-aJq
+rGi
+fnh
+gJm
+gok
 tbv
 uiI
 rPf
-ahe
-aHh
-aHh
+afp
+rMG
+lUD
 gct
 gct
 gct
 gct
 gct
 jQR
-aHh
-eMv
+lUD
+gRr
 aoJ
 aHh
 aHh
@@ -114628,15 +114625,15 @@ ahe
 xKl
 cHX
 lLz
-xQN
-hsw
-tiK
-qcV
-hYl
+aJq
+aJq
+aJq
+aJq
+aJq
 sLf
-pAZ
-qbe
-ahe
+uiI
+rPf
+afp
 hFp
 gMy
 aFk
@@ -114646,12 +114643,12 @@ aFk
 iRo
 aoJ
 aHh
-aHh
+nBt
 hFp
-aHh
-aHh
-iam
-bPc
+eHq
+lUD
+lPi
+deC
 pYX
 kxk
 pYX
@@ -114888,12 +114885,12 @@ sZg
 kIv
 dfm
 dGD
-dfm
-dfm
-dfm
-wPL
-xbE
-ahe
+dgK
+nfx
+sLf
+uiI
+rPf
+afp
 aHh
 iwt
 aFk
@@ -114903,12 +114900,12 @@ aFk
 aFk
 aoJ
 ogK
-aHh
-aHh
-aHh
+rMG
+lUD
+iqQ
 pNr
 aoJ
-bPc
+imi
 aHh
 wYf
 aHh
@@ -115145,12 +115142,12 @@ dhY
 bco
 jKI
 scw
-ayk
-ayk
-ayk
+pmk
+jFp
+uIC
 sdR
 qhl
-ahe
+afp
 wMo
 fdq
 aFk
@@ -115402,12 +115399,12 @@ wSk
 uXx
 fyX
 xRY
-eCj
-eCj
-eCj
+mhV
+nfx
+sLf
 wBx
 qVg
-ahe
+afp
 aJj
 aJj
 aJj
@@ -115420,7 +115417,7 @@ dkB
 cse
 cse
 cse
-cse
+rva
 tcg
 pqA
 agn
@@ -115658,13 +115655,13 @@ xaE
 aOd
 rEs
 hKu
-fFj
-ayk
-ayk
-gHr
-mhV
-nsi
-ahe
+cJQ
+xMN
+uFc
+sLf
+aiZ
+qVg
+afp
 tYf
 tYf
 iom
@@ -115916,12 +115913,12 @@ drR
 sQf
 ayk
 fFj
-ayk
-aIE
+jZh
+aJq
 cdm
-lml
+rWw
 pJZ
-ahe
+afp
 tYf
 tYf
 ozg
@@ -115929,9 +115926,9 @@ wRS
 ozg
 oAU
 ruw
-lur
+aJj
 dPt
-lUZ
+aJj
 xXN
 pVW
 lrr
@@ -116168,30 +116165,30 @@ aJF
 drR
 ajC
 abS
-azv
+veL
 drR
 kiL
-mVl
+uXx
 fFj
-ayk
 pXS
 gLw
-oIA
+qHk
 mfI
+aPn
 aPn
 aJj
 bZf
-gzH
-boH
-boH
-boH
-nVU
-awz
+oAU
+ozg
+ozg
+ozg
+ruw
+aJj
 peF
 irS
 bSj
 aAJ
-aAJ
+wIF
 jMR
 aqp
 aqp
@@ -116430,24 +116427,24 @@ aOd
 drR
 joq
 iZv
-atD
+mhV
 mIn
 hvl
 vql
 jMp
 lyK
-arb
-arb
-iJh
+aPn
+aPn
+aJj
 aMk
 aMk
 aJj
 aJj
 aJj
 obF
-fgX
 asO
-pdN
+tsh
+cwc
 pfc
 aqp
 aqp
@@ -116687,24 +116684,24 @@ aJC
 drR
 eMP
 fFj
-ayk
 mhV
+sFn
 eFa
 vId
-uxM
+aYF
 bNW
 quE
-fTX
+aPn
 pZN
 jpa
 alA
 fLo
 jXR
-uxT
+tiX
 uGg
-asO
+wfy
 jIO
-asO
+wqz
 aqp
 aqp
 aqp
@@ -116944,14 +116941,14 @@ atU
 drR
 hQP
 tit
-nzP
 lml
 aPn
-aGk
-fOJ
+nIv
+aYF
+aYF
 pRm
 krp
-fTX
+aPn
 fIs
 rHy
 xeC
@@ -116959,9 +116956,9 @@ die
 ctX
 gSw
 rOe
-asO
-asO
-cfQ
+sJB
+wnH
+drg
 aqp
 aqp
 aqp
@@ -117201,9 +117198,9 @@ aOd
 aOd
 cID
 jVA
-khf
-wDa
+ahe
 aPn
+sTv
 rpS
 rUV
 aYF
@@ -117214,11 +117211,11 @@ qmj
 kvW
 rTI
 uhk
-uxT
+aJj
 jXk
 asO
 asO
-asO
+quu
 aqp
 aqp
 aqp
@@ -117454,16 +117451,16 @@ aTU
 aTU
 aTU
 aJj
-scv
+aJj
 vkj
 fQZ
 pQu
-vRX
 rQj
 aPn
-toS
-jFD
+mgd
 ule
+jFD
+iVY
 pIs
 fTX
 pSy
@@ -117475,7 +117472,7 @@ uxT
 eyq
 asO
 cua
-asO
+quu
 aqp
 aqp
 aqp
@@ -117711,27 +117708,27 @@ aBu
 aBu
 aTU
 aJj
-tkw
+aJj
 rDv
 dbQ
 rHj
-asO
 sud
 aPn
+mgM
 csp
 vsN
-iVY
+ule
 urH
-aPn
+bnP
 hUL
-asO
+uUo
 rDw
 tJJ
 qtt
-uxT
+cqB
 knn
-asO
-asO
+gTs
+fgX
 lPh
 aqp
 aqp
@@ -117968,18 +117965,18 @@ aBu
 aBu
 aTU
 aJj
-wuG
+aJj
 rJw
 uAV
 aqU
-wHu
 uAV
 aPn
 dzz
+uOD
 eEz
 omj
 oQc
-fTX
+aPn
 wjt
 iuh
 exT
@@ -118229,8 +118226,8 @@ aJj
 aJj
 pVi
 oEg
-vIH
-gSW
+aJj
+aPn
 aPn
 aPn
 cYf
@@ -118244,7 +118241,7 @@ aJj
 hAQ
 aJj
 jzc
-asO
+oNt
 asO
 mXg
 aqp
@@ -118482,14 +118479,14 @@ aKe
 dvm
 aTU
 aJj
-wuG
+aJj
 bZq
 hSz
 uaF
 ndZ
 myA
-dqq
-lWz
+hJu
+ugz
 qfe
 sSd
 sUr
@@ -118739,14 +118736,14 @@ aOL
 vtF
 ahN
 aJj
-pfg
+aJj
 jqs
 cfQ
 lXQ
 mXv
 uZc
 eyp
-eyp
+swq
 bDH
 gxt
 dMP
@@ -118758,8 +118755,8 @@ eyp
 jdA
 bly
 ppQ
-asO
-asO
+cWh
+mrp
 iOJ
 aqp
 aqp
@@ -118998,12 +118995,12 @@ hiX
 aJj
 vpj
 pYp
-tuG
+wDS
 wDS
 wDS
 ssp
 pIm
-pIm
+gCe
 jCM
 nvE
 vKg
@@ -119016,7 +119013,7 @@ bjH
 whl
 wzi
 rDJ
-uMl
+sDl
 bnm
 aqp
 aqp
@@ -119260,7 +119257,7 @@ aYa
 aYa
 aYa
 aYa
-aDu
+aJj
 aAy
 aIh
 cdG
@@ -119269,9 +119266,9 @@ aAy
 jOs
 jaf
 uMl
-qTL
+uMl
 vXp
-ozg
+qbz
 cyj
 gmW
 fpZ
@@ -119526,12 +119523,12 @@ aAy
 aAy
 aVM
 aNX
-rNV
-grt
-ozg
+uxT
+uxT
+aVM
 hTN
-cqg
-asO
+gmW
+quu
 aqp
 aqp
 aqp
@@ -119782,13 +119779,13 @@ aAy
 aAy
 aAy
 gdX
-oZh
-maT
-sSu
 ozg
-cyj
-nwN
-asO
+ozg
+sSu
+uxT
+urj
+gmW
+quu
 aqp
 aqp
 aqp
@@ -120042,10 +120039,10 @@ aKN
 dAa
 maT
 niA
-ozg
+uxT
 wFY
-yhR
-asO
+gmW
+quu
 aqp
 aqp
 aqp
@@ -120297,12 +120294,12 @@ nwg
 aAy
 vHx
 szs
-maT
+szs
 iFM
-omJ
+aVM
 lTU
-kGZ
-asO
+gmW
+quu
 aqp
 aqp
 aqp
@@ -120554,12 +120551,12 @@ nYv
 aAy
 aVM
 fcF
-cBJ
-qNR
-asO
-tsh
-asO
-asO
+fdm
+fdm
+mNZ
+rmj
+qkm
+quu
 aqp
 aqp
 aqp
@@ -120811,13 +120808,13 @@ qcd
 aAy
 ots
 qDT
-fle
-nnB
+asO
+cua
 hYt
 vxW
 sFQ
-sFQ
-sFQ
+ddv
+rZp
 aqp
 aqp
 aqp
@@ -121068,11 +121065,11 @@ eRU
 aAy
 xfS
 mzz
-wJA
-qNR
+pdN
+asO
 jLp
 tsh
-asO
+vdG
 asO
 asO
 aqp
@@ -121324,11 +121321,11 @@ ldu
 fLl
 aAy
 neQ
-nkM
-wJA
+mzz
+asO
 ufN
-jVe
-dCb
+asO
+tsh
 pFQ
 eFi
 coo
@@ -121582,7 +121579,7 @@ aAy
 aAy
 baA
 xNW
-aVu
+asO
 tbh
 sVk
 cYN
@@ -121837,7 +121834,7 @@ phM
 fTh
 afF
 afF
-aJj
+aVM
 dLn
 sYl
 fzB


### PR DESCRIPTION
# Document the changes in your pull request

Touches up AsteroidStation's Engineering. It felt really open and for some reason had THREE EngiDrobes, which is too many.
New one here:
![image](https://user-images.githubusercontent.com/5091394/203503687-ec0cf477-5a35-494c-a151-a46cf2c6f974.png)
Added some stairs, changed the wiring (to even function correctly because it was bad) and shortens engineering lobby and closes it off, giving them an outer "lobby" where people can wait. Also gives them a windoor and bell. Shortens Engine Room entrance as this is wildly big.

# Changelog

:cl:  
mapping: Touches up AsteroidStation Engineering
mapping: Shortens AsteroidStation Engineering Foyer
mapping: Expands AsteroidStation Chief Engineer Office
mapping: Fix bad wall by AsteroidStation Vacant Room
/:cl:
