### PR TITLE
Gives brig physician nitrile gloves instead of latex gloves

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -321,3 +321,4 @@
 	new /obj/item/tank/internals/anesthetic(src)
 	new /obj/item/clothing/mask/breath/medical(src)
 	new /obj/item/defibrillator/loaded(src)
+	new /obj/item/clothing/gloves/color/latex/nitrile

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -49,7 +49,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
 	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician
-	gloves = /obj/item/clothing/gloves/color/latex
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	head = /obj/item/clothing/head/soft/emt/phys
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med


### PR DESCRIPTION
Nitrile gloves are the upgraded version of latex gloves
Weird that security wouldn't be able to supply them for their physician

:cl:  
rscadd: Adds a pair of nitrile gloves to brig physician's locker
tweak: Gives brig physician nitrile gloves instead of latex gloves
/:cl:
