### PR TITLE
Hotfixes a single typo where laser sight color button icon changes into an infrared sight

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -267,7 +267,7 @@
 	att?.toggle_on()
 	UpdateButtonIcon()
 
-/datum/action/item_action/change_laser_sight_color/UpdateButtonIcon(status_only = FALSE, force)
+/datum/action/item_action/toggle_infrared_sight/UpdateButtonIcon(status_only = FALSE, force)
 	button_icon_state = "ifr_sight[att?.is_on ? "_on" : ""]"
 	..()
 


### PR DESCRIPTION
# Document the changes in your pull request

sorry

# Changelog

:cl:  
bugfix: fixed laser sight change color button morphing into an infrared sight
bugfix: fixed infrared sight button icon not updating
/:cl:
