### PR TITLE
Lets overcharging Ethereals transfer power into APCs + eating buff

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -689,7 +689,7 @@
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, span_notice("You receive some charge from the [fitting]."))
-						stomach.adjust_charge(5)
+						stomach.adjust_charge(50)
 					else
 						to_chat(H, span_notice("You can't receive charge from the [fitting]."))
 				return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -689,7 +689,7 @@
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, span_notice("You receive some charge from the [fitting]."))
-						stomach.adjust_charge(50)
+						stomach.adjust_charge(5)
 					else
 						to_chat(H, span_notice("You can't receive charge from the [fitting]."))
 				return


### PR DESCRIPTION
Closes: #16901

When they overcharge they're force to just suffer for a while
Now they can use grab intent on an APC to channel extra power into it

:cl:  
rscadd: Lets overcharging Ethereals transfer power into APCs
/:cl:
