### PR TITLE
Makes all action figures small instead of medium

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1374,6 +1374,7 @@ obj/item/toy/turn_tracker
 	desc = null
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "nuketoy"
+	w_class = WEIGHT_CLASS_SMALL
 	var/cooldown = 0
 	var/toysay = "What the fuck did you do?"
 	var/toysound = 'sound/machines/click.ogg'


### PR DESCRIPTION
# Document the changes in your pull request
They look small enough and having them fill your backpack after putting just 4 of those inside is kinda stupid.

Legends say that if you collect all 39 of them you get... absolutely nothing!

# Changelog

:cl:  
tweak: Made action figures small instead of medium
/:cl:
