### PR TITLE
Traitors Among Traitors: Adds Sole Survivor objective + exchange objective tweaks

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -97,7 +97,7 @@
 		is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 8) 	//Set up an exchange if there are enough traitors
+	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 4) 	//Set up an exchange if there are enough traitors. YOGSTATION CHANGE: 8 TO 4.
 		if(!SSticker.mode.exchange_red)
 			SSticker.mode.exchange_red = owner
 		else
@@ -110,12 +110,20 @@
 		forge_single_objective()
 
 	if(is_hijacker && objective_count <= toa) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount
-		if (!(locate(/datum/objective/hijack) in objectives))
-			var/datum/objective/hijack/hijack_objective = new
-			hijack_objective.owner = owner
-			add_objective(hijack_objective)
-			return
-
+		//Start of Yogstation change: adds /datum/objective/sole_survivor
+		if(!(locate(/datum/objective/hijack) in objectives) && !(locate(/datum/objective/sole_survivor) in objectives))
+			if(SSticker.has_hijackers)
+				var/datum/objective/sole_survivor/survive_objective = new
+				survive_objective.owner = owner
+				add_objective(survive_objective)
+				SSticker.has_hijackers = TRUE
+			else
+				var/datum/objective/hijack/hijack_objective = new
+				hijack_objective.owner = owner
+				add_objective(hijack_objective)
+				SSticker.has_hijackers = TRUE
+				return
+		//End of yogstation change.
 
 	var/martyr_compatibility = 1 //You can't succeed in stealing if you're dead.
 	for(var/datum/objective/O in objectives)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -112,7 +112,7 @@
 	if(is_hijacker && objective_count <= toa) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount
 		//Start of Yogstation change: adds /datum/objective/sole_survivor
 		if(!(locate(/datum/objective/hijack) in objectives) && !(locate(/datum/objective/sole_survivor) in objectives))
-			if(SSticker.has_hijackers)
+			if(SSticker.mode.has_hijackers)
 				var/datum/objective/sole_survivor/survive_objective = new
 				survive_objective.owner = owner
 				add_objective(survive_objective)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -97,7 +97,7 @@
 		is_hijacker = prob(10)
 	var/martyr_chance = prob(20)
 	var/objective_count = is_hijacker 			//Hijacking counts towards number of objectives
-	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 4) 	//Set up an exchange if there are enough traitors. YOGSTATION CHANGE: 8 TO 4.
+	if(!SSticker.mode.exchange_blue && SSticker.mode.traitors.len >= 6) 	//Set up an exchange if there are enough traitors. YOGSTATION CHANGE: 8 TO 6.
 		if(!SSticker.mode.exchange_red)
 			SSticker.mode.exchange_red = owner
 		else

--- a/yogstation/code/game/gamemodes/game_mode.dm
+++ b/yogstation/code/game/gamemodes/game_mode.dm
@@ -1,3 +1,6 @@
+/datum/game_mode
+	var/has_hijackers = FALSE
+
 /datum/game_mode/get_players_for_role(role)
 	var/list/players = list() // All players who are ready and able
 	var/list/candidates = list() // All players who could POSSIBLY be an antag (acting as a fallback if filtered_candidates isn't enough)

--- a/yogstation/code/game/gamemodes/objective.dm
+++ b/yogstation/code/game/gamemodes/objective.dm
@@ -4,3 +4,26 @@ GLOBAL_LIST_INIT(infiltrator_objective_areas, typecacheof(list(/area/yogs/infilt
 	if(..())
 		return TRUE
 	return !considered_alive(target)
+
+/datum/objective/sole_survivor
+	name = "sole survivor"
+	explanation_text = "Escape on the shuttle to ensure <b>no one except you</b> escapes alive and out of custody."
+	team_explanation_text = "Escape on the shuttle to ensure <b>no one except your team</b> escapes alive and out of custody. Leave no team member behind."
+	martyr_compatible = 0 //Technically you won't get both anyway.
+
+/datum/objective/sole_survivor/check_completion() // Requires all owners to escape.
+	if(..())
+		return TRUE
+	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
+		return TRUE
+	for(var/mob/living/player in GLOB.player_list)
+		var/datum/mind/M = player.mind
+		if(!M)
+			continue
+		if(M in owners)
+			if(!considered_alive(M) || !SSshuttle.emergency.shuttle_areas[get_area(M.current)]) //Teammember in area.
+				return FALSE
+		else
+			if(considered_alive(player.mind) && SSshuttle.emergency.shuttle_areas[get_area(M.current)]) //Non-teammember in area.
+				return FALSE
+	return TRUE


### PR DESCRIPTION
Adds new sole survivor objective where if two (or more) traitors get hijack, the non-first traitor (or traitors) will get an objective to be the **only** survivor on a shuttle.

Exchange objective minimum traitor count requirements were reduced from 8 to 6 in hopes that it will occur more often.

# Details

Description of the objective:
_Escape on the shuttle to ensure **no one except you** escapes alive and out of custody._

If traitor A rolls for objectives and gets a hijack objective, then they will get the hijack objective.
If traitor B rolls for objectives and doesn't get a hijack objective, then they will not get the hijack objective.
if traitor C rolls for objectives and gets a hijack objective, then INSTEAD they will get a sole survivor objective.
if traitor D rolls for objectives and gets a hijack objective, then INSTEAD they will get a sole survivor objective.
If traitor E rolls for objectives and doesn't get a hijack objective, then they will not get the hijack objective.

So basically if in the rare chance that two or more traitors get hijack, the first traitor will get the regular hijack objective but the second traitor (and so on) will not get it but instead the sole survivor objective. The chance of this happening is very uncommon but it can still happen and I'm sure will be quite fun for the whole family.

The reasoning behind this change is that too many a time traitors team up with other traitors with hijack and end up stomping the entire station. It's a little lame and I think I want to counter that more by making that a little less safer than normal by making it so that sometimes, traitors can get an objective to kill EVERYONE on the shuttle (except themselves) in an attempt to hijack it.



Also inb4 someone tells me that /datum/antagonist/traitor/ and /datum/objective/ are no longer used in favor of dynamic and this PR is meaningless.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Traitor needs to be updated to include the new objective.

# Changelog

:cl:  BurgerBB
rscadd: Adds new sole survivor objective where if two (or more) traitors get hijack, the non-first traitor (or traitors) will get an objective to be the only survivor on a shuttle.
tweak: Changes the exchange objective minimum traitor count from 8 to 6.
/:cl:
