### PR TITLE
Showers splash for less

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -13,7 +13,7 @@
 	var/current_temperature = SHOWER_NORMAL
 	var/datum/looping_sound/showering/soundloop
 	var/reagent_id = /datum/reagent/water
-	var/reaction_volume = 200
+	var/reaction_volume = 100
 
 /obj/machinery/shower/Initialize()
 	. = ..()


### PR DESCRIPTION
now instead of splashing for 200u per tick
they splash for 100u

this is equal to -10 fire_stacks rather than -20
this happens both on initial enter and each tick

this still lets it put out fire instantly but hopefully not have any preternis that either accidentally walks through or gets bumped into it be sentenced to death

:cl:  
tweak: Showers splish splash less
/:cl:
