### PR TITLE
Adds two lobby songs from the Loop Hero OST

### DIFF
--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -56,7 +56,9 @@
 		"https://www.youtube.com/watch?v=8DNoXUnaQ9k",						// Chris Christodoulou - Dies Irae
 		"https://www.youtube.com/watch?v=Nn9trJXUrp0",						// Chris Christodoulou - ...con lentitud poderosa
 		"https://www.youtube.com/watch?v=rkas-NHQnsI",						// Clint Eastwood - Magnum Force Theme 
-		"https://www.youtube.com/watch?v=e3t_dbLaw-M"						// DM Dokuro - Treasures Within The Abomination
+		"https://www.youtube.com/watch?v=e3t_dbLaw-M",						// DM Dokuro - Treasures Within The Abomination
+		"https://www.youtube.com/watch?v=2O4C8J4bcXw",						// Blinch - Loop Hero OST - Loop Blues
+		"https://www.youtube.com/watch?v=4q-La8uR0HU"						// Blinch - Loop Hero OST - Dark Matter Moon
 		)						
 	selected_lobby_music = pick(songs)
 


### PR DESCRIPTION
More music = More good

Quite a lot of songs from loop hero fit the aesthetic that SS13 has
I couldn't decide between these two so I chose to add both because they're different enough from each other

adds 
https://www.youtube.com/watch?v=2O4C8J4bcXw Loop Blues
https://www.youtube.com/watch?v=4q-La8uR0HU Dark Matter Moon

:cl:  
rscadd: Adds Dark Matter Moon and Loop Blues from the Loop Hero OST to Lobby music
/:cl:
