### PR TITLE
Handheld flashes knockdown instead of hardstun

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -138,7 +138,7 @@
 				to_chat(M, span_userdanger("[user] blinds you with the flash!"))
 			else
 				to_chat(M, span_userdanger("You are blinded by [src]!"))
-			M.Paralyze(rand(80,120))
+			M.Knockdown(rand(80,120))
 		else if(user)
 			visible_message(span_disarm("[user] fails to blind [M] with the flash!"))
 			to_chat(user, span_warning("You fail to blind [M] with the flash!"))


### PR DESCRIPTION
# Document the changes in your pull request

Revival of #16951

Flashes will remain useful, disarms and slows are very powerful and blinding someone means that A. they can't pick up the weapons they dropped and B. they can't fight back

With this, it will just no longer be a one click win and as a result officers will have to use their (actually balanced) batons to arrest

Clicking someone once and their game being over immediately is not healthy for the game

Also, no, "chain stuns" are not the problem. 8-12 seconds is PLENTY time to end your game.

# Changelog

:cl:  
tweak: Handheld flashes now knockdown instead of paralyze
/:cl:
