### PR TITLE
Makes the IPC martial art more accessible

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -169,11 +169,9 @@
 /datum/uplink_item/race_restricted/ultra_violence
 	name = "Version one upgrade module"
 	desc = "A module full of forbidden techniques that will make you capable of ultimate bloodshed."
-	cost = 20
+	cost = 16
 	item = /obj/item/book/granter/martial/ultra_violence
 	restricted_species = list("ipc")
-	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
-	cant_discount = TRUE
 
 /datum/uplink_item/stealthy_weapons/camera_flash
 	name = "Camera Flash"


### PR DESCRIPTION
Since it got added over a month ago, i don't think there's been a single person to use it
There's no info if it's even well balanced because no one uses it
I probably went overboard on restrictions

Couple tweaks to it in the uplink
Costs 16 TC instead of 20 TC
Can receive discounts now
No longer limited to martyr and hijack

:cl:    
tweak: IPC martial art now costs 16TC, CAN get discounted, and has no objective restrictions
/:cl:
