### PR TITLE
Fix crafting recipe duplication of equipment and clothing tab

### DIFF
--- a/code/datums/components/crafting/makeshift.dm
+++ b/code/datums/components/crafting/makeshift.dm
@@ -67,7 +67,7 @@
 	result = /obj/item/storage/belt/utility/makeshift
 	time = 20 SECONDS
 	category = CAT_APPAREL
-	category = CAT_EQUIPMENT
+	subcategory = CAT_EQUIPMENT
 
 /datum/crafting_recipe/makeshiftknife
 	name = "Makeshift Knife"

--- a/code/datums/components/crafting/makeshift.dm
+++ b/code/datums/components/crafting/makeshift.dm
@@ -66,6 +66,7 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/storage/belt/utility/makeshift
 	time = 20 SECONDS
+	category = CAT_APPAREL
 	category = CAT_EQUIPMENT
 
 /datum/crafting_recipe/makeshiftknife

--- a/yogstation/code/modules/crafting/recipes.dm
+++ b/yogstation/code/modules/crafting/recipes.dm
@@ -96,6 +96,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
 		/obj/item/reagent_containers/syringe = 1
 	)
+	category = CAT_APPAREL
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/poppy2
@@ -106,6 +107,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/poppy = 1,
 		/obj/item/stack/rods = 1
 	)
+	category = CAT_APPAREL
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/ashtray

--- a/yogstation/code/modules/crafting/recipes.dm
+++ b/yogstation/code/modules/crafting/recipes.dm
@@ -97,7 +97,7 @@
 		/obj/item/reagent_containers/syringe = 1
 	)
 	category = CAT_APPAREL
-	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/poppy2
 	name = "poppy pin"
@@ -108,7 +108,7 @@
 		/obj/item/stack/rods = 1
 	)
 	category = CAT_APPAREL
-	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
 
 /datum/crafting_recipe/ashtray
 	name = "Ashtray"


### PR DESCRIPTION
fix #15823
Someone fucking set `category` of make shift toolbelt as CAT_EQUIPMENT instead of CAT_APPAREL, same goes to others

# Document the changes in your pull request

Fix crafting recipe duplication of equipment and clothing tab





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix crafting recipe duplication of equipment and clothing tab
/:cl:
