### PR TITLE
Hypernoblium formation rework

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -47,7 +47,7 @@
 #define STIMULUM_SECOND_RISE				0.0009
 #define STIMULUM_ABSOLUTE_DROP				0.00000335
 #define REACTION_OPPRESSION_THRESHOLD		5
-#define NOBLIUM_FORMATION_ENERGY			2e7 	//1 Mole of Noblium takes the planck energy to condense.
+#define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
 #define STIM_BALL_GAS_AMOUNT				5
 #define STIM_BALL_MAX_REACT_RATE			36		//up to 36 moles of each reactant consumed per reaction, somewhere around twice that of plasma
 #define STIM_BALL_MOLES_REQUIRED			2		//moles of reactant per radball emitted

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -464,7 +464,7 @@ nobliumformation = 1001
 		"TEMP" = 5000000)
 
 /datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)
-	var/nob_formed = min(air.get_moles(/datum/gas/tritium)/10,air.get_moles(/datum/gas/nitrogen)/20)
+	var/nob_formed = min(max(air.get_moles(/datum/gas/bz), 1) * (log(air.return_temperature())**2), air.get_moles(/datum/gas/tritium)/10, air.get_moles(/datum/gas/nitrogen)/20)
 	var/old_heat_capacity = air.heat_capacity()
 	var/energy_taken = nob_formed*(NOBLIUM_FORMATION_ENERGY/(max(air.get_moles(/datum/gas/bz),1)))
 	air.adjust_moles(/datum/gas/tritium, -10*nob_formed)


### PR DESCRIPTION
# Document the changes in your pull request

Hypernoblium is now more endothermic and has a limit to how much can form in a tick which can be increased by adding BZ and more heat.

Highly recommend merging #17092 first.

Closes #16874

# Changelog

:cl:  
tweak: hypernoblium formation is more endothermic and doesn't form all at once
/:cl:
