### PR TITLE
stechkins your .357 (the ammo is cheaper)

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -56,15 +56,15 @@
 			new /obj/item/flashlight/emp(src) //2 TC
 			new /obj/item/jammer(src) //5 TC
 
-		if("guns") //Total cost of 31 TC
+		if("guns") //Total cost of 29 TC
 			new /obj/item/gun/ballistic/revolver(src) //6 TC
 			new /obj/item/gun/ballistic/revolver(src) //6 TC
 			new /obj/item/gun/ballistic/automatic/pistol(src) //6 TC
 			new /obj/item/gun/ballistic/automatic/pistol(src) //6 TC
-			new /obj/item/ammo_box/a357(src) //1 TC
-			new /obj/item/ammo_box/a357(src) //1 TC
-			new /obj/item/ammo_box/a357(src) //1 TC
-			new /obj/item/ammo_box/a357(src) //1 TC
+			new /obj/item/ammo_box/a357(src) //1 TC for two
+			new /obj/item/ammo_box/a357(src) //See above
+			new /obj/item/ammo_box/a357(src) //1 TC for two
+			new /obj/item/ammo_box/a357(src) //See above
 			new /obj/item/ammo_box/magazine/m10mm(src) //1 TC for two
 			new /obj/item/ammo_box/magazine/m10mm(src) //See above
 			new /obj/item/ammo_box/magazine/m10mm(src) //1 TC for two
@@ -124,11 +124,11 @@
 			new /obj/item/pizzabox/bomb(src) //6 TC
 			new /obj/item/storage/box/syndie_kit/emp(src) //2 TC
 
-		if("sniper") //30 TC, you only get 11 shots total with the sniper and 14 with the revolver. A mini-ebow would probably be better than the sniper in a normal traitor game
+		if("sniper") //28 TC, you only get 11 shots total with the sniper and 14 with the revolver. A mini-ebow would probably be better than the sniper in a normal traitor game
 			new /obj/item/gun/ballistic/automatic/sniper_rifle(src) //12 TC, nukies only
 			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src) //5 TC, nukies only
 			new /obj/item/gun/ballistic/revolver(src) //6 TC
-			new /obj/item/ammo_box/a357/heartpiercer(src) //3 TC
+			new /obj/item/ammo_box/a357/heartpiercer(src) //1 TC
 			new /obj/item/clothing/glasses/thermal/syndi(src) //4 TC
 			new /obj/item/clothing/gloves/color/latex/nitrile(src) //Free?
 			new /obj/item/clothing/mask/gas/clown_hat(src) //Free?
@@ -540,6 +540,20 @@
 /obj/item/storage/box/syndie_kit/pistolsleepyammo/PopulateContents()
 	for(var/i in 1 to 2)
 		new /obj/item/ammo_box/magazine/m10mm/sp(src)
+
+/obj/item/storage/box/syndie_kit/revolverammo
+	real_name = ".357 speed loader box"
+
+/obj/item/storage/box/syndie_kit/revolverammo/PopulateContents()
+	for(var/i in 1 to 2)
+		new /obj/item/ammo_box/a357(src)
+
+/obj/item/storage/box/syndie_kit/revolvershotgunammo
+	real_name = ".357 Ironfeather speed loader box"
+
+/obj/item/storage/box/syndie_kit/revolvershotgunammo/PopulateContents()
+	for(var/i in 1 to 2)
+		new /obj/item/ammo_box/a357(src)
 
 /obj/item/storage/box/syndie_kit/nuke
 	real_name = "box"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -99,8 +99,7 @@
 				to_chat(user, span_warning("You can't modify it!"))
 				return TRUE
 			magazine.caliber = "357"
-			fire_delay = 12 //What no you don't get to mag dump plus the bullet isn't meant for this cylinder
-			spread = 25 //Can be wildly inaccurate randomly
+			fire_delay = 8 //What no you don't get to mag dump plus the bullet isn't meant for this cylinder. Plus, if you perfectly slam fire with the .38 and hit all your shots, you (should) do more lethal damage than using .357 at this fire_delay
 			fire_sound = 'sound/weapons/revolver357shot.ogg'
 			desc = "The barrel and chamber assembly seems to have been modified."
 			to_chat(user, span_notice("You reinforce the barrel of [src]. Now it will fire .357 rounds."))
@@ -115,7 +114,7 @@
 				to_chat(user, span_warning("You can't modify it!"))
 				return
 			magazine.caliber = "38"
-			fire_delay = 0 //Fixed again
+			fire_delay = 0 //Blessed mag dump
 			spread = 0
 			fire_sound = 'sound/weapons/revolver38shot.ogg'
 			desc = initial(desc)

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -82,7 +82,7 @@
 
 /obj/item/projectile/bullet/pellet/a357_ironfeather
 	name = ".357 Ironfeather pellet"
-	damage = 8.5 //Total of 51 damage assuming PBS
+	damage = 8 //Total of 48 damage assuming PBS; so no, it's not a two-shot anymore
 	wound_bonus = 7 //So it might be able to actually wound things
 	bare_wound_bonus = 7
 	tile_dropoff = 0.4 //Loses 0.05 damage less per tile than standard damaging pellets
@@ -104,20 +104,20 @@
 
 /obj/item/projectile/bullet/a357/metalshock/on_hit(atom/target, blocked = FALSE)
 	..()
-	tesla_zap(target, 4, 17500, TESLA_MOB_DAMAGE)
+	tesla_zap(target, 4, 20000, TESLA_MOB_DAMAGE) //Should do around 33 burn to the first target it
 	return BULLET_ACT_HIT
 
 /obj/item/projectile/bullet/a357/heartpiercer
 	name = ".357 Heartpiercer bullet"
 	damage = 35
-	armour_penetration = 35
+	armour_penetration = 30 //Not as good AP-wise relative to the stechy - both are a 5-hit against bulletproof armor, whereas this 3-hits normal armor versus 4 hits. Revolver has much lower RoF, too
 	penetrating = TRUE //Goes through a single mob before ending on the next target
 	penetrations = 1
 
 /obj/item/projectile/bullet/a357/wallstake
 	name = ".357 Wallstake bullet"
-	damage = 25 //Consider that they're also being thrown into the wall
-	wound_bonus = -50 //Minor chance of dislocation from the bullet itself
+	damage = 36 //Almost entirely a meme round at this point. 36 damage barely four-shots standard armor
+	wound_bonus = -60 //Minor chance of dislocation from the bullet itself
 	sharpness = SHARP_NONE //Blunt
 
 /obj/item/projectile/bullet/a357/wallstake/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -815,46 +815,42 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ammo_box/magazine/m12g/flechette
 
 /datum/uplink_item/ammo/revolver
-	name = ".357 Speed Loader"
-	desc = "A speed loader that contains seven additional .357 rounds; usable with the Syndicate revolver."
-	item = /obj/item/ammo_box/a357
+	name = ".357 Speed Loader Box"
+	desc = "A box with two .357 speed loaders. These speed loaders contain seven .357 rounds each; usable with the Syndicate revolver."
+	item = /obj/item/storage/box/syndie_kit/revolverammo
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/revolver/ironfeather
-	name = ".357 Ironfeather Speed Loader"
-	desc = "A speed loader that contains seven .357 Ironfeather rounds; usable with the Syndicate revolver. \
-			These shells contain six pellets which are less damaging than buckshot but mildly better over range."
-	item = /obj/item/ammo_box/a357/ironfeather
+	name = ".357 Ironfeather Speed Loader Box"
+	desc = "A box with two .357 Ironfeather speed loaders. These speed loaders contain seven .357 Ironfeather shells; usable with the Syndicate revolver. \
+			Ironfeather shells contain six pellets which are less damaging than buckshot but mildly better over range."
+	item = /obj/item/storage/box/syndie_kit/revolvershotgunammo
 
 /datum/uplink_item/ammo/revolver/nutcracker
 	name = ".357 Nutcracker Speed Loader"
 	desc = "A speed loader that contains seven .357 Nutcracker rounds; usable with the Syndicate revolver. \
 			These rounds lose moderate stopping power in exchange for being able to rapidly destroy doors and windows."
 	item = /obj/item/ammo_box/a357/nutcracker
-	cost = 2
 
 /datum/uplink_item/ammo/revolver/metalshock
 	name = ".357 Metalshock Speed Loader"
 	desc = "A speed loader that contains seven .357 Metalshock rounds; usable with the Syndicate revolver. \
 			These rounds convert some lethality into an electric payload, which can bounce between targets."
 	item = /obj/item/ammo_box/a357/metalshock
-	cost = 2
 
 /datum/uplink_item/ammo/revolver/heartpiercer
 	name = ".357 Heartpiercer Speed Loader"
 	desc = "A speed loader that contains seven .357 Heartpiercer rounds; usable with the Syndicate revolver. \
 			These rounds are less damaging, but penetrate through armor and up to two bodies at once."
 	item = /obj/item/ammo_box/a357/heartpiercer
-	cost = 3
 
 /datum/uplink_item/ammo/revolver/wallstake
 	name = ".357 Wallstake Speed Loader"
 	desc = "A speed loader that contains seven .357 Wallstake rounds; usable with the Syndicate revolver. \
-			These blunt rounds are less damaging but can knock people against walls."
+			These blunt rounds are slightly less damaging but can knock people against walls."
 	item = /obj/item/ammo_box/a357/wallstake
-	cost = 3
 
 /datum/uplink_item/ammo/rifle
 	name = "5.56mm Toploader Magazine"


### PR DESCRIPTION
# Document the changes in your pull request

I don't want to come up with a way to make .357 not miserable considering printing out 10mm boxes at the lathe is super easy to top off your magazines and printing off new .357 rounds to fill your speed loaders is much more miserable so I guess I would just rather not have the .357 exist as another TC dumb noob trap thingy because the mini ebow still exists mind you and the hardlight bow exists more now too

So all .357 speed loaders cost 1 TC now, and you can buy normal and Ironfeather in pairs

To offset this cost change some of the absurd ammos have been made less absurd while some of the less absurd ammos have been made more absurd. Namely,

- Ironfeather does 8 damage per pellet now, for a total max damage of 48 instead of 51
- Metalshock has its tesla value up to 20000 from 17500 (which is about 29 to 33 burn on first target my math might be wrong)
- Heartpiercer has 5 less AP so it takes 5 bullets to crit bulletproof armor now, still 3 for standard armor
- Wallstake does 9 more damage because wallstun doesn't exist anymore so it's pretty mid and meme-tier

.38 modified also should have less spread and fire rate because the significant fire delay kind of made .357 loading into your revolver even deader than it was before. .38 should still outclass .357 in raw DPS (not even considering stamina damage) so knock yourself off with the powergaming bullets I guess

# Wiki Documentation

TC costs to be updated on Syndicate Items, also the standard and Ironfeather to be replaced with da box
Damage values to be adjusted on Guide to Combat

# Changelog

:cl:  
tweak: Makes .357 Ironfeather not able to two shot at point blank
tweak: .357 Metalshock tesla arc does even more damage now (about 33 burn on first target)
tweak: .357 Heartpiercer has just slightly less AP to the point where it performs the same against bulletproof armor as 10mm AP HOWEVER it still 3-shots normal armor
tweak: .357 Wallstake now does 36 damage instead of 25 since wallstun no longer exists so it's more of a meme ammo now
tweak: You now purchase .357 and .357 Ironfeather speed loaders in pairs for 1 TC
tweak: All other single .357 speed loaders now cost 1 TC
tweak: .38 modified no longer has absurd spread and as slow of a fire rate; its reduced fire rate should still do less DPS than .38, even regarding lethal damage
/:cl:
