### PR TITLE
adds tactical fingerless gloves to uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -146,11 +146,11 @@
 
 /obj/item/storage/box/syndicate/bundle_B/PopulateContents()
 	switch (pickweight(list("v" = 2, "oddjob" = 2, "neo" = 1, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2, "gang_boss" = 1)))
-		if("v") //Big Boss. Total of ~28 TC.
+		if("v") //Big Boss. Total of ~26 TC.
 			new /obj/item/clothing/under/syndicate/camo(src) //Reskinned tactical turtleneck, free
 			new /obj/item/clothing/glasses/eyepatch/bigboss(src) //Gives flash protection and night vision, probably around 2-3 TC
 			new /obj/item/clothing/shoes/combat(src) //Drip is essential. Free
-			new /obj/item/clothing/gloves/fingerless/bigboss(src) //Like a much lighter version of the Gloves of the North Star, but also helps with carrying bodies. Worth maybe 4 TC
+			new /obj/item/clothing/gloves/fingerless/bigboss(src) //Like a much lighter version of the Gloves of the North Star, but also helps with carrying bodies. Worth maybe 2 TC
 			new /obj/item/storage/belt/military(src) //Can't be concealed, basically just 7-slot belt, no normal items allowed. Free
 			new /obj/item/book/granter/martial/cqc(src) //13 TC, ABSOLUTELY mandatory
 			new /obj/item/gun/ballistic/automatic/toy/pistol/riot(src) //1 TC, not a tranq pistol but it's something

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -29,7 +29,7 @@
 	if(slot == SLOT_GLOVES)
 		ADD_TRAIT(user, carrytrait, CLOTHING_TRAIT)
 		if(!worn) //Literally just in case there's some weirdness so you can't cheese this
-			boss.physiology.do_after_speed *= 0.9 //Does stuff 10% faster
+			boss.physiology.do_after_speed *= 0.8 //Does stuff 20% faster
 			worn = TRUE
 
 /obj/item/clothing/gloves/fingerless/bigboss/dropped(mob/user)
@@ -37,7 +37,7 @@
 	var/mob/living/carbon/human/boss = user
 	REMOVE_TRAIT(user, carrytrait, CLOTHING_TRAIT)
 	if(worn) //This way your speed isn't slowed if you never actually put on the gloves
-		boss.physiology.do_after_speed /= 0.9
+		boss.physiology.do_after_speed /= 0.8
 		worn = FALSE
 
 /obj/item/clothing/gloves/botanic_leather

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1670,6 +1670,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/toolbox/syndicate
 	cost = 1
 
+/datum/uplink_item/device_tools/tactical_gloves
+	name = "Tactical Fingerless Gloves"
+	desc = "A pair of simple fabric gloves without fingertips that allow one to perform tasks faster and act quicker in unarmed manuevers. \
+			Also greatly assists with the carrying of bodies."
+	item = /obj/item/clothing/gloves/fingerless/bigboss
+	cost = 4
+
 /datum/uplink_item/device_tools/hacked_module
 	name = "Hacked AI Law Upload Module"
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1675,7 +1675,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pair of simple fabric gloves without fingertips that allow one to perform tasks faster and act quicker in unarmed manuevers. \
 			Also greatly assists with the carrying of bodies."
 	item = /obj/item/clothing/gloves/fingerless/bigboss
-	cost = 4
+	cost = 2
 
 /datum/uplink_item/device_tools/hacked_module
 	name = "Hacked AI Law Upload Module"


### PR DESCRIPTION
# Document the changes in your pull request

Makes the gloves that the V bundle has available to any uplink for 2 TC because rule of cool

The gloves also had their do_after coefficient buffed to 0.8 instead of 0.9 because I thought it was fairly minuscule for something that makes it so you don't have insuls and they aren't metashielded either

# Wiki Documentation

Gloves should be included under Devices and Tools section in Syndicate Items

# Changelog

:cl:  
rscadd: Tactical Fingerless Gloves from the V bundle are now available in the uplink for 2 TC
tweak: do_after for fingerless gloves buffed to 0.8 from 0.9
/:cl:
