### PR TITLE
Remove slowdown from snow tiles

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -208,7 +208,6 @@
 	icon = 'icons/turf/snow.dmi'
 	desc = "Looks cold."
 	icon_state = "snow"
-	slowdown = 2
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -218,7 +218,6 @@
 	planetary_atmos = TRUE
 	floor_tile = null
 	initial_gas_mix = FROZEN_ATMOS
-	slowdown = 2
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND
@@ -247,7 +246,6 @@
 		set_basalt_light(src)
 
 /turf/open/floor/grass/snow/safe
-	slowdown = 1.5
 	planetary_atmos = FALSE
 
 

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -136,7 +136,6 @@
 	icon_state = "snow"
 	icon_plating = "snow"
 	initial_gas_mix = FROZEN_ATMOS
-	slowdown = 2
 	environment_type = "snow"
 	flags_1 = NONE
 	planetary_atmos = TRUE


### PR DESCRIPTION

# Document the changes in your pull request

"What if we made a mining map, and it was a really cool and well designed mining map, BUT, we gimped all the miners with every block giving you a 2 slowdown"

Slow snowing you down sucks, and the main gripe people usually hold about ice stations is the incessant slowdown given to you by walking in snow.

# Spriting

# Wiki Documentation


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: snow no longer slows you down 
/:cl:
