### PR TITLE
Ice tile no longer has a slowdown

### DIFF
--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -176,7 +176,6 @@
 	temperature = 180
 	planetary_atmos = TRUE
 	baseturfs = /turf/open/floor/plating/ice
-	slowdown = 1
 	attachment_holes = FALSE
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_FLOOR


### PR DESCRIPTION
# Document the changes in your pull request

If it slips you why the hell is it going to slow you down when you have the proper equipment to not slip

Ice will no longer slow you down

# Spriting


# Wiki Documentation



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: ice will no longer slow you down by 1
/:cl:
