### PR TITLE
removes the printable traitor items from the medlathe

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -493,17 +493,6 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/noslipwater
-	name = "Slip Resistance Implant"
-	desc = "An implant that uses sensors and motors to detect when you are slipping and attempt to prevent it. It probably won't help if the floor is too slippery."
-	id = "noslipwater"
-	build_type = PROTOLATHE | MECHFAB
-	construction_time = 80
-	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1500, /datum/material/silver = 1000, /datum/material/diamond = 1000, /datum/material/uranium = 400)
-	build_path = /obj/item/organ/cyberimp/leg/galosh
-	category = list("Implants", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
 /datum/design/jumpbootsimplant
 	name = "Jumpboots implant"
 	desc = "An implant with a specialized propulsion system for rapid foward movement."
@@ -512,17 +501,6 @@
 	construction_time = 80
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000, /datum/material/uranium = 1000)
 	build_path = /obj/item/organ/cyberimp/leg/jumpboots
-	category = list("Implants", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
-/datum/design/wheeliesimplant
-	name = "Wheelies implant"
-	desc = "Wicked sick wheelies, but now they're not in the heel of your shoes, they just in your heels."
-	id = "wheeliesimplant"
-	build_type = PROTOLATHE | MECHFAB
-	construction_time = 80
-	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000, /datum/material/gold = 500)
-	build_path = /obj/item/organ/cyberimp/leg/wheelies
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -519,7 +519,7 @@
 	display_name = "Advanced Cybernetic Implants"
 	description = "Upgraded and more powerful cybernetic implants."
 	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDs")
-	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus", "jumpbootsimplant", "wheeliesimplant", "magbootimplant")
+	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus", "jumpbootsimplant", "magbootimplant")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/combat_cyber_implants
@@ -535,7 +535,7 @@
 	display_name = "Illegal Cybernetic Implants"
 	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
 	prereq_ids = list("combat_cyber_implants","syndicate_basic")
-	design_ids = list("ci-xray", "noslipwater")
+	design_ids = list("ci-xray")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 ////////////////////////Tools////////////////////////


### PR DESCRIPTION
what if we stopped powercreeping implants?

these two are literally traitor items except they can't be pulled off of you and the wheelie implant is missing the one thing that makes it situational (the fact that it's VERY visible) and enabling more medliz/roboticist powergaming is not actually a good thing

# Changelog

:cl:  
rscdel: you cant print no slip implants and wheelie implants any more
/:cl:
