### PR TITLE
Makes fake death a bit less obviously fake

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -266,9 +266,7 @@
 		addtimer(CALLBACK(src, .proc/coma, M), 60)
 
 /datum/symptom/heal/coma/proc/coma(mob/living/M)
-	if(deathgasp)
-		M.emote("deathgasp")
-	M.fakedeath("regenerative_coma")
+	M.fakedeath("regenerative_coma", !deathgasp)
 	M.update_stat()
 	M.update_mobility()
 	addtimer(CALLBACK(src, .proc/uncoma, M), 300)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -153,6 +153,9 @@
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
+		if(HAS_TRAIT(src, TRAIT_FAKEDEATH))
+			holder.icon_state = "huddefib"
+			return
 		if(tod)
 			var/tdelta = round(world.time - timeofdeath)
 			if(tdelta < (DEFIB_TIME_LIMIT))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -834,7 +834,7 @@
 	if(!client || !hud_used)
 		return
 	if(hud_used.healths)
-		if(stat != DEAD)
+		if(stat != DEAD && !HAS_TRAIT(src, TRAIT_FAKEDEATH))
 			. = 1
 			if(shown_health_amount == null)
 				shown_health_amount = health
@@ -884,6 +884,7 @@
 	update_damage_hud()
 	update_health_hud()
 	update_stamina_hud()
+	med_hud_set_health()
 	med_hud_set_status()
 
 //called when we get cuffed/uncuffed

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -114,7 +114,6 @@
 
 /datum/nanite_program/fake_death/enable_passive_effect()
 	. = ..()
-	host_mob.emote("deathgasp")
 	host_mob.fakedeath("nanites")
 
 /datum/nanite_program/fake_death/disable_passive_effect()


### PR DESCRIPTION
# Document the changes in your pull request

1) Fixes the double deathgasp that happens with death simulation nanites and regen coma
2) Dead icon when fake-dead is now less obvious that something's not right
3) Health on medical HUDs now updates properly

# Changelog

:cl:  
tweak: makes dead icon on medical HUDs no longer give away fake death
bugfix: fixes double deathgasp from death simulation and regen coma
bugfix: fixes health on medical HUDs not updating properly
/:cl:
