### PR TITLE
Removes the head blacklist from vampire revive since it breaks reviving, and moves the revive to below the limb reattachment

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -323,14 +323,14 @@
 	addtimer(CALLBACK(src, /obj/effect/proc_holder/spell/self/revive.proc/revive, L), 600)
 
 /obj/effect/proc_holder/spell/self/revive/proc/revive(mob/living/user)
-	user.revive(full_heal = TRUE)
-	user.visible_message(span_warning("[user] reanimates from death!"), span_notice("We get back up."))
 	var/list/missing = user.get_missing_limbs()
 	if(missing.len)
 		playsound(user, 'sound/magic/demon_consume.ogg', 50, 1)
 		user.visible_message(span_warning("Shadowy matter takes the place of [user]'s missing limbs as they reform!"))
-		user.regenerate_limbs(0, list(BODY_ZONE_HEAD))
+		user.regenerate_limbs()
 		user.regenerate_organs()
+	user.revive(full_heal = TRUE)
+	user.visible_message(span_warning("[user] reanimates from death!"), span_notice("We get back up."))
 
 
 /obj/effect/proc_holder/spell/targeted/disease


### PR DESCRIPTION
# Document the changes in your pull request

The vampire revive fails if the user has no head. This is probably unintended, as vampires can survive without a head otherwise, and the code is similar to changeling revives (which do the same thing)



# Changelog

:cl:  
tweak: vampire revive now replaces the head. This is important, apparently, for being revived. I assume it was like this because it was copied from changeling revive, but changelings can put their heads back on and vampires can't.
bugfix: vampire revive no longer fails if the head is not present
/:cl:
