### PR TITLE
Renames GaxStation to the NVS Gax

### DIFF
--- a/_maps/gaxstation.json
+++ b/_maps/gaxstation.json
@@ -1,5 +1,5 @@
 {
-	"map_name": "GaxStation",
+	"map_name": "NVS Gax",
 	"map_path": "map_files/GaxStation",
 	"map_file": "GaxStation.dmm",
 	"shuttles": {


### PR DESCRIPTION
# Document the changes in your pull request

It's a ship. Its designation is "NVS Gax". The thrusters are hidden from view for gameplay reasons (the sprite is ugly). It was designed as a ship. It's draws inspiration from a ship on a different server. It's a ship.

# Wiki Documentation

It's public facing name will have to be changed here:
https://wiki.yogstation.net/wiki/Maps
https://wiki.yogstation.net/wiki/GaxStation

All locations will have to be changed from "GaxStation" to "NVS Gax"

# Changelog

:cl:  
tweak: Renames GaxStation to the NVS Gax
/:cl:
