### PR TITLE
gangrel frenzy damage capped at 2

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_frenzy.dm
@@ -106,4 +106,4 @@
 		user.clear_cuffs(legcuffs, TRUE)
 	if(!bloodsuckerdatum.frenzied)
 		return
-	user.adjustFireLoss(0.5 + (bloodsuckerdatum.humanity_lost / 15))
+	user.adjustFireLoss(min(0.5 + (bloodsuckerdatum.humanity_lost / 15), bloodsuckerdatum.my_clan == CLAN_GANGREL ? 2 : 100))


### PR DESCRIPTION
# Document the changes in your pull request

Gangrel gets an objective to frenzy and an immediate loss of humanity, increasing the damage they take from frenzy, but don't have any particular benefits for being in frenzy, which is extremely dangerous with high humanity loss due to the increase in damage AND required blood to exit
to remedy this I have reduced the damage they take from frenzy to 2 maximum


:cl:  
tweak: gangrel bloodsuckers have their frenzy damage from being in frenzy capped at 2 points so minor slipups won't make their objective near impossible
/:cl:
