### PR TITLE
Adds check_flags to leg implant abilities

### DIFF
--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -165,6 +165,7 @@
 	desc = "Dash forward."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "jetboot"
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS|AB_CHECK_LYING
 	COOLDOWN_DECLARE(dash_cooldown)
 	var/cooldownlength = 6 SECONDS
 	var/jumpdistance = 5 //-1 from to see the actual distance, e.g 4 goes over 3 tiles
@@ -218,6 +219,7 @@
 	desc = "Pops out or in your wheely-heel's wheels."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "wheelys"
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS|AB_CHECK_LYING
 	var/mob/living/carbon/human/holder
 	var/wheelToggle = FALSE //False means wheels are not popped out
 	var/obj/vehicle/ridden/scooter/wheelys/W
@@ -278,6 +280,7 @@
 	desc = "Switch between walking and hovering."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "airshoes_a"
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS|AB_CHECK_LYING
 	var/mob/living/carbon/human/holder
 	var/wheelToggle = FALSE //False means wheels are not popped out
 	var/obj/vehicle/ridden/scooter/airshoes/W

--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -165,7 +165,7 @@
 	desc = "Dash forward."
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "jetboot"
-	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS|AB_CHECK_LYING
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS
 	COOLDOWN_DECLARE(dash_cooldown)
 	var/cooldownlength = 6 SECONDS
 	var/jumpdistance = 5 //-1 from to see the actual distance, e.g 4 goes over 3 tiles


### PR DESCRIPTION
What is this, my 3rd pr fixing something i forgot in the original pr?
No more using leg implant abilities while unconscious or stunned 

closes: #16769

:cl:  
bugfix: Adds check_flags to leg implant abilities
/:cl:
