### PR TITLE
removes the sleepers and medkits from reebe because new players get confused

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -40,15 +40,6 @@
 /obj/structure/destructible/clockwork/massive/celestial_gateway,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"al" = (
-/obj/machinery/sleeper/clockwork,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
-"am" = (
-/obj/structure/table/reinforced/brass,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "an" = (
 /obj/structure/noticeboard,
 /obj/item/paper/fluff/ruins/djstation{
@@ -66,18 +57,6 @@
 /area/reebe/city_of_cogs)
 "aq" = (
 /obj/machinery/computer/camera_advanced/ratvar,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
-"ar" = (
-/obj/machinery/sleeper/clockwork{
-	dir = 8
-	},
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
-"as" = (
-/obj/machinery/sleeper/clockwork{
-	dir = 4
-	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
 "at" = (
@@ -120,12 +99,6 @@
 "aA" = (
 /obj/machinery/door/airlock/clockwork/brass{
 	name = "Infirmary"
-	},
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
-"aC" = (
-/obj/machinery/sleeper/clockwork{
-	dir = 1
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
@@ -260,6 +233,11 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
+"px" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/paper/servant_primer/infirmarypaper,
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
 "wm" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/kitchen/fork{
@@ -276,9 +254,17 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
+"wT" = (
+/obj/structure/table/reinforced/brass,
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
 "Ct" = (
 /turf/closed/indestructible/riveted,
 /area/reebe)
+"Nw" = (
+/obj/item/clockwork/alloy_shards,
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
 "Vl" = (
 /obj/structure/table/reinforced/brass,
 /obj/effect/landmark/servant_of_ratvar/scarab,
@@ -4599,11 +4585,11 @@ aj
 aj
 aj
 ai
-am
+px
 aj
 aj
 aj
-as
+Nw
 ah
 ah
 aH
@@ -4695,7 +4681,7 @@ aj
 aj
 aj
 aj
-aC
+Nw
 ah
 ai
 ag
@@ -4782,7 +4768,7 @@ aj
 aj
 aj
 ah
-al
+Nw
 aj
 aj
 aj
@@ -4966,7 +4952,7 @@ aj
 aj
 aj
 ah
-ar
+Nw
 aj
 aj
 aA
@@ -5059,7 +5045,7 @@ aj
 aj
 ah
 aQ
-am
+wT
 ai
 aj
 aj

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -360,6 +360,10 @@ Credit where due:
 	if(!is_servant_of_ratvar(user) && !isobserver(user))
 		. += span_danger("You can't understand any of the words on [src].")
 
+/obj/item/paper/servant_primer/infirmarypaper
+	name = "IOU"
+	info = "We pawned the sleepers and medkits in here off for some tomato sauce so we wouldn't have to eat dry pasta anymore. Shouldn't be an issue, if you need to heal yourself or a fellow servant cast Sentinel's Compromise or use a Vitality Matrix"
+
 /obj/effect/spawner/lootdrop/clockcult
 	name = "clock tile"
 	lootdoubles = 0

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -362,7 +362,7 @@ Credit where due:
 
 /obj/item/paper/servant_primer/infirmarypaper
 	name = "IOU"
-	info = "We pawned the sleepers and medkits in here off for some tomato sauce so we wouldn't have to eat dry pasta anymore. Shouldn't be an issue, if you need to heal yourself or a fellow servant cast Sentinel's Compromise or use a Vitality Matrix"
+	info = "We pawned the sleepers and medkits in here off for some tomato sauce so we wouldn't have to eat dry pasta anymore. Shouldn't be an issue, if you need to heal yourself or a fellow servant cast Sentinel's Compromise or use a Vitality Matrix."
 
 /obj/effect/spawner/lootdrop/clockcult
 	name = "clock tile"


### PR DESCRIPTION
not actually a clock cult nerf because i also added a paper telling people how to heal each other, because i see way too many new players following the thought process of 'sleepers heal people, so i should dump my dying or dead teammates in there and hope for the best!'

# Changelog

:cl:  
rscadd: added a paper to reebe telling you how to heal and resurrect teammates (spoilers: its not with the super shitty reebe sleepers)
rscdel: the sleepers and medkits are removed from reebe
/:cl:
