### PR TITLE
Fixes a incorrectly coloured and unnamed pipe and manifold in meta station atmos

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -77757,7 +77757,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -78094,11 +78094,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "vQi" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4;
-	name = "Scrubbers Pipe";
-	color = "#ff0000";
-	pipe_color = "#ff0000"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
 	},
 /turf/closed/wall,
 /area/engine/atmos_distro)

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -78095,7 +78095,10 @@
 /area/medical/morgue)
 "vQi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
+	dir = 4;
+	name = "Scrubbers Pipe";
+	color = "#ff0000";
+	pipe_color = "#ff0000"
 	},
 /turf/closed/wall,
 /area/engine/atmos_distro)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Changes a pipe and manifold leading to waste on mix loop to the correct type in meta station atmos 

# Changelog

:cl:  
tweak: Changes  a pipe and manifold to the correct one in meta station atmos
/:cl:


> Also we don't mapedit pipes like this. Use the available ones that are coded in.

