### PR TITLE
Clockwork tiles no longer space the station

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -156,7 +156,6 @@
 	name = "clockwork floor"
 	desc = "Tightly-pressed brass tiles. They emit minute vibration."
 	icon_state = "plating"
-	baseturfs = /turf/open/floor/clockwork
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW


### PR DESCRIPTION
# Document the changes in your pull request

Tested on station and on reebe with explosions, doesn't break anything

# Changelog

:cl:  
tweak: clockwork tiles no longer space the station when pried off
/:cl:
