### PR TITLE
Capitalization of "sulphur" in the chem dispenser

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -851,7 +851,7 @@
 	..()
 
 /datum/reagent/sulphur
-	name = "sulphur"
+	name = "Sulphur"
 	description = "A sickly yellow solid mostly known for its nasty smell. It's actually much more helpful than it looks in biochemisty."
 	reagent_state = SOLID
 	color = "#BF8C00" // rgb: 191, 140, 0


### PR DESCRIPTION
# Document the changes in your pull request

Changes "sulpher" to "Sulpher" in the chem dispenser buttons

***NOTE: This was also fixed by [#16959] but that PR was merged into a branch and not the master. If [#16959] merged correctly to the master it will also fix the same issue this PR is fixing plus any other remaining misspellings. Do not merge this current PR [#17032] before [#16959] is correctly merged. If [#16959] is merged then there is no need to merge [#17032] and I will close it.

NOTE: this 

# Spriting


# Wiki Documentation


# Changelog


:cl:  

spellcheck: Capitalizes "S" in "sulphur" (only in the chem dispenser)

/:cl:
