### PR TITLE
Revert "Removes mindswap from the spellbook (only)"

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -155,6 +155,11 @@
 	spell_type = /obj/effect/proc_holder/spell/pointed/trigger/blind
 	cost = 1
 
+/datum/spellbook_entry/mindswap
+	name = "Mindswap"
+	spell_type = /obj/effect/proc_holder/spell/targeted/mind_transfer
+	category = "Mobility"
+
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
 	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall


### PR DESCRIPTION
Reverts yogstation13/Yogstation#15785

since when is "it gets a bit confusing for admins" a reason to remove something? if it is confusing to admins, then tooling needs to be fixed and not this innocent spell