### PR TITLE
Fix surgery computer and nanites hub not recognizing ruin tech

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -90,3 +90,6 @@
 
 ///This determines how many general points that the ruin_tech techweb gets, since they don't utilize servers
 #define RUIN_GENERATION_PER_TICK 70
+
+///This determines how many nanites points that the ruin_tech techweb gets, since they lack research tools.
+#define NANITES_RESEARCH_RUIN_PER_TICK 10

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -81,7 +81,7 @@ SUBSYSTEM_DEF(research)
 			science_tech.remove_stored_point_type(i, boost_amt)
 	science_tech.add_point_list(bitcoins)
 	//add RUIN_GENERATION_PER_TICK even without any servers, for things like freeminers
-	ruin_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = RUIN_GENERATION_PER_TICK))
+	ruin_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = RUIN_GENERATION_PER_TICK, TECHWEB_POINT_TYPE_NANITES = NANITES_RESEARCH_RUIN_PER_TICK))
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -265,6 +265,7 @@
 	if(host_mob.stat == DEAD)
 		research_value *= 0.75
 	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
+	SSresearch.ruin_tech.add_point_list(list(TECHWEB_POINT_TYPE_NANITES = research_value))
 
 /datum/component/nanites/proc/nanite_scan(datum/source, mob/user, full_scan)
 	if(!full_scan)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -11,11 +11,13 @@
 	var/list/obj/linked_beds = list()
 	var/list/advanced_surgeries = list()
 	var/datum/techweb/linked_techweb
+	var/datum/techweb/linked_ruin_techweb
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/operating/Initialize()
 	. = ..()
 	linked_techweb = SSresearch.science_tech
+	linked_ruin_techweb = SSresearch.ruin_tech
 	find_table()
 
 /obj/machinery/computer/operating/Destroy()
@@ -38,6 +40,11 @@
 
 /obj/machinery/computer/operating/proc/sync_surgeries()
 	for(var/i in linked_techweb.researched_designs)
+		var/datum/design/surgery/D = SSresearch.techweb_design_by_id(i)
+		if(!istype(D))
+			continue
+		advanced_surgeries |= D.surgery
+	for(var/i in linked_ruin_techweb.researched_designs)
 		var/datum/design/surgery/D = SSresearch.techweb_design_by_id(i)
 		if(!istype(D))
 			continue

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -16,8 +16,7 @@
 
 /obj/machinery/computer/operating/Initialize()
 	. = ..()
-	linked_techweb = SSresearch.science_tech
-	linked_ruin_techweb = SSresearch.ruin_tech
+	find_tech()
 	find_table()
 
 /obj/machinery/computer/operating/Destroy()
@@ -44,11 +43,6 @@
 		if(!istype(D))
 			continue
 		advanced_surgeries |= D.surgery
-	for(var/i in linked_ruin_techweb.researched_designs)
-		var/datum/design/surgery/D = SSresearch.techweb_design_by_id(i)
-		if(!istype(D))
-			continue
-		advanced_surgeries |= D.surgery
 
 /obj/machinery/computer/operating/proc/find_table()
 	for(var/direction in GLOB.alldirs)
@@ -58,6 +52,14 @@
 		var/datum/component/surgery_bed/SB = table.GetComponent(/datum/component/surgery_bed)
 		if(SB && SB.link_computer(src))
 			break
+
+/obj/machinery/computer/operating/proc/find_tech()
+	for(var/direction in GLOB.alldirs)
+		var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in urange(30, src)
+		if(ruin_tech)
+			linked_techweb = SSresearch.ruin_tech
+		else
+			linked_techweb = SSresearch.science_tech
 
 /obj/machinery/computer/operating/ui_state(mob/user)
 	return GLOB.not_incapacitated_state

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -11,7 +11,6 @@
 	var/list/obj/linked_beds = list()
 	var/list/advanced_surgeries = list()
 	var/datum/techweb/linked_techweb
-	var/datum/techweb/linked_ruin_techweb
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/operating/Initialize()
@@ -54,12 +53,11 @@
 			break
 
 /obj/machinery/computer/operating/proc/find_tech()
-	for(var/direction in GLOB.alldirs)
-		var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in urange(30, src)
-		if(ruin_tech)
-			linked_techweb = SSresearch.ruin_tech
-		else
-			linked_techweb = SSresearch.science_tech
+	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in urange(30, src)
+	if(ruin_tech)
+		linked_techweb = SSresearch.ruin_tech
+	else
+		linked_techweb = SSresearch.science_tech
 
 /obj/machinery/computer/operating/ui_state(mob/user)
 	return GLOB.not_incapacitated_state

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -53,7 +53,7 @@
 			break
 
 /obj/machinery/computer/operating/proc/find_tech()
-	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in urange(30, src)
+	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in range(10, src)
 	if(ruin_tech)
 		linked_techweb = SSresearch.ruin_tech
 	else

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -53,7 +53,7 @@
 			break
 
 /obj/machinery/computer/operating/proc/find_tech()
-	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in range(10, src)
+	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in range(20, src)
 	if(ruin_tech)
 		linked_techweb = SSresearch.ruin_tech
 	else

--- a/code/modules/research/nanites/nanite_program_hub.dm
+++ b/code/modules/research/nanites/nanite_program_hub.dm
@@ -24,7 +24,14 @@
 
 /obj/machinery/nanite_program_hub/Initialize()
 	. = ..()
-	linked_techweb = SSresearch.science_tech
+	find_tech()
+
+/obj/machinery/nanite_program_hub/proc/find_tech()
+	var/ruin_tech = locate(/obj/machinery/computer/rdconsole/nolock/ruin) in range(20, src)
+	if(ruin_tech)
+		linked_techweb = SSresearch.ruin_tech
+	else
+		linked_techweb = SSresearch.science_tech
 
 /obj/machinery/nanite_program_hub/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/disk/nanite_program))


### PR DESCRIPTION
- FIxes #16830
If there is a R&D Ruin type console nearby 20 tiles it will get its surgery tech otherwise get station surgery tech.
# Document the changes in your pull request
Fix surgery computer and nanites hub not recognizing ruin tech
ruin_tech will generate 10 nanite points per tick




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fixed surgery computer and nanites hub not recognizing ruin tech. Now if there is a R&D Ruin type console nearby 20 tiles it will get its own ruin techs otherwise get station techs
rscadd: ruin_tech will generate 10 nanite points per tick
/:cl:
