### PR TITLE
[AsteroidStation] Adds an Autolathe to Service Hall

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -1625,11 +1625,6 @@
 "anj" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
-"ank" = (
-/obj/structure/table,
-/obj/item/key/janitor,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "anm" = (
 /turf/closed/wall,
 /area/chapel/office)
@@ -2644,13 +2639,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"auL" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/fork,
-/obj/item/reagent_containers/glass/mixbowl,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "auT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22257,6 +22245,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
+"gFv" = (
+/obj/structure/table,
+/obj/item/kitchen/knife,
+/obj/item/kitchen/fork,
+/obj/item/reagent_containers/glass/mixbowl,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "gFE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -32070,15 +32066,6 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
-"jUr" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "jUu" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -37090,6 +37077,12 @@
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plating/airless,
 /area/ruin/powered)
+"lQj" = (
+/obj/structure/table,
+/obj/item/key/janitor,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "lQw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -67664,6 +67657,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"vZB" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "vZC" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plasteel,
@@ -100482,7 +100482,7 @@ wWd
 aRI
 aZa
 aGb
-jUr
+vZB
 akZ
 agw
 ape
@@ -101508,8 +101508,8 @@ xXv
 aFr
 lkU
 aRI
-ank
-auL
+lQj
+gFv
 dwg
 akZ
 aRI


### PR DESCRIPTION
# Document the changes in your pull request

Adds an Autolathe to the Service Hall in Asteroid Station. I did have to remove a table to get it to fit, and I moved the rolling pin to the other cooking items table, and the bucket to the table with the key on it. This makes it equal to box as it has both types of lathes.

:cl:  
mapping: Adjusts the Service Hall on Asteroid Station to include an autolathe, removing a table and moving some items to make it fit.
/:cl:
