### PR TITLE
Emp immunity implant overloads if emped too often

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -155,20 +155,49 @@
 
 /obj/item/implant/empshield
 	name = "EMP shield implant"
+	desc = "An implant that completely protects from electro magnetic pulses. It will shut down briefly if triggered too often."
 	activated = 0
+	var/lastemp = 0
+	var/numrecent = 0
+	var/warning = TRUE
+	var/overloadtimer = 10 SECONDS
 
 /obj/item/implant/empshield/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(..())
 		if(ishuman(target))
 			target.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
+			RegisterSignal(target, COMSIG_ATOM_EMP_ACT, .proc/overloaded, target)
 		return TRUE
 
 /obj/item/implant/empshield/removed(mob/target, silent = FALSE, special = 0)
 	if(..())
 		if(ishuman(target))
 			var/datum/component/empprotection/empshield = target.GetExactComponent(/datum/component/empprotection)
-			empshield.RemoveComponent()
+			if(empshield)
+				empshield.Destroy()
+			UnregisterSignal(target, COMSIG_ATOM_EMP_ACT)
 		return TRUE
+
+/obj/item/implant/empshield/proc/overloaded(mob/living/target)
+	if(world.time - lastemp > overloadtimer)
+		numrecent = 0
+	numrecent ++
+	lastemp = world.time
+
+	if(recentemp >= 5 && ishuman(target))
+		if(warning)
+			to_chat(target, span_userdanger("You feel a twinge inside from your [src], you get the feeling it won't protect you anymore."))
+			warning = FALSE
+		var/datum/component/empprotection/empshield = target.GetExactComponent(/datum/component/empprotection)
+		if(empshield)
+			empshield.Destroy()
+		addtimer(CALLBACK(src, .proc/refreshed, target), overloadtimer, TIMER_OVERRIDE | TIMER_UNIQUE)
+
+/obj/item/implant/empshield/proc/refreshed(mob/living/target)
+	to_chat(target, span_usernotice("A familiar feeling resonates from your [src], it seems to be functioning properly again."))
+	warning = TRUE
+	if(ishuman(target))
+		target.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
 
 /obj/item/implanter/empshield
 	name = "implanter (EMP shield)"

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -155,7 +155,7 @@
 
 /obj/item/implant/empshield
 	name = "EMP shield implant"
-	desc = "An implant that completely protects from electro magnetic pulses. It will shut down briefly if triggered too often."
+	desc = "An implant that completely protects from electro-magnetic pulses. It will shut down briefly if triggered too often."
 	activated = 0
 	var/lastemp = 0
 	var/numrecent = 0

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -184,7 +184,7 @@
 	numrecent ++
 	lastemp = world.time
 
-	if(recentemp >= 5 && ishuman(target))
+	if(numrecent >= 5 && ishuman(target))
 		if(warning)
 			to_chat(target, span_userdanger("You feel a twinge inside from your [src], you get the feeling it won't protect you anymore."))
 			warning = FALSE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2038,7 +2038,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/superior_augmentation
 	name = "Superior Augmentation Kit"
 	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
-			Finally, it includes an implant to render the subject and their innards immune to EMP, however, it will shut down briefly if triggered too often. Repair of body will still require a welder and wires."
+			Finally, it includes an implant to render the subject and their innards immune to EMP; however, it will shut down briefly if triggered too often. Repair of the body will still require a welder and wires."
 	item = /obj/item/storage/box/syndie_kit/augmentation/superior
 	cost = 45
 	surplus = 0

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2038,7 +2038,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/superior_augmentation
 	name = "Superior Augmentation Kit"
 	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
-			Finally, it includes an implant to render the subject and their innards immune to EMP. Repair of body will still require a welder and wires."
+			Finally, it includes an implant to render the subject and their innards immune to EMP, however, it will shut down briefly if triggered too often. Repair of body will still require a welder and wires."
 	item = /obj/item/storage/box/syndie_kit/augmentation/superior
 	cost = 45
 	surplus = 0


### PR DESCRIPTION
Currently this is the main culprit of the nukie bundle being too strong
Augmentation is incredibly powerful with a downside of emp weakness, the implant completely removed that

They can take 5 emps total within a 10 second period, getting hit by an emp refreshes the 10 second period
After 5 emps, the implant will shut off for 10 seconds, getting hit by an emp during this time will reset the cooldown timer

:cl:  
tweak: Emp immunity implant overloads if emped too often
bugfix: Emp immunity from the implant now properly gets removed if the implant does
/:cl:
