### PR TITLE
adds a delay to stabilized cerulean

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -718,6 +718,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/cerulean/tick()
 	if(owner.stat == DEAD)
 		if(clone && clone.stat != DEAD)
+			owner.visible_message(span_warning("[owner] begins to glow with brilliant light."))
+			sleep(30 SECONDS)
 			owner.visible_message(span_warning("[owner] blazes with brilliant light, [linked_extract] whisking [owner.p_their()] soul away."),
 				span_notice("You feel a warm glow from [linked_extract], and you open your eyes... elsewhere."))
 			if(owner.mind)


### PR DESCRIPTION
Mewsy hitlist

-=Stablized Cerulean=-
if you get killed with it in your backpack, you get teleported back to your body, so basically you're unkillable permanently, and can stack stables into their inventory to make you even harder to kill, can have a bunch of them at once for infinite lives
-=Possible Solutions to it=-
*give a message nearby to people that their soul warped to a new body or something, maybe add a pointer to which way the body is
*make it unstackable somehow, make it kill you if used more than once or do damage or something
*make people have a certain thing to their person when holding the extract so people know it exists somewhere, allowing them to hunt it
*make it take like a minute or 2 before it transfers the body, allowing time for people to react rather than instantly

:cl:  
tweak: stabilized cerulean has a 30 second delay
/:cl:
