### PR TITLE
Radiation anomaly and radioactive goat balance tweaks + new spell

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -364,12 +364,13 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "radiation_anomaly"
 	density = TRUE
+	var/has_effect = TRUE //For goat spawning
 
 /obj/effect/anomaly/radiation/anomalyEffect()
 	..()
 	for(var/i = 1 to 10)
 		fire_nuclear_particle_wimpy()
-	radiation_pulse(src, 100, 2)
+	radiation_pulse(src, 500, 5)
 
 /obj/effect/anomaly/radiation/proc/makegoat()
 	var/turf/open/T = get_turf(src)
@@ -382,10 +383,22 @@
 		log_game("[key_name(S.key)] was made into a radioactive goat by radiation anomaly at [AREACOORD(T)].")
 
 /obj/effect/anomaly/radiation/detonate()
-	INVOKE_ASYNC(src, .proc/makegoat)
-	radiation_pulse(src, 3000, 5)
+	INVOKE_ASYNC(src, .proc/rad_Spin)
+	has_effect = FALSE //Don't want rad anomaly to keep spamming rad goat
+
+/obj/effect/anomaly/radiation/proc/rad_Spin()
+	radiation_pulse(src, 5000, 7)
 	var/turf/T = get_turf(src)
-	for(var/i = 1 to 72)
+	for(var/i=1 to 100)
 		var/angle = i * 10
 		T.fire_nuclear_particle_wimpy(angle)
-		sleep(1)
+		sleep(0.7)
+
+/obj/effect/anomaly/radiation/process()
+	anomalyEffect()
+	if(death_time < world.time)
+		if(loc)
+			if(has_effect)
+				INVOKE_ASYNC(src, .proc/makegoat)
+			detonate()
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, src), 150)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -128,3 +128,25 @@
 		if(T)
 			bloodman.forceMove(T)
 			playsound(usr, 'sound/magic/exit_blood.ogg', 100, 1)
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/radiation_anomaly
+	name = "Spawn Radiation Anomaly"
+	desc = "Spawn a radiation anomaly, this one is too week to spawn a radioactive goat but can fire enough rad particles to heal you and damage others."
+	action_background_icon_state = "bg_default"
+	action_icon = 'icons/obj/projectiles.dmi'
+	action_icon_state = "radiation_anomaly"
+	clothes_req = FALSE
+	charge_max = 90 SECONDS
+	invocation = "none"
+	invocation_type = "none"
+	summon_type = list(/obj/effect/anomaly/radiation)
+	summon_amt = 0
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/radiation_anomaly/cast(list/targets, mob/user)
+	. = ..()
+	var/mob/living/simple_animal/hostile/retaliate/goat/radioactive/S = user
+	var/obj/effect/anomaly/radiation/anomaly = new (S.loc, 150)
+	anomaly.has_effect = FALSE
+	playsound(S, 'sound/weapons/resonator_fire.ogg', 100, TRUE)
+	S.visible_message(span_notice("You see \the radiation anomaly emerges from \the [S]."), span_notice("\the radiation anomaly emerges from your body."))
+	notify_ghosts("The Radioactive Goat has spawned a radiation anomaly!", source = anomaly, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Radiation Anomaly Spawned!")

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -148,5 +148,5 @@
 	var/obj/effect/anomaly/radiation/anomaly = new (S.loc, 150)
 	anomaly.has_effect = FALSE
 	playsound(S, 'sound/weapons/resonator_fire.ogg', 100, TRUE)
-	S.visible_message(span_notice("You see \the radiation anomaly emerges from \the [S]."), span_notice("\the radiation anomaly emerges from your body."))
+	S.visible_message(span_notice("You see \the radiation anomaly emerges from \the [S]."), span_notice("\The radiation anomaly emerges from your body."))
 	notify_ghosts("The Radioactive Goat has spawned a radiation anomaly!", source = anomaly, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Radiation Anomaly Spawned!")

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -173,9 +173,14 @@
 	speed = -0.5
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
-	health = 100
+	health = 200
 	maxHealth = 100
+	var/datum/action/innate/rad_goat/rad
 
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/Initialize(mapload)
+	. = ..()
+	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/radiation_anomaly)
+	
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
 	. = ..()
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
@@ -186,8 +191,8 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
+	radiation_pulse(src, 600) // It gets stronker as time passes
 	if(stat == CONSCIOUS)
-		radiation_pulse(src, 600) // It gets stronker as time passes
 		adjustBruteLoss(-0.5)
 		adjustFireLoss(-0.5) //gets healed over time
 

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -167,15 +167,15 @@
 	gold_core_spawnable = NO_SPAWN
 	light_power = 5
 	light_range = 4
-	light_color = LIGHT_COLOR_GREEN
 	melee_damage_lower = 15
 	melee_damage_upper = 25
 	speed = -0.5
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
 	health = 200
-	maxHealth = 100
-	var/datum/action/innate/rad_goat/rad
+	maxHealth = 200
+	var/datum/action/innate/rad_goat/rad_switch
+	var/rad_emit = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Initialize(mapload)
 	. = ..()
@@ -191,10 +191,31 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
-	radiation_pulse(src, 600) // It gets stronker as time passes
 	if(stat == CONSCIOUS)
 		adjustBruteLoss(-0.5)
 		adjustFireLoss(-0.5) //gets healed over time
+	if(rad_emit)
+		light_color = LIGHT_COLOR_GREEN
+		radiation_pulse(src, 600)
+	else
+		light_color = initial(light_color)
+
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/Initialize(mapload)
+	. = ..()
+	rad_switch = new
+	rad_switch.Grant(src)
+
+/datum/action/innate/rad_goat //This is for rad goat only.
+	name = "Rad emission switch"
+	desc = "If you want to enable/disable radiation emission."
+	background_icon_state = "bg_default"
+	icon_icon = 'icons/obj/wizard.dmi'
+	button_icon_state = "greentext"
+
+/datum/action/innate/rad_goat/Activate()
+	var/mob/living/simple_animal/hostile/retaliate/goat/radioactive/S = owner
+	S.rad_emit = !S.rad_emit
+	to_chat(S, span_notice("You [S.rad_emit? "enable" : "disable"] radiation emission."))
 
 /mob/living/simple_animal/hostile/retaliate/goat/rainbow
 	name = "Rainbow Goat"

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -180,7 +180,8 @@
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Initialize(mapload)
 	. = ..()
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/radiation_anomaly)
-	
+	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
+
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
 	. = ..()
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
@@ -190,7 +191,6 @@
 		adjustFireLoss(-10)
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
-	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
 	if(stat == CONSCIOUS)
 		adjustBruteLoss(-0.5)
 		adjustFireLoss(-0.5) //gets healed over time


### PR DESCRIPTION
You can choose to be a friendly goat or a hostile one, it's up to you
# Document the changes in your pull request

- **Radiation anomaly now spawn only one rad goat instead of 4** Yes you no longer have to see 1.5E99999 goats running at you
- Rad goat health is buffed to 200 accumulate this
- Slight rad emission buffs for anomaly
 - Give radioactive goat a spell that can spawn radiation anomaly (This one has fewer lifespan and won't spawn radioactive goat) spell cooldown is 90 seconds
- Give radioactive goat rad emission switch if it wants to stop emitting radiation

![image](https://user-images.githubusercontent.com/89688125/205650980-964febd1-9495-448d-890a-8e07dafe1f31.png)



# Wiki Documentation
Everything in document of changes

# Changelog



:cl:  
tweak: Radiation anomaly now spawn only one rad goat instead of 4
tweak: Rad goat health is buffed to 200 accumulate this
tweak: Slight rad emission buffs for anomaly
rscadd: Give radioactive goat a spell that can spawn radiation anomaly (This one has fewer lifespan and won't spawn radioactive goat) spell cooldown is 90 seconds
rscadd: Give radioactive goat rad emission switch if it wants to stop emitting radiation
/:cl:
