### PR TITLE
fixes .32 trac speedloader desc

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -74,7 +74,7 @@
 /obj/item/ammo_box/tra32
 	name = "speed loader (.32 TRAC)"
 	desc = "A seven-shot speed loader designed for the Caldwell Tracking Revolver. \
-			These needle-like rounds deal miniscule damage, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is fifteen minutes."
+			These needle-like rounds deal miniscule damage, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is five minutes."
 	icon_state = "32trac"
 	ammo_type = /obj/item/ammo_casing/tra32
 	max_ammo = 7


### PR DESCRIPTION
# Document the changes in your pull request

oops

# Changelog

:cl:  
spellcheck: .32 TRAC speedloader properly reports that it lasts 5 minutes instead of 15
/:cl:
