### PR TITLE
Fix Decontamination unit being able to be unsecured and dragged around

### DIFF
--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -183,8 +183,6 @@
 	dump_mob()
 
 /obj/machinery/decontamination_unit/attackby(obj/item/W, mob/user)
-	if(default_unfasten_wrench(user, W))
-		return
 	if(W.tool_behaviour == TOOL_MULTITOOL)
 		reset_emag(user)
 		return


### PR DESCRIPTION
Shouldn't be secured, forgot to remove the code while debugging

# Document the changes in your pull request

Fix Decontamination unit being able to be unsecured and dragged around



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fixed Decontamination unit being able to be unsecured and dragged around
/:cl:
