### PR TITLE
Remove "!>" when examinating

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -6,7 +6,7 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 
-	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>!>")
+	. = list("<span class='info'>This is [icon2html(src, user)] \a <EM>[src]</EM>")
 	var/list/obscured = check_obscured_slots()
 
 	if (handcuffed)


### PR DESCRIPTION
- Resolves #16970

# Document the changes in your pull request
Remove "!>" when examinating
![image](https://user-images.githubusercontent.com/89688125/206484808-68a5e628-d5c4-4036-99e9-01ffc02e1681.png)
this is fucking weird af

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

spellcheck: Remove "!>" when examinating
/:cl:
