### PR TITLE
Overhauls Malf AI Objectives and updates win condition.

### DIFF
--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -51,18 +51,18 @@
 			return FALSE
 	return TRUE
 
+//Start of Yogstation change: Victory criteria.
 /datum/game_mode/malf/set_round_result()
 	..()
-
-	if(station_was_nuked)
-		SSticker.mode_result = "win - AI doomsday"
-	else if(didAntagsWin(traitors, /datum/antagonist/traitor/malf))
-		SSticker.mode_result = "win - AI achieved their objectives"
+	if(didAntagsWin(traitors, /datum/antagonist/traitor/malf))
+		SSticker.mode_result = "AI Major Victory - AI achieved their objectives"
+	else if(station_was_nuked)
+		SSticker.mode_result = "AI Minor Victory - AI did not achieve their objectives, but nuked the station."
 	else if(!are_special_antags_dead())
-		SSticker.mode_result = "halfwin - evacuation - AI survived"
-
+		SSticker.mode_result = "Crew Minor Victory - AI did not achieve their objectives, but survived."
 	else
-		SSticker.mode_result = "loss - evacuation - AI killed"
+		SSticker.mode_result = "Crew Major Victory - AI did not achieve their objectives, and did not survive."
+//End of Yogstation change: Victory criteria.
 
 /datum/game_mode/malf/generate_report()
 	return "A [pick(list("huge electrical storm","photon emitter","meson generator","blue swirly thing"))] was recently picked up by a nearby station's sensors in your sector. \

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3619,6 +3619,7 @@
 #include "yogstation\code\modules\antagonists\infiltrator\items\ai_hijack.dm"
 #include "yogstation\code\modules\antagonists\infiltrator\items\hardsuit.dm"
 #include "yogstation\code\modules\antagonists\infiltrator\items\services.dm"
+#include "yogstation\code\modules\antagonists\malf\malf.dm"
 #include "yogstation\code\modules\antagonists\nukeop\clownop.dm"
 #include "yogstation\code\modules\antagonists\nukeop\nukeop.dm"
 #include "yogstation\code\modules\antagonists\nukeop\equipment\nuclearbomb.dm"

--- a/yogstation/code/game/gamemodes/objective.dm
+++ b/yogstation/code/game/gamemodes/objective.dm
@@ -4,3 +4,36 @@ GLOBAL_LIST_INIT(infiltrator_objective_areas, typecacheof(list(/area/yogs/infilt
 	if(..())
 		return TRUE
 	return !considered_alive(target)
+
+
+
+/datum/objective/protect_mindless_living
+	name = "protect living"
+	var/mob/living/protect_target
+
+/datum/objective/protect_mindless_living/proc/set_target(mob/living/L)
+	protect_target = L
+	update_explanation_text()
+
+/datum/objective/protect_mindless_living/update_explanation_text()
+	. = ..()
+	if(protect_target)
+		explanation_text = "Protect \the [protect_target] at all costs."
+	else
+		explanation_text = "Free Objective"
+
+/datum/objective/protect_mindless_living/check_completion()
+
+	if(..())
+		return TRUE
+
+	if(!protect_target)
+		return TRUE
+
+	if(QDELETED(protect_target))
+		return FALSE
+
+	if(protect_target.stat == DEAD)
+		return FALSE
+
+	return TRUE //All good!

--- a/yogstation/code/game/gamemodes/objective.dm
+++ b/yogstation/code/game/gamemodes/objective.dm
@@ -4,36 +4,4 @@ GLOBAL_LIST_INIT(infiltrator_objective_areas, typecacheof(list(/area/yogs/infilt
 	if(..())
 		return TRUE
 	return !considered_alive(target)
-
-
-
-/datum/objective/protect_mindless_living
-	name = "protect living"
-	var/mob/living/protect_target
-
-/datum/objective/protect_mindless_living/proc/set_target(mob/living/L)
-	protect_target = L
-	update_explanation_text()
-
-/datum/objective/protect_mindless_living/update_explanation_text()
-	. = ..()
-	if(protect_target)
-		explanation_text = "Protect \the [protect_target] at all costs."
-	else
-		explanation_text = "Free Objective"
-
-/datum/objective/protect_mindless_living/check_completion()
-
-	if(..())
-		return TRUE
-
-	if(!protect_target)
-		return TRUE
-
-	if(QDELETED(protect_target))
-		return FALSE
-
-	if(protect_target.stat == DEAD)
-		return FALSE
-
-	return TRUE //All good!
+	

--- a/yogstation/code/game/gamemodes/objective.dm
+++ b/yogstation/code/game/gamemodes/objective.dm
@@ -4,4 +4,3 @@ GLOBAL_LIST_INIT(infiltrator_objective_areas, typecacheof(list(/area/yogs/infilt
 	if(..())
 		return TRUE
 	return !considered_alive(target)
-	

--- a/yogstation/code/modules/antagonists/malf/malf.dm
+++ b/yogstation/code/modules/antagonists/malf/malf.dm
@@ -16,26 +16,6 @@
 		var/datum/objective/robot_army/army_objective = new //Have 8 or more connected cyborgs.
 		army_objective.owner = owner
 		add_objective(army_objective)
-	else if(!protect_objective.target || !prob(80)) //Gameplay optimization.
-		var/list/possible_pets = list()
-		for(var/mob/living/simple_animal/M in GLOB.alive_mob_list)
-			//This is a hacky way of getting unique pets.
-			if(M.gold_core_spawnable != NO_SPAWN) //Not unique.
-				continue
-			if(!M.healable || M.del_on_death) //Annoying to protect.
-				continue
-			if(M.status_flags & GODMODE) //lol
-				continue
-			if(!M.z || !is_station_level(M.z))
-				continue
-			possible_pets += M
-		if(length(possible_pets)) //I don't see this failing, but whatever.
-			var/datum/objective/protect_mindless_living/pettect_objective = new //Protect a pet from dying.
-			pettect_objective.owner = owner
-			pettect_objective.protect_target = pick(possible_pets)
-			pettect_objective.update_explanation_text()
-			add_objective(pettect_objective)
-
 
 	murderbone_objective = new murderbone_objective
 	murderbone_objective.owner = owner

--- a/yogstation/code/modules/antagonists/malf/malf.dm
+++ b/yogstation/code/modules/antagonists/malf/malf.dm
@@ -1,0 +1,45 @@
+/datum/antagonist/traitor/malf/forge_ai_objectives()
+
+	var/list/datum/objective/possible_murderbone_objectives = list(
+		/datum/objective/block = 100, //No organics on the shuttle.
+		/datum/objective/purge = 50 //No mutants on the shuttle.
+	)
+	var/datum/objective/murderbone_objective = pickweight(possible_murderbone_objectives) //Kill kill kill.
+
+
+	var/datum/objective/protect/protect_objective = new //Protect someone from dying. Prevents indiscriminate plasma floods.
+	protect_objective.owner = owner
+	protect_objective.find_target()
+	add_objective(protect_objective)
+
+	if(!protect_objective.target || !prob(80)) //Gameplay optimization.
+		var/list/possible_pets = list()
+		for(var/mob/living/simple_animal/M in GLOB.alive_mob_list)
+			//This is a hacky way of getting unique pets.
+			if(M.gold_core_spawnable != NO_SPAWN) //Not unique.
+				continue
+			if(!M.healable || M.del_on_death) //Annoying to protect.
+				continue
+			if(M.status_flags & GODMODE) //lol
+				continue
+			if(!M.z || !is_station_level(M.z))
+				continue
+			possible_pets += M
+		if(length(possible_pets)) //I don't see this failing, but whatever.
+			var/datum/objective/protect_mindless_living/pettect_objective = new //Protect a pet from dying.
+			pettect_objective.owner = owner
+			pettect_objective.protect_target = pick(possible_pets)
+			pettect_objective.update_explanation_text()
+			add_objective(pettect_objective)
+	else if(GLOB.joined_player_list.len >= 20 && prob(GLOB.joined_player_list.len*2))
+		var/datum/objective/robot_army/army_objective = new //Have 8 or more connected cyborgs.
+		army_objective.owner = owner
+		add_objective(army_objective)
+
+	murderbone_objective = new murderbone_objective
+	murderbone_objective.owner = owner
+	add_objective(murderbone_objective)
+
+	var/datum/objective/survive/exist/exist_objective = new //Live live live.
+	exist_objective.owner = owner
+	add_objective(exist_objective)

--- a/yogstation/code/modules/antagonists/malf/malf.dm
+++ b/yogstation/code/modules/antagonists/malf/malf.dm
@@ -12,7 +12,11 @@
 	protect_objective.find_target()
 	add_objective(protect_objective)
 
-	if(!protect_objective.target || !prob(80)) //Gameplay optimization.
+	if(GLOB.joined_player_list.len >= 40)
+		var/datum/objective/robot_army/army_objective = new //Have 8 or more connected cyborgs.
+		army_objective.owner = owner
+		add_objective(army_objective)
+	else if(!protect_objective.target || !prob(80)) //Gameplay optimization.
 		var/list/possible_pets = list()
 		for(var/mob/living/simple_animal/M in GLOB.alive_mob_list)
 			//This is a hacky way of getting unique pets.
@@ -31,10 +35,7 @@
 			pettect_objective.protect_target = pick(possible_pets)
 			pettect_objective.update_explanation_text()
 			add_objective(pettect_objective)
-	else if(GLOB.joined_player_list.len >= 20 && prob(GLOB.joined_player_list.len*2))
-		var/datum/objective/robot_army/army_objective = new //Have 8 or more connected cyborgs.
-		army_objective.owner = owner
-		add_objective(army_objective)
+
 
 	murderbone_objective = new murderbone_objective
 	murderbone_objective.owner = owner


### PR DESCRIPTION
# What was changed

## AI objectives now have more variety.  ##

The way it works:

- 1 random murderbone objective is rolled. It is either "Ensure no organics on the shuttle escape." or "Ensure no non-humans on the shuttle escape.". There is a higher chance to roll the former.
- 1 protect crewmember objective is rolled. 1 randomly chosen crewmember will be set as the AI's protect target. They must survive until the end.
- If the population is above 40 players, the AI will be given an objective to convert 8 crewmembers into borgs. Otherwise, there is a 20% chance to be given a protect pet objective.
- Of course, the stay alive to the end still exists.

## There are now 4 different victories for MALF. ##

- Condition 1: AI completes all their objectives. AI Major Victory.
- Condition 2: AI uses the nuke. AI Minor Victory.
- Condition 3: AI does not complete their objectives nor uses the nuke, but is still alive. Crew Minor Victory.
- Condition 4: AI dies and does not use the nuke nor complete their objectives. Crew Major Victory.

# Why this should be added to the game.

MALF is currently a really repetitive gamemode. The MALF usually stealths it way to the nuke and then plasmafloods the station, which isn't really fun. To make things more interesting, MALF AIs will be given a protect objective, and a "Convert 8 people into borgs" or a protect pet objective, depending on playercount and chance.

The new objective changes should prevent indiscriminate murderboning usually reserved for wizard, hijack, or nuke ops while at the same time making the AI actually think about how they're going to complete their protect objectives or convert people into cyborgs.

# Changelog

:cl:  BurgerBB
experimental: Malfunctioning AIs now have new objectives. Remember to read them carefully!
tweak: Changes the completely cosmetic win message conditions for the MALF gamemode.
/:cl:
