### PR TITLE
Space Bar cleanbot can now be operated by the space bartender

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -322,4 +322,4 @@ Maintenance panel panel is [open ? "opened" : "closed"]"})
 
 /mob/living/simple_animal/bot/cleanbot/spacebar/Initialize()
 	. = ..()
-	bot_core.req_access = list(ACCESS_BAR)
+	bot_core.req_one_access = list(ACCESS_BAR)


### PR DESCRIPTION
# Document the changes in your pull request

Fixed the cleanbot on the space bar (Frank Cleansington III) so that it accepts the bartender's ID and can be operated by said bartender.

# Changelog

:cl:  
bugfix: The Space Bar cleanbot once again respects the bartender's authority.
/:cl:
