### PR TITLE
nerfs admantine armour

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -133,7 +133,7 @@ Slimecrossing Armor
 	item_state = "adamsuit"
 	flags_inv = NONE
 	obj_flags = IMMUTABLE_SLOW
-	armor = list(MELEE = 60, BULLET = 50, LASER = 30, ENERGY = 50, BOMB = 80, BIO = 100, RAD = 0, FIRE = 90, ACID = 90)
+	armor = list(MELEE = 50, BULLET = 40, LASER = 0, ENERGY = 30, BOMB = 70, BIO = 100, RAD = 0, FIRE = 70, ACID = 70)
 	slowdown = 4
 	var/hit_reflect_chance = 40
 


### PR DESCRIPTION
Mewsy hitlist

-=Adamantine Armor=-
very very high armor, with a huge slowdown that can be negated by a stable red, basically free elite operative armor, it can be stacked with chemicals, nanites, stable purple, and being antags like bloodsuckers with their health gain, and various other things.
-=Possible Solutions to it=-
*wearing the armor now reduces healing recieved by 50-75% due to the high armor while worn, this way it's a direct nerf to the item rather than needing to affect other things that only really make this broken- most of the time atleast.
*it now still gives the slow through stable red, magically
*reduce the armor values of melee and bullet and things

went with the lowest effort solution, about 10 less on every defense except for laser which was removed because it already has a 40% chance to reflect lasers

:cl:  
tweak: nerfs admantine armour
/:cl:
