### PR TITLE
Adds Mech piloting crash course book + Mech pilot suit stuff

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1296,7 +1296,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if(skill)
 			evaNum *= skill.piloting_speed
 
-		var/obj/item/clothing/under/clothes = H.get_item_by_slot(SLOT_WEAR_SUIT) //if the suit directly assists the pilot
+		var/obj/item/clothing/under/clothes = H.get_item_by_slot(SLOT_W_UNIFORM) //if the suit directly assists the pilot
 		if(clothes)
 			var/datum/component/mech_pilot/MP = clothes.GetComponent(/datum/component/mech_pilot)
 			if(MP)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -574,3 +574,14 @@
 								/datum/crafting_recipe/tribalmantle,
 								/datum/crafting_recipe/leathercape,
 								/datum/crafting_recipe/hidemantle)
+
+//for upstart mech pilots to move faster
+/obj/item/book/granter/mechpiloting
+	name = "Mech Piloting for Dummies"
+	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
+	remarks = list("Hmm, press forward to go forwards...", "Avoid getting hit to reduce damage...", "Welding to repair..?", "Make sure to turn it on...", "EMP bad...", "I need to turn internals on?", "What's a gun ham?")
+
+/obj/item/book/granter/mechpiloting/on_reading_finished(mob/user)
+	. = ..()
+	user.AddComponent(/datum/component/mech_pilot, 0.8)
+	onlearned(user)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -578,7 +578,7 @@
 //for upstart mech pilots to move faster
 /obj/item/book/granter/mechpiloting
 	name = "Mech Piloting for Dummies"
-	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
+	desc = "A step-by-step guide on how to effectively pilot a mech, written in such a way that even a clown could understand."
 	remarks = list("Hmm, press forward to go forwards...", "Avoid getting hit to reduce damage...", "Welding to repair..?", "Make sure to turn it on...", "EMP bad...", "I need to turn internals on?", "What's a gun ham?")
 
 /obj/item/book/granter/mechpiloting/on_reading_finished(mob/user)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -793,7 +793,7 @@
 
 /obj/item/clothing/under/mech_suit/ComponentInitialize()
 	..()
-	AddComponent(/datum/component/mech_pilot, 0.8)
+	AddComponent(/datum/component/mech_pilot, 0.9)
 
 /obj/item/clothing/under/mech_suit/white
 	name = "white mech pilot's suit"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1888,16 +1888,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10	//this is genuinely a REALLY strong effect, don't sleep on it
 	cant_discount = TRUE
 
-/obj/item/book/granter/mechpiloting
-	name = "Mech Piloting for Dummies"
-	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
-	remarks = list("Hmm, press forward to go forwards...", "Avoid getting hit to reduce damage...", "Welding to repair..?", "Make sure to turn it on...", "EMP bad...", "I need to turn internals on?", "What's a gun ham?")
-
-/obj/item/book/granter/mechpiloting/on_reading_finished(mob/user)
-	. = ..()
-	user.AddComponent(/datum/component/mech_pilot, 0.8)
-	onlearned(user)
-
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1885,8 +1885,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Mech Piloting for Dummies"
 	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
 	item = /obj/item/book/granter/mechpiloting
-	cost = 10	//this is genuinely a REALLY strong effect, don't sleep on it
-	cant_discount = TRUE
+	cost = 5	//this is genuinely a REALLY strong effect, don't sleep on it
 
 // Implants
 /datum/uplink_item/implants

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1881,6 +1881,23 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/attachment/laser_sight
 	cost = 2
 
+/datum/uplink_item/device_tools/mechpilotguide
+	name = "Mech Piloting for Dummies"
+	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
+	item = /obj/item/book/granter/mechpiloting
+	cost = 10	//this is genuinely a REALLY strong effect, don't sleep on it
+	cant_discount = TRUE
+
+/obj/item/book/granter/mechpiloting
+	name = "Mech Piloting for Dummies"
+	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
+	remarks = list("Hmm, press forward to go forwards...", "Avoid getting hit to reduce damage...", "Welding to repair..?", "Make sure to turn it on...", "EMP bad...", "I need to turn internals on?", "What's a gun ham?")
+
+/obj/item/book/granter/mechpiloting/on_reading_finished(mob/user)
+	. = ..()
+	user.AddComponent(/datum/component/mech_pilot, 0.8)
+	onlearned(user)
+
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1883,7 +1883,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/mechpilotguide
 	name = "Mech Piloting for Dummies"
-	desc = "A step-by-step guide on how to effectively pilot a mech. Written in such a way that even a clown could understand."
+	desc = "A step-by-step guide on how to effectively pilot a mech, written in such a way that even a clown could understand."
 	item = /obj/item/book/granter/mechpiloting
 	cost = 5	//this is genuinely a REALLY strong effect, don't sleep on it
 


### PR DESCRIPTION
Since the component was added, it was made possible to apply to mobs
I have now utilized that effect by adding an uplink item for 10TC that teaches a person to pilot mechs better

Because the mech pilot suit is a piece of clothing and can be stolen I have reduced it's mech pilot speed
This is also to make sure that stacking the two doesn't make mechs go unreasonably fast

Also fixes a bug where it would check the outer suit slot rather than the inner suit slot for clothing based pilot speed
(This means that the suit was actually doing nothing prior)

:cl:  
rscadd: Adds a book to traitor uplink to learn better mech piloting skills
bugfix: Check_Eva now properly checks inner suit and not outer suit
tweak: Mech pilot suit gives less mech piloting speed
/:cl:
