### PR TITLE
Replaces adamantine armor with a weaker form of armor polish

### DIFF
--- a/code/game/objects/items/armor_polish.dm
+++ b/code/game/objects/items/armor_polish.dm
@@ -5,6 +5,10 @@
 	icon_state = "armor_polish"
 	w_class = WEIGHT_CLASS_TINY
 	var/remaining_uses = 2
+	var/melee_armor_max = 30
+	var/bullet_armor_max = 30
+	var/laser_armor_max = 20
+	var/energy_armor_max = 25
 
 /obj/item/armorpolish/examine(mob/user)
 	. = ..()
@@ -16,13 +20,13 @@ obj/item/armorpolish/afterattack(atom/target, mob/user, proximity)
 		var/obj/item/clothing/I = target;
 		//theos said 30/30/20/25
 		//make sure it's not too strong already ((busted))
-		if((I.armor.melee < 30) || (I.armor.bullet < 30) || (I.armor.laser < 20) || (I.armor.energy < 25))
+		if((I.armor.melee < melee_armor_max) || (I.armor.bullet < bullet_armor_max) || (I.armor.laser < laser_armor_max) || (I.armor.energy < energy_armor_max))
 			//it is weak enough to benefit
 			I.armor = I.armor.setRating(
-				melee = I.armor.melee < 30 ? 30 : I.armor.melee,
-				bullet = I.armor.bullet < 30 ? 30 : I.armor.bullet,
-				laser = I.armor.laser < 20 ? 20 : I.armor.laser,
-				energy = I.armor.energy < 25 ? 25 : I.armor.energy
+				melee = I.armor.melee < melee_armor_max ? melee_armor_max : I.armor.melee,
+				bullet = I.armor.bullet < bullet_armor_max ? bullet_armor_max : I.armor.bullet,
+				laser = I.armor.laser < laser_armor_max ? laser_armor_max : I.armor.laser,
+				energy = I.armor.energy < energy_armor_max ? energy_armor_max : I.armor.energy
 			)
 			remaining_uses -= 1
 			to_chat(user, "You apply [src] to the [target.name].")
@@ -43,3 +47,15 @@ obj/item/armorpolish/afterattack(atom/target, mob/user, proximity)
 			
 	else
 		to_chat(user, span_warning("You can only polish suits and headgear!"))
+
+/obj/item/armorpolish/adamantine
+	name = "adamantine dust"
+	desc = "A handful of adamantine dust capable of mildly reinforcing thicker outer clothing."
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "adamantine slime extract"
+	w_class = WEIGHT_CLASS_TINY
+	remaining_uses = 1
+	melee_armor_max = 15
+	bullet_armor_max = 10
+	laser_armor_max = 10
+	energy_armor_max = 10

--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -310,11 +310,11 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/adamantine
 	colour = "adamantine"
-	effect_desc = "Solidifies into a set of adamantine armor."
+	effect_desc = "Creates a small pile of clothing-reinforcing adamantine dust."
 
 /obj/item/slimecross/chilling/adamantine/do_effect(mob/user)
-	user.visible_message(span_notice("[src] creaks and breaks as it shifts into a heavy set of armor!"))
-	new /obj/item/clothing/suit/armor/heavy/adamantine(get_turf(user))
+	user.visible_message(span_notice("[src] suddenly falls apart, forming a small amount of fine greenish dust!"))
+	new /obj/item/armorpolish/adamantine(get_turf(user))
 	..()
 
 /obj/item/slimecross/chilling/rainbow


### PR DESCRIPTION
Ok lets be real, adamantine armor from xenobio is like one of the biggest issues with antags spending an hour in there and then coming out unkillable. This replaces the absurd armor with something that is actually useful for a lot of people: armor polish but weaker! 
The adamantine dust grants 15 melee armor and 10 bullet, laser, and energy armor to any suit item. This is NOT additive, but sets it to that value IF it's not that high. For example, this will not do anything to a standard armor vest, but a regular labcoat will be given these armor values.

Credit to slicer for the initial idea


# Spriting
It just uses the regular adamantine extract sprite. If someone wants to sprite a tiny pile of green dust I'll happily slap it in.

# Wiki Documentation

Replace adamantine armor with:
"Creates a small amount of limited armor-reinforcing dust."

# Changelog


:cl:  
rscadd: Adds a weakened version of armor polish for xenobio to make!
rscdel: Adamantine armor is no longer available to xenobiologists.
tweak: Also armor polish has more variables for admins to play with
/:cl:
