### PR TITLE
Makes tcomms monitor and traffic control get tcomms servers in zlevel instead of limited range

### DIFF
--- a/code/game/machinery/telecomms/computers/telemonitor.dm
+++ b/code/game/machinery/telecomms/computers/telemonitor.dm
@@ -93,7 +93,8 @@
 					temp = "<font color = #D70B00>- FAILED: CANNOT PROBE WHEN BUFFER FULL -</font color>"
 
 				else
-					for(var/obj/machinery/telecomms/T in urange(25, src))
+					var/turf/turf = get_turf(src)
+					for(var/obj/machinery/telecomms/T in turf.z)
 						if(T.network == network)
 							machinelist.Add(T)
 

--- a/yogstation/code/game/machinery/telecomms/computers/traffic_control.dm
+++ b/yogstation/code/game/machinery/telecomms/computers/traffic_control.dm
@@ -223,7 +223,8 @@
 					temp = "<font color = #D70B00>- FAILED: CANNOT PROBE WHEN BUFFER FULL -</font color>"
 
 				else
-					for(var/obj/machinery/telecomms/server/T in range(25, src))
+					var/turf/turf = get_turf(src)
+					for(var/obj/machinery/telecomms/server/T in turf.z)
 						if(T.network == network)
 							servers.Add(T)
 


### PR DESCRIPTION
fix #16960 
for QoL
# Document the changes in your pull request

Makes tcomms monitor and traffic control get tcomms servers in zlevel instead of limited range



# Wiki Documentation

Makes tcomms monitor and traffic control get tcomms servers in zlevel instead of limited range

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Makes tcomms monitor and traffic control get tcomms servers in zlevel instead of limited range
/:cl:
