### PR TITLE
makes .38 a fully lethal round as it should be

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -53,21 +53,21 @@
 /obj/item/ammo_box/c38/hotshot
 	name = "speed loader (.38 Hot Shot)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade exhaustive properties for an incendiary payload which sets targets ablaze."
+			These rounds trade some damage for an incendiary payload which sets targets ablaze."
 	icon_state = "38hot"
 	ammo_type = /obj/item/ammo_casing/c38/hotshot
 
 /obj/item/ammo_box/c38/iceblox
 	name = "speed loader (.38 Iceblox)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade exhaustive properties for a cryogenic payload which significantly reduces the body temperature of targets hit."
+			These rounds trade some damage for a cryogenic payload which significantly reduces the body temperature of targets hit."
 	icon_state = "38ice"
 	ammo_type = /obj/item/ammo_casing/c38/iceblox
 
 /obj/item/ammo_box/c38/gutterpunch
 	name = "speed loader (.38 Gutterpunch)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade exhaustive properties for an emetic payload which induces nausea in targets."
+			These rounds trade some damage for an emetic payload which induces nausea in targets."
 	icon_state = "38gut"
 	ammo_type = /obj/item/ammo_casing/c38/gutterpunch
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -14,16 +14,14 @@
 
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 15 // yogs - Nerfed revolver damage
-	//knockdown = 60 //yogs - commented out
-	stamina = 35 // yogs
-	wound_bonus = -20
+	damage = 25 //High damaging but...
+	armour_penetration = -40 //Almost doubles the armor of any bullet armor it hits
+	wound_bonus = -10
 	bare_wound_bonus = 10
 
 /obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
-	damage = 15
-	stamina = 0
+	damage = 20
 
 /obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))
@@ -34,8 +32,7 @@
 
 /obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
-	damage = 15
-	stamina = 0
+	damage = 20
 	var/temperature = 100
 
 /obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
@@ -46,8 +43,7 @@
 
 /obj/item/projectile/bullet/c38/gutterpunch //Vomit bullets my favorite
 	name = ".38 Gutterpunch bullet"
-	damage = 15
-	stamina = 0
+	damage = 20
 
 /obj/item/projectile/bullet/c38/gutterpunch/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))


### PR DESCRIPTION
# Document the changes in your pull request

woo boy this is a bad idea

Removes stamina damage from the .38 and instead makes it a 25 damage bullet with -40 armour piercing to represent its ineffectiveness against armour.

Why is this good? It reduces its overall effective damage while also making it weaker against people with armor so it's less good against prepared antags so detective isn't quite as much of a valid tool and it's considered to be some self defense weapon more strictly instead of a better disabler

The special rounds, as a result, have had their damage upped to 20, but they still retain the negative AP

# Wiki Documentation

Description will no doubt have to be changed on the Detective page and the Guide to Combat which I CAN DO

# Changelog

:cl:  
tweak: .38 now does 25 damage with -40 AP, it has lost its stamina damage
tweak: .38 experimental rounds raised to 20 damage as a result, though they retain the negative AP
experimental: Police brutality.
/:cl:
