### PR TITLE
abruptly makes augmentation kits much more expensive for "balance"

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2017,13 +2017,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/augmentation
 	cost = 15
 	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/implants/augmentation/superior
 	name = "Superior Augmentation Kit"
 	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
 			Finally, it includes an implant to render the subject and their innards immune to EMP. Repair of body will still require a welder and wires."
 	item = /obj/item/storage/box/syndie_kit/augmentation/superior
-	cost = 25
+	cost = 45
 	include_modes = list(/datum/game_mode/nuclear)
 
 // Events


### PR DESCRIPTION
# Document the changes in your pull request

Um hm hrm having nukies take 3 damage per shot is kinda problematic but you know someone should probably adjust the price of the elite suit too but for now this will do

# Wiki Documentation

Prices and gamemodes to be adjusted on Syndicate Items page

# Changelog

:cl:  
tweak: Nukies can no longer buy the default aug kit
tweak: The superior aug kit that nukies can only buy has had its price raised to 45 from 25 TC.
/:cl:
