### PR TITLE
Chilled Bluespace extract link cap

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/chilling.dm
+++ b/code/modules/research/xenobiology/crossbreeding/chilling.dm
@@ -140,9 +140,10 @@ Chilling extracts:
 
 /obj/item/slimecross/chilling/bluespace
 	colour = "bluespace"
-	effect_desc = "Touching people with this extract adds them to a list, when it is activated it teleports everyone on that list to the user."
+	effect_desc = "Touching people with this extract adds them to a limited list, when it is activated it teleports everyone on that list to the user."
 	var/list/allies = list()
 	var/active = FALSE
+	var/linkcap = 5
 
 /obj/item/slimecross/chilling/bluespace/afterattack(atom/target, mob/user, proximity)
 	if(!proximity || !isliving(target) || active)
@@ -150,9 +151,11 @@ Chilling extracts:
 	if(target in allies)
 		allies -= target
 		to_chat(user, span_notice("You unlink [src] with [target]."))
-	else
+	else if(LAZYLEN(allies) < linkcap)
 		allies |= target
 		to_chat(user, span_notice("You link [src] with [target]."))
+	else
+		to_chat(user, span_notice("The [src] seems to be unable to handle more links."))
 	return
 
 /obj/item/slimecross/chilling/bluespace/do_effect(mob/user)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108117184/204161660-bc81547d-557a-423f-b60e-fd7da0ef0507.png)

I do as i am told

:cl:  
tweak: Chilled Bluespace extract has a limit of 5 links
/:cl:
