### PR TITLE
Minor typo fixes for job titles and adds new title option for Curator

### DIFF
--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -11,7 +11,7 @@
 
 	outfit = /datum/outfit/job/curator
 
-	alt_titles = list("Librarian", "Journalist", "Archivist")
+	alt_titles = list("Librarian", "Journalist", "Archivist", "Cartographer")
 
 	added_access = list()
 	base_access = list(ACCESS_LIBRARY, ACCESS_CONSTRUCTION, ACCESS_MINING_STATION)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -77,12 +77,12 @@ GLOBAL_LIST_INIT(alt_engineering_positions, list(
 
 GLOBAL_LIST_INIT(alt_medical_positions, list(
 	"Medical Director", "Head of Medical",
-	"Physician", "Surgeon", "Nurse", "Medical Resident", "Attending Physician", "Chief Surgeon", "Chief Surgeon", "Medical Subdirector", "General Practitioner",
+	"Physician", "Surgeon", "Nurse", "Medical Resident", "Attending Physician", "Chief Surgeon", "Medical Subdirector", "General Practitioner",
 	"DNA Mechanic", "Bioengineer", "Junior Geneticist", "Gene Splicer",
 	"Microbiologist", "Pathologist", "Junior Disease Researcher", "Epidemiologist",
 	"Pharmacist", "Chemical Analyst", "Chemistry Lab Technician", "Chemical Specialist",
 	"EMT", "Paramedic Trainee", "Rapid Response Medic",
-	"Councilor", "Therapist", "Mentalist",
+	"Counsellor", "Therapist", "Mentalist",
 	"Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer",
 	"Security Medic", "Security Medical Support", "Penitentiary Medical Care Unit", "Junior Brig Physician", "Detention Center Health Officer",))
 
@@ -101,7 +101,7 @@ GLOBAL_LIST_INIT(alt_civilian_positions, list(
 	"Barkeep", "Tapster", "Barista", "Mixologist",
 	"Ecologist", "Agriculturist", "Botany Greenhorn", "Hydroponicist",
 	"Chef", "Hash Slinger", "Sous-chef", "Culinary Artist",
-	"Custodian", "Sanitation Worker", "Cleaner", "Caretaker",
+	"Custodian", "Sanitation Worker", "Cleaner", "Caretaker", "Maid",
 	"Librarian", "Journalist", "Archivist",
 	"Prosecutor", "Defense Attorney", "Paralegal", "Ace Attorney",
 	"Priest", "Preacher", "Cleric", "Exorcist",

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(alt_civilian_positions, list(
 	"Ecologist", "Agriculturist", "Botany Greenhorn", "Hydroponicist",
 	"Chef", "Hash Slinger", "Sous-chef", "Culinary Artist",
 	"Custodian", "Sanitation Worker", "Cleaner", "Caretaker", "Maid",
-	"Librarian", "Journalist", "Archivist",
+	"Librarian", "Journalist", "Archivist", "Cartographer",
 	"Prosecutor", "Defense Attorney", "Paralegal", "Ace Attorney",
 	"Priest", "Preacher", "Cleric", "Exorcist",
 	"Entertainer", "Comedian", "Jester",


### PR DESCRIPTION
# Document the changes in your pull request

This PR fixes issues some minor typos in `jobs.dm` that caused certain customized titles to not show up in the correct categories in Crew Monitors and Crew Manifests. 

![crew_manifest](https://user-images.githubusercontent.com/2159739/204050805-7cfccbdb-5743-4d59-bdf7-2c90c05dccaf.PNG)

In my cursory search I found two that had an issue: "Counsellor" and "Maid". 

I also added a new job title option for the Curator, as I noticed that they have a tendency to use the space suit costume to explore space. I called it "Cartographer" - I thought that would be an interesting name for someone who explores and maps outer space z-levels. But I understand that this is somewhat outside of scope so let me know if it isn't desirable and I can omit it from the PR. 

# Wiki Documentation

Requires update to "Alternative Titles" in Curator wiki page, if Cartographer is added.

# Changelog

:cl:  
rscadd: Nanotrasen now hiring Space Cartographers to explore outside station.
bugfix: Fixes Counsellor and Maid title showing up in incorrect Crew Categories.
/:cl:
