### PR TITLE
should fix bloodsuckers not dying when they exit a dead transformation (from dying)

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsucker_mobs.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_mobs.dm
@@ -155,9 +155,9 @@
 	. = ..()
 	if(bloodsucker && mind)
 		mind.transfer_to(bloodsucker)
-		bloodsucker.adjustBruteLoss(200)
 		if(bloodsucker.status_flags & GODMODE)
 			bloodsucker.status_flags -= GODMODE
+		bloodsucker.adjustBruteLoss(200)
 
 /mob/living/simple_animal/hostile/bloodsucker/proc/devour(mob/living/target)
 	if(maxHealth > target.maxHealth / 4 + health)


### PR DESCRIPTION
# Document the changes in your pull request

remove god mode before dealing damage :+1::+1::+1:

# Changelog

:cl:  
bugfix: bloodsuckers now die when they are killed (while transformed)
/:cl:
