### PR TITLE
Traitor gamemode no longer counts innate traitor twice when determining midround

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -96,7 +96,7 @@
 		cur_traitors += pre_traitors
 	if(cur_traitors >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
-	if((SSticker.mode.traitors.len) <= (traitorcap - 2) || prob(100 / (tsc * 2)))
+	if((cur_traitors) <= (traitorcap - 2) || prob(100 / (tsc * 2)))
 		if(antag_flag in character.client.prefs.be_special)
 			if(!is_banned_from(character.ckey, list(ROLE_TRAITOR, ROLE_SYNDICATE)) && !QDELETED(character))
 				if(age_check(character.client))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -92,8 +92,8 @@
 	var/traitorcap = min(round(GLOB.joined_player_list.len / (tsc * 2)) + 2 + num_modifier, round(GLOB.joined_player_list.len / tsc) + num_modifier)
 	var/cur_traitors = SSticker.mode.traitors.len
 	// [SANITY] Uh oh! Somehow the pre_traitors aren't in the traitors list! Add them!
-	if(SSticker.mode.traitors.len < pre_traitors)
-		cur_traitors += pre_traitors
+	if(SSticker.mode.traitors.len < pre_traitors.len)
+		cur_traitors += pre_traitors.len
 	if(cur_traitors >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
 	if((cur_traitors) <= (traitorcap - 2) || prob(100 / (tsc * 2)))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -90,9 +90,9 @@
 /datum/game_mode/traitor/make_antag_chance(mob/living/carbon/human/character) //Assigns traitor to latejoiners
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)
 	var/traitorcap = min(round(GLOB.joined_player_list.len / (tsc * 2)) + 2 + num_modifier, round(GLOB.joined_player_list.len / tsc) + num_modifier)
-	if((SSticker.mode.traitors.len + pre_traitors.len) >= traitorcap) //Upper cap for number of latejoin antagonists
+	if((SSticker.mode.traitors.len) >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
-	if((SSticker.mode.traitors.len + pre_traitors.len) <= (traitorcap - 2) || prob(100 / (tsc * 2)))
+	if((SSticker.mode.traitors.len) <= (traitorcap - 2) || prob(100 / (tsc * 2)))
 		if(antag_flag in character.client.prefs.be_special)
 			if(!is_banned_from(character.ckey, list(ROLE_TRAITOR, ROLE_SYNDICATE)) && !QDELETED(character))
 				if(age_check(character.client))

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -90,7 +90,11 @@
 /datum/game_mode/traitor/make_antag_chance(mob/living/carbon/human/character) //Assigns traitor to latejoiners
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)
 	var/traitorcap = min(round(GLOB.joined_player_list.len / (tsc * 2)) + 2 + num_modifier, round(GLOB.joined_player_list.len / tsc) + num_modifier)
-	if((SSticker.mode.traitors.len) >= traitorcap) //Upper cap for number of latejoin antagonists
+	var/cur_traitors = SSticker.mode.traitors.len
+	// [SANITY] Uh oh! Somehow the pre_traitors aren't in the traitors list! Add them!
+	if(SSticker.mode.traitors.len < pre_traitors)
+		cur_traitors += pre_traitors
+	if(cur_traitors >= traitorcap) //Upper cap for number of latejoin antagonists
 		return
 	if((SSticker.mode.traitors.len) <= (traitorcap - 2) || prob(100 / (tsc * 2)))
 		if(antag_flag in character.client.prefs.be_special)


### PR DESCRIPTION
# Document the changes in your pull request

This was added in https://github.com/tgstation/tgstation/pull/29561 https://github.com/tgstation/tgstation/commit/3f2b689790fb8bb6ddda912124d6f64e1b301f6d to fix a bug where roundstart traitors were not counted in the traitors list and thus players could exploit this to guarantee a midround traitor spawn by joining fast after the round started.

This was since patched, so now it makes it so every roundstart traitor is counted twice when determining whether to spawn midround traitors and it caps out earlier than it's supposed to, preventing traitor spawns.

# Changelog

:cl:  
bugfix: Roundstart traitors are no longer counted twice over when considering midround traitor spawns
/:cl:
