### PR TITLE
Removes boners

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -538,7 +538,7 @@
 	category = CAT_TOOLS
 
 /datum/crafting_recipe/bone_bonesetter
-	name = "Bone Bonersetter"
+	name = "Bone Bonesetter"
 	result = /obj/item/bonesetter/bone
 	time = 8 SECONDS
 	reqs = list(/obj/item/stack/sheet/bone = 2,


### PR DESCRIPTION
# Document the changes in your pull request

Last bits of ERP gone. Bone bonesetters are now spelled correctly.

# Changelog

:cl:  
spellcheck: Spells bone bonesetters corectly.
/:cl:
