### PR TITLE
Fix world topic logs that are wrong and bad

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -175,8 +175,10 @@ GLOBAL_VAR(restart_counter)
 			break
 
 	if((!handler || initial(handler.log)) && config && CONFIG_LOADED && CONFIG_GET(flag/log_world_topic))
-		var/static/regex/key_regex = regex(@"(&?)key=[^&]+(&?)", "g")
-		log_topic("\"[key_regex.Replace(T, "$1\[COMMS KEY\]$2")]\", from:[addr], master:[master], key:[CONFIG_GET(string/comms_key) == key ? "" : "in"]correct")
+		var/list/params = params2list(T) // Different list from input so it can be sanatized without breaking the rest of the topic
+		if("key" in params)
+			params["key"] = CONFIG_GET(string/comms_key) == params["key"] ? "correct" : "incorrect"
+		log_topic("\"[list2params(params)]\", from:[addr], master:[master], ckey:[key]")
 
 	if(!handler)
 		return


### PR DESCRIPTION
# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

I misunderstood the parameters of /world/Topic, also regex bad

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed comms key always being logged as wrong
tweak: improved comms key log sanatization 
/:cl:
