### PR TITLE
[ADMIN] Post-round lobby music will no longer interrupt admin music

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -178,6 +178,10 @@
 	if(REALTIMEOFDAY >= SSticker.music_available)
 		for(var/client/C in GLOB.clients)
 			C.playtitlemusic(40)
+	else // this looks worse but is better than uselessly comparing for every client
+		for(var/client/C in GLOB.clients)
+			if(!(C.prefs.toggles & SOUND_MIDI))
+				C.playtitlemusic(40)
 
 	var/popcount = gather_roundend_feedback()
 	display_report(popcount)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -174,8 +174,10 @@
 	LAZYCLEARLIST(round_end_events)
 
 	RollCredits()
-	for(var/client/C in GLOB.clients)
-		C.playtitlemusic(40)
+	// Don't interrupt admin music
+	if(REALTIMEOFDAY >= SSticker.music_available)
+		for(var/client/C in GLOB.clients)
+			C.playtitlemusic(40)
 
 	var/popcount = gather_roundend_feedback()
 	display_report(popcount)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -58,6 +58,8 @@ SUBSYSTEM_DEF(ticker)
 	var/mode_result = "undefined"
 	var/end_state = "undefined"
 
+	var/music_available = 0
+
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	load_mode()
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -103,6 +103,13 @@
 					music_extra_data["end"] = data["end_time"]
 					music_extra_data["link"] = data["webpage_url"]
 					music_extra_data["title"] = data["title"]
+					if(data["duration"])
+						var/mus_len = data["duration"] SECONDS
+						if(data["start_time"])
+							mus_len -= data["start_time"] SECONDS
+						if(data["end_time"])
+							mus_len -= (data["duration"] SECONDS - data["end_time"] SECONDS)
+						SSticker.music_available = REALTIMEOFDAY + mus_len
 
 					var/res = alert(usr, "Show the title of and link to this song to the players?\n[title]",, "No", "Yes", "Cancel")
 					switch(res)
@@ -123,6 +130,7 @@
 			message_admins("[key_name(src)] stopped web sound")
 			web_sound_url = null
 			stop_web_sounds = TRUE
+			SSticker.music_available = 0
 
 		if(web_sound_url && !findtext(web_sound_url, GLOB.is_http_protocol))
 			to_chat(src, span_boldwarning("BLOCKED: Content URL not using http(s) protocol"), confidential=TRUE)


### PR DESCRIPTION
Sets a timer forward of the expected duration of the song and if the round ends before it's expected to be over then it won't play lobby music