### PR TITLE
Thralls now get anti-glowy

### DIFF
--- a/yogstation/code/modules/antagonists/shadowling/thrall.dm
+++ b/yogstation/code/modules/antagonists/shadowling/thrall.dm
@@ -28,6 +28,11 @@ GLOBAL_LIST_INIT(thrall_spell_types, typecacheof(list(/obj/effect/proc_holder/sp
 	owner.special_role = "thrall"
 	message_admins("[key_name_admin(owner.current)] was enthralled by a shadowling!")
 	log_game("[key_name(owner.current)] was enthralled by a shadowling!")
+
+	var/mob/living/carbon/M = owner
+	if (M)
+		M.dna.add_mutation(ANTIGLOWY)
+
 	owner.AddSpell(new /obj/effect/proc_holder/spell/self/lesser_shadowling_hivemind(null))
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_glare(null))
 	owner.AddSpell(new /obj/effect/proc_holder/spell/self/lesser_shadow_walk(null))
@@ -44,6 +49,9 @@ GLOBAL_LIST_INIT(thrall_spell_types, typecacheof(list(/obj/effect/proc_holder/sp
 		if(is_type_in_typecache(S, GLOB.thrall_spell_types)) //only remove thrall spells!
 			owner.RemoveSpell(S)
 	var/mob/living/M = owner.current
+	var/mob/living/carbon/C = owner
+	if (C)
+		C.dna.remove_mutation(ANTIGLOWY)
 	if(issilicon(M))
 		M.audible_message(span_notice("[M] lets out a short blip, followed by a low-pitched beep."))
 		to_chat(M,span_userdanger("You have been turned into a[ iscyborg(M) ? " cyborg" : "n AI" ]! You are no longer a thrall! Though you try, you cannot remember anything about your servitude..."))


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

This way, it serves to make thralls more obvious to security instead of just doing xenobio as they used to and being not worse off for it. Nobody actually inspects eyes to check for thrall anymore because it is just so time consuming.
Also, this helps counter glowy by making it so thralls can just walk up to a glowy person and counteract their glowy.

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->
Thralls now get anti-glowy in shadowlign enthrall power
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Thralls now get anti-glowy
/:cl:
