### PR TITLE
Adds Reinforced windows to the bottom of TEG area on meta station

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -123302,7 +123302,7 @@ moI
 xrY
 xrY
 xrY
-uBz
+tWL
 lMJ
 lMJ
 aaa
@@ -123559,7 +123559,7 @@ rjN
 rjN
 qtD
 xrY
-uBz
+tWL
 lMJ
 lMJ
 lMJ
@@ -123816,7 +123816,7 @@ nSS
 kcB
 kRB
 xrY
-uBz
+tWL
 lMJ
 aaa
 aaa
@@ -124330,7 +124330,7 @@ fIG
 kcB
 kRB
 xrY
-uBz
+tWL
 lMJ
 aaa
 aaa
@@ -124587,7 +124587,7 @@ jTL
 jTL
 dWv
 xrY
-uBz
+tWL
 lMJ
 lMJ
 lMJ
@@ -124844,7 +124844,7 @@ xrY
 xrY
 xrY
 xrY
-uBz
+tWL
 lMJ
 lMJ
 aaa


### PR DESCRIPTION
# Document the changes in your pull request

Adds Reinforced windows to the bottom of TEG area on meta station in place of the R-walls making piping gasses in from a space loop easier and creating a cold loop for the TEG easier also makes the area look nicer and more aesthetic 

# Changelog

:cl:  
rscadd: Added R-windows in there place
rscdel: Removes R-walls
/:cl:
