### PR TITLE
Light prisms are dimmer

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -55,7 +55,7 @@ Slimecrossing Armor
 	. = ..()
 	color = newcolor
 	light_color = newcolor
-	set_light(1)
+	set_light(2)
 
 /obj/structure/light_prism/attack_hand(mob/user)
 	to_chat(user, span_notice("You dispel [src]"))

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -55,7 +55,7 @@ Slimecrossing Armor
 	. = ..()
 	color = newcolor
 	light_color = newcolor
-	set_light(5)
+	set_light(1)
 
 /obj/structure/light_prism/attack_hand(mob/user)
 	to_chat(user, span_notice("You dispel [src]"))


### PR DESCRIPTION
# Document the changes in your pull request

Light prisms don't have a cooldown and just one can light up a small room. This way xenobiology has to work a little more (still not much) to get their dark antag valids.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Light prisms are dimmer
/:cl: