### PR TITLE
38 speedloaders are normal sized

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -49,6 +49,7 @@
 	max_ammo = 6
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	materials = list(/datum/material/iron = 20000)
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/ammo_box/c38/hotshot
 	name = "speed loader (.38 Hot Shot)"


### PR DESCRIPTION
no detective needs to have boxes and boxes of ammo in their bag for their emp-proof lethal revolver, and now that the bullets are exclusively lethal (thanks skrem) detectives have no excuse for this outside of trying to valid kill people for breaking into eva
note that detective shoulder holster can still hold 2 speedloaders and you can carry more in your backpack if you really need to

# Changelog

:cl:  
tweak: 38 speedloaders are normal sized
/:cl:
