### PR TITLE
Nocturnal Regen heals less

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -205,7 +205,7 @@
 			return power
 
 /datum/symptom/heal/darkness/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 2 * actual_power
+	var/heal_amt = 1 * actual_power
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 


### PR DESCRIPTION
mewsy hitlist

-=Nocturnal Regen=-
gives a ton of healing while in the dark, heals brute reaaaally fast, when paired with water healing and or plasma healing (it can fit both of those with it if done right), only downside is that people can use flashlights, but that barely stops it in maints and when you break lights or cut power, it's conditional, but very big heals if done right
-=Possible Solutions to it=-
*nerf the healing down a bit

:cl:  
tweak: Nocturnal Regen heals less
/:cl:
