### PR TITLE
black powder explosions are instant, securing a chemical grenade takes 3 seconds.

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -58,9 +58,11 @@
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == GRENADE_WIRED)
 			if(beakers.len)
-				stage_change(GRENADE_READY)
-				to_chat(user, span_notice("You lock the [initial(name)] assembly."))
 				I.play_tool_sound(src, 25)
+				to_chat(user, span_notice("You begin to secure the grenade assembly."))
+				if(do_after(user, 3 SECONDS, src))
+					stage_change(GRENADE_READY)
+					to_chat(user, span_notice("You lock the [initial(name)] assembly."))
 			else
 				to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
 		else if(stage == GRENADE_READY)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -103,10 +103,6 @@
 	required_temp = 474
 	strengthdiv = 6
 	modifier = 1
-	mix_message = span_boldannounce("Sparks start flying around the black powder!")
-
-/datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
-	addtimer(CALLBACK(src, .proc/explode, holder, created_volume), rand(5,10) SECONDS)
 
 /datum/chemical_reaction/thermite
 	name = "Thermite"


### PR DESCRIPTION
makes it marginally harder to ignore grenades blowing up through emps, and I should have considered this earlier honestly also makes it so you can't ignore large grenades existing with blackpowder explosions from a bluespace beaker, which were previously delayed... like a grenade.

# Wiki Documentation
black powder explosions are now instant

# Changelog

:cl:  
tweak: it takes three seconds to secure a chemical grenade
tweak: black powder explosions are now instant
/:cl:
