### PR TITLE
NEW FEATURE: Thermite can now burn Reinforced Walls

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -13,12 +13,11 @@
 	var/static/list/immunelist = typecacheof(list(
 		/turf/closed/wall/mineral/diamond,
 		/turf/closed/indestructible,
-		/turf/open/indestructible,
-		/turf/closed/wall/r_wall)
+		/turf/open/indestructible)
 		)
 	
 	var/static/list/resistlist = typecacheof(
-		/turf/closed/wall/mineral
+		/turf/closed/wall/r_wall
 		)
 
 /datum/component/thermite/Initialize(_amount)


### PR DESCRIPTION
Thermite kinda sucks since clf3 just does its job but better, so now I made it so you can use thermite on reinforced walls with a random chance to try and get through it.

🆑
tweak: mineral walls can now be burnt with thermite
tweak: reinforced walls can now be burnt with thermite
/🆑