### PR TITLE
Revert "makes .38 a fully lethal round as it should be"

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -53,21 +53,21 @@
 /obj/item/ammo_box/c38/hotshot
 	name = "speed loader (.38 Hot Shot)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade some damage for an incendiary payload which sets targets ablaze."
+			These rounds trade exhaustive properties for an incendiary payload which sets targets ablaze."
 	icon_state = "38hot"
 	ammo_type = /obj/item/ammo_casing/c38/hotshot
 
 /obj/item/ammo_box/c38/iceblox
 	name = "speed loader (.38 Iceblox)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade some damage for a cryogenic payload which significantly reduces the body temperature of targets hit."
+			These rounds trade exhaustive properties for a cryogenic payload which significantly reduces the body temperature of targets hit."
 	icon_state = "38ice"
 	ammo_type = /obj/item/ammo_casing/c38/iceblox
 
 /obj/item/ammo_box/c38/gutterpunch
 	name = "speed loader (.38 Gutterpunch)"
 	desc = "A six-shot speed loader designed for .38 revolvers. \
-			These rounds trade some damage for an emetic payload which induces nausea in targets."
+			These rounds trade exhaustive properties for an emetic payload which induces nausea in targets."
 	icon_state = "38gut"
 	ammo_type = /obj/item/ammo_casing/c38/gutterpunch
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -14,14 +14,16 @@
 
 /obj/item/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 25 //High damaging but...
-	armour_penetration = -40 //Almost doubles the armor of any bullet armor it hits
-	wound_bonus = -10
+	damage = 15 // yogs - Nerfed revolver damage
+	//knockdown = 60 //yogs - commented out
+	stamina = 35 // yogs
+	wound_bonus = -20
 	bare_wound_bonus = 10
 
 /obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
-	damage = 20
+	damage = 15
+	stamina = 0
 
 /obj/item/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))
@@ -32,7 +34,8 @@
 
 /obj/item/projectile/bullet/c38/iceblox //see /obj/item/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
-	damage = 20
+	damage = 15
+	stamina = 0
 	var/temperature = 100
 
 /obj/item/projectile/bullet/c38/iceblox/on_hit(atom/target, blocked = FALSE)
@@ -43,7 +46,8 @@
 
 /obj/item/projectile/bullet/c38/gutterpunch //Vomit bullets my favorite
 	name = ".38 Gutterpunch bullet"
-	damage = 20
+	damage = 15
+	stamina = 0
 
 /obj/item/projectile/bullet/c38/gutterpunch/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16722

i look away for ONE second and someone does this? now people are whining it is being used to validhunt and trying to nerf it, when there was 0 issues with the old one. it's supposed to be a self-defense weapon, and all of our self-defense weapons are purely non-lethal (See HOP's mini disabler)