### PR TITLE
Resilient glowy can no longer be turned off

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -191,7 +191,7 @@
 	quality = POSITIVE
 	text_gain_indication = span_notice("Your skin begins to glow softly.")
 	instability = 5
-	var/obj/effect/dummy/luminescent_glow/glowth //shamelessly copied from luminescents
+	var/obj/effect/dummy/luminescent_glow/glowy/glowth //shamelessly copied from luminescents
 	var/glow = 3.5
 	var/range = 2.5
 	var/color
@@ -199,11 +199,21 @@
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
 
+/obj/effect/dummy/luminescent_glow/glowy
+	var/resilient = FALSE
+
+/obj/effect/dummy/luminescent_glow/glowy/set_light(range, power, color)
+	if (resilient && (range <= 1 || power <= 1))
+		return
+	. = ..()
+
+
 /datum/mutation/human/glow/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()
 	if(.)
 		return
 	glowth = new(owner)
+	glowth.resilient = mutadone_proof
 	modify()
 
 /datum/mutation/human/glow/modify()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -202,8 +202,8 @@
 /obj/effect/dummy/luminescent_glow/glowy
 	var/resilient = FALSE
 
-/obj/effect/dummy/luminescent_glow/glowy/set_light(range, power, color = NONSENSICAL_VALUE)
-	if (resilient && (range <= 1 || power <= 1))
+/obj/effect/dummy/luminescent_glow/glowy/set_light(l_range, l_power, l_color = NONSENSICAL_VALUE)
+	if (resilient && (l_range <= 1 || l_power <= 1))
 		return
 	. = ..()
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -202,7 +202,7 @@
 /obj/effect/dummy/luminescent_glow/glowy
 	var/resilient = FALSE
 
-/obj/effect/dummy/luminescent_glow/glowy/set_light(range, power, color)
+/obj/effect/dummy/luminescent_glow/glowy/set_light(range, power, color = NONSENSICAL_VALUE)
 	if (resilient && (range <= 1 || power <= 1))
 		return
 	. = ..()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -202,7 +202,7 @@
 /obj/effect/dummy/luminescent_glow/glowy
 	var/resilient = FALSE
 
-/obj/effect/dummy/luminescent_glow/glowy/set_light(l_range, l_power, l_color = NONSENSICAL_VALUE)
+/obj/effect/dummy/luminescent_glow/glowy/set_light(l_range, l_power, l_color = -99999)
 	if (resilient && (l_range <= 1 || l_power <= 1))
 		return
 	. = ..()


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->
More counterplay to shadowlings; now you have the choice of having more range but having it being able to be turned off, or you can have it so it can't be turned off but less range.
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->
Resilient glowy can no longer be turned off by any means
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Resilient glowy can no longer be turned off by any means
/:cl:
