### PR TITLE
Shadowling veil nullifies glowy for ALL TIME

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -140,18 +140,7 @@
 		var/mob/living/carbon/M = H
 		var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
 		if(G)
-			G.glowth.set_light(0, 0) // Set glowy to no light
-			if(G.current_nullify_timer)
-				deltimer(G.current_nullify_timer) // Stacks
-			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 5 SECONDS, TIMER_STOPPABLE)
-
-/obj/effect/proc_holder/spell/aoe_turf/proc/giveGlowyBack(mob/living/carbon/M)
-	if(!M)
-		return
-	var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
-	if(G)
-		G.modify() // Re-sets glowy
-		G.current_nullify_timer = null
+			M.dna.remove_mutation(GLOWY)
 
 /obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets,mob/user = usr)
 	if(!shadowling_check(user) && !admin_override)


### PR DESCRIPTION
I'VE HAD IT

See round 44257 for evidence that slings need SOMETHING for glowy. Mutadone requires accessing medbay, which is hard for loud antags at the best of times. This is not the best of times because medbay is full of hostile DoT fields.
It only takes one geneticist with lifeticks to checkmate any sling game.

"waa waa this is their only counter" play a sling round sometime. Glowy isn't a counter, it's a win condition, and you can reach it in 5 minutes.

closes #17004 
# Document the changes in your pull request

Veil removes the glowy mutation.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Veil removes glowy. Bring spare mutators.
/:cl: