### PR TITLE
Reduces the slowdown on radsuits

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -147,7 +147,7 @@
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/tank/internals/ipc_coolant, /obj/item/geiger_counter)
-	slowdown = 1.5
+	slowdown = 0.5
 	armor = list(MELEE = 5, BULLET = 5, LASER = 0,ENERGY = 0, BOMB = 5, BIO = 60, RAD = 100, FIRE = 30, ACID = 30)
 	strip_delay = 60
 	equip_delay_other = 60


### PR DESCRIPTION
They are literally only useful for rad protection, which is already super limited
This lets non rad-immune species not get a ridiculous slowdown, worse than space suits, when needing to deal with radiation
also with #16924 merged, they're strictly worse than the hardsuit now

:cl:  
tweak: Reduces the slowdown on radsuits
/:cl:
