### PR TITLE
Admin RCD is ranged

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -814,6 +814,7 @@ RLD
 	name = "admin RCD"
 	max_matter = INFINITY
 	matter = INFINITY
+	ranged = TRUE
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
 
 


### PR DESCRIPTION
# Document the changes in your pull request

There's an admin RCD with infinite ammo and no range
There's an advanced RCD with finite ammo and range
Why isn't there one with both
Why make a new one if the admin RCD is for admin stuff anyway

# Changelog

:cl:  
tweak: Admin RCD is ranged
/:cl: