### PR TITLE
Plasma fixation heals less

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -402,7 +402,7 @@
 		. +=  power * 0.75
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 4 * actual_power
+	var/heal_amt = actual_power
 
 	if(prob(5))
 		to_chat(M, span_notice("You feel yourself absorbing plasma inside and around you..."))
@@ -416,7 +416,7 @@
 		if(prob(5))
 			to_chat(M, span_notice("You feel warmer."))
 
-	M.adjustToxLoss(-heal_amt)
+	M.adjustToxLoss(-heal_amt * 4)
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 	if(!parts.len)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -402,7 +402,7 @@
 		. +=  power * 0.75
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = actual_power
+	var/heal_amt = 2 * actual_power
 
 	if(prob(5))
 		to_chat(M, span_notice("You feel yourself absorbing plasma inside and around you..."))
@@ -416,7 +416,7 @@
 		if(prob(5))
 			to_chat(M, span_notice("You feel warmer."))
 
-	M.adjustToxLoss(-heal_amt * 4)
+	M.adjustToxLoss(-heal_amt * 3)
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 	if(!parts.len)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -416,7 +416,7 @@
 		if(prob(5))
 			to_chat(M, span_notice("You feel warmer."))
 
-	M.adjustToxLoss(-heal_amt * 3)
+	M.adjustToxLoss(-heal_amt * 2)
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 	if(!parts.len)


### PR DESCRIPTION
mewsy hitlist

-=Plasma Fixation=-
gives an incredibly good heal with no real effort required, can make it extremely easily and there's only 1 other virus in it's recipe rng, making it even easier to get, it heals every brute, burn, AND toxins while plasma is in your body, you can get a bluespace beaker filled with plasma, and a bluespace syringe, fill the syringe with 60 units of plasma, then inject yourself with a miracle healing chemical 20 units at a time, easy to die while fighting and right before them, can be stacked with anything with no downsides, this with my adamantine armor thingy i was doing would've made me TRULY unkillable, worse than a wizard kind of thing, can be stacked with water healing and or dark healing, and or space healing, PLUS  tumors if made correctly, this with any armor can make you really reaaaaaally hard to kill, and makes you worse then most xenobio things if you get a holopara and syndiehardsuit, it let me 1v6 security in maints with it while they had lethals
-=Possible Solutions to it=-
*nerf the amount it heals, keep the toxins healing since it's the only one that does this aside from space healing, but nerf it down a bunch

:cl:    
tweak: Plasma fixation heals less
/:cl:
