### PR TITLE
Makes spray bottle stream mode do touch application of reagents

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -112,12 +112,12 @@
 				if(isliving(T))
 					var/mob/living/M = T
 					if((M.mobility_flags & MOBILITY_STAND) || !range_left)
-						D.reagents.reaction(M, VAPOR)
+						D.reagents.reaction(M, TOUCH)
 						puff_reagent_left -= 1
 						var/contained = D.reagents.log_list() // looks like more copypasta but now the reagents are in a different place fuck you old coder
 						log_combat(user, M,  "sprayed with", src, addition="which had [contained]")
 				else if(!range_left)
-					D.reagents.reaction(T, VAPOR)
+					D.reagents.reaction(T, TOUCH)
 			else
 				D.reagents.reaction(T, VAPOR)
 				if(ismob(T))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108117184/206306071-05694d56-8308-484c-8b01-de8bafdc89c3.png)

it's a constant stream of reagent, why would it count as vapour, it's the equivalent of a water gun
spray mode still counts as vapour

This differentiates the modes more than just range and reagent transfer amount
Allows certain chems to apply different effects
Water makes people wet instead of putting water in their body (preternis nerf)

:cl:  
tweak: Spray bottle stream mode applies reagents via touch rather than vapour
/:cl:
