### PR TITLE
Revert "Dark spirit now only lets you move 21 tiles away"

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -980,8 +980,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 			if(affecting.health <= 10)
 				to_chat(G, span_cultitalic("Your body can no longer sustain the connection!"))
 				break
-			if(get_dist(G, affecting) > 21)
-				G.forceMove(get_turf(affecting))
 			sleep(0.5 SECONDS)
 		CM.Remove(G)
 		GM.Remove(G)


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16553

Now with new and improved mqiib branch! Anyways this is still a bad change, my reasoning isn't any different from the last revert pr. 