### PR TITLE
Griddle no longer hides items when the alt-click menu is used

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/griddle.dm
@@ -23,7 +23,7 @@
 
 /obj/machinery/griddle/Initialize()
 	. = ..()
-	end_processing() //doen't start on
+	end_processing() //doesn't start on
 	grill_loop = new(list(src), FALSE)
 	variant = rand(1,3)
 
@@ -39,13 +39,14 @@
 		to_chat(user, "<span class='notice'>[src] can't fit more items!</span>")
 		return
 	if(user.transferItemToLoc(I, src))
+		I.pixel_x = pick(-(world.icon_size/4), 0, (world.icon_size/4))
+		I.pixel_y = pick(-(world.icon_size/8), 0, (world.icon_size/4))
 		var/list/click_params = params2list(params)
-		//Center the icon where the user clicked.
-		if(!click_params || !click_params["icon-x"] || !click_params["icon-y"])
-			return
-		//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
-		I.pixel_x = clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
-		I.pixel_y = clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
+		//Attempt to center the icon where the user clicked.
+		if(click_params && click_params["icon-x"] && click_params["icon-y"])
+			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
+			I.pixel_x = clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/4), world.icon_size/4)
+			I.pixel_y = clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/8), world.icon_size/4)
 		to_chat(user, "<span class='notice'>You place [I] on [src].</span>")
 		AddToGrill(I, user)
 		update_icon()


### PR DESCRIPTION
![humanfood](https://user-images.githubusercontent.com/2159739/205209019-400e9d30-a63a-480a-81ab-358f7616a9e2.gif)

# Document the changes in your pull request
Griddle would move items into a bluespace void if you tried to place the item on the griddle using the alt-click menu because it couldn't ascertain your mouse coordinates with that method and returned from it's add function early.

This fixes that issue and also ensures that even when you do click the griddle to place the item normally, the item is placed (roughly) onto the griddle cooking area instead of anywhere on top of the machine you happened to click; effectively tightens up the clamp method used for sanity checking the players mouse coordinates. For example, you can't place an egg to cover up the griddle power indicator anymore. Trust me, I tried.

Resolves #16516.

### Testing

Tested with eggs, see above. Also donk pockets. And assorted cookery... I'm no chef!
Tested both normal clicking and alt-clicking, large and small items.

# Changelog

:cl:  
bugfix: Alt-clicking the griddle no longer hides items.
/:cl:
