### PR TITLE
Removes Disintegrate from the wizard Spellbook.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -119,10 +119,6 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/projectile/magic_missile
 	category = "Defensive"
 
-/datum/spellbook_entry/disintegrate
-	name = "Disintegrate"
-	spell_type = /obj/effect/proc_holder/spell/targeted/touch/disintegrate
-
 /datum/spellbook_entry/pacify
 	name = "Pacify"
 	spell_type = /obj/effect/proc_holder/spell/targeted/touch/pacify


### PR DESCRIPTION
# Document the changes in your pull request
Disintegrate has been removed from the Spellbook as having an instant uncounterable instagib is maybe a tad too imbalanced for even wizard. hopefully this encourages wizards to try more fun loadouts that solo murderbone because that's the most optimal thing in the game.

Jamie gave me the ok about this on discord.
# Wiki Documentation
Remove from the section or add a note to disintegrate on the wizard page that disintegrate is no longer obtainable outside of begging an admin or something.
# Changelog
:cl:
rscdel: Removed Disintegrate from the Spell book
/:cl:
