### PR TITLE
oilslime explosions are now mostly fire

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -503,8 +503,7 @@
 
 /datum/chemical_reaction/slime/slimeexplosion/proc/boom(datum/reagents/holder)
 	if(holder && holder.my_atom)
-		explosion(get_turf(holder.my_atom), 0 ,4, 8)
-
+		explosion(get_turf(holder.my_atom), 0 , 0, 4, flame_range = 12) //same radius as before 4 heavy + 8 light is 12
 
 /datum/chemical_reaction/slime/slimecornoil
 	name = "Slime Corn Oil"


### PR DESCRIPTION
mewsy hit list

-=Oil Slimes=-
creates an easy explosion with a bit of plasma, can just get a bunch of these, and a bluespace beaker with plasma and a normal syringe, can effectively make a ton of easy grenades
-=Possible Solutions to it=-
*make the normal oil slimes only create a fire explosion rather than a real one
*nerf how big the boom is 
*make all versions of the oil slimes, like the slime crossbreeding ones, fire bomb things, and or smaller, and make the burning oil slime nerfed to what a normal oil slime explosion would be



:cl:  
tweak: oilslime explosions are now mostly fire
/:cl:
