### PR TITLE
stabilized red extract makes you a bit faster but doesnt have slowdown immunity

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -756,11 +756,11 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "red"
 
 /datum/status_effect/stabilized/red/on_apply()
-	owner.ignore_slowdown("slimestatus")
+	owner.add_movespeed_modifier("stabilized_red_speed", update=TRUE, priority=100, multiplicative_slowdown=-0.3, blacklisted_movetypes=(FLYING|FLOATING))
 	return ..()
 
 /datum/status_effect/stabilized/red/on_remove()
-	owner.unignore_slowdown("slimestatus")
+	owner.remove_movespeed_modifier("stabilized_red_speed")
 
 /datum/status_effect/stabilized/green
 	id = "stabilizedgreen"

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -102,7 +102,7 @@ Stabilized extracts:
 
 /obj/item/slimecross/stabilized/red
 	colour = "red"
-	effect_desc = "Nullifies all equipment based slowdowns."
+	effect_desc = "Makes the owner slightly faster."
 
 /obj/item/slimecross/stabilized/green
 	colour = "green"


### PR DESCRIPTION
me completely ignoring game mechanics because i spent 20 minutes in my xenobio mancave so now i have a nukeop elite hardsuit with no downsides (also you cant slow me with damage)

# Changelog

:cl:  
tweak: stabilized red extracts make you faster instead of giving you slowdown immunity
/:cl:
