### PR TITLE
Malf doomsday no longer kills IPCs

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -345,6 +345,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 			continue
 		if(issilicon(L))
 			continue
+		if(isipc(L))
+			continue
 		to_chat(L, span_userdanger("The blast wave from [src] tears you atom from atom!"))
 		L.dust()
 	to_chat(world, "<B>The AI cleansed the station of life with the doomsday device!</B>")


### PR DESCRIPTION
# Document the changes in your pull request

IPCs aren't organic and don't count as such for their objectives so I don't see a reason they should be killed by the doomsday weapon that exclusively kills organics.

# Changelog

:cl:  
tweak: malf doomsday no longer kills IPCs
/:cl:
