### PR TITLE
Nerfs stabilized bluespace extract

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -648,7 +648,7 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/bluespacestabilization
 	id = "stabilizedbluespacecooldown"
-	duration = 1200
+	duration = 3 MINUTES
 	alert_type = null
 
 /datum/status_effect/stabilized/bluespace
@@ -678,6 +678,10 @@ datum/status_effect/stabilized/blue/on_remove()
 			to_chat(owner, span_notice("[linked_extract] will take some time to re-align you on the bluespace axis."))
 			do_sparks(5,FALSE,owner)
 			owner.apply_status_effect(/datum/status_effect/bluespacestabilization)
+			to_chat(owner, span_warning("You feel sick after [linked_extract] dragged you through bluespace."))
+			owner.vomit()
+			owner.Stun(1 SECONDS)
+			owner.dizziness += 20
 	healthcheck = owner.health
 	return ..()
 

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -679,9 +679,8 @@ datum/status_effect/stabilized/blue/on_remove()
 			do_sparks(5,FALSE,owner)
 			owner.apply_status_effect(/datum/status_effect/bluespacestabilization)
 			to_chat(owner, span_warning("You feel sick after [linked_extract] dragged you through bluespace."))
-			owner.vomit()
 			owner.Stun(1 SECONDS)
-			owner.dizziness += 20
+			owner.dizziness += 30
 	healthcheck = owner.health
 	return ..()
 


### PR DESCRIPTION
from the mewsy hitlist

-=Stablized Bluespace=-
On a 2 minute cooldown it teleports you instantly away from a place automatically, making you very very slippery, can be paired with a high damaging item to be extremely hard to deal with
-=Possible Solutions to it=-
*up the cooldown
*make it give a slight nausea when it activates


1 minute longer cooldown
stuns for 1 second, makes you dizzy, and throw up

:cl:  
tweak: Nerfs stabilized bluespace extract
/:cl:
