### PR TITLE
legcuffs can now be cut like handcuffs

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -60,6 +60,11 @@
 		if(do_after(user, 1.5 SECONDS, C))
 			to_chat(C, span_notice("You succesfuly remove the durathread strand."))
 			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+	else if(istype(C) && C.legcuffed && (C.legcuffed.type == /obj/item/restraints/legcuffs/bola || istype(C.legcuffed, /obj/item/restraints/legcuffs/beartrap/energy)))
+		user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
+		qdel(C.legcuffed)
+		C.legcuffed = null
+		return	
 	else if(!(user.a_intent == INTENT_HARM) && attempt_initiate_surgery(src, C, user))
 		return
 	else

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -46,6 +46,11 @@
 			user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
 			qdel(C.handcuffed)
 			return
+		if(istype(C) && C.legcuffed)
+			user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
+			qdel(C.legcuffed)
+			C.legcuffed = null
+			return
 		else
 			..()
 	else


### PR DESCRIPTION
pretty strange how you can cut handcuffs with a jaws of life/wirecutters, but you can't do the same with legcuffs

Wirecutters can cut energy bolas (hard light is fragile) and regular bolas (they're literally made out of cable coil)

Jaws of Life can cut the same and every thing else, most notably including beartraps which took 30 fucking seconds to remove on top of causing guaranteed wounding if you got hit by one

also im sick of the bola meta because 1 click ranged wins are not funny

# Changelog

:cl:  
tweak: legcuffs can now be cut with wirecutters or jaws of life
/:cl:
