### PR TITLE
Reduces flash paralyze duration on paralyzed targets

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -138,7 +138,10 @@
 				to_chat(M, span_userdanger("[user] blinds you with the flash!"))
 			else
 				to_chat(M, span_userdanger("You are blinded by [src]!"))
-			M.Paralyze(rand(80,120))
+			if(M.IsParalyzed())
+				M.Paralyze(rand(20,30))
+			else
+				M.Paralyze(rand(80,120))
 		else if(user)
 			visible_message(span_disarm("[user] fails to blind [M] with the flash!"))
 			to_chat(user, span_warning("You fail to blind [M] with the flash!"))


### PR DESCRIPTION
Might as well throw my hat in the ring

This will either force people to burn out their flash faster to keep them down
Or give them a brief moment where they can escape or fight back

:cl:  
tweak: Flashes paralyze for a shorter duration on already paralyzed targets
/:cl:
