### PR TITLE
Updates missed obj/screen/alert

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -511,7 +511,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	alerttooltipstyle = "parasite"
 
 //IPC martial arts
-/obj/screen/alert/ipcmartial
+/atom/movable/screen/alert/ipcmartial
 	name = "Dashes"
 	desc = "This is how many dash charges you have."
 	icon_state = "ipcdash"

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -118,7 +118,7 @@
 	ADD_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN, "martial")
 	ADD_TRAIT(H, TRAIT_NO_STUN_WEAPONS, "martial")
 	ADD_TRAIT(H, TRAIT_STUNIMMUNE, "martial")///mainly so emps don't end you instantly, they still do damage though
-	H.throw_alert("dash_charge", /obj/screen/alert/ipcmartial, dashes+1)
+	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 	usr.click_intercept = src //probably breaks something, don't know what though
 	H.dna.species.GiveSpeciesFlight(H)//because... c'mon
 
@@ -241,7 +241,7 @@
 	dashes = clamp(dashes, 0, 3)
 	if(dashes == 3)
 		deltimer(dash_timer)//stop regen when full
-	H.throw_alert("dash_charge", /obj/screen/alert/ipcmartial, dashes+1)
+	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 
 /datum/martial_art/ultra_violence/proc/InterceptClickOn(mob/living/carbon/human/H, params, atom/A)
 	if(H.a_intent == INTENT_DISARM && !H.IsUnconscious())
@@ -263,7 +263,7 @@
 		dashing = TRUE
 		H.throw_at(A, MAX_DASH_DIST, 1.5, H, FALSE, TRUE, callback = CALLBACK(src, .proc/dash_end, H))
 		dashes -= 1
-		H.throw_alert("dash_charge", /obj/screen/alert/ipcmartial, dashes+1)
+		H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 
 /datum/martial_art/ultra_violence/proc/dash_end(mob/living/carbon/human/H)
 	dashing = FALSE

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -234,7 +234,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 			H.emote("scream")
 			to_chat(H, span_userdanger("Your entire being screams in agony as your wires short from getting wet!"))
 		soggy = TRUE
-		H.throw_alert("preternis_wet", /obj/screen/alert/preternis_wet)
+		H.throw_alert("preternis_wet", /atom/movable/screen/alert/preternis_wet)
 	else if(soggy)
 		H.remove_movespeed_modifier("preternis_water")
 		to_chat(H, "You breathe a sigh of relief as you dry off.")

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/screen_alerts.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/screen_alerts.dm
@@ -7,7 +7,7 @@
 	desc = "Find a power cell to recharge from or you may lose power."
 	icon_state = "lowcell"
 
-/obj/screen/alert/preternis_wet
+/atom/movable/screen/alert/preternis_wet
 	name = "Wet"
 	desc = "Your circuits are shorting from all the water!"
 	icon_state = "wet"


### PR DESCRIPTION
obj/screen/alert
was updated to
atom/movable/screen/alert

but these two came from PRs that happened at the same time, so they were missed in the update pass

This makes IPC martial art dash charges and preternis water damage alert appear again

:cl:  
bugfix: Fixed a bug where some screen alerts weren't showing up
/:cl:
