### PR TITLE
Bugfix for #16490 - Makes atmospherics pressure valve actually work

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
@@ -1,7 +1,7 @@
 /obj/machinery/atmospherics/components/binary/pressure_valve
 	icon_state = "pvalve_map-3"
 	name = "pressure valve"
-	desc = "An activable one-way valve that let gas pass through if the pressure on the input side is higher than the set pressure."
+	desc = "An activatable one-way valve that lets gas pass through if the pressure on the input side is higher than the set pressure."
 
 	can_unwrench = TRUE
 	shift_underlay_only = FALSE
@@ -49,7 +49,7 @@
 		icon_state = "pvalve_off-[set_overlay_offset(piping_layer)]"
 
 /obj/machinery/atmospherics/components/binary/pressure_valve/process_atmos()
-	if(!on || is_operational())
+	if(!on || !is_operational())
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]
@@ -59,8 +59,10 @@
 		if(air1.release_gas_to(air2, air1.return_pressure()))
 			update_parents()
 			is_gas_flowing = TRUE
+		else
+			is_gas_flowing = FALSE //unable to release gas (valve mechanism underpressurized, or etc)
 	else
-		is_gas_flowing = FALSE
+		is_gas_flowing = FALSE //simply not enough pressure to activate
 	update_icon_nopipes()
 
 /obj/machinery/atmospherics/components/binary/pressure_valve/proc/set_frequency(new_frequency)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #16490 so that the pressure valve will actually function for the first time in at least 2 years. There was merely a 1 character typo in the check for whether the thing was on or not. :face_exhaling: 

![image](https://user-images.githubusercontent.com/2159739/204418560-18c87ce4-f4c8-495f-b2df-6629fe5166b5.png)

### Testing

I tested that it transfers the gas now, and it doesn't seem to spit out any errors. And the code that was written for it *appears* sound. But I haven't tested any edge cases or anything, mostly just wanted to ensure that the change I made works. Tested on master branch. 719eb4dc3f6eef170314260b92c9aa338f7c56e5

# Changelog

:cl:  
bugfix: A now-functional design of the Pressure Valve has been provided to Atmos RPDs.
/:cl:
