### PR TITLE
You can no longer PDA bomb silicons

### DIFF
--- a/code/modules/modular_computers/computers/item/integrated_tablet/integrated_tablet.dm
+++ b/code/modules/modular_computers/computers/item/integrated_tablet/integrated_tablet.dm
@@ -23,6 +23,7 @@
 		borgo = null
 		stack_trace("[type] initialized outside of a borg, deleting.")
 		return INITIALIZE_HINT_QDEL
+	RegisterSignal(src, COMSIG_PDA_CHECK_DETONATE, .proc/pda_no_detonate)
 
 /obj/item/modular_computer/tablet/integrated/Destroy()
 	borgo = null


### PR DESCRIPTION
# Document the changes in your pull request

i forgot, oversight, old PDAs had this

# Changelog

:cl:  
tweak: You can no longer PDA bomb silicons
/:cl:
