### PR TITLE
Rebalances Ethereal "eating"

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -187,7 +187,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(200)
+			stomach.adjust_charge(10 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 			to_chat(M,span_notice("You get charged by [src]."))
 	//yogs edit end  ----------------------------------
 	if(iscyborg(M))

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -187,7 +187,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(20)
+			stomach.adjust_charge(200)
 			to_chat(M,span_notice("You get charged by [src]."))
 	//yogs edit end  ----------------------------------
 	if(iscyborg(M))

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -689,7 +689,7 @@
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, span_notice("You receive some charge from the [fitting]."))
-						stomach.adjust_charge(5)
+						stomach.adjust_charge(50)
 					else
 						to_chat(H, span_notice("You can't receive charge from the [fitting]."))
 				return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -689,7 +689,7 @@
 					var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 					if(istype(stomach))
 						to_chat(H, span_notice("You receive some charge from the [fitting]."))
-						stomach.adjust_charge(50)
+						stomach.adjust_charge(25 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 					else
 						to_chat(H, span_notice("You can't receive charge from the [fitting]."))
 				return

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -29,7 +29,7 @@
 			var/mob/living/carbon/human/H = C
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 			if(istype(stomach))
-				stomach.adjust_charge(200)
+				stomach.adjust_charge(10 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 				to_chat(C,span_notice("You get charged by [src]."))
 		//yogstation edit end ---------------------------------------------
 

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -29,7 +29,7 @@
 			var/mob/living/carbon/human/H = C
 			var/obj/item/organ/stomach/ethereal/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 			if(istype(stomach))
-				stomach.adjust_charge(20)
+				stomach.adjust_charge(200)
 				to_chat(C,span_notice("You get charged by [src]."))
 		//yogstation edit end ---------------------------------------------
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -743,7 +743,7 @@
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(reac_volume * REM * 10)
+			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -743,7 +743,7 @@
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(reac_volume * REM)
+			stomach.adjust_charge(reac_volume * REM * 10)
 
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M)
 	if(prob(25) && !isethereal(M))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -135,7 +135,7 @@
 	var/did_we_charge = FALSE
 	var/obj/item/organ/stomach/ethereal/eth_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 	if(istype(eth_stomach))
-		eth_stomach.adjust_charge(3)
+		eth_stomach.adjust_charge(30)
 		did_we_charge = TRUE
 	if(ispreternis(H))
 		var/datum/species/preternis/preternis = H.dna.species

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -135,7 +135,7 @@
 	var/did_we_charge = FALSE
 	var/obj/item/organ/stomach/ethereal/eth_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 	if(istype(eth_stomach))
-		eth_stomach.adjust_charge(30)
+		eth_stomach.adjust_charge(15 * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 		did_we_charge = TRUE
 	if(ispreternis(H))
 		var/datum/species/preternis/preternis = H.dna.species

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -183,7 +183,7 @@
 /obj/item/organ/stomach/ethereal/proc/on_electrocute(datum/source, shock_damage, siemens_coeff = 1, illusion = FALSE)
 	if(illusion)
 		return
-	adjust_charge(shock_damage * siemens_coeff * 2)
+	adjust_charge(shock_damage * siemens_coeff * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	to_chat(owner, span_notice("You absorb some of the shock into your body!"))
 
 /obj/item/organ/stomach/ethereal/proc/adjust_charge(amount)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -161,7 +161,7 @@
 	name = "biological battery"
 	icon_state = "stomach-p" //Welp. At least it's more unique in functionaliy.
 	desc = "A crystal-like organ that stores the electric charge of ethereals."
-	var/crystal_charge = ETHEREAL_CHARGE_FULL
+	var/crystal_charge = ETHEREAL_CHARGE_ALMOSTFULL
 
 /obj/item/organ/stomach/ethereal/on_life()
 	..()


### PR DESCRIPTION
Something must have happened when ethereal discharge was added
most things charge for so little that you need to constantly eat in order to recharge

So i multiplied all sources of charging by 10
Removes tedium and should make it easier to 

They also started completely full, meaning even a single point of charge started making them overfull

if it ends up being too easy to maintain charge, just tweak the ETHEREAL_CHARGE_FACTOR define

:cl:  
tweak: Ethereal fill up hunger faster
tweak: Ethereal no longer start completely full
/:cl:
