### PR TITLE
Fixes inhand_holder (pAI hats, held mob sprites)

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -15,6 +15,12 @@
 	. = ..()
 	if(weight > MOB_SIZE_SMALL)
 		w_class = weight + 2 // rough conversion
+	if(clothing_layer)
+		alternate_worn_layer = clothing_layer
+	if(held_icon)
+		mob_overlay_icon = held_icon
+	if(worn_state)
+		item_state = worn_state
 	if(lh_icon)
 		lefthand_file = lh_icon
 	if(rh_icon)	


### PR DESCRIPTION
# Document the changes in your pull request
Basically fixes some of the code #14395 broke. This fixes mothroach hat sprites, monkey held sprites (See below), and many others.

Closes #16593
Closes #13174

![image](https://user-images.githubusercontent.com/49160555/205452633-cc6dc7b8-632f-46a2-a55d-a79192084e59.png)
![image](https://user-images.githubusercontent.com/49160555/205452644-3f0bc5eb-9623-4db3-82ea-1aeb40b244f5.png)


# Changelog

:cl: 
bugfix: fixed held and wear mob sprites (As beautiful as the day I lost them)  
/:cl:
