### PR TITLE
Nuclear particle rebalancing/tweaks

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -14,7 +14,7 @@
 	var/framebuildstackamount = 5
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 0
-	var/list/allowed_projectile_typecache = list(/obj/item/projectile/beam)
+	var/list/allowed_projectile_typecache = list(/obj/item/projectile/beam, /obj/item/projectile/energy/nuclear_particle)
 	var/rotation_angle = -1
 
 /obj/structure/reflector/Initialize()

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,9 +3,9 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 1
+	damage = 5
 	damage_type = BURN
-	irradiate = 20
+	irradiate = 400
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray
@@ -31,7 +31,7 @@
 
 /obj/item/projectile/energy/nuclear_particle/wimpy
 	irradiate = 100
-	damage = 3
+	damage = 2
 
 /atom/proc/fire_nuclear_particle_wimpy(angle = rand(0,360))
 	var/obj/item/projectile/energy/nuclear_particle/wimpy/P = new /obj/item/projectile/energy/nuclear_particle/wimpy(src)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -263,3 +263,11 @@ adjust_charge - take a positive or negative value to adjust the charge level
 
 /datum/species/preternis/has_toes()//their toes are mine, they shall never have them back
 	return FALSE
+
+/datum/species/preternis/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+	// called before a projectile hit
+	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+		H.fire_nuclear_particle_wimpy()
+		H.visible_message(span_danger("[P] deflects off of [H]!"), span_userdanger("[P] deflects off of you!"))
+		return 1
+	return 0


### PR DESCRIPTION
# Document the changes in your pull request

Nuclear particles were somewhat recently made to be near harmless, and the purpose of this PR is to make them more of a danger. This also makes the weaker version made my the radiation anomalies do less burn damage. Also they can now be redirected by reflectors and deflected by preternis.

# Changelog

:cl:  
tweak: standard nuclear particles do more damage, weak ones do less
tweak: nuclear particles can be redirected by reflectors
tweak: nuclear particles deflect off of preternis
/:cl:
