### PR TITLE
darklord kit band aid #2

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -155,7 +155,7 @@
 /obj/item/book/granter/spell/fireball
 	spell = /obj/effect/proc_holder/spell/aimed/fireball
 	spellname = "fireball"
-	icon_state ="bookfireball"
+	icon_state = "bookfireball"
 	desc = "This book feels warm to the touch."
 	remarks = list("Aim...AIM, FOOL!", "Just catching them on fire won't do...", "Accounting for crosswinds... really?", "I think I just burned my hand...", "Why the dumb stance? It's just a flick of the hand...", "OMEE... ONI... Ugh...", "What's the difference between a fireball and a pyroblast...")
 
@@ -167,14 +167,14 @@
 /obj/item/book/granter/spell/sacredflame
 	spell = /obj/effect/proc_holder/spell/targeted/sacred_flame
 	spellname = "sacred flame"
-	icon_state ="booksacredflame"
+	icon_state = "booksacredflame"
 	desc = "Become one with the flames that burn within... and invite others to do so as well."
 	remarks = list("Well, it's one way to stop an attacker...", "I'm gonna need some good gear to stop myself from burning to death...", "Keep a fire extinguisher handy, got it...", "I think I just burned my hand...", "Apply flame directly to chest for proper ignition...", "No pain, no gain...", "One with the flame...")
 
 /obj/item/book/granter/spell/smoke
 	spell = /obj/effect/proc_holder/spell/targeted/smoke
 	spellname = "smoke"
-	icon_state ="booksmoke"
+	icon_state = "booksmoke"
 	desc = "This book is overflowing with the dank arts."
 	remarks = list("Smoke Bomb! Heh...", "Smoke bomb would do just fine too...", "Wait, there's a machine that does the same thing in chemistry?", "This book smells awful...", "Why all these weed jokes? Just tell me how to cast it...", "Wind will ruin the whole spell, good thing we're in space... Right?", "So this is how the spider clan does it...")
 
@@ -192,7 +192,7 @@
 /obj/item/book/granter/spell/blind
 	spell = /obj/effect/proc_holder/spell/pointed/trigger/blind
 	spellname = "blind"
-	icon_state ="bookblind"
+	icon_state = "bookblind"
 	desc = "This book looks blurry, no matter how you look at it."
 	remarks = list("Well I can't learn anything if I can't read the damn thing!", "Why would you use a dark font on a dark background...", "Ah, I can't see an Oh, I'm fine...", "I can't see my hand...!", "I'm manually blinking, damn you book...", "I can't read this page, but somehow I feel like I learned something from it...", "Hey, who turned off the lights?")
 
@@ -204,13 +204,13 @@
 /obj/item/book/granter/spell/mindswap
 	spell = /obj/effect/proc_holder/spell/targeted/mind_transfer
 	spellname = "mindswap"
-	icon_state ="bookmindswap"
+	icon_state = "bookmindswap"
 	desc = "This book's cover is pristine, though its pages look ragged and torn."
 	var/mob/stored_swap //Used in used book recoils to store an identity for mindswaps
 	remarks = list("If you mindswap from a mouse, they will be helpless when you recover...", "Wait, where am I...?", "This book is giving me a horrible headache...", "This page is blank, but I feel words popping into my head...", "GYNU... GYRO... Ugh...", "The voices in my head need to stop, I'm trying to read here...", "I don't think anyone will be happy when I cast this spell...")
 
 /obj/item/book/granter/spell/mindswap/onlearned()
-	spellname = pick("fireball","smoke","blind","forcewall","knock","barnyard","charge")
+	spellname = pick("fireball", "smoke", "blind", "forcewall", "knock", "barnyard", "charge")
 	icon_state = "book[spellname]"
 	name = "spellbook of [spellname]" //Note, desc doesn't change by design
 	..()
@@ -238,7 +238,7 @@
 /obj/item/book/granter/spell/forcewall
 	spell = /obj/effect/proc_holder/spell/targeted/forcewall
 	spellname = "forcewall"
-	icon_state ="bookforcewall"
+	icon_state = "bookforcewall"
 	desc = "This book has a dedication to mimes everywhere inside the front cover."
 	remarks = list("I can go through the wall! Neat.", "Why are there so many mime references...?", "This would cause much grief in a hallway...", "This is some surprisingly strong magic to create a wall nobody can pass through...", "Why the dumb stance? It's just a flick of the hand...", "Why are the pages so hard to turn, is this even paper?", "I can't mo Oh, i'm fine...")
 
@@ -251,7 +251,7 @@
 /obj/item/book/granter/spell/knock
 	spell = /obj/effect/proc_holder/spell/aoe_turf/knock
 	spellname = "knock"
-	icon_state ="bookknock"
+	icon_state = "bookknock"
 	desc = "This book is hard to hold closed properly."
 	remarks = list("Open Sesame!", "So THAT'S the magic password!", "Slow down, book. I still haven't finished this page...", "The book won't stop moving!", "I think this is hurting the spine of the book...", "I can't get to the next page, it's stuck t- I'm good, it just turned to the next page on it's own.", "Yeah, staff of doors does the same thing. Go figure...")
 
@@ -263,7 +263,7 @@
 /obj/item/book/granter/spell/barnyard
 	spell = /obj/effect/proc_holder/spell/targeted/barnyardcurse
 	spellname = "barnyard"
-	icon_state ="bookhorses"
+	icon_state = "bookhorses"
 	desc = "This book is more horse than your mind has room for."
 	remarks = list("Moooooooo!","Moo!","Moooo!", "NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!", "Oink!", "Squeeeeeeee!", "Oink Oink!", "Ree!!", "Reee!!", "REEE!!", "REEEEE!!")
 
@@ -281,7 +281,7 @@
 /obj/item/book/granter/spell/charge
 	spell = /obj/effect/proc_holder/spell/targeted/charge
 	spellname = "charge"
-	icon_state ="bookcharge"
+	icon_state = "bookcharge"
 	desc = "This book is made of 100% postconsumer wizard."
 	remarks = list("I feel ALIVE!", "I CAN TASTE THE MANA!", "What a RUSH!", "I'm FLYING through these pages!", "THIS GENIUS IS MAKING IT!", "This book is ACTION PAcKED!", "HE'S DONE IT", "LETS GOOOOOOOOOOOO")
 
@@ -293,7 +293,7 @@
 /obj/item/book/granter/spell/summonitem
 	spell = /obj/effect/proc_holder/spell/targeted/summonitem
 	spellname = "instant summons"
-	icon_state ="booksummons"
+	icon_state = "booksummons"
 	desc = "This book is bright and garish, very hard to miss."
 	remarks = list("I can't look away from the book!", "The words seem to pop around the page...", "I just need to focus on one item...", "Make sure to have a good grip on it when casting...", "Slow down, book. I still haven't finished this page...", "Sounds pretty great with some other magical artifacts...", "Magicians must love this one.")
 
@@ -302,28 +302,16 @@
 	to_chat(user,span_warning("[src] suddenly vanishes!"))
 	qdel(src)
 
-/obj/item/book/granter/spell/teslablast
-	spell = /obj/effect/proc_holder/spell/targeted/tesla
-	spellname = "tesla blast"
-	desc = "A book that crackles with power."
-	remarks = list("ZAP!", "I feel some tingling in my fingers...", "Swirl your hands to charge...?", "Let loose a bolt of pure electricity? Shocking...", "FEEL THE THUNDER!")
+/obj/item/book/granter/spell/lightningbolt
+	spell = /obj/effect/proc_holder/spell/aimed/lightningbolt
+	spellname = "lightning bolt"
+	desc = "A book that crackles with energy."
+	remarks = list("ZAP!", "I feel some tingling in my fingers...", "Swirl your hands to charge...?", "Unlimited... power...? Shocking...", "FEEL THE THUNDER!")
 
-/obj/item/book/granter/spell/teslablast/recoil(mob/user)
+/obj/item/book/granter/spell/lightningbolt/recoil(mob/user)
 	..()
 	to_chat(user, span_warning("The book twists into lightning and leaps at you!"))
 	tesla_zap(user, 8, 20000, TESLA_MOB_DAMAGE) //Will chain at a range of 8, but shouldn't straight up crit
-	qdel(src)
-
-/obj/item/book/granter/spell/repulse
-	spell = /obj/effect/proc_holder/spell/aoe_turf/repulse
-	spellname = "repulse"
-	desc = "A book that pushes against your touch."
-	remarks = list("The words seem to push away from me...", "Flick a hand and flick everything around me? Awesome", "My mind feels a little percussive.", "Just a little shove...", "Book almost flew out of my hands...")
-
-/obj/item/book/granter/spell/repulse/recoil(mob/user)
-	..()
-	to_chat(user, span_warning("The book bursts into a gale of force!"))
-	user.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)), 8, 10) //Random 8 tile throw with 10 force; will break bones
 	qdel(src)
 
 /obj/item/book/granter/spell/random

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -178,15 +178,17 @@
 			new /obj/item/card/id/syndicate(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
 
-		if("darklord") //This is now basically just a wizard instead of just desword: the kit. Hard to quantify the TC cost of spells, but taking SP * 4 would yield a theoretical TC of 31-ish
+		if("darklord") //This is now basically just a wizard instead of just desword: the kit. Hard to quantify the TC cost of spells, but taking SP * 4 would yield a theoretical TC of 27-ish
 			new /obj/item/melee/transforming/energy/sword/saber/red(src) //8 TC. A red lightsaber. Enough said
 			new /obj/item/clothing/mask/chameleon/syndicate(src) //Not even 1 TC, the real value of the chameleon kit is the jumpsuit. However this is absolutely necessary for your Sithsona
 			new /obj/item/card/id/syndicate(src) //2 TC, so you can give yourself a proper name
-			new /obj/item/clothing/suit/wizrobe/black(src) //Dark robes for the dark lord. Free
-			new /obj/item/clothing/head/wizard/black(src) //Works as a fix for the robe check now until I think of something new
+			new /obj/item/clothing/head/yogs/sith_hood(src) //The DRIP
+			new /obj/item/clothing/neck/yogs/sith_cloak(src) //See above
+			new /obj/item/clothing/suit/yogs/armor/sith_suit(src) //See above
+			new /obj/item/clothing/shoes/combat(src) //See above
 			new /obj/item/clothing/gloves/combat(src) //Maybe 1 TC, so you don't shock yourself
-			new /obj/item/book/granter/spell/teslablast(src) //Lightning bolt, LIGHTNING BOLT. A 2 SP cost spell that requires robes
-			new /obj/item/book/granter/spell/repulse(src) //"Force Push". 2 SP cost spell that requires robes
+			new /obj/item/book/granter/spell/lightningbolt(src) //Lightning bolt, LIGHTNING BOLT. A 2 SP cost spell that doesn't require robes and provides ranged potential
+			new /obj/item/book/granter/spell/forcewall(src) //It has the word force in it? But more importantly, it doesn't require robes and it's 1 SP and it's VERY good defense
 			new /obj/item/book/granter/spell/summonitem(src) //So you can throw your lightsaber and call it back. A 1 SP cost spell that doesn't require robes
 
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else


### PR DESCRIPTION
# Document the changes in your pull request

Makes the spells on darklord bundle a little more interesting™ because tesla arc sucks and repulse sucks even more now that you can't wall stun (gee I wonder if that change considered how much stuff was balanced around wall stuns)

Coincidentally these new spells lightning bolt and force wall are not only better but they don't require spells AND they have a lower cooldown so this kit should suck less now

Sith outfit included because you shouldn't need robes unless the wiki has lied to me

# Wiki Documentation

Contents of the kit have been updated; namely it's a full sith outfit (hood, cloak, suit) instead of wizard hat and robes. Tesla arc and repulse book are now lightning bolt and force wall respectively

# Changelog

:cl:  
tweak: Darklord bundle now has lightning bolt and force wall instead of tesla arc (sucks) and repulse respectively
tweak: Darklord spells should no longer require robes so they now don sith garb as they should
/:cl:
