### PR TITLE
Updates the mining medic locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -129,14 +129,13 @@
 	new /obj/item/clothing/suit/toggle/labcoat/emt/explorer(src)
 	new /obj/item/clothing/head/beret/emt/mining(src)
 	new /obj/item/clothing/under/yogs/rank/miner/medic(src)
+	new /obj/item/storage/belt/medical/mining(src)
+	new /obj/item/clothing/glasses/hud/health/meson(src)
+	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/shoes/sneakers/white(src)
-	new /obj/item/cartridge/medical(src)
-	new /obj/item/radio/headset/headset_cargo(src)
-	new /obj/item/storage/firstaid/toxin(src)
+	new	/obj/item/radio/headset/headset_medcargo(src)
 	new /obj/item/clothing/mask/gas/explorer(src)
-	new /obj/item/pickaxe(src)
 	new /obj/item/twohanded/binoculars(src)
-	new /obj/item/clothing/ears/earmuffs(src)
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/sensor_device(src)
 	new /obj/item/bodybag/environmental(src)
@@ -144,7 +143,7 @@
 	new /obj/item/reagent_containers/medspray/synthflesh(src)
 	var/obj/item/key/K = new(src)
 	K.name = "ATV key"
-	K.desc = "It's a small grey key. Don't let those goddamn ashwalkers get it."
+	K.desc = "It's a small grey key. Don't let those goddamn ashwalkers or plantpeople get it."
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -43,7 +43,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/explorer
 	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
 	l_hand = /obj/item/storage/firstaid/hypospray/qmc
-	gloves = /obj/item/clothing/gloves/color/latex
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	head = /obj/item/clothing/head/soft/emt/mining
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med


### PR DESCRIPTION
replaced the regular cargo headset with the medcargo
gives another mining medical webbing
gives another mining medical hud
gives another pair of gloves
removes the toxins medkit, there's already a box with medkits that this one isn't needed and just adds clutter
got rid of the pick, mining tools are so common that they aren't needed here
removes earmuffs because there's no reason to ever use them

also gives mining medic nitrile gloves instead of regular latex gloves

:cl:  
rscadd: Spare webbing, hud, gloves, and headset to mining medic locker
rscdel: Pickaxe, earmuffs, and misplaced medkit from mining medic locker
tweak: Mining medic now gets nitrile gloves instead of latex
/:cl:
