### PR TITLE
Neural Overclocker makes progress bars faster

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -253,12 +253,14 @@
 			COOLDOWN_START(src, startsoundcooldown, 1 SECONDS)
 		owner.add_movespeed_modifier("spinalimplant", priority=100, multiplicative_slowdown=-1)
 		owner.next_move_modifier *= 0.7
+		owner?.dna?.species?.action_speed_coefficient *= 0.7
 		RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/move_react)
 	else
 		if(COOLDOWN_FINISHED(src, endsoundcooldown))
 			playsound(owner, 'sound/effects/spinal_implant_off.ogg', 70)
 			COOLDOWN_START(src, endsoundcooldown, 1 SECONDS)
 		owner.next_move_modifier /= 0.7
+		owner?.dna?.species?.action_speed_coefficient /= 0.7
 		owner.remove_movespeed_modifier("spinalimplant")
 		UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 	on = !on


### PR DESCRIPTION
This wasn't a thing when i initially made the implant
I was wanting to add this, but i never got around to it

:cl:  
rscadd: Neural Overclocker speeds up progress bars
/:cl:
