### PR TITLE
non-antag targeted flashes against humans will burn out after one use

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -268,7 +268,7 @@
 	overheat = TRUE
 	addtimer(CALLBACK(src, .proc/cooldown), flashcd * 2)
 
-/obj/item/assembly/flash/armimplant/try_use_flash(mob/user = null)
+/obj/item/assembly/flash/armimplant/try_use_flash(mob/user = null, burnout = FALSE)
 	if(user && HAS_TRAIT(user, TRAIT_NO_STUN_WEAPONS))
 		to_chat(user, span_warning("You can't seem to remember how this works!"))
 		return FALSE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -307,7 +307,7 @@
 /obj/item/assembly/flash/tator
 	name = "camera"
 	desc = "This flash is morbin'. You shouldn't see it."  //Anyone wouldn't see this so it is ok
-	burnout_resistance = 999999   //No burning out
+	can_burn_out = FALSE   //No burning out
 	icon = 'icons/obj/artstuff.dmi'
 	icon_state = "camera"
 	item_state = "camera"


### PR DESCRIPTION
Title.

Things this does not affect: AoE flashes (they can still burn out normally, although it will work like how it does currently) Portable flashers Mounted flashers Traitor flash cameras Revolutionary flash implants Targeted flashes against borgs because everyone would shit themselves that they can't chainstun borgs with 0 effort

Still better than stun batons, their boon is that they can't be used against you if you drop them and they're an instant hardstun, but now they're single use instead of being a direct upgrade. Security techfabs can print flashes now, so you're not at any risk of running out. Still good at arresting single targets, but the point of this is now you have to put in a tiny amount of effort into actually stunning people instead of chainflashing huge groups with no effort. Cyborgs are worse, but everyone hates cyborgs so this shouldn't be a problem, and emagged/malf cyborgs have their malf modules to stun and attack people with, so they don't lose out.

:cl:  
tweak: handheld flashes, when targeted against humans, will burn out in one use
/:cl:
