### PR TITLE
Removes objective lock from Neural Overclocker implant and makes it cost 14TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2021,7 +2021,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Neural Overclocker Implant"
 	desc = "Overloads your central nervous system in order to do everything faster. Careful not to overuse it."
 	item = /obj/item/autosurgeon/syndicate/spinalspeed
-	cost = 20
+	cost = 14
 	surplus = 0
 	limited_stock = 1
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2024,7 +2024,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	surplus = 0
 	limited_stock = 1
-	include_objectives = list(/datum/objective/martyr, /datum/objective/nuclear) //martyr traitors "straight to the top" or nukies
 
 /datum/uplink_item/implants/augmentation
 	name = "Full Augmentation Kit"


### PR DESCRIPTION
Wasn't as strong as expected
Gibs you if you get emped enough times with it active
Only time people were using it was in conjunction with the emp immunity implant
This makes it more accessible

:cl:  
tweak: Neural Overclocker implant can be purchased by anyone with an uplink now
tweak: Neural Overclocker implant now only costs 14TC
/:cl:
