### PR TITLE
Hotfixes for golden crucifix

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -273,7 +273,7 @@
 	
 
 /obj/item/nullrod/attack_self(mob/user)
-	if(user.mind && (user.mind.holy_role) && !reskinned)
+	if(user.mind && (user.mind.holy_role) && !reskinned && type == /obj/item/nullrod)
 		reskin_holy_weapon(user)
 
   /*
@@ -902,8 +902,16 @@
 	user.add_overlay(holy_glow_fx)
 	holy_glow_light = user.mob_light(_color = LIGHT_COLOR_HOLY_MAGIC, _range = 2)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/unwield)
-	RegisterSignal(src, COMSIG_ITEM_DROPPED, .proc/unwield)
+	RegisterSignal(src, COMSIG_ITEM_PREDROPPED, .proc/drop_unwield)
 	START_PROCESSING(SSfastprocess, src)
+
+/obj/item/nullrod/cross/Destroy()
+	if(held_up && isliving(loc))
+		unwield(loc)
+	. = ..()
+
+/obj/item/nullrod/cross/proc/drop_unwield(obj/item, mob/user)
+	unwield(user)
 
 /obj/item/nullrod/cross/proc/unwield(mob/user)
 	if(!held_up)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -273,7 +273,7 @@
 	
 
 /obj/item/nullrod/attack_self(mob/user)
-	if(user.mind && (user.mind.holy_role) && !reskinned && type == /obj/item/nullrod)
+	if(user.mind && (user.mind.holy_role) && !reskinned)
 		reskin_holy_weapon(user)
 
   /*


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so chaplains can only reskin base nullrod and cannot reskin spawned nullrods with skins already set

Registers to `COMSIG_ITEM_PREDROPPED` instead of `COMSIG_ITEM_DROPPED`

`drop_unwield()` to properly parse user from signal

Unwields on `Destroy()`

# Changelog

:cl:  
bugfix: fixed golden crucifix not removing glow
/:cl:
