### PR TITLE
thermite can't burn rwalls

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -13,11 +13,12 @@
 	var/static/list/immunelist = typecacheof(list(
 		/turf/closed/wall/mineral/diamond,
 		/turf/closed/indestructible,
-		/turf/open/indestructible)
+		/turf/open/indestructible,
+		/turf/closed/wall/r_wall)
 		)
 	
 	var/static/list/resistlist = typecacheof(
-		/turf/closed/wall/r_wall
+		/turf/closed/wall/mineral
 		)
 
 /datum/component/thermite/Initialize(_amount)


### PR DESCRIPTION
me when it takes 0 seconds of effort and no time investment to destroy reinforced walls by pressing 3 buttons on a chemical dispenser (i hate chemistry players)

# Changelog

:cl:  
tweak: mineral walls are thermite resistant
tweak: reinforced walls are now thermite proof
/:cl:
