### PR TITLE
makes the vxtvul hammer as deadly as i wanted to make it, but i was too scared to do it before

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1001,7 +1001,7 @@
 	spark_system.attach(src)
 
 /obj/item/twohanded/vxtvulhammer/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(attack_type == PROJECTILE_ATTACK)
+	if(attack_type == PROJECTILE_ATTACK || !wielded) //Doesn't work against ranged or if it's not wielded
 		final_block_chance = 0 //Please show me how you can block a bullet with an industrial hammer I would LOVE to see it
 	return ..()
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1047,7 +1047,7 @@
 	else
 		set_light(0)
 		force_wielded -= 12 //Back to 4 + 24 = 28
-		armour_penetration = 50
+		armour_penetration = initial(armour_penetration)
 	update_icon()
 
 /obj/item/twohanded/vxtvulhammer/proc/charge_hammer(mob/living/carbon/user)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1042,11 +1042,11 @@
 	supercharged = !supercharged
 	if(supercharged)
 		set_light(2) //Glows when charged
-		force_wielded += 22 //4 + 24 + 22 = 50 total damage because fuck you
+		force_wielded += 12 //4 + 24 + 22 = 40 total damage because fuck you
 		armour_penetration = 100
 	else
 		set_light(0)
-		force_wielded -= 22 //Back to 4 + 24 = 28
+		force_wielded -= 12 //Back to 4 + 24 = 28
 		armour_penetration = 50
 	update_icon()
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -981,6 +981,7 @@
 	armour_penetration = 50 //Designed for shattering walls in a single blow, I don't think it cares much about armor
 	throwforce = 18
 	attack_verb = list("attacked", "hit", "struck", "bludgeoned", "bashed", "smashed")
+	block_chance = 30 //Only works in melee, but I bet your ass you could raise its handle to deflect a sword
 	sharpness = SHARP_NONE //Blunt, breaks bones
 	wound_bonus = -10
 	bare_wound_bonus = 15
@@ -998,6 +999,11 @@
 	spark_system = new
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
+
+/obj/item/twohanded/vxtvulhammer/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(attack_type == PROJECTILE_ATTACK)
+		final_block_chance = 0 //Please show me how you can block a bullet with an industrial hammer I would LOVE to see it
+	return ..()
 
 /obj/item/twohanded/vxtvulhammer/Destroy() //Even though the hammer won't probably be destroyed, Ever™
 	QDEL_NULL(spark_system)
@@ -1032,12 +1038,16 @@
 /obj/item/twohanded/vxtvulhammer/AltClick(mob/living/carbon/user)
 	charge_hammer(user)
 
-/obj/item/twohanded/vxtvulhammer/proc/supercharge() //Proc to handle when it's charged for light + sprite
+/obj/item/twohanded/vxtvulhammer/proc/supercharge() //Proc to handle when it's charged for light + sprite + damage
 	supercharged = !supercharged
 	if(supercharged)
 		set_light(2) //Glows when charged
+		force_wielded += 22 //4 + 24 + 22 = 50 total damage because fuck you
+		armour_penetration = 100
 	else
 		set_light(0)
+		force_wielded -= 22 //Back to 4 + 24 = 28
+		armour_penetration = 50
 	update_icon()
 
 /obj/item/twohanded/vxtvulhammer/proc/charge_hammer(mob/living/carbon/user)


### PR DESCRIPTION
# Document the changes in your pull request

Two things

1) The Vxtvul Hammer now has a block chance of 30 that exclusively works in melee IF it's wielded because otherwise unlike every other competitive melee weapon it has zero defense against stun batons which is SUPER SCARY and icky when you really should be able to use its handle to block stuff because that's fucking BADASS

2) A charged hit now has 100 AP and does a total of 40 damage, instead of just throwing and paralyzing people. The throw and paralyze have stuck around, because the throw can really save someone by sending them very far from the person who clearly intends to kill them. Also, it does a lot more damage to everything else, so why doesn't it do a shitton of damage to people?

For some context, the wielded force of the weapon normally is 28 force with 50 AP.

# Wiki Documentation

Numbers and description will require adjusting on Guide to Combat

# Changelog

:cl:  
tweak: The force and AP of the Vxtvul Hammer have been significantly increased while it's supercharged
tweak: The Vxtvul Hammer offers 30 block chance against melee ONLY IF it's being held in both hands
/:cl:
