### PR TITLE
Make the elite hardsuit 15 TC because Skrem didn't have the guts to do it

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1509,14 +1509,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Nanotrasen crew who spot these suits are known to panic."
 	item = /obj/item/clothing/suit/space/hardsuit/syndi
 	cost = 8
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/infiltration) //you can't buy it in nuke, because the elite hardsuit costs the same while being better // yogs: infiltration
+	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration and nuke ops can buy their signature suit now
 
 /datum/uplink_item/suits/hardsuit/elite
 	name = "Elite Syndicate Hardsuit"
 	desc = "An upgraded, elite version of the Syndicate hardsuit. It features fireproofing, and also \
 			provides the user with superior armor and mobility compared to the standard Syndicate hardsuit."
 	item = /obj/item/clothing/suit/space/hardsuit/syndi/elite
-	cost = 8
+	cost = 15
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	exclude_modes = list()
 


### PR DESCRIPTION
# Document the changes in your pull request

#16690

Elite Hardsuit is 15 TC now because it's just better hardsuit for incredibly cheap.
Since the elite is pricier than the regular now nuke ops can buy the basic syndie hardsuit for their reinforcements.

# Wiki Documentation

Elite hardsuit cost 15 TC now
Syndicate hardsuit can be bought by nuclear operatives

# Changelog

:cl:  The lzayness of balance coding
tweak: Elite hardsuit cost 15 TC now, nuke ops can buy the regular hardsuit
/:cl:
