### PR TITLE
skrem broke nukeops

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2035,7 +2035,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/implants/augmentation/superior
+/datum/uplink_item/implants/superior_augmentation
 	name = "Superior Augmentation Kit"
 	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
 			Finally, it includes an implant to render the subject and their innards immune to EMP. Repair of body will still require a welder and wires."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2041,6 +2041,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Finally, it includes an implant to render the subject and their innards immune to EMP. Repair of body will still require a welder and wires."
 	item = /obj/item/storage/box/syndie_kit/augmentation/superior
 	cost = 45
+	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 
 // Events


### PR DESCRIPTION
subtyping makes this have flags to both exclude and include nukeops which the uplink does not like

# Changelog

:cl:  
bugfix: superior augmentation kit can be purchased again
/:cl:
