### PR TITLE
move the Gax docking port back against the airlocks

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -90017,11 +90017,11 @@ vRP
 vRP
 vRP
 vRP
+vRP
+vRP
+vRP
+vRP
 jzc
-vRP
-vRP
-vRP
-vRP
 aCE
 hCF
 jmf


### PR DESCRIPTION
# Document the changes in your pull request

I moved it out of the way because I was extending escape, and then forgot to grab it when i was attaching the rest of escape to the station.

This happened: 
![image](https://user-images.githubusercontent.com/5091394/206799477-7d2545ac-488e-4447-8dbd-ef0f38fe7768.png)


# Changelog

:cl:  
mapping: moves NVS Gax escape docking port back to an accessible location
/:cl:
