### PR TITLE
light pink regenerative extract is no longer full heal

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -262,7 +262,11 @@ Regenerative extracts:
 	if(target == user)
 		return
 	var/mob/living/U = user
-	U.revive(full_heal = 1)
+	U.adjustBruteLoss(-25)
+	U.adjustFireLoss(-25)
+	U.adjustOxyLoss(-25)
+	U.adjustToxLoss(-25)
+	U.adjustCloneLoss(-50)
 	to_chat(U, span_notice("Some of the milky goo sprays onto you, as well!"))
 
 /obj/item/slimecross/regenerative/adamantine


### PR DESCRIPTION
Mewsy hit list

-=Regenerative Grey + Regenerative Light Pink=-
can instantly fully heal a target, kind of like a legion core, but heals fully to full health, also extremely easy to make- also can be paired with stable rainbow to autouse when you goto crit
-=Possible Solutions to it=-
*make it not heal fully, make it heal less, maybe rework stable rainbow into something interesting/fun

grey wasn't the problem, light pink was
now it just heals the same amount as grays, making it 2x effect rather than full heal

:cl:  
tweak: light pink regenerative extract is no longer full heal
/:cl:
