### PR TITLE
Prevent Space Heaters and Electrolyzers from operating indefinitely

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -98,7 +98,11 @@
 	removed.adjust_moles(/datum/gas/hydrogen, (proportion * 2 * workingPower))
 	env.merge(removed) //put back the new gases in the turf
 	air_update_turf()
-	cell.use((5 * proportion * workingPower) / (efficiency + workingPower))
+	if (!cell.use((5 * proportion * workingPower) / (efficiency + workingPower)))
+		//automatically turn off machine when cell depletes
+		on = FALSE
+		update_icon()
+		return PROCESS_KILL
 
 /obj/machinery/electrolyzer/RefreshParts()
 	var/lasers = 0

--- a/tgui/packages/tgui/interfaces/Electrolyzer.js
+++ b/tgui/packages/tgui/interfaces/Electrolyzer.js
@@ -23,7 +23,7 @@ export const Electrolyzer = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={!data.hasPowercell}
+                disabled={!data.hasPowercell || (!data.on && data.powerLevel <= 0)}
                 onClick={() => act('power')} />
             </Fragment>
           )}>

--- a/tgui/packages/tgui/interfaces/SpaceHeater.js
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.js
@@ -71,8 +71,8 @@ export const SpaceHeater = (props, context) => {
                     target: value,
                   })} />
               ) || (
-                  data.targetTemp + '°C'
-                )}
+                data.targetTemp + '°C'
+              )}
             </LabeledList.Item>
             <LabeledList.Item label="Mode">
               {!data.open && 'Auto' || (

--- a/tgui/packages/tgui/interfaces/SpaceHeater.js
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.js
@@ -23,7 +23,7 @@ export const SpaceHeater = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={!data.hasPowercell}
+                disabled={!data.hasPowercell || (!data.on && data.powerLevel <= 0)}
                 onClick={() => act('power')} />
             </Fragment>
           )}>
@@ -71,8 +71,8 @@ export const SpaceHeater = (props, context) => {
                     target: value,
                   })} />
               ) || (
-                data.targetTemp + '°C'
-              )}
+                  data.targetTemp + '°C'
+                )}
             </LabeledList.Item>
             <LabeledList.Item label="Mode">
               {!data.open && 'Auto' || (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2159739/204955633-ed75b854-a70f-453b-8dde-355ba8009c22.png) ![image](https://user-images.githubusercontent.com/2159739/204955950-c807d15b-5db7-4ff8-a903-27dcc07baa81.png)


# Document the changes in your pull request

I noticed that the Space Heater sprite seemed to change even when the cell was depleted. I was even more surprised to find it continued to actually heat and cool without any charge. With some research I found that this is because it will operate as long as the charge is > 0. It never reaches 0 in practical use however because `cell.use()` simply returns false if you try to pull more joules than it has stored, instead of dropping to 0. This allows the machine to continue to operate indefinitely at the bottom of it's battery charge. Since in my research the Electrolyzer appears to be based off of the Space Heater code, I fixed that one as well. 

There were some minor improvements to the code - these devices automatically shut off when they run out of charge instead of having the appearance of running and yet not doing anything. And finally, JavaScript UI has been adjusted to not allow you to turn on these machines if their charge is < 0.5 (an artifact of rounding arithmetic).

Recommend checking diffs with whitespace ignored, as I changed indentation of a block.

### Testing
Tested against 2f1642e8df2035d0f2c7cc47a2f62e850177a288
Electrolyzer and Space Heater both tested at extreme ranges of cell charge level, with 3 different cell types (including yellow slime core) and also UI tested to work when depleted and when at full charge. Tested at Tier 4 and Tier 1 upgrade levels.

# Changelog

:cl:  
bugfix: Space Heaters and Electrolyzers now obey the laws of thermodynamics.
/:cl:
