### PR TITLE
Shadowling veil nullifies glowy for 5 seconds

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -195,6 +195,7 @@
 	var/glow = 3.5
 	var/range = 2.5
 	var/color
+	var/current_nullify_timer // For veil yogstation\code\modules\antagonists\shadowling\shadowling_abilities.dm
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -136,6 +136,22 @@
 		if(cold)
 			extinguishItem(F, TRUE)
 		extinguishItem(F)
+	if(iscarbon(H))
+		var/mob/living/carbon/M = H
+		var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
+		if(G)
+			G.glowth.set_light(0, 0) // Set glowy to no light
+			if(G.current_nullify_timer)
+				deltimer(G.current_nullify_timer) // Stacks
+			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 5 SECONDS, TIMER_STOPPABLE)
+
+/obj/effect/proc_holder/spell/aoe_turf/veil/proc/giveGlowyBack(mob/living/carbon/M)
+	if(!M)
+		return
+	var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
+	if(G)
+		G.modify() // Re-sets glowy
+		G.current_nullify_timer = null
 
 /obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets,mob/user = usr)
 	if(!shadowling_check(user) && !admin_override)

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -145,7 +145,7 @@
 				deltimer(G.current_nullify_timer) // Stacks
 			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 5 SECONDS, TIMER_STOPPABLE)
 
-/obj/effect/proc_holder/spell/aoe_turf/veil/proc/giveGlowyBack(mob/living/carbon/M)
+/obj/effect/proc_holder/spell/aoe_turf/proc/giveGlowyBack(mob/living/carbon/M)
 	if(!M)
 		return
 	var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)


### PR DESCRIPTION
# Document the changes in your pull request

Veil will make glowy have no light for 5 seconds and then restores it

If a veil is used and then another veil, the previous 5 second timer will be removed and replaced with the new one

# Changelog

:cl:  
tweak: Shadowling veil now nullifies glowy for 5 seconds
/:cl:
