### PR TITLE
[New Shuttle] First Class

### DIFF
--- a/_maps/shuttles/emergency_firstclass.dmm
+++ b/_maps/shuttles/emergency_firstclass.dmm
@@ -39,18 +39,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
-"aq" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "au" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -319,6 +307,17 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
+"tA" = (
+/obj/machinery/door/airlock/silver/glass{
+	name = "First Class Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "vi" = (
 /obj/machinery/light{
 	dir = 8
@@ -327,12 +326,35 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/shuttle/escape)
+"wq" = (
+/obj/machinery/door/airlock/silver/glass{
+	name = "First Class Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "wQ" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"xz" = (
+/obj/structure/table/wood,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/shuttle/escape)
 "zq" = (
 /obj/structure/table/wood/poker,
@@ -350,14 +372,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/shuttle/escape)
-"Au" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 8
+"AD" = (
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/mushroom,
+/obj/item/pizzabox/pineapple,
+/obj/item/pizzabox/seafood,
+/obj/item/pizzabox/vegetable,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/closet/secure_closet/freezer,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "AN" = (
@@ -371,39 +400,6 @@
 	pixel_y = -3
 	},
 /turf/open/floor/carpet/royalblue,
-/area/shuttle/escape)
-"AY" = (
-/obj/machinery/door/airlock/silver/glass{
-	name = "Lounge Shuttle Brig";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/escape)
-"Bh" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/fridge/open{
-	desc = "A fridge, full of pizza!";
-	name = "Pizza Fridge"
-	},
-/obj/item/pizzabox/margherita,
-/obj/item/pizzabox/meat,
-/obj/item/pizzabox/mushroom,
-/obj/item/pizzabox/pineapple,
-/obj/item/pizzabox/seafood,
-/obj/item/pizzabox/vegetable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "Cq" = (
 /obj/machinery/vending/boozeomat/all_access,
@@ -514,6 +510,29 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"OH" = (
+/obj/machinery/door/airlock/titanium{
+	name = "First Class Shuttle Brig Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"OW" = (
+/obj/structure/table/wood,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "PI" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/lootdrop/gambling,
@@ -553,17 +572,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
-"Ud" = (
-/obj/machinery/door/airlock/silver/glass{
-	name = "Lounge Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/shuttle/escape)
 "WW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -577,16 +585,6 @@
 	},
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/carpet/red,
-/area/shuttle/escape)
-"XB" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "XL" = (
 /obj/machinery/door/firedoor/border_only{
@@ -636,7 +634,7 @@ ak
 aP
 aP
 aP
-aq
+OH
 aP
 aZ
 aP
@@ -780,7 +778,7 @@ Xw
 aH
 aw
 aH
-AY
+wq
 gE
 Ap
 oA
@@ -825,7 +823,7 @@ aw
 al
 aJ
 aJ
-Ud
+tA
 aK
 aK
 aK
@@ -952,10 +950,10 @@ qs
 MN
 WW
 Cq
-XB
-Au
+OW
+xz
 Sf
-Bh
+AD
 iD
 aM
 aE

--- a/_maps/shuttles/emergency_firstclass.dmm
+++ b/_maps/shuttles/emergency_firstclass.dmm
@@ -1,0 +1,990 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"ad" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"ae" = (
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"ag" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"ai" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ak" = (
+/turf/template_noop,
+/area/template_noop)
+"al" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"am" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"ao" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"aq" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"au" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"av" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aw" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/space/basic,
+/area/shuttle/escape)
+"ay" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"az" = (
+/obj/machinery/computer/communications/unlocked{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"aA" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"aD" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"aE" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"aG" = (
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"aH" = (
+/turf/closed/wall/mineral/silver,
+/area/shuttle/escape)
+"aJ" = (
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"aK" = (
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"aM" = (
+/turf/closed/wall/mineral/wood,
+/area/shuttle/escape)
+"aP" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"aQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"aU" = (
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"aV" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"aZ" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Lounge Shuttle"
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"bI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"cI" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"dA" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"dF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"dT" = (
+/obj/structure/closet/crate,
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"eh" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"ey" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"gm" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"gE" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/silver,
+/area/shuttle/escape)
+"iD" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"jm" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"km" = (
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"lk" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"me" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"mx" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"ob" = (
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/wood/fancy/exoticblue,
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"oz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"oA" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"oS" = (
+/obj/structure/table/wood/poker,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"pu" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"qs" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"rA" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"rZ" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"sT" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"te" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"ts" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"vi" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/jukebox,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"wQ" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"zq" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/beer,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Aj" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Ap" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Au" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"AN" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"AY" = (
+/obj/machinery/door/airlock/silver/glass{
+	name = "Lounge Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Bh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/fridge/open{
+	desc = "A fridge, full of pizza!";
+	name = "Pizza Fridge"
+	},
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/mushroom,
+/obj/item/pizzabox/pineapple,
+/obj/item/pizzabox/seafood,
+/obj/item/pizzabox/vegetable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Cq" = (
+/obj/machinery/vending/boozeomat/all_access,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"DC" = (
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/crowbar,
+/obj/structure/table/wood/fancy/exoticblue,
+/turf/open/floor/carpet/exoticblue,
+/area/shuttle/escape)
+"DH" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"DS" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Ex" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"FH" = (
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Hx" = (
+/obj/structure/closet,
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"HX" = (
+/obj/item/storage/box/fancy/donut_box{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Jf" = (
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Jp" = (
+/obj/item/ashtray{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Md" = (
+/obj/machinery/light,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/cognac{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"MN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Nk" = (
+/obj/structure/chair/comfy,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ns" = (
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"PI" = (
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/lootdrop/gambling,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Qs" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Rz" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Sf" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife{
+	pixel_x = 10
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"SS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"TI" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Ud" = (
+/obj/machinery/door/airlock/silver/glass{
+	name = "Lounge Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"WW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"Xw" = (
+/obj/item/storage/box/fancy/cigarettes/cigars/havana{
+	pixel_y = 5
+	},
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"XB" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"XL" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Yi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Yn" = (
+/obj/structure/mineral_door/wood,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"YU" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/carpet/orange,
+/area/shuttle/escape)
+"Za" = (
+/obj/machinery/flasher{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/machinery/button/flasher{
+	pixel_x = 24;
+	pixel_y = -6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+ak
+ak
+ak
+ak
+aP
+aP
+aP
+aq
+aP
+aZ
+aP
+aw
+aw
+aw
+aP
+au
+aP
+au
+aP
+aP
+aP
+ak
+"}
+(2,1,1) = {"
+ak
+aP
+aP
+aP
+DS
+Nk
+Ns
+av
+aH
+Ap
+aK
+aK
+aK
+aK
+aQ
+aK
+aM
+aU
+me
+Hx
+aP
+aP
+"}
+(3,1,1) = {"
+aP
+DS
+aV
+aA
+aH
+Nk
+av
+Nk
+aH
+Ap
+aK
+aK
+aK
+aK
+aK
+aK
+Yn
+aU
+aU
+Hx
+aD
+ay
+"}
+(4,1,1) = {"
+aP
+ey
+pu
+cI
+aH
+HX
+av
+Nk
+aH
+Ap
+rZ
+rZ
+rZ
+rZ
+rZ
+dF
+aM
+aU
+aU
+Hx
+aD
+ay
+"}
+(5,1,1) = {"
+aw
+rA
+aG
+aG
+aH
+Nk
+av
+Nk
+aH
+XL
+eh
+eh
+eh
+eh
+eh
+oz
+aM
+ad
+aU
+dT
+aD
+ay
+"}
+(6,1,1) = {"
+aw
+rA
+aJ
+Jp
+aH
+Nk
+Za
+Yi
+aH
+Ap
+Ex
+dA
+dA
+dA
+dA
+aK
+Yn
+aU
+aU
+dT
+aD
+ay
+"}
+(7,1,1) = {"
+aw
+al
+aJ
+Xw
+aH
+aw
+aH
+AY
+gE
+Ap
+oA
+oA
+oA
+oA
+oA
+aK
+aM
+YU
+gm
+YU
+aD
+ay
+"}
+(8,1,1) = {"
+aw
+ag
+aJ
+Md
+aH
+SS
+aK
+aK
+vi
+Ap
+aK
+aK
+aK
+aK
+aK
+ai
+aM
+aM
+aM
+aM
+aP
+ak
+"}
+(9,1,1) = {"
+aw
+al
+aJ
+aJ
+Ud
+aK
+aK
+aK
+Ap
+Ap
+aK
+rZ
+rZ
+rZ
+rZ
+aK
+aM
+am
+jm
+am
+aD
+ay
+"}
+(10,1,1) = {"
+aw
+AN
+aJ
+km
+aH
+sT
+sT
+te
+sT
+bI
+oz
+eh
+eh
+eh
+eh
+oz
+Yn
+ae
+ae
+ae
+aD
+ay
+"}
+(11,1,1) = {"
+aw
+DH
+aG
+aG
+aH
+FH
+TI
+zq
+TI
+Rz
+aK
+dA
+dA
+dA
+dA
+aK
+aM
+ae
+ae
+DC
+aD
+ay
+"}
+(12,1,1) = {"
+aP
+Aj
+ts
+ts
+aH
+Jf
+lk
+oS
+zq
+wQ
+aK
+oA
+oA
+oA
+oA
+aK
+aM
+ac
+ae
+ob
+aD
+ay
+"}
+(13,1,1) = {"
+aP
+DS
+ao
+az
+aH
+FH
+Qs
+zq
+PI
+Rz
+aK
+aK
+aK
+aK
+aK
+aK
+Yn
+ae
+ae
+ae
+aD
+ay
+"}
+(14,1,1) = {"
+ak
+aP
+aP
+aP
+DS
+FH
+FH
+qs
+MN
+WW
+Cq
+XB
+Au
+Sf
+Bh
+iD
+aM
+aE
+mx
+aE
+aP
+aP
+"}
+(15,1,1) = {"
+ak
+ak
+ak
+ak
+aP
+aP
+aP
+aw
+aP
+aP
+aP
+aw
+aw
+aw
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+ak
+"}

--- a/_maps/shuttles/emergency_firstclass.dmm
+++ b/_maps/shuttles/emergency_firstclass.dmm
@@ -135,13 +135,6 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
-"bI" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/green,
-/area/shuttle/escape)
 "cI" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -161,6 +154,19 @@
 	},
 /turf/open/floor/wood,
 /area/shuttle/escape)
+"dP" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
 "dT" = (
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/orange,
@@ -171,6 +177,25 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"fV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
+"gg" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "gm" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -216,14 +241,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
-"lQ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+"lJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "me" = (
 /obj/machinery/light{
@@ -248,6 +273,16 @@
 /obj/structure/table/wood/fancy/exoticblue,
 /turf/open/floor/carpet/exoticblue,
 /area/shuttle/escape)
+"ov" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "oA" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -265,6 +300,16 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
+"pU" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
 "qs" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -281,21 +326,6 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/shuttle/escape)
-"sT" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/shuttle/escape)
-"te" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "ts" = (
 /obj/structure/chair/comfy/brown{
@@ -334,13 +364,6 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/shuttle/escape)
-"wQ" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "xz" = (
 /obj/structure/table/wood,
@@ -480,6 +503,15 @@
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
+"Mf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "MN" = (
 /obj/machinery/light{
 	dir = 4
@@ -539,20 +571,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
-"Rn" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/shuttle/escape)
-"Rz" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/green,
-/area/shuttle/escape)
 "Sf" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife{
@@ -576,13 +594,6 @@
 /area/shuttle/escape)
 "TI" = (
 /obj/structure/table/wood/poker,
-/turf/open/floor/carpet/green,
-/area/shuttle/escape)
-"WW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "Xw" = (
@@ -631,6 +642,16 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"Zr" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 ak
@@ -677,7 +698,7 @@ aM
 aU
 me
 Hx
-aP
+DS
 aP
 "}
 (3,1,1) = {"
@@ -739,12 +760,12 @@ av
 Nk
 aH
 XL
-Rn
-Rn
-Rn
-Rn
-Rn
-lQ
+ov
+ov
+ov
+ov
+ov
+Mf
 aM
 ad
 aU
@@ -854,17 +875,17 @@ AN
 aJ
 km
 aH
-sT
-sT
-te
-sT
-bI
-lQ
-Rn
-Rn
-Rn
-Rn
-lQ
+lJ
+lJ
+gg
+lJ
+dP
+Mf
+ov
+ov
+ov
+ov
+Mf
 Yn
 ae
 ae
@@ -882,7 +903,7 @@ FH
 TI
 zq
 TI
-Rz
+fV
 aK
 dA
 dA
@@ -906,7 +927,7 @@ Jf
 lk
 oS
 zq
-wQ
+Zr
 aK
 oA
 oA
@@ -930,7 +951,7 @@ FH
 Qs
 zq
 PI
-Rz
+fV
 aK
 aK
 aK
@@ -954,7 +975,7 @@ FH
 FH
 qs
 MN
-WW
+pU
 Cq
 OW
 xz
@@ -965,7 +986,7 @@ aM
 aE
 mx
 aE
-aP
+DS
 aP
 "}
 (15,1,1) = {"

--- a/_maps/shuttles/emergency_firstclass.dmm
+++ b/_maps/shuttles/emergency_firstclass.dmm
@@ -165,13 +165,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/orange,
 /area/shuttle/escape)
-"eh" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/shuttle/escape)
 "ey" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light{
@@ -223,6 +216,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
+"lQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "me" = (
 /obj/machinery/light{
 	dir = 8
@@ -245,12 +247,6 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/wood/fancy/exoticblue,
 /turf/open/floor/carpet/exoticblue,
-/area/shuttle/escape)
-"oz" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "oA" = (
 /obj/structure/chair/comfy/black{
@@ -543,6 +539,16 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
+"Rn" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "Rz" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/carpet/green,
@@ -733,12 +739,12 @@ av
 Nk
 aH
 XL
-eh
-eh
-eh
-eh
-eh
-oz
+Rn
+Rn
+Rn
+Rn
+Rn
+lQ
 aM
 ad
 aU
@@ -853,12 +859,12 @@ sT
 te
 sT
 bI
-oz
-eh
-eh
-eh
-eh
-oz
+lQ
+Rn
+Rn
+Rn
+Rn
+lQ
 Yn
 ae
 ae

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -220,13 +220,19 @@
 	description = "We did not expect an evacuation this quickly. All we have available is two escape pods."
 	admin_notes = "For player punishment."
 
+/datum/map_template/shuttle/emergency/firstclass
+	suffix = "firstclass"
+	name = "First Class Shuttle"
+	description = "For those who want something more classy than the Emergency Escape Bar but not something as gaudy as the Luxury Shuttle, this shuttle provides a lounge-like environment and a comfortable ride home for your crew. Food and drink provided."
+	credit_cost = 10000 //privisional price, can see it being upped but setting at 15000 seemed too much
+
 /datum/map_template/shuttle/emergency/pool
 	suffix = "pool"
 	name = "Pool Party!"
 	description = "A modified version of the Box escape shuttle that comes with a preinstalled pool. Fun for the whole family!"
 	admin_notes = "Pool filter can be very easily filled with acid or other harmful chemicals."
 	credit_cost = 15000
-	
+
 /datum/map_template/shuttle/emergency/russiafightpit
 	suffix = "russiafightpit"
 	name = "Mother Russia Bleeds"
@@ -439,7 +445,7 @@
 	suffix = "fancy"
 	name = "fancy transport ferry"
 	description = "At some point, someone upgraded the ferry to have fancier flooring... and fewer seats."
-	
+
 /datum/map_template/shuttle/ferry/kilo
 	suffix = "kilo"
 	name = "kilo transport ferry"
@@ -476,7 +482,7 @@
 /datum/map_template/shuttle/cargo/birdboat
 	suffix = "birdboat"
 	name = "supply shuttle (Birdboat)"
-	
+
 /datum/map_template/shuttle/cargo/kilo
 	suffix = "kilo"
 	name = "supply shuttle (Kilo)"
@@ -512,7 +518,7 @@
 /datum/map_template/shuttle/mining/box
 	suffix = "box"
 	name = "mining shuttle (Box)"
-	
+
 /datum/map_template/shuttle/mining/kilo
 	suffix = "kilo"
 	name = "mining shuttle (Kilo)"
@@ -520,7 +526,7 @@
 /datum/map_template/shuttle/labour/box
 	suffix = "box"
 	name = "labour shuttle (Box)"
-	
+
 /datum/map_template/shuttle/labour/kilo
 	suffix = "kilo"
 	name = "labour shuttle (Kilo)"
@@ -552,7 +558,7 @@
 /datum/map_template/shuttle/arrival/omega
 	suffix = "omega"
 	name = "arrival shuttle (Omega)"
-	
+
 /datum/map_template/shuttle/arrival/kilo
 	suffix = "kilo"
 	name = "arrival shuttle (Kilo)"


### PR DESCRIPTION
# Document the changes in your pull request

Babby's first mapping project: a new shuttle!
I'm a sucker for turning things into lounges. So here we have a lounge shuttle! However that sounds boring, and it's fairly fancy so I am calling it "First Class." Comfy chairs and nice tables for the crew to put their things on, pizza and booze, carpeted rooms (look medbay just scrub the blood out), a poker table, etc. It's bigger than the standard shuttle, though has fewer seats because class obviously equals legroom. 

The cost is currently set at 10,000 credits. I am, however, willing to see it adjusted. I am also, down the line, considering adding 2 of the "barmaids" from the Bar Shuttle as "flight attendants," though I might look at procuring a custom sprite for it if people like the shuttle enough. Price might increase then.

Also, I added a new song to the jukebox: The Roost from Animal Crossing (the coffee house). I used the Smash version. It's just over 3m long.

![FirstClassShuttle](https://user-images.githubusercontent.com/70451213/205495834-70ce5472-90f2-4d06-be6a-c2b83a3133d3.png)

# Wiki Documentation

New shuttle to be added to the list on the wiki page.

# Changelog

:cl:  
rscadd: New Shuttle to buy at the communications console for 10,000 credits 
soundadd: Added a new song to the jukebox list (The Roost)  
mapping: New shuttle map: First Class. Bigger than the standard box shuttle. Wood and carpet floors (except for brig), food and drinks provided.
/:cl:

