### PR TITLE
Shadowling veil nullifies glowy for SOME TIME and enthrall removes it for ALL TIME

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -143,7 +143,7 @@
 			G.glowth.set_light(0, 0) // Set glowy to no light
 			if(G.current_nullify_timer)
 				deltimer(G.current_nullify_timer) // Stacks
-			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 5 SECONDS, TIMER_STOPPABLE)
+			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 120 SECONDS, TIMER_STOPPABLE)
 
 /obj/effect/proc_holder/spell/aoe_turf/proc/giveGlowyBack(mob/living/carbon/M)
 	if(!M)
@@ -337,6 +337,11 @@
 		target.visible_message(span_big("[target] looks to have experienced a revelation!"), \
 							   span_warning("False faces all d<b>ark not real not real not--</b>"))
 		target.setOxyLoss(0) //In case the shadowling was choking them out
+		if(iscarbon(H))
+			var/mob/living/carbon/M = H
+			var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
+			if(G)
+				M.dna.remove_mutation(GLOWY)
 		target.mind.special_role = "thrall"
 		var/obj/item/organ/internal/shadowtumor/ST = new
 		ST.Insert(target, FALSE, FALSE)

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -143,7 +143,7 @@
 			G.glowth.set_light(0, 0) // Set glowy to no light
 			if(G.current_nullify_timer)
 				deltimer(G.current_nullify_timer) // Stacks
-			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 120 SECONDS, TIMER_STOPPABLE)
+			G.current_nullify_timer = addtimer(CALLBACK(src, .proc/giveGlowyBack, M), 40 SECONDS, TIMER_STOPPABLE)
 
 /obj/effect/proc_holder/spell/aoe_turf/proc/giveGlowyBack(mob/living/carbon/M)
 	if(!M)

--- a/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
+++ b/yogstation/code/modules/antagonists/shadowling/shadowling_abilities.dm
@@ -337,8 +337,8 @@
 		target.visible_message(span_big("[target] looks to have experienced a revelation!"), \
 							   span_warning("False faces all d<b>ark not real not real not--</b>"))
 		target.setOxyLoss(0) //In case the shadowling was choking them out
-		if(iscarbon(H))
-			var/mob/living/carbon/M = H
+		if(iscarbon(target))
+			var/mob/living/carbon/M = target
 			var/datum/mutation/human/glow/G = M.dna.get_mutation(GLOWY)
 			if(G)
 				M.dna.remove_mutation(GLOWY)


### PR DESCRIPTION
# Document the changes in your pull request

Veil turns off glowy's light for 40 seconds. If someone is enthralled, their glowy is removed

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Veil turns off glowy's light for 40 seconds. If someone is enthralled, their glowy is removed
/:cl: