### PR TITLE
Make hypernob formation reaction actually not being stopped by hypernob supression reaction

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -209,6 +209,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			//at this point, all requirements for the reaction are satisfied. we can now react()
 
 			. |= reaction.react(src, holder)
+			if (!reaction.bypass_nobstop)
+				continue
 			if (. & STOP_REACTIONS)
 				break
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -66,6 +66,7 @@ nobliumformation = 1001
 	var/priority = 100 //lower numbers are checked/react later than higher numbers. if two reactions have the same priority they may happen in either order
 	var/name = "reaction"
 	var/id = "r"
+	var/bypass_nobstop = FALSE
 
 /datum/gas_reaction/New()
 	init_reqs()
@@ -456,6 +457,7 @@ nobliumformation = 1001
 	priority = 1001 //Ensure this value is higher than nobstop
 	name = "Hyper-Noblium condensation"
 	id = "nobformation"
+	bypass_nobstop = TRUE	//Bypass nobsupress
 
 /datum/gas_reaction/nobliumformation/init_reqs()
 	min_requirements = list(


### PR DESCRIPTION
- Not a bug, but the guy at #9180 didn't properly test it, they just changed two numbers and hope it worked

# Document the changes in your pull request
Make hypernob formation reaction actually not being stopped by hypernob supression reaction

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Make hypernob formation reaction actually not being stopped by hypernob supression reaction
/:cl:
