### PR TITLE
Mining medic time requirement

### DIFF
--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -8,6 +8,10 @@
 	spawn_positions = 1
 	supervisors = "the chief medical officer and the quartermaster"
 	selection_color = "#d4ebf2"
+	minimal_player_age = 4
+	exp_requirements = 120
+	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/miningmedic
 


### PR DESCRIPTION
Mining medic is a limited job with only 1 slot
it requires knowledge of both mining and medical to be even the least bit effective
There's no reason to believe a new player would be capable of this job
It isn't even a good job for learning because of how it is just sitting around waiting for miners to get hurt

The requirement isn't intensive, 
4 days since first log in and 2 hours in medical is more so to prevent fresh logins from choosing it and being overwhelmed
:cl:  
tweak: Adds a mining medic time requirement
/:cl:
