### PR TITLE
Marker beacons are dimmer

### DIFF
--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -68,15 +68,15 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 
 /obj/structure/marker_beacon
 	name = "marker beacon"
-	desc = "A Prism-brand path illumination device. It is anchored in place and glowing steadily."
+	desc = "A Prism-brand path illumination device. It is anchored in place and glowing softly."
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "marker"
 	layer = BELOW_OPEN_DOOR_LAYER
 	armor = list(MELEE = 50, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 25, BIO = 100, RAD = 100, FIRE = 25, ACID = 0)
 	max_integrity = 50
 	anchored = TRUE
-	light_range = 2
-	light_power = 3
+	light_range = 1
+	light_power = 1
 	var/remove_speed = 15
 	var/picked_color
 


### PR DESCRIPTION
# Document the changes in your pull request

They don't need to glow brightly to be seen on lavaland. If they're not on Lavaland, they're being used to validhunt.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Marker beacons are dimmer
/:cl: