### PR TITLE
New Triage Shuttle

### DIFF
--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -148,19 +148,20 @@
 "aX" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"ba" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "dI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -328,12 +329,6 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"oi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "os" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -358,6 +353,16 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"px" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "qa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -371,12 +376,6 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/hypospray/basic/hypo,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"qu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "qA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -399,6 +398,25 @@
 "qN" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rn" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"rB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "sW" = (
 /obj/structure/closet,
@@ -1005,7 +1023,7 @@ aK
 aK
 aK
 oA
-Kj
+rn
 ax
 ay
 ay
@@ -1109,15 +1127,15 @@ Gy
 ae
 ae
 av
-qu
+cr
 QU
-ba
+rB
 QU
-oi
+rB
 QU
-oi
+rB
 QU
-ba
+rB
 kk
 RX
 aK
@@ -1136,12 +1154,12 @@ az
 az
 ae
 ae
+Qr
 ae
+px
 ae
-Gy
 Qr
-Qr
-Qr
+ae
 Qr
 ae
 Gy

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -5,10 +5,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"ac" = (
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
@@ -161,6 +157,12 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"br" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/iv_drip,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "bt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -184,22 +186,6 @@
 	dir = 1
 	},
 /turf/open/floor/noslip,
-/area/shuttle/escape)
-"eH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"fM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "gI" = (
 /obj/machinery/door/airlock/shuttle,
@@ -255,20 +241,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"iJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "jq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -312,20 +284,6 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"km" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/storage/toolbox/drone,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "kN" = (
@@ -479,12 +437,14 @@
 /obj/item/storage/firstaid/advanced,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"wy" = (
+"wG" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Triage Shuttle Cabin"
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public/glass,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "wQ" = (
@@ -615,6 +575,15 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"EG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "ES" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -666,6 +635,20 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"Nk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "NG" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -689,6 +672,18 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Pe" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Pk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -725,6 +720,16 @@
 "RU" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Sm" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Uq" = (
@@ -777,11 +782,11 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"Wb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/iv_drip,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/mineral/titanium/white,
+"VQ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Wx" = (
 /obj/machinery/sleeper{
@@ -803,11 +808,19 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"YL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"Zi" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 10
 	},
-/turf/open/floor/mineral/titanium,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -827,10 +840,10 @@ Uw
 Uw
 ae
 ae
-ae
 gI
+BC
+Sm
 ae
-eH
 ae
 BC
 ae
@@ -853,10 +866,10 @@ Vx
 ki
 qA
 ai
-WK
+EG
 aK
 aK
-aK
+VQ
 sW
 yy
 Uq
@@ -879,8 +892,8 @@ aX
 hI
 aD
 at
-AQ
-fM
+EG
+aK
 aK
 aK
 aK
@@ -905,7 +918,7 @@ aX
 hI
 aD
 ad
-ac
+EG
 kj
 Es
 lY
@@ -931,7 +944,7 @@ aV
 hI
 aa
 ah
-ac
+EG
 GO
 aK
 AV
@@ -956,8 +969,8 @@ aX
 af
 hI
 aX
-km
-ac
+Zi
+EG
 GO
 aK
 AV
@@ -983,7 +996,7 @@ uz
 xm
 wQ
 Pk
-wy
+wG
 aK
 aK
 AV
@@ -1008,8 +1021,8 @@ aX
 aX
 aX
 aX
-iJ
-ac
+Nk
+EG
 GO
 aK
 AV
@@ -1034,8 +1047,8 @@ aX
 aX
 aX
 aX
-Wb
-ac
+br
+EG
 GO
 aK
 AV
@@ -1061,7 +1074,7 @@ yv
 NG
 yv
 gT
-ac
+EG
 PY
 GX
 VO
@@ -1087,7 +1100,7 @@ aX
 dz
 aX
 dI
-ac
+EG
 aK
 aK
 aK
@@ -1113,8 +1126,8 @@ oi
 zR
 ba
 kk
-WK
-YL
+Pe
+aK
 gW
 gW
 sW
@@ -1140,7 +1153,7 @@ Qr
 ae
 Gy
 ae
-ae
+Gy
 Qr
 Qr
 Qr

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -5,13 +5,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"ad" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "ae" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -207,6 +200,15 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"im" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "in" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium,
@@ -235,20 +237,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"jr" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "jJ" = (
 /obj/structure/chair/comfy/shuttle{
@@ -418,18 +406,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"uz" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "uJ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/advanced{
@@ -438,6 +414,19 @@
 	},
 /obj/item/storage/firstaid/advanced,
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"va" = (
+/obj/structure/table,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/storage/toolbox/drone,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "wa" = (
 /obj/machinery/stasis{
@@ -671,6 +660,20 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"OI" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/wrench/medical,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Pk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -928,7 +931,7 @@ aX
 aX
 hI
 aD
-ad
+im
 AJ
 zB
 Es
@@ -980,7 +983,7 @@ aX
 af
 hI
 aX
-jr
+OI
 tu
 lU
 aK
@@ -1003,7 +1006,7 @@ ae
 Mw
 qa
 wQ
-uz
+va
 xm
 wQ
 Pk

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -1,452 +1,581 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
+/area/shuttle/escape)
+"b" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "c" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"d" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
-"e" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/template_noop)
-"g" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 9
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"i" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"k" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"n" = (
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/template_noop)
-"q" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/template_noop)
-"t" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
-/area/template_noop)
-"u" = (
+/area/shuttle/escape)
+"d" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
+/obj/structure/table/optable{
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"v" = (
+/area/shuttle/escape)
+"e" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/stasis,
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"f" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"g" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"h" = (
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"i" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"j" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/template_noop)
-"w" = (
-/obj/machinery/door/airlock/shuttle/glass,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/template_noop)
-"z" = (
-/turf/template_noop,
-/area/template_noop)
-"A" = (
+/area/shuttle/escape)
+"k" = (
+/obj/machinery/door/airlock/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/template_noop)
-"B" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/area/shuttle/escape)
+"l" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"C" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/template_noop)
-"D" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"E" = (
+/area/shuttle/escape)
+"m" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"G" = (
-/turf/open/floor/mineral/titanium,
-/area/template_noop)
-"I" = (
+/area/shuttle/escape)
+"n" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"J" = (
+/area/shuttle/escape)
+"o" = (
+/obj/structure/window/shuttle,
+/turf/template_noop,
+/area/shuttle/escape)
+"p" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"q" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"r" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"s" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"M" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"N" = (
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
-"O" = (
-/obj/structure/window/shuttle,
-/turf/template_noop,
-/area/template_noop)
-"P" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"Q" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"S" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"T" = (
+/area/shuttle/escape)
+"t" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"V" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/area/shuttle/escape)
+"u" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"v" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"w" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 1
-	},
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"W" = (
+/area/shuttle/escape)
+"x" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/template_noop)
-"X" = (
+/area/shuttle/escape)
+"y" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"z" = (
+/turf/template_noop,
 /area/template_noop)
-"Y" = (
+"A" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
+/obj/item/storage/firstaid/advanced{
+	pixel_y = 10
+	},
+/obj/machinery/door/window/brigdoor/southright,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"B" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"C" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"D" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"E" = (
+/obj/structure/table/optable,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"F" = (
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"G" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"H" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"I" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"J" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"K" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
 	layer = 2.35;
 	level = 1
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"L" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"M" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"N" = (
+/turf/closed/wall/mineral/titanium,
 /area/template_noop)
+"O" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"P" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Q" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"R" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"S" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"T" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"U" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/docking_port/mobile/emergency,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"V" = (
+/obj/machinery/door/airlock/shuttle/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"W" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"X" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Y" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Z" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 z
 z
 z
 z
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
+J
+J
+J
+k
+J
+U
+J
+J
+J
+J
+J
+J
 z
 z
 z
-N
-N
-N
+J
+J
+J
 "}
 (2,1,1) = {"
 z
-N
-N
-N
-e
-A
-A
-A
-d
-g
-Q
-Q
-Q
+J
+J
+J
+u
+f
+v
 Q
 M
-e
-N
-N
-N
-e
-n
-C
+b
+d
+H
+d
+K
+D
+u
+J
+J
+J
+u
+h
+q
 "}
 (3,1,1) = {"
-N
-e
-z
-z
-N
-A
-A
-A
-N
-B
-X
-X
-X
-X
-a
-O
-G
-G
-G
-G
-q
-C
-"}
-(4,1,1) = {"
-N
-z
-z
-z
-N
-A
-A
-A
-N
-B
-X
-X
-X
-X
-a
-O
-G
-v
-t
-G
-q
-C
-"}
-(5,1,1) = {"
-N
-z
-z
-z
-N
-A
-A
-A
-N
-B
-X
-X
-X
-X
-a
-N
-G
-v
-t
-G
-q
-C
-"}
-(6,1,1) = {"
-N
-z
-z
-z
-N
-A
-A
-A
-N
-B
-X
-X
-X
-X
-D
-w
-G
-v
-t
-G
-q
-C
-"}
-(7,1,1) = {"
-N
-z
-z
-z
-N
-N
-N
-N
-N
-B
-X
-X
-X
-Y
-T
-N
-G
-v
-t
-G
-q
-C
-"}
-(8,1,1) = {"
-N
-z
-z
-z
-N
+J
+u
+Z
+Z
+J
 E
 Q
-k
-Q
-P
-X
-X
-X
 i
 J
-O
+P
+b
+b
+b
 G
-v
-t
-G
+x
+o
+g
+Z
+Z
+g
+I
 q
+"}
+(4,1,1) = {"
+J
+Z
+g
+Z
+J
+A
+Q
+i
+J
+y
+b
+b
+p
+G
+s
+o
+Z
+j
+c
+Z
+I
+q
+"}
+(5,1,1) = {"
+J
+Z
+Z
+Z
+J
+F
+Q
+i
+J
+P
+S
+S
+S
+O
+t
+J
+Z
+j
+c
+Z
+I
+q
+"}
+(6,1,1) = {"
+J
+Z
+g
+Z
+J
+R
+v
+i
+N
+P
+r
+w
+W
+b
 C
+V
+Z
+j
+c
+Z
+I
+q
+"}
+(7,1,1) = {"
+J
+Z
+Z
+Z
+J
+J
+J
+J
+J
+P
+b
+b
+b
+b
+X
+J
+Z
+j
+c
+Z
+I
+q
+"}
+(8,1,1) = {"
+J
+Z
+g
+Z
+J
+b
+a
+m
+m
+l
+p
+b
+b
+p
+X
+o
+Z
+j
+c
+Z
+I
+q
 "}
 (9,1,1) = {"
-N
-e
-z
-z
-N
-S
+J
+u
+Z
+Z
+J
+b
+p
+b
+b
+b
+b
+b
+b
+b
 X
-X
-X
-X
-X
-X
-X
-i
-W
-O
-G
-G
-G
-G
+o
+g
+Z
+Z
+g
+I
 q
-C
 "}
 (10,1,1) = {"
 z
-N
-N
-N
-e
-c
-I
-I
-I
-I
-I
-I
-I
+J
+J
+J
 u
-V
-e
-N
-N
-N
-e
+B
+T
+T
+L
 n
-C
+Y
+n
+n
+Y
+e
+u
+J
+J
+J
+u
+h
+q
 "}
 (11,1,1) = {"
 z
 z
 z
 z
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
-N
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
 z
 z
 z
-N
-N
-N
+J
+J
+J
 "}

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -1,32 +1,25 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"b" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"c" = (
+"ac" = (
 /obj/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"d" = (
+"ad" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"e" = (
+"ae" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"f" = (
+"af" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 3;
@@ -35,18 +28,18 @@
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"g" = (
+"ag" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"h" = (
+"ah" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"i" = (
+"ai" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -55,58 +48,500 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"j" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"k" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/stasis,
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/noslip,
-/area/shuttle/escape)
-"l" = (
+"al" = (
 /obj/machinery/door/airlock/shuttle,
 /obj/docking_port/mobile/emergency,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"m" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/comfy/shuttle{
+"as" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"at" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"n" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"o" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+"au" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/machinery/computer/operating{
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"av" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"aw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ax" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"p" = (
+"ay" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"az" = (
+/turf/template_noop,
+/area/template_noop)
+"aD" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"aH" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"aK" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"aL" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"aN" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aO" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aP" = (
+/obj/machinery/computer/security,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"aR" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aS" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"aV" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"aX" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ba" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/sleeper,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"q" = (
+"bt" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"dz" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"eH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"fM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gI" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gT" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"gW" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"hr" = (
+/obj/machinery/computer/communications,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"hG" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"hI" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"in" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"iF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"jq" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"jJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"ki" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/sleeper,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"kj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"kk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"kN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"lU" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"lY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ma" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Triage Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"mz" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ni" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"oi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"os" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ox" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -29;
+	pixel_y = 0
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"oA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Triage Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"qa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qk" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/hypospray/basic/hypo,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"qu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qH" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"qN" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"sW" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"uf" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Triage Brig Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"uz" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"uJ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/advanced{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"wy" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"wQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xl" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"xm" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xo" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"yv" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"yy" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"zR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"zV" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"AQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"AV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"BC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"BZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -118,461 +553,587 @@
 /obj/item/storage/firstaid/advanced{
 	pixel_y = 10
 	},
-/obj/machinery/door/window/brigdoor/southright,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "2"
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"r" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+"Dk" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"s" = (
+"El" = (
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Er" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Es" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ED" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ES" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"EY" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Gy" = (
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"t" = (
+"GO" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"GX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ic" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"JB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 1
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"u" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"v" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"w" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"x" = (
+"Kj" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"y" = (
+"Lm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = 24
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"z" = (
-/turf/template_noop,
-/area/template_noop)
-"A" = (
+"NG" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"B" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"C" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"D" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"F" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/table/optable{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"G" = (
-/obj/structure/table/optable,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"H" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"I" = (
-/obj/machinery/door/airlock/shuttle/glass,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"J" = (
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"K" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"L" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"M" = (
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"N" = (
+"NR" = (
 /obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"O" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"P" = (
+"OK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/table,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Q" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"R" = (
-/obj/structure/window/reinforced{
+/obj/machinery/computer/operating{
 	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Pk" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"PY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"S" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"T" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"U" = (
-/obj/machinery/door/airlock/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"V" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"W" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"Qr" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/stasis,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plating,
 /area/shuttle/escape)
-"X" = (
-/turf/open/floor/mineral/titanium/white,
+"QW" = (
+/obj/machinery/light,
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"Y" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"RO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plating,
 /area/shuttle/escape)
-"Z" = (
+"RU" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Uq" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Uw" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"UB" = (
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"UI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Vx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6;
-	layer = 2.35;
-	level = 1
-	},
+/obj/machinery/sleeper,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"VO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Wx" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"WK" = (
+/obj/machinery/light,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"XY" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"YL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
-z
-z
-z
-z
-e
-e
-e
-U
-e
-l
-e
-e
-e
-e
-e
-e
-z
-z
-z
-e
-e
-e
+az
+az
+az
+az
+az
+ae
+BC
+ae
+uf
+ae
+al
+ae
+Uw
+Uw
+ae
+ae
+ae
+gI
+ae
+eH
+ae
+BC
+ae
+ae
 "}
 (2,1,1) = {"
-z
-e
-e
-e
-v
-g
-C
-S
-s
-X
-F
-j
-F
-Z
-i
-v
-e
-e
-e
-v
-J
-L
+az
+ae
+ae
+ae
+ae
+av
+ag
+El
+iF
+as
+Kj
+Vx
+Vx
+ki
+qA
+ai
+WK
+aK
+aK
+aK
+sW
+yy
+Uq
+aL
 "}
 (3,1,1) = {"
-e
-v
-K
-K
-e
-G
-S
-O
-e
-w
-X
-X
-X
-D
-t
-c
-n
-K
-K
-n
-H
-L
+ae
+WK
+bt
+ox
+EY
+ae
+qH
+aS
+aO
+QW
+aw
+aX
+aX
+hI
+aD
+at
+AQ
+fM
+aK
+aK
+aK
+aK
+aH
+aL
 "}
 (4,1,1) = {"
-e
-K
-n
-K
-e
-q
-S
-O
-e
-Y
-X
-X
-T
-D
-d
-c
-K
-m
-R
-K
-H
-L
+RO
+mz
+ES
+aK
+Er
+AQ
+BZ
+aS
+UI
+ae
+aw
+aX
+aX
+hI
+aD
+ad
+ac
+kj
+Es
+lY
+jq
+Es
+aH
+aL
 "}
 (5,1,1) = {"
-e
-K
-K
-K
-e
-M
-S
-O
-e
-w
-A
-A
-A
-a
-h
-e
-K
-m
-R
-K
-H
-L
+RO
+qN
+ES
+aK
+RU
+ae
+xl
+aS
+aO
+ae
+aw
+aX
+aV
+hI
+aa
+ah
+ac
+GO
+aK
+AV
+aR
+aK
+aH
+aL
 "}
 (6,1,1) = {"
-e
-K
-n
-K
-e
-N
-C
-O
-e
-w
-V
-f
-B
-X
-r
-I
-K
-m
-R
-K
-H
-L
+RO
+NR
+aK
+aK
+Ic
+ae
+aN
+aS
+jJ
+ae
+zV
+aX
+af
+hI
+aX
+Dk
+ac
+GO
+aK
+AV
+aR
+aK
+aH
+aL
 "}
 (7,1,1) = {"
-e
-K
-K
-K
-e
-e
-e
-e
-e
-w
-X
-X
-X
-X
-Q
-e
-K
-m
-R
-K
-H
-L
+RO
+in
+aK
+aK
+UB
+ae
+Gy
+ma
+ae
+kN
+qa
+wQ
+uz
+xm
+wQ
+Pk
+wy
+aK
+aK
+AV
+aR
+aK
+aH
+aL
 "}
 (8,1,1) = {"
-e
-K
-n
-K
-e
-X
-x
-y
-y
-u
-T
-X
-X
-T
-Q
-c
-K
-m
-R
-K
-H
-L
+RO
+NR
+aK
+aK
+aK
+oA
+Kj
+ax
+ay
+ay
+au
+aX
+aX
+aX
+aX
+JB
+ac
+GO
+aK
+AV
+aR
+aK
+aH
+aL
 "}
 (9,1,1) = {"
-e
-v
-K
-K
-e
-X
-T
-X
-X
-X
-X
-X
-X
-X
-Q
-c
-n
-K
-K
-n
-H
-L
+RO
+hr
+ES
+aK
+qk
+ae
+Lm
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+aX
+ni
+ac
+GO
+aK
+AV
+lU
+aK
+aH
+aL
 "}
 (10,1,1) = {"
-z
-e
-e
-e
-v
-b
-p
-p
-P
-W
-o
-W
-W
-o
-k
-v
-e
-e
-e
-v
-J
-L
+RO
+aP
+ES
+aK
+uJ
+gZ
+ED
+xo
+yv
+NG
+yv
+NG
+yv
+NG
+yv
+gT
+ac
+PY
+GX
+VO
+XY
+GX
+aH
+aL
 "}
 (11,1,1) = {"
-z
-z
-z
-z
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-z
-z
-z
-e
-e
-e
+ae
+WK
+os
+aK
+Wx
+QW
+aw
+hG
+aX
+dz
+aX
+dz
+aX
+dz
+aX
+dI
+ac
+aK
+aK
+aK
+aK
+aK
+aH
+aL
+"}
+(12,1,1) = {"
+az
+ae
+ae
+ae
+ae
+av
+qu
+OK
+ba
+zR
+oi
+zR
+oi
+zR
+ba
+kk
+WK
+YL
+gW
+gW
+sW
+yy
+Uq
+aL
+"}
+(13,1,1) = {"
+az
+az
+az
+az
+az
+ae
+ae
+ae
+ae
+Gy
+Qr
+Qr
+Qr
+Qr
+ae
+Gy
+ae
+ae
+Qr
+Qr
+Qr
+Gy
+ae
+ae
 "}

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -157,12 +157,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"br" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/iv_drip,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -231,6 +225,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"hN" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "in" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium,
@@ -251,6 +251,20 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"jr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "jJ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -269,13 +283,6 @@
 /obj/machinery/sleeper,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"kj" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "kk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -403,6 +410,15 @@
 /obj/structure/closet,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"tu" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "uf" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Triage Brig Airlock";
@@ -435,16 +451,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/advanced,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"wG" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Triage Shuttle Cabin"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "wQ" = (
@@ -484,6 +490,16 @@
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"zB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "zR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -504,6 +520,18 @@
 	pixel_y = 30
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"AJ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "AQ" = (
 /obj/machinery/light{
@@ -575,15 +603,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"EG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "ES" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -601,10 +620,6 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"GO" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "GX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -635,20 +650,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Nk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "NG" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -660,8 +661,46 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"NM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "NR" = (
 /obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ot" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/iv_drip,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ow" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Triage Shuttle Cabin"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"OC" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "OK" = (
@@ -673,18 +712,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Pe" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "Pk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/door/firedoor/border_only{
@@ -692,11 +719,14 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"PY" = (
+"PB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Qr" = (
@@ -722,13 +752,15 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Sm" = (
-/obj/machinery/door/airlock/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+"RX" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -765,6 +797,20 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"Vc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "Vx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -781,12 +827,6 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"VQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Wx" = (
 /obj/machinery/sleeper{
@@ -808,20 +848,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"Zi" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/storage/toolbox/drone,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 
 (1,1,1) = {"
 az
@@ -842,7 +868,7 @@ ae
 ae
 gI
 BC
-Sm
+OC
 ae
 ae
 BC
@@ -866,10 +892,10 @@ Vx
 ki
 qA
 ai
-EG
+tu
 aK
 aK
-VQ
+hN
 sW
 yy
 Uq
@@ -892,7 +918,7 @@ aX
 hI
 aD
 at
-EG
+tu
 aK
 aK
 aK
@@ -918,8 +944,8 @@ aX
 hI
 aD
 ad
-EG
-kj
+AJ
+zB
 Es
 lY
 jq
@@ -944,8 +970,8 @@ aV
 hI
 aa
 ah
-EG
-GO
+tu
+lU
 aK
 AV
 aR
@@ -969,9 +995,9 @@ aX
 af
 hI
 aX
-Zi
-EG
-GO
+jr
+tu
+lU
 aK
 AV
 aR
@@ -996,7 +1022,7 @@ uz
 xm
 wQ
 Pk
-wG
+Ow
 aK
 aK
 AV
@@ -1021,9 +1047,9 @@ aX
 aX
 aX
 aX
-Nk
-EG
-GO
+Vc
+tu
+lU
 aK
 AV
 aR
@@ -1047,9 +1073,9 @@ aX
 aX
 aX
 aX
-br
-EG
-GO
+Ot
+tu
+lU
 aK
 AV
 lU
@@ -1074,8 +1100,8 @@ yv
 NG
 yv
 gT
-EG
-PY
+NM
+PB
 GX
 VO
 XY
@@ -1100,7 +1126,7 @@ aX
 dz
 aX
 dI
-EG
+tu
 aK
 aK
 aK
@@ -1126,7 +1152,7 @@ oi
 zR
 ba
 kk
-Pe
+RX
 aK
 gW
 gW

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -834,10 +834,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"WK" = (
-/obj/machinery/light,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "XY" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/window/reinforced{
@@ -878,7 +874,7 @@ ae
 (2,1,1) = {"
 az
 ae
-ae
+BC
 ae
 ae
 av
@@ -903,7 +899,7 @@ aL
 "}
 (3,1,1) = {"
 ae
-WK
+av
 bt
 ox
 EY
@@ -1111,7 +1107,7 @@ aL
 "}
 (11,1,1) = {"
 ae
-WK
+av
 os
 aK
 Wx
@@ -1138,7 +1134,7 @@ aL
 (12,1,1) = {"
 az
 ae
-ae
+Gy
 ae
 ae
 av

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -1,0 +1,452 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"c" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"e" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"i" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"n" = (
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/template_noop)
+"t" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/template_noop)
+"u" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"v" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/template_noop)
+"w" = (
+/obj/machinery/door/airlock/shuttle/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"z" = (
+/turf/template_noop,
+/area/template_noop)
+"A" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/template_noop)
+"B" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"C" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/template_noop)
+"D" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"E" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"G" = (
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"M" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"N" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"O" = (
+/obj/structure/window/shuttle,
+/turf/template_noop,
+/area/template_noop)
+"P" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"Q" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"S" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"T" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"V" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"W" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"X" = (
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+"Y" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6;
+	layer = 2.35;
+	level = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/template_noop)
+
+(1,1,1) = {"
+z
+z
+z
+z
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+z
+z
+z
+N
+N
+N
+"}
+(2,1,1) = {"
+z
+N
+N
+N
+e
+A
+A
+A
+d
+g
+Q
+Q
+Q
+Q
+M
+e
+N
+N
+N
+e
+n
+C
+"}
+(3,1,1) = {"
+N
+e
+z
+z
+N
+A
+A
+A
+N
+B
+X
+X
+X
+X
+a
+O
+G
+G
+G
+G
+q
+C
+"}
+(4,1,1) = {"
+N
+z
+z
+z
+N
+A
+A
+A
+N
+B
+X
+X
+X
+X
+a
+O
+G
+v
+t
+G
+q
+C
+"}
+(5,1,1) = {"
+N
+z
+z
+z
+N
+A
+A
+A
+N
+B
+X
+X
+X
+X
+a
+N
+G
+v
+t
+G
+q
+C
+"}
+(6,1,1) = {"
+N
+z
+z
+z
+N
+A
+A
+A
+N
+B
+X
+X
+X
+X
+D
+w
+G
+v
+t
+G
+q
+C
+"}
+(7,1,1) = {"
+N
+z
+z
+z
+N
+N
+N
+N
+N
+B
+X
+X
+X
+Y
+T
+N
+G
+v
+t
+G
+q
+C
+"}
+(8,1,1) = {"
+N
+z
+z
+z
+N
+E
+Q
+k
+Q
+P
+X
+X
+X
+i
+J
+O
+G
+v
+t
+G
+q
+C
+"}
+(9,1,1) = {"
+N
+e
+z
+z
+N
+S
+X
+X
+X
+X
+X
+X
+X
+i
+W
+O
+G
+G
+G
+G
+q
+C
+"}
+(10,1,1) = {"
+z
+N
+N
+N
+e
+c
+I
+I
+I
+I
+I
+I
+I
+u
+V
+e
+N
+N
+N
+e
+n
+C
+"}
+(11,1,1) = {"
+z
+z
+z
+z
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+N
+z
+z
+z
+N
+N
+N
+"}

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -1,30 +1,70 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "b" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/sleeper,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "c" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium/blue,
+/obj/structure/window/shuttle,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/table/optable{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "e" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"f" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"g" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"h" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"i" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"j" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"k" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -34,123 +74,39 @@
 	},
 /turf/open/floor/noslip,
 /area/shuttle/escape)
-"f" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/mineral/plastitanium/red/brig,
+"l" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/docking_port/mobile/emergency,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"g" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"h" = (
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"i" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"j" = (
+"m" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"k" = (
-/obj/machinery/door/airlock/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig,
+"n" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"l" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"m" = (
+"o" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/computer/operating{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"n" = (
+"p" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/stasis,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"o" = (
-/obj/structure/window/shuttle,
-/turf/template_noop,
-/area/shuttle/escape)
-"p" = (
-/obj/machinery/light/floor,
+/obj/machinery/sleeper,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "q" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"r" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"s" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"t" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"u" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"v" = (
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"w" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"x" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"y" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"z" = (
-/turf/template_noop,
-/area/template_noop)
-"A" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -165,60 +121,186 @@
 /obj/machinery/door/window/brigdoor/southright,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"B" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"C" = (
+"r" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"D" = (
+"s" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+	dir = 8
 	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"t" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"E" = (
-/obj/structure/table/optable,
+"u" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"v" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"w" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"x" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"y" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"z" = (
+/turf/template_noop,
+/area/template_noop)
+"A" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"B" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"C" = (
+/obj/machinery/light/floor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"F" = (
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"G" = (
+"D" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"H" = (
+"F" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/computer/operating{
-	dir = 4
+/obj/structure/table/optable{
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"I" = (
+"G" = (
+/obj/structure/table/optable,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"H" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"I" = (
+/obj/machinery/door/airlock/shuttle/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "J" = (
-/turf/closed/wall/mineral/titanium,
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "K" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"L" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"M" = (
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"N" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"O" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"P" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Q" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"R" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"S" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"T" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"U" = (
+/obj/machinery/door/airlock/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"V" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"W" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"X" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Y" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Z" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -229,353 +311,268 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"L" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"M" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"N" = (
-/turf/closed/wall/mineral/titanium,
-/area/template_noop)
-"O" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"P" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Q" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"R" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"S" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"T" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"U" = (
-/obj/machinery/door/airlock/shuttle,
-/obj/docking_port/mobile/emergency,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"V" = (
-/obj/machinery/door/airlock/shuttle/glass,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"W" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"X" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Y" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Z" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 
 (1,1,1) = {"
 z
 z
 z
 z
-J
-J
-J
-k
-J
+e
+e
+e
 U
-J
-J
-J
-J
-J
-J
+e
+l
+e
+e
+e
+e
+e
+e
 z
 z
 z
-J
-J
-J
+e
+e
+e
 "}
 (2,1,1) = {"
 z
-J
-J
-J
-u
-f
+e
+e
+e
 v
-Q
-M
-b
-d
-H
-d
-K
-D
-u
+g
+C
+S
+s
+X
+F
+j
+F
+Z
+i
+v
+e
+e
+e
+v
 J
-J
-J
-u
-h
-q
+L
 "}
 (3,1,1) = {"
-J
-u
-Z
-Z
-J
-E
-Q
-i
-J
-P
-b
-b
-b
+e
+v
+K
+K
+e
 G
-x
-o
-g
-Z
-Z
-g
-I
-q
-"}
-(4,1,1) = {"
-J
-Z
-g
-Z
-J
-A
-Q
-i
-J
-y
-b
-b
-p
-G
-s
-o
-Z
-j
-c
-Z
-I
-q
-"}
-(5,1,1) = {"
-J
-Z
-Z
-Z
-J
-F
-Q
-i
-J
-P
-S
-S
 S
 O
+e
+w
+X
+X
+X
+D
 t
-J
-Z
-j
 c
-Z
-I
+n
+K
+K
+n
+H
+L
+"}
+(4,1,1) = {"
+e
+K
+n
+K
+e
 q
+S
+O
+e
+Y
+X
+X
+T
+D
+d
+c
+K
+m
+R
+K
+H
+L
+"}
+(5,1,1) = {"
+e
+K
+K
+K
+e
+M
+S
+O
+e
+w
+A
+A
+A
+a
+h
+e
+K
+m
+R
+K
+H
+L
 "}
 (6,1,1) = {"
-J
-Z
-g
-Z
-J
-R
-v
-i
+e
+K
+n
+K
+e
 N
-P
-r
-w
-W
-b
 C
+O
+e
+w
 V
-Z
-j
-c
-Z
+f
+B
+X
+r
 I
-q
+K
+m
+R
+K
+H
+L
 "}
 (7,1,1) = {"
-J
-Z
-Z
-Z
-J
-J
-J
-J
-J
-P
-b
-b
-b
-b
+e
+K
+K
+K
+e
+e
+e
+e
+e
+w
 X
-J
-Z
-j
-c
-Z
-I
-q
+X
+X
+X
+Q
+e
+K
+m
+R
+K
+H
+L
 "}
 (8,1,1) = {"
-J
-Z
-g
-Z
-J
-b
-a
-m
-m
-l
-p
-b
-b
-p
+e
+K
+n
+K
+e
 X
-o
-Z
-j
+x
+y
+y
+u
+T
+X
+X
+T
+Q
 c
-Z
-I
-q
+K
+m
+R
+K
+H
+L
 "}
 (9,1,1) = {"
-J
-u
-Z
-Z
-J
-b
-p
-b
-b
-b
-b
-b
-b
-b
+e
+v
+K
+K
+e
 X
-o
-g
-Z
-Z
-g
-I
-q
+T
+X
+X
+X
+X
+X
+X
+X
+Q
+c
+n
+K
+K
+n
+H
+L
 "}
 (10,1,1) = {"
 z
-J
-J
-J
-u
-B
-T
-T
-L
-n
-Y
-n
-n
-Y
 e
-u
+e
+e
+v
+b
+p
+p
+P
+W
+o
+W
+W
+o
+k
+v
+e
+e
+e
+v
 J
-J
-J
-u
-h
-q
+L
 "}
 (11,1,1) = {"
 z
 z
 z
 z
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
-J
+e
+e
+e
+e
+e
+e
+e
+e
+e
+e
+e
+e
 z
 z
 z
-J
-J
-J
+e
+e
+e
 "}

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -255,6 +255,20 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"iJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "jq" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -300,6 +314,20 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"km" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "kN" = (
 /obj/machinery/light{
 	dir = 4
@@ -340,11 +368,6 @@
 "mz" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"ni" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "oi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -558,19 +581,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"Dk" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "El" = (
 /obj/machinery/flasher{
 	id = "shuttle_flasher";
@@ -638,11 +648,6 @@
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"JB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Kj" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -771,6 +776,12 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Wb" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/iv_drip,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Wx" = (
 /obj/machinery/sleeper{
@@ -945,7 +956,7 @@ aX
 af
 hI
 aX
-Dk
+km
 ac
 GO
 aK
@@ -997,7 +1008,7 @@ aX
 aX
 aX
 aX
-JB
+iJ
 ac
 GO
 aK
@@ -1023,7 +1034,7 @@ aX
 aX
 aX
 aX
-ni
+Wb
 ac
 GO
 aK

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -153,16 +153,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"cr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 31;
-	pixel_y = -5
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "dI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/stasis{
@@ -288,12 +278,15 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"kN" = (
+"lQ" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/closed/wall/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "lU" = (
 /obj/structure/chair/comfy/shuttle,
@@ -329,6 +322,16 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"nj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "os" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -352,16 +355,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"px" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "qa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -398,25 +391,6 @@
 "qN" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"rn" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"rB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 31;
-	pixel_y = -5
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "sW" = (
 /obj/structure/closet,
@@ -649,6 +623,13 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"Mw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
 "NM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -786,6 +767,16 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"UP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 31;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "Vc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/closet/secure_closet{
@@ -822,6 +813,15 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"XI" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "XY" = (
 /obj/structure/chair/comfy/shuttle,
@@ -1000,7 +1000,7 @@ ae
 Gy
 ma
 ae
-kN
+Mw
 qa
 wQ
 uz
@@ -1023,7 +1023,7 @@ aK
 aK
 aK
 oA
-rn
+XI
 ax
 ay
 ay
@@ -1127,15 +1127,15 @@ Gy
 ae
 ae
 av
-cr
+UP
 QU
-rB
+nj
 QU
-rB
+nj
 QU
-rB
+nj
 QU
-rB
+nj
 kk
 RX
 aK
@@ -1156,7 +1156,7 @@ ae
 ae
 Qr
 ae
-px
+lQ
 ae
 Qr
 ae

--- a/_maps/shuttles/emergency_triage.dmm
+++ b/_maps/shuttles/emergency_triage.dmm
@@ -162,15 +162,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"dz" = (
-/obj/machinery/stasis{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "dI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/stasis{
@@ -215,12 +206,6 @@
 /obj/machinery/computer/communications,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"hG" = (
-/obj/machinery/stasis{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "hI" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
@@ -240,6 +225,15 @@
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"jp" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "jq" = (
 /obj/structure/window/reinforced{
@@ -453,6 +447,13 @@
 /obj/item/storage/firstaid/advanced,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"wa" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "wQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -470,14 +471,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"xo" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yv" = (
@@ -499,18 +492,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"zR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "zV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -650,17 +631,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"NG" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "NM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -703,15 +673,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"OK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "Pk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/machinery/door/firedoor/border_only{
@@ -735,6 +696,16 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"QU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "QW" = (
 /obj/machinery/light,
@@ -1087,13 +1058,13 @@ aK
 uJ
 gZ
 ED
-xo
+jp
 yv
-NG
+jp
 yv
-NG
+jp
 yv
-NG
+jp
 yv
 gT
 NM
@@ -1113,13 +1084,13 @@ aK
 Wx
 QW
 aw
-hG
+wa
 aX
-dz
+wa
 aX
-dz
+wa
 aX
-dz
+wa
 aX
 dI
 tu
@@ -1139,13 +1110,13 @@ ae
 ae
 av
 qu
-OK
+QU
 ba
-zR
+QU
 oi
-zR
+QU
 oi
-zR
+QU
 ba
 kk
 RX

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -214,6 +214,12 @@
 	Has medical facilities."
 	credit_cost = 5000
 
+/datum/map_template/shuttle/emergency/triage
+	suffix = "triage"
+	name = "Emergency Triage Shuttle"
+	description = "Do you have plenty of crew who need to be wheeled or dragged to safety? This shuttle is equipped with ample medical equipment to help your medical staff recover as many people as possible."
+	credit_cost = 5000 // Yes this is pretty cheap for all the shuttle offers, but considering it's to be used in an extreme medical emergency, it cannot be too expensive.
+
 /datum/map_template/shuttle/emergency/pod
 	suffix = "pod"
 	name = "Emergency Pods"
@@ -226,7 +232,7 @@
 	description = "A modified version of the Box escape shuttle that comes with a preinstalled pool. Fun for the whole family!"
 	admin_notes = "Pool filter can be very easily filled with acid or other harmful chemicals."
 	credit_cost = 15000
-	
+
 /datum/map_template/shuttle/emergency/russiafightpit
 	suffix = "russiafightpit"
 	name = "Mother Russia Bleeds"
@@ -439,7 +445,7 @@
 	suffix = "fancy"
 	name = "fancy transport ferry"
 	description = "At some point, someone upgraded the ferry to have fancier flooring... and fewer seats."
-	
+
 /datum/map_template/shuttle/ferry/kilo
 	suffix = "kilo"
 	name = "kilo transport ferry"
@@ -476,7 +482,7 @@
 /datum/map_template/shuttle/cargo/birdboat
 	suffix = "birdboat"
 	name = "supply shuttle (Birdboat)"
-	
+
 /datum/map_template/shuttle/cargo/kilo
 	suffix = "kilo"
 	name = "supply shuttle (Kilo)"
@@ -512,7 +518,7 @@
 /datum/map_template/shuttle/mining/box
 	suffix = "box"
 	name = "mining shuttle (Box)"
-	
+
 /datum/map_template/shuttle/mining/kilo
 	suffix = "kilo"
 	name = "mining shuttle (Kilo)"
@@ -520,7 +526,7 @@
 /datum/map_template/shuttle/labour/box
 	suffix = "box"
 	name = "labour shuttle (Box)"
-	
+
 /datum/map_template/shuttle/labour/kilo
 	suffix = "kilo"
 	name = "labour shuttle (Kilo)"
@@ -552,7 +558,7 @@
 /datum/map_template/shuttle/arrival/omega
 	suffix = "omega"
 	name = "arrival shuttle (Omega)"
-	
+
 /datum/map_template/shuttle/arrival/kilo
 	suffix = "kilo"
 	name = "arrival shuttle (Kilo)"


### PR DESCRIPTION
# Document the changes in your pull request

A shuttle with expanded medical facilities for an evac with many severe injuries. Comes with a multitude of stasis beds, some sleepers, a cryotube system, and plenty of kits. As well as room for people to move patients around in without interfering much with surgeries or other treatment.

![image](https://user-images.githubusercontent.com/70451213/207840519-823790e2-b0a8-48e3-bfbe-c06270527e36.png)
(Note: I did use the "loaded" version of the defib mounts, and tested that they're loaded and powered and able to be used in the space above the stasis bed.)
# Wiki Documentation

A new shuttle would need to be added to the list.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: New Triage Shuttle, for medical heavy evacs. 
mapping: A new map, which just so happens to be the triage shuttle. What a shocker.
/:cl:
