### PR TITLE
Increases the maximum reagents in crafted food by 50 to allow more space for ingredient reagents

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -179,6 +179,7 @@ All foods are distributed among various categories. Use common sense.
 /obj/item/reagent_containers/food/snacks/CheckParts(list/parts_list, datum/crafting_recipe/food/R)
 	..()
 	reagents.clear_reagents()
+	reagents.maximum_volume = 100
 	for(var/obj/item/reagent_containers/RC in contents)
 		RC.reagents.trans_to(reagents, RC.reagents.maximum_volume)
 	for(var/reagent in R.reqs)


### PR DESCRIPTION
# Document the changes in your pull request

HAS THIS EVER HAPPENED TO YOU
put together nice food item made of several botanical ingredient :)
half of the ingredients just don't show up :(
that's because the maximum reagent amount is 50 which is SMALL and BAD

I have increased this amount by 50 (double!) to allow food items to contain more reagents, the same amount as a plant with the densified chemicals gene would.

# Wiki Documentation

Crafted foods now have double the reagent capacity even though there is no way this is documented

# Changelog

:cl:  
tweak: Crafted foods now have double the reagent capacity of normal foods
/:cl:
