### PR TITLE
Tweaks how the speed potion works

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -898,11 +898,11 @@
 		to_chat(user, span_warning("The potion can only be used on simple animals!"))
 		return
 	var/mob/living/simple_animal/zipzoom = target
-	if(zipzoom.speed <= -1)
+	if(zipzoom.speed <= initial(zipzoom.speed))//if they're already sped up
 		to_chat(user, span_warning("[target] is already as fast as it can be!"))
 		return
 
-	zipzoom.set_varspeed(-1)
+	zipzoom.set_varspeed(zipzoom.speed - 1)
 	to_chat(user, span_notice("You slather the red gunk over [target], making it faster."))
 	zipzoom.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	zipzoom.add_atom_colour("#FF0000", FIXED_COLOUR_PRIORITY)


### PR DESCRIPTION
First round with extensive testing, probably a bit strong
Now it applies an even -1 to speed so it's equally as effective on all simplemobs rather than being busted on slower simplemobs
This is pretty much a nerf to most uses of it
However, this lets it work on already really fast simplemobs like drones and spiderbots now


:cl:  
tweak: Speed potion now reduces speed by 1 rather than setting it to -1
/:cl:
