### PR TITLE
Removes unbearable jam mechanics from makeshift pistol

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -106,10 +106,4 @@
 	desc = "A small, makeshift 10mm handgun. It's a miracle if it'll even fire."
 	icon_state = "makeshift"
 	spawnwithmagazine = FALSE
-
-/obj/item/gun/ballistic/automatic/pistol/makeshift/chamber_round(keep_bullet = FALSE)
-	if(prob(40))
-		playsound(src, dry_fire_sound, 30, TRUE)
-		update_icon()
-		return
-	return ..()
+	fire_delay = 6


### PR DESCRIPTION
# Document the changes in your pull request

Now fires as fast as a syndicate revolver instead, .2 seconds slower than other guns (6 deciseconds) (click cooldown is 4 deciseconds)

The thing has a 4 round magazine jesus christ it's an antag item guys

# Changelog

:cl:  
tweak: Makeshift pistol can no longer jam
tweak: Makeshift pistol now fires slightly slower
/:cl:
