### PR TITLE
Plasmeme are now considered undead instead of inorganic

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -7,7 +7,7 @@
 	species_traits = list(NOBLOOD,NOTRANSSTING,HAS_BONE, AGENDER)
 	// plasmemes get hard to wound since they only need a severe bone wound to dismember, but unlike skellies, they can't pop their bones back into place.
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_NOHUNGER,TRAIT_CALCIUM_HEALER,TRAIT_ALWAYS_CLEAN,TRAIT_HARDLY_WOUNDED)
-	inherent_biotypes = list(MOB_INORGANIC, MOB_HUMANOID)
+	inherent_biotypes = list(MOB_UNDEAD, MOB_HUMANOID)
 	default_features = list("plasmaman_helmet")
 	mutantlungs = /obj/item/organ/lungs/plasmaman
 	mutanttongue = /obj/item/organ/tongue/bone/plasmaman


### PR DESCRIPTION
They ARE organic, they're literally a skeleton reanimated by some plasma fuckery
The only other inorganic mobs are literally made of metal or whatnot, or literally a ghost

**Things to note**
this DOESN'T give them fakedeath on health hud
Necrotic Metabolism will be required on viruses instead of inorganic biology
they will be able to get nanites, just like regular skeletons can

:cl:  
tweak: Plasmeme are considered undead
/:cl:
