### PR TITLE
Un-Nerfs slime speed potion 

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -878,7 +878,7 @@
 	if(isitem(C))
 		// yogs start - change speed potion
 		var/obj/item/I = C
-		if(I.slowdown <= 2 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown <= 0.9 || I.obj_flags & IMMUTABLE_SLOW)
 			to_chat(user, span_warning("The [C] can't be made any faster!"))
 			return ..()
 		I.slowdown--


### PR DESCRIPTION
# Document the changes in your pull request

Changes the required slowdown on gear from <=2 to <=0.9 for slime speed potion meaning it can actually be used on things that are not super niche and rarely seen (you can use it on fire suits again!)

since the nerf i have never even seen a slime speed potion used hopefully with this it will be seen more often as the required slow on gear was crazy gear with a slowdown of 2 is basically unusable and literally requires a slime speed potion to be used therefore is just never used 

also for some reason the potion was only usable on gear that had greater than 2 slow gear with 2 slow did not work with the potion im not sure why this is which is why ive changed it to 0.9 meaning all gear slowdown 1 or higher can use the potion now
 
so previous was 2.1 slowdown now its 1 slowdown
# Changelog
:cl:  
tweak: Changes slowdown required on gear from <=2 to <=0.9  
/:cl:
