### PR TITLE
Nerf rad goat again and minor rad anomaly tweaks

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -368,7 +368,7 @@
 
 /obj/effect/anomaly/radiation/anomalyEffect()
 	..()
-	for(var/i = 1 to 10)
+	for(var/i = 1 to 15)
 		fire_nuclear_particle_wimpy()
 	radiation_pulse(src, 500, 5)
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -364,7 +364,7 @@
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "radiation_anomaly"
 	density = TRUE
-	var/has_effect = TRUE //For goat spawning
+	var/spawn_goat = TRUE //For goat spawning
 
 /obj/effect/anomaly/radiation/anomalyEffect()
 	..()
@@ -384,7 +384,7 @@
 
 /obj/effect/anomaly/radiation/detonate()
 	INVOKE_ASYNC(src, .proc/rad_Spin)
-	has_effect = FALSE //Don't want rad anomaly to keep spamming rad goat
+	spawn_goat = FALSE //Don't want rad anomaly to keep spamming rad goat
 
 /obj/effect/anomaly/radiation/proc/rad_Spin()
 	radiation_pulse(src, 5000, 7)
@@ -398,7 +398,7 @@
 	anomalyEffect()
 	if(death_time < world.time)
 		if(loc)
-			if(has_effect)
+			if(spawn_goat)
 				INVOKE_ASYNC(src, .proc/makegoat)
 			detonate()
 			addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, src), 150)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -369,7 +369,7 @@
 /obj/effect/anomaly/radiation/anomalyEffect()
 	..()
 	for(var/i = 1 to 15)
-		fire_nuclear_particle_wimpy()
+		fire_nuclear_particle()
 	radiation_pulse(src, 500, 5)
 
 /obj/effect/anomaly/radiation/proc/makegoat()
@@ -391,7 +391,7 @@
 	var/turf/T = get_turf(src)
 	for(var/i=1 to 100)
 		var/angle = i * 10
-		T.fire_nuclear_particle_wimpy(angle)
+		T.fire_nuclear_particle(angle)
 		sleep(0.7)
 
 /obj/effect/anomaly/radiation/process()

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -368,7 +368,7 @@
 
 /obj/effect/anomaly/radiation/anomalyEffect()
 	..()
-	for(var/i = 1 to 15)
+	for(var/i = 1 to 10)
 		fire_nuclear_particle_wimpy()
 	radiation_pulse(src, 500, 5)
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -55,10 +55,7 @@
 	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
 	if(!P.nodamage)
 		last_damage = P.name
-		if((istype(P, /obj/item/projectile/energy/nuclear_particle)) && (getarmor(null, RAD) >= 100))
-			P.damage = 0
-		else
-			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness())
+		apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness())
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
 	if(P.penetrating && (P.penetration_type == 0 || P.penetration_type == 2) && P.penetrations > 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -55,7 +55,10 @@
 	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
 	if(!P.nodamage)
 		last_damage = P.name
-		apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness())
+		if((istype(P, /obj/item/projectile/energy/nuclear_particle)) && (getarmor(null, RAD) >= 100))
+			return BULLET_ACT_BLOCK
+		else
+			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness())
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
 	if(P.penetrating && (P.penetration_type == 0 || P.penetration_type == 2) && P.penetrations > 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -56,7 +56,7 @@
 	if(!P.nodamage)
 		last_damage = P.name
 		if((istype(P, /obj/item/projectile/energy/nuclear_particle)) && (getarmor(null, RAD) >= 100))
-			return BULLET_ACT_BLOCK
+			P.damage = 0
 		else
 			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness())
 		if(P.dismemberment)

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -30,7 +30,7 @@
 	P.fire(angle)
 
 /obj/item/projectile/energy/nuclear_particle/wimpy
-	irradiate = 100
+	irradiate = 500
 	damage = 2
 
 /atom/proc/fire_nuclear_particle_wimpy(angle = rand(0,360))

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -30,7 +30,7 @@
 	P.fire(angle)
 
 /obj/item/projectile/energy/nuclear_particle/wimpy
-	irradiate = 500
+	irradiate = 100
 	damage = 2
 
 /atom/proc/fire_nuclear_particle_wimpy(angle = rand(0,360))

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -28,11 +28,3 @@
 /atom/proc/fire_nuclear_particle(angle = rand(0,360)) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
 	var/obj/item/projectile/energy/nuclear_particle/P = new /obj/item/projectile/energy/nuclear_particle(src)
 	P.fire(angle)
-
-/obj/item/projectile/energy/nuclear_particle/wimpy
-	irradiate = 500
-	damage = 2
-
-/atom/proc/fire_nuclear_particle_wimpy(angle = rand(0,360))
-	var/obj/item/projectile/energy/nuclear_particle/wimpy/P = new /obj/item/projectile/energy/nuclear_particle/wimpy(src)
-	P.fire(angle)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -146,7 +146,7 @@
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/goat/radioactive/S = user
 	var/obj/effect/anomaly/radiation/anomaly = new (S.loc, 150)
-	anomaly.has_effect = FALSE
+	anomaly.spawn_goat = FALSE
 	playsound(S, 'sound/weapons/resonator_fire.ogg', 100, TRUE)
 	S.visible_message(span_notice("You see \the radiation anomaly emerges from \the [S]."), span_notice("\The radiation anomaly emerges from your body."))
 	notify_ghosts("The Radioactive Goat has spawned a radiation anomaly!", source = anomaly, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Radiation Anomaly Spawned!")

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -267,7 +267,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 /datum/species/preternis/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
 	// called before a projectile hit
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
-		H.fire_nuclear_particle_wimpy()
+		H.fire_nuclear_particle()
 		H.visible_message(span_danger("[P] deflects off of [H]!"), span_userdanger("[P] deflects off of you!"))
 		return 1
 	return 0

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -182,13 +182,14 @@
 	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/radiation_anomaly)
 	ADD_TRAIT(src, TRAIT_RADIMMUNE, GENETIC_MUTATION)
 
-/mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
-	. = ..()
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
-		P.damage = 0
 		adjustBruteLoss(-10)
 		adjustFireLoss(-10)
+		return BULLET_ACT_BLOCK //No damaging goat
+	return ..()
+
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	if(stat == CONSCIOUS)

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -191,8 +191,8 @@
 	. = ..()
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
-		adjustBruteLoss(-0.2)
-		adjustFireLoss(-0.2)
+		adjustBruteLoss(1)
+		adjustFireLoss(1)
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	if(stat == CONSCIOUS)

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -171,6 +171,8 @@
 	melee_damage_upper = 25
 	speed = -0.5
 	robust_searching = 1
+	turns_per_move = 5
+	dodging = 1
 	stat_attack = UNCONSCIOUS
 	health = 75
 	maxHealth = 75

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -172,8 +172,8 @@
 	speed = -0.5
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
-	health = 60
-	maxHealth = 60
+	health = 75
+	maxHealth = 75
 	var/datum/action/innate/rad_goat/rad_switch
 	var/rad_emit = TRUE
 

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -172,8 +172,8 @@
 	speed = -0.5
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
-	health = 120
-	maxHealth = 120
+	health = 60
+	maxHealth = 60
 	var/datum/action/innate/rad_goat/rad_switch
 	var/rad_emit = TRUE
 

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -184,12 +184,15 @@
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
-		// abosrbs nuclear particle to heal
 		P.damage = 0 //No damaging goat
-		adjustBruteLoss(-0.2)
-		adjustFireLoss(-0.2)
 	return ..()
 
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
+	. = ..()
+	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+		// abosrbs nuclear particle to heal
+		adjustBruteLoss(-0.2)
+		adjustFireLoss(-0.2)
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	if(stat == CONSCIOUS)

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -172,8 +172,8 @@
 	speed = -0.5
 	robust_searching = 1
 	stat_attack = UNCONSCIOUS
-	health = 200
-	maxHealth = 200
+	health = 120
+	maxHealth = 120
 	var/datum/action/innate/rad_goat/rad_switch
 	var/rad_emit = TRUE
 

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -193,8 +193,8 @@
 	. = ..()
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
-		adjustBruteLoss(1)
-		adjustFireLoss(1)
+		adjustBruteLoss(-1)
+		adjustFireLoss(-1)
 
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/Life()
 	if(stat == CONSCIOUS)

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -186,8 +186,8 @@
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
 		P.damage = 0 //No damaging goat
-		adjustBruteLoss(-10)
-		adjustFireLoss(-10)
+		adjustBruteLoss(-0.2)
+		adjustFireLoss(-0.2)
 	return ..()
 
 

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -185,9 +185,9 @@
 /mob/living/simple_animal/hostile/retaliate/goat/radioactive/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
+		P.damage = 0 //No damaging goat
 		adjustBruteLoss(-10)
 		adjustFireLoss(-10)
-		return BULLET_ACT_BLOCK //No damaging goat
 	return ..()
 
 


### PR DESCRIPTION
Closes #16989
Also nerf rad goat because people whining about it
# Document the changes in your pull request
- Rad particles irradiation from rad anomaly is higher than standard rad particles (500 irradiation to 400 irradiation)
- Rad anomaly ball counts per shot 10->15
- Nerf rad goat healing from anomaly particles (10->1)
- Nerf rad goat health 200-75
- fix rad particles damaging rad goat



# Wiki Documentation
In doc of changes

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Rad particles irradiation from rad anomaly is higher than standard rad particles by 100 (500 irradiation to 400 irradiation)
tweak: Rad anomaly ball counts per shot 10->15
tweak: Nerf rad goat healing from anomaly particles(10->1)
tweak: Nerf rad goat health 200->75
bugfix: fix rad particles damaging rad goat
/:cl: