### PR TITLE
Traitors will be given less telecrystals on low sec

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/locked = TRUE
 	var/allow_restricted = TRUE
 	var/telecrystals
+	var/docked = 0 // If this uplink was docked due to low security or other reasons, and how much it can be re-compensated
 	var/selected_cat
 	var/owner = null
 	var/datum/game_mode/gamemode

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -368,8 +368,23 @@
 		I.implant(traitor_mob, null, silent = TRUE)
 		if(!silent)
 			to_chat(traitor_mob, "<span class='boldnotice'>[employer] has cunningly implanted you with a Syndicate Uplink (although uplink implants cost valuable TC, so you will have slightly less). Simply trigger the uplink to access it.</span>")
-		return I
+		. = I
 
+	var/datum/uplink_holder = .
+	var/datum/component/uplink/U = uplink_holder.GetComponent(/datum/component/uplink)
+	var/datum/job/hos = SSjob.GetJob("Head of Security")
+	var/datum/job/warden = SSjob.GetJob("Warden")
+	var/datum/job/officers = SSjob.GetJob("Security Officer")
+	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
+	// 0 sec = 13TC
+	// 1 sec = 15TC
+	// 2 sec = 17TC
+	// 3 sec = 19TC
+	// Latejoin sec will give TC back to get back to 20TC
+	if(sec_amount < 4)
+		U.telecrystals = (TELECRYSTALS_DEFAULT - 7) + sec_amount * 2
+		U.docked = TELECRYSTALS_DEFAULT - U.telecrystals
+		to_chat(traitor_mob, span_userdanger("Your telecrystal amount is lower than normal due to low security in this sector. You will be compensated if more security are hired."))
 
 
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -403,6 +403,19 @@
 
 		character.update_parallax_teleport()
 
+		if(rank == "Head of Security" || rank == "Warden" || rank == "Security Officer")
+			for(var/datum/component/uplink/U in GLOB.uplinks)
+				if(U.docked > 0)
+					var/amt = 2
+					U.docked -= amt
+					if(U.docked < 0)
+						amt += U.docked
+						U.docked = 0
+					U.telecrystals += amt
+					if(U.owner)
+						to_chat(U.owner, span_notice("You have been given [amt]TC due to a member of security being hired."))
+
+
 	SSticker.minds += character.mind
 	character.client.init_verbs() // init verbs for the late join
 	var/mob/living/carbon/human/humanc


### PR DESCRIPTION
# Document the changes in your pull request

Traitors will be given less telecrystals if there are less than 4 members of security (HoS,Warden,Officers)

Latejoin security will give traitors telecrystals back, up to the normal amount (20TC)

`(TELECRYSTALS_DEFAULT - 7) + sec_amount * 2`

# Wiki Documentation

	// 0 sec = 13TC
	// 1 sec = 15TC
	// 2 sec = 17TC
	// 3 sec = 19TC
	// Latejoin sec will give TC back to get back to 20TC

# Changelog

:cl:  
tweak: Traitors will be docked telecrystals when there is a low amount of security. Telecrystals will be given back on latejoin security.
/:cl:
