### PR TITLE
Removes a lie

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -397,7 +397,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	short_desc = "You are a space bartender!"
-	flavour_text = "Time to mix drinks and change lives. Smoking space drugs makes it easier to understand your patrons' odd dialect."
+	flavour_text = "Time to mix drinks and change lives. Unfortunately, you can't understand your patrons' odd dialect."
 	assignedrole = "Space Bartender"
 	id_job = "Bartender"
 

--- a/code/modules/language/beachbum.dm
+++ b/code/modules/language/beachbum.dm
@@ -1,6 +1,6 @@
 /datum/language/beachbum
 	name = "Beachtongue"
-	desc = "An ancient language from the distant Beach Planet. People magically learn to speak it under the influence of space drugs."
+	desc = "An ancient language from the distant Beach Planet."
 	speech_verb = "mumbles"
 	ask_verb = "grills"
 	exclaim_verb = "hollers"


### PR DESCRIPTION
# Document the changes in your pull request

Space drugs do not confer beachtongue. Now the game won't tell you it does.
Someone else fix this then revert.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscdel: Beachtongue's description no longer lies about having a relationship to space drugs
/:cl: