### PR TITLE
traitor+devil (testmerge before fully merging so i can know how broken this is please)

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -87,6 +87,11 @@
 	integer = FALSE
 	min_val = 1
 
+/datum/config_entry/number/devil_scaling_coeff	//how much does the amount of players get divided by to determine devils
+	config_entry_value = 4
+	integer = FALSE
+	min_val = 1
+
 /datum/config_entry/number/ecult_scaling_coeff	//how much does the amount of players get divided by to determine e_cult
 	config_entry_value = 6
 	integer = FALSE

--- a/code/game/gamemodes/devil/traitordevil.dm
+++ b/code/game/gamemodes/devil/traitordevil.dm
@@ -1,0 +1,76 @@
+/datum/game_mode/traitor/devil
+	name = "traitor+devil"
+	config_tag = "traitordevil"
+	report_type = "traitordevil"
+	false_report_weight = 10
+	traitors_possible = 3 //hard limit on traitors if scaling is turned off
+	restricted_jobs = list("AI", "Cyborg")
+	required_players = 40
+	required_enemies = 1	// how many of each type are required
+	recommended_enemies = 3
+	reroll_friendly = 1
+	announce_span = "Traitors and Devils"
+	announce_text = "There are infernal soul merchants along with some syndicate operatives out for their own gain! Do not let the devils or the traitors succeed!"
+	title_icon = "devil"
+
+	var/list/possible_devils = list()
+	var/list/devils = list()
+	var/const/devil_amount = 1 //hard limit on devils if scaling is turned off
+
+/datum/game_mode/traitor/devil/can_start()
+	if(!..())
+		return FALSE
+	possible_devils = get_players_for_role(ROLE_DEVIL)
+	if(possible_devils.len < required_enemies)
+		return FALSE
+	return TRUE
+
+/datum/game_mode/traitor/devil/pre_setup()
+	if(CONFIG_GET(flag/protect_roles_from_antagonist))
+		restricted_jobs += protected_jobs
+
+	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
+		restricted_jobs += "Assistant"
+
+	var/list/datum/mind/possible_devils = get_players_for_role(ROLE_DEVIL)
+
+	var/num_devils = 1
+
+	var/csc = CONFIG_GET(number/devil_scaling_coeff)
+	if(csc)
+		num_devils = max(1, min(round(num_players() / (csc * 4)) + 2, round(num_players() / (csc * 2))))
+	else
+		num_devils = max(1, min(num_players(), devil_amount/2))
+
+	if(possible_devils.len>0)
+		for(var/j = 0, j < num_devils, j++)
+			if(!possible_devils.len)
+				break
+			var/datum/mind/devil = antag_pick(possible_devils)
+			antag_candidates -= devil
+			possible_devils -= devil
+			devil.special_role = ROLE_DEVIL
+			devils += devil
+			devil.restricted_roles = restricted_jobs
+		return ..()
+	else
+		return TRUE
+
+/datum/game_mode/traitor/devil/post_setup()
+	for(var/datum/mind/devil in devils)
+		devil.add_antag_datum(/datum/antagonist/devil)
+	return ..()
+	
+/datum/game_mode/traitor/devil/generate_credit_text()
+	var/list/round_credits = list()
+	var/datum/antagonist/devil/devil_info
+	round_credits += "<center><h1>The [syndicate_name()] Spies:</h1>"
+	for(var/datum/mind/M in devils)
+		var/datum/antagonist/devil/devil = M.has_antag_datum(/datum/antagonist/devil)
+		if(devil)
+			round_credits += "<center><h2>[devil_info.truename] in the form of [devil.name]</h2>"
+			devil_info = null
+	for(var/datum/mind/traitor in traitors)
+		round_credits += "<center><h2>[traitor.name] as a [syndicate_name()] traitor</h2>"
+	round_credits += ..()
+	return round_credits 

--- a/code/game/gamemodes/devil/traitordevil.dm
+++ b/code/game/gamemodes/devil/traitordevil.dm
@@ -12,9 +12,7 @@
 	announce_span = "Traitors and Devils"
 	announce_text = "There are infernal soul merchants along with some syndicate operatives out for their own gain! Do not let the devils or the traitors succeed!"
 	title_icon = "devil"
-
 	var/list/possible_devils = list()
-	var/list/devils = list()
 	var/const/devil_amount = 1 //hard limit on devils if scaling is turned off
 
 /datum/game_mode/traitor/devil/can_start()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -108,6 +108,7 @@ PROBABILITY DARKSPAWN 6
 PROBABILITY HERESY 4
 PROBABILITY INFILTRATION 0
 PROBABILITY BLOODSUCKER 4
+PROBABILITY TRAITORDEVIL 0 #DISABLED UNTIL TESTING AND FEEDBACK IS DONE -GUS
 
 # Lowpop
 PROBABILITY TRAITOR 5
@@ -166,6 +167,7 @@ CONTINUOUS SHADOWLING
 CONTINUOUS VAMPIRE
 CONTINUOUS DYNAMIC
 CONTINUOUS HERESY
+CONTINOUS TRAITORDEVIL
 
 ##Note: do not toggle continuous off for these modes, as they have no antagonists and would thus end immediately!
 
@@ -188,6 +190,7 @@ MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 #MIDROUND_ANTAG  MONKEY
 MIDROUND_ANTAG MALF
+MIDROUND_ANTAG TRAITORDEVIL
 
 ## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
@@ -250,6 +253,7 @@ SHUTTLE_REFUEL_DELAY 12000
 TRAITOR_SCALING_COEFF 7
 BROTHER_SCALING_COEFF 10
 CHANGELING_SCALING_COEFF 8
+DEVIL_SCALING_COEFF 4 #SUBJECT TO CHANGE -GUS
 
 ## Variables calculate how number of open security officer positions will scale to population.
 ## Used as (Officers = Population / Coeff)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -685,6 +685,7 @@
 #include "code\game\gamemodes\brother\traitor_bro.dm"
 #include "code\game\gamemodes\changeling\changeling.dm"
 #include "code\game\gamemodes\changeling\traitor_chan.dm"
+#include "code\game\gamemodes\devil\traitordevil.dm"
 #include "code\game\gamemodes\clock_cult\clock_cult.dm"
 #include "code\game\gamemodes\clown_ops\bananium_bomb.dm"
 #include "code\game\gamemodes\clown_ops\clown_ops.dm"


### PR DESCRIPTION
# Currently set up to not roll outside of admins setting the round type

Combines Devil with Traitor. I think this will improve Devils into not being horrible in a few ways.
1: A traitor is the perfect person for a Devil contract. Examples include giving them Hulk so they can escape perma, or reviving them if they died and got brig morgued, at the cost of their soul. Some of these are probably really, ridiculously powerful especially since traitors basically have a 0% chance of being revived anyways, but they can be adjusted as needed.
2: Devils get focus fired too hard. Outside of devils that have 7+ souls, the devil will usually get hunted and will get chainkilled and round removed because they're not great at killing people, by design.
3: Nobody buys devil contracts. Since they don't make you antags and require selling your soul, very few people will take up the offer to sign a devil contract. Traitors should be different, which will make the lives of the devils much easier.

# Changelog

:cl:  
rscadd: traitor+devil, a game mode that combines traitors and devils
/:cl:
