### PR TITLE
Fixes Mining Point Duplication bug, issue #16617

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -190,11 +190,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 		for(var/obj/item/card/id/miner in shuttle_area.gem_payout)
 			miner.mining_points += shuttle_area.gem_payout[miner]
-			shuttle_area.gem_payout &= miner
 			playsound(miner, 'sound/machines/ping.ogg', 15, TRUE)
 			var/mob/card_holder = recursive_loc_check(miner, /mob)
 			if(ismob(card_holder))
 				to_chat(card_holder, "You have been credited with [shuttle_area.gem_payout[miner]] mining points from sold gems!")
+			shuttle_area.gem_payout.Remove(miner)
 
 	if(ex.exported_atoms)
 		ex.exported_atoms += "." //ugh


### PR DESCRIPTION
# Document the changes in your pull request

Resolves the issue with the gems. The gem array was not having the miner ID card removed from its keys upon redemption, resulting in cascading redemptions. I used list.Remove() proc and it seems to fix the issue. Also, it was removing at the wrong time; when it did manage to remove from the list, it caused the message to null-ref. Resolved.

Tested against latest master locally at 8a405ed27d82cdf9edb411c5c9d7015e65813035

Cannot reproduce with these fixes. Additionally, list appears to have the id card removed properly now, even when 2 different mobs (distinct id cards) are used. I have not tested several gems at once per player, nor have I tested with many players or non-mobs. 

Resolves #16617

# Changelog

:cl:  
bugfix: Miners will not be overcompensated for gems anymore
/:cl:
