### PR TITLE
Fixes some antags thinking they're on lavaland and getting lavaland speed permanently

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -6,12 +6,12 @@
 
 /mob/living/carbon/human/update_move_intent_slowdown()
 	var/turf/T = get_turf(src)
-	if(T && !is_mining_level(T.z))
+	if(!T || !is_mining_level(T.z)) // If we can't get the turf, assume it's not on mining.
 		return ..()
 
 	var/mod = 0
 	if(m_intent == MOVE_INTENT_WALK)
-		mod = 4
+		mod = CONFIG_GET(number/movedelay/walk_delay) / 1.5 // 4
 	else
-		mod = 1.5
+		mod = CONFIG_GET(number/movedelay/run_delay) * 0.75 // 1.5
 	add_movespeed_modifier(MOVESPEED_ID_MOB_WALK_RUN_CONFIG_SPEED, TRUE, 100, override = TRUE, multiplicative_slowdown = mod)


### PR DESCRIPTION
# Document the changes in your pull request

I solved the mystery

Also lavaland speed mod uses config values instead of hardcoding

# Changelog

:cl:  
bugfix: Fixed some antags (wizard, alien) getting lavaland speed bonuses on spawn
/:cl:
