### PR TITLE
Hypernoblium now stops hotspots

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -13,6 +13,9 @@
 	if(!air)
 		return
 
+	if(air.get_moles(/datum/gas/hypernoblium) > REACTION_OPPRESSION_THRESHOLD)
+		return
+
 	var/oxy = air.get_moles(/datum/gas/oxygen)
 	if (oxy < 0.5)
 		return


### PR DESCRIPTION
# Document the changes in your pull request

Hypernoblium now stops hotspots from forming, so it will prevent fires like it's supposed to. Combustion reactions can still happen if you heat them any other way, which is being fixed in another PR.
# Changelog

:cl:  
tweak: hypernoblium stops hotspots from forming
/:cl:
