### PR TITLE
Space heater and electrolyzer main power source will be APC power

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -65,6 +65,7 @@
 		on = FALSE
 	if(!on)
 		active_power_usage = 0
+		update_icon()
 		return PROCESS_KILL
 
 	if((stat & NOPOWER) && (!cell || cell.charge <= 0))

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -178,7 +178,6 @@
 	data["open"] = panel_open
 	data["on"] = on
 	data["hasPowercell"] = !isnull(cell)
-	data["HasPower"] = use_power
 	if(cell)
 		data["powerLevel"] = round(cell.percent(), 1)
 	return data

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -4,15 +4,14 @@
 /obj/machinery/electrolyzer
 	anchored = FALSE
 	density = TRUE
-	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OFFLINE
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "electrolyzer-off"
 	name = "space electrolyzer"
 	desc = "Thanks to the fast and dynamic response of our electrolyzers, on-site hydrogen production is guaranteed. Warranty void if used by clowns"
 	max_integrity = 250
 	circuit = /obj/item/circuitboard/machine/electrolyzer
-	/// We don't use area power, we always use the cell
-	use_power = NO_POWER_USE
+	use_power = ACTIVE_POWER_USE
 	///used to check if there is a cell in the machine
 	var/obj/item/stock_parts/cell/cell
 	///check if the machine is on or off
@@ -23,6 +22,8 @@
 	var/workingPower = 1
 	///Decrease the amount of power usage, changed by upgrading the capacitor tier
 	var/efficiency = 0.5
+	//Recharge cell when drawing power from apc
+	var/charge_rate = 10
 
 /obj/machinery/electrolyzer/get_cell()
 	return cell
@@ -60,15 +61,15 @@
 		add_overlay("electrolyzer-open")
 
 /obj/machinery/electrolyzer/process(delta_time)
-	if(!is_operational() && on)
+	if((stat & (BROKEN|MAINT)) && on)
 		on = FALSE
 	if(!on)
 		return PROCESS_KILL
 
-	if(!cell || cell.charge <= 0)
+	if((stat & NOPOWER) && (!cell || cell.charge <= 0))
 		on = FALSE
 		update_icon()
-		return PROCESS_KILL
+		return FALSE
 
 	var/turf/L = loc
 	if(!istype(L))
@@ -98,19 +99,38 @@
 	removed.adjust_moles(/datum/gas/hydrogen, (proportion * 2 * workingPower))
 	env.merge(removed) //put back the new gases in the turf
 	air_update_turf()
-	if (!cell.use((5 * proportion * workingPower) / (efficiency + workingPower)))
-		//automatically turn off machine when cell depletes
-		on = FALSE
-		update_icon()
+
+	var/working = TRUE
+
+	if(stat & NOPOWER)
+		if (!cell.use((5 * proportion * workingPower) / (efficiency + workingPower)))
+			//automatically turn off machine when cell depletes
+			on = FALSE
+			update_icon()
+			working = FALSE
+	else
+		active_power_usage = (5 * proportion * workingPower) / (efficiency + workingPower)
+		cell.give(charge_rate)
+
+	if(!working)
 		return PROCESS_KILL
+
+/obj/machinery/electrolyzer/power_change()
+	. = ..()
+	if(stat & NOPOWER)
+		use_power = NO_POWER_USE
+	else
+		use_power = ACTIVE_POWER_USE
 
 /obj/machinery/electrolyzer/RefreshParts()
 	var/lasers = 0
 	var/cap = 0
+	charge_rate = 500
 	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
 		lasers += L.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)
 		cap += M.rating
+		charge_rate = initial(charge_rate)*M.rating
 
 	workingPower = lasers / 2 //used in the amount of moles processed
 
@@ -159,6 +179,7 @@
 	data["open"] = panel_open
 	data["on"] = on
 	data["hasPowercell"] = !isnull(cell)
+	data["HasPower"] = use_power
 	if(cell)
 		data["powerLevel"] = round(cell.percent(), 1)
 	return data

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -125,7 +125,6 @@
 /obj/machinery/electrolyzer/RefreshParts()
 	var/lasers = 0
 	var/cap = 0
-	charge_rate = 500
 	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
 		lasers += L.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -64,6 +64,7 @@
 	if((stat & (BROKEN|MAINT)) && on)
 		on = FALSE
 	if(!on)
+		active_power_usage = 0
 		return PROCESS_KILL
 
 	if((stat & NOPOWER) && (!cell || cell.charge <= 0))

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -201,7 +201,6 @@
 	data["on"] = on
 	data["mode"] = setMode
 	data["hasPowercell"] = !!cell
-	data["HasPower"] = use_power
 	if(cell)
 		data["powerLevel"] = round(cell.percent(), 1)
 	data["targetTemp"] = round(targetTemperature - T0C, 1)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -5,7 +5,7 @@
 /obj/machinery/space_heater
 	anchored = FALSE
 	density = TRUE
-	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN
+	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OFFLINE
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "sheater-off"
 	name = "space heater"
@@ -13,7 +13,7 @@
 	max_integrity = 250
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 100, FIRE = 80, ACID = 10)
 	circuit = /obj/item/circuitboard/machine/space_heater
-	use_power = NO_POWER_USE
+	use_power = ACTIVE_POWER_USE
 	var/obj/item/stock_parts/cell/cell
 	var/on = FALSE
 	var/mode = HEATER_MODE_STANDBY
@@ -24,6 +24,7 @@
 	var/temperatureTolerance = 1
 	var/settableTemperatureMedian = 30 + T0C
 	var/settableTemperatureRange = 30
+	var/charge_rate = 10
 
 /obj/machinery/space_heater/get_cell()
 	return cell
@@ -57,22 +58,19 @@
 		. += "<span class='notice'>The status display reads: Temperature range at <b>[settableTemperatureRange]°C</b>.<br>Heating power at <b>[heatingPower*0.001]kJ</b>.<br>Power consumption at <b>[(efficiency*-0.0025)+150]%</b>.<span>" //100%, 75%, 50%, 25%
 
 /obj/machinery/space_heater/update_icon()
-	if(on)
-		icon_state = "sheater-[on ? "[mode]" : "off"]"
-	else
-		icon_state = "sheater-off"
+	icon_state = "sheater-[on ? "[mode]" : "off"]"
 
 	cut_overlays()
 	if(panel_open)
 		add_overlay("sheater-open")
 
 /obj/machinery/space_heater/process()
-	if(!on || !is_operational())
+	if(!on || stat & (BROKEN|MAINT))
 		if (on) // If it's broken, turn it off too
 			on = FALSE
 		return PROCESS_KILL
 
-	if(!cell || cell.charge <= 0)
+	if((stat & NOPOWER) && (!cell || cell.charge <= 0))
 		on = FALSE
 		update_icon()
 		return PROCESS_KILL
@@ -106,18 +104,35 @@
 	if(requiredPower < 1)
 		return
 
-	if (cell.use(requiredPower / efficiency))
-		var/deltaTemperature = requiredPower / heat_capacity
-		if(mode == HEATER_MODE_COOL)
-			deltaTemperature *= -1
-		if(deltaTemperature)
-			env.set_temperature(env.return_temperature() + deltaTemperature)
-			air_update_turf()
+	var/deltaTemperature = requiredPower / heat_capacity
+	if(mode == HEATER_MODE_COOL)
+		deltaTemperature *= -1
+	if(deltaTemperature)
+		env.set_temperature(env.return_temperature() + deltaTemperature)
+		air_update_turf()
+
+	var/working = TRUE
+
+	if(stat & NOPOWER)
+		if (!cell.use(requiredPower / efficiency))
+			//automatically turn off machine when cell depletes
+			on = FALSE
+			update_icon()
+			working = FALSE		
 	else
-		//automatically turn off machine when cell depletes
-		on = FALSE
-		update_icon()
+		active_power_usage = requiredPower / efficiency
+		cell.give(charge_rate)
+	
+	if(!working)
 		return PROCESS_KILL
+
+/obj/machinery/space_heater/power_change()
+	. = ..()
+	if(stat & NOPOWER)
+		use_power = NO_POWER_USE
+	else
+		use_power = ACTIVE_POWER_USE
+
 
 /obj/machinery/space_heater/RefreshParts()
 	var/laser = 2
@@ -126,6 +141,7 @@
 		laser += M.rating
 	for(var/obj/item/stock_parts/capacitor/M in component_parts)
 		cap += M.rating
+		charge_rate = initial(charge_rate)*M.rating
 
 	heatingPower = laser * 40000
 
@@ -185,6 +201,7 @@
 	data["on"] = on
 	data["mode"] = setMode
 	data["hasPowercell"] = !!cell
+	data["HasPower"] = use_power
 	if(cell)
 		data["powerLevel"] = round(cell.percent(), 1)
 	data["targetTemp"] = round(targetTemperature - T0C, 1)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -68,6 +68,8 @@
 	if(!on || stat & (BROKEN|MAINT))
 		if (on) // If it's broken, turn it off too
 			on = FALSE
+		active_power_usage = 0
+		update_icon()
 		return PROCESS_KILL
 
 	if((stat & NOPOWER) && (!cell || cell.charge <= 0))

--- a/tgui/packages/tgui/interfaces/Electrolyzer.js
+++ b/tgui/packages/tgui/interfaces/Electrolyzer.js
@@ -23,7 +23,7 @@ export const Electrolyzer = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={!data.hasPowercell || (!data.on && data.powerLevel <= 0)}
+                disabled={!data.hasPowercell && data.hasPower == 0}
                 onClick={() => act('power')} />
             </Fragment>
           )}>

--- a/tgui/packages/tgui/interfaces/Electrolyzer.js
+++ b/tgui/packages/tgui/interfaces/Electrolyzer.js
@@ -23,7 +23,6 @@ export const Electrolyzer = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={!data.hasPowercell && data.hasPower == 0}
                 onClick={() => act('power')} />
             </Fragment>
           )}>

--- a/tgui/packages/tgui/interfaces/SpaceHeater.js
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.js
@@ -23,7 +23,7 @@ export const SpaceHeater = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={!data.hasPowercell || (!data.on && data.powerLevel <= 0)}
+                disabled={(!data.hasPowercell && data.hasPower == 0)}
                 onClick={() => act('power')} />
             </Fragment>
           )}>

--- a/tgui/packages/tgui/interfaces/SpaceHeater.js
+++ b/tgui/packages/tgui/interfaces/SpaceHeater.js
@@ -23,7 +23,6 @@ export const SpaceHeater = (props, context) => {
                 icon={data.on ? 'power-off' : 'times'}
                 content={data.on ? 'On' : 'Off'}
                 selected={data.on}
-                disabled={(!data.hasPowercell && data.hasPower == 0)}
                 onClick={() => act('power')} />
             </Fragment>
           )}>


### PR DESCRIPTION
Why is it good for game? First, cyborgs can't put a cell in an electrolyzer or a space heater to run them, this will make them be able to use this to run these machines without a cell. Second, machinery main power should be power source instead of cell as it's obsolete and inefficient
# Document the changes in your pull request
Space heater and electrolyzer main power source is now APC power, during this time cell be recharged slowly. When no apc power, it will use cell power as it last backup source.



# Wiki Documentation
Space heater and electrolyzer main power source is now APC power, during this time cell be recharged slowly. When no apc power, it will use cell power as it last backup source.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Space heater and electrolyzer main power source is now APC power, during this time cell be recharged slowly. When no apc power, it will use cell power as it last backup source.
/:cl:
