### PR TITLE
[ENGINEERING BUFFS] Pyro and radiation anomaly spawned by supermatter now takes 40 seconds to detonate

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1084,9 +1084,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			if(GRAVITATIONAL_ANOMALY)
 				new /obj/effect/anomaly/grav(L, 250)
 			if(PYRO_ANOMALY)
-				new /obj/effect/anomaly/pyro(L, 200)
+				new /obj/effect/anomaly/pyro(L, 400)
 			if(RADIATION_ANOMALY)
-				new /obj/effect/anomaly/radiation(L, 300)
+				new /obj/effect/anomaly/radiation(L, 400)
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart, range = 3, power)
 	. = zapstart.dir


### PR DESCRIPTION
MAkes them take longer to detonate, so engineers can respond in time and neutralize these anomalies

# Document the changes in your pull request
Pyro and radiation anomaly spawned by supermatter now takes 40 seconds to detonate



# Wiki Documentation
Pyro and radiation anomaly spawned by supermatter now takes 40 seconds to detonate

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Pyro and radiation anomaly spawned by supermatter now takes 40 seconds to detonate
/:cl:
