### PR TITLE
Nerfs industrial gray extracts

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -55,7 +55,7 @@ Industrial extracts:
 	colour = "grey"
 	effect_desc = "Produces monkey cubes."
 	itempath = /obj/item/reagent_containers/food/snacks/monkeycube
-	itemamount = 5
+	itemamount = 3
 
 /obj/item/slimecross/industrial/orange
 	colour = "orange"


### PR DESCRIPTION
from the mewsy hitlist

-=Industrial Grey=-
makes 5 monkey cubes for 2 plasma, can give you monkeys easily and super fast- while this doesnt really make you "unkillable" or a combat advantage, it speeds up xeno extremely easily and early and is very strong in it's own way
-=Possible Solutions to it=-
*reduce the amount of monkey cubes it gets to 3


:cl:  
tweak: industrial gray extracts now give less monkey cubes
/:cl:
