### PR TITLE
Blind people can no longer be flashed

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/get_eye_protection()
 	. = ..()
+	if(HAS_TRAIT(src, TRAIT_BLIND))
+	return INFINITY //Can't get flashed if you cant see
 	var/obj/item/organ/eyes/E = getorganslot(ORGAN_SLOT_EYES)
 	if(!E)
 		return INFINITY //Can't get flashed without eyes

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/get_eye_protection()
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_BLIND))
-	return INFINITY //Can't get flashed if you cant see
+		return INFINITY //Can't get flashed if you cant see
 	var/obj/item/organ/eyes/E = getorganslot(ORGAN_SLOT_EYES)
 	if(!E)
 		return INFINITY //Can't get flashed without eyes


### PR DESCRIPTION
# Document the changes in your pull request

Blind people could be affected (stunned, converted by revs, etc.) by flashes for some reason, though usually wearing their blindfold (for roundstart blind people) would prevent this nothing about actually being blind prevented flashes from working on you.  Now, it does.  Blind people are buffed.

# Wiki Documentation

N/A

# Changelog

:cl:  Cark
bugfix: blind people can't be flashed anymore
/:cl:
