### PR TITLE
Fix decontamination unit not clearing contamination from objects, and fix icon flickering

### DIFF
--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -25,7 +25,7 @@
 	var/datum/looping_sound/decontamination_unit/decon
 	var/datum/looping_sound/decontamination_unit/emagged/decon_emagged
 
-	var/eject_time = 9.5
+	var/flick_waitTime = 9.5 //Waits for flick animation to complete before opening the door or it will be weird..
 
 /obj/machinery/decontamination_unit/open
 	state_open = TRUE
@@ -120,12 +120,12 @@
 			flick("tube_up", src)
 			decon_emagged.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject_emagged), eject_time)
+			addtimer(CALLBACK(src, .proc/decon_eject_emagged), flick_waitTime)
 		else
 			flick("tube_up", src)
 			decon.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject), eject_time)
+			addtimer(CALLBACK(src, .proc/decon_eject), flick_waitTime)
 
 /obj/machinery/decontamination_unit/proc/decon_eject_emagged()
 	var/mob/living/mob_occupant = occupant

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -120,12 +120,12 @@
 			flick("tube_up", src)
 			decon_emagged.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject_emagged), emagged_time)
+			addtimer(CALLBACK(src, .proc/decon_eject_emagged), eject_time)
 		else
 			flick("tube_up", src)
 			decon.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject), ejected_time)
+			addtimer(CALLBACK(src, .proc/decon_eject), eject_time)
 
 /obj/machinery/decontamination_unit/proc/decon_eject_emagged()
 	var/mob/living/mob_occupant = occupant

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -157,6 +157,7 @@
 		dump_mob()
 	if(contents.len)
 		things_to_clear += contents
+	things_to_clear += src //clean itself aswell
 	for(var/am in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
 		var/atom/movable/dirty_movable = am
 		dirty_movable.wash(CLEAN_ALL)

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -25,6 +25,8 @@
 	var/datum/looping_sound/decontamination_unit/decon
 	var/datum/looping_sound/decontamination_unit/emagged/decon_emagged
 
+	var/eject_time = 9.5
+
 /obj/machinery/decontamination_unit/open
 	state_open = TRUE
 	density = FALSE
@@ -118,12 +120,12 @@
 			flick("tube_up", src)
 			decon_emagged.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject_emagged), 12)
+			addtimer(CALLBACK(src, .proc/decon_eject_emagged), emagged_time)
 		else
 			flick("tube_up", src)
 			decon.stop()
 			playsound(src, 'sound/machines/decon/decon-up.ogg', 100, TRUE)
-			addtimer(CALLBACK(src, .proc/decon_eject), 12)
+			addtimer(CALLBACK(src, .proc/decon_eject), ejected_time)
 
 /obj/machinery/decontamination_unit/proc/decon_eject_emagged()
 	var/mob/living/mob_occupant = occupant

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -157,7 +157,6 @@
 		dump_mob()
 	if(contents.len)
 		things_to_clear += contents
-	things_to_clear += src //clean itself aswell
 	for(var/am in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
 		var/atom/movable/dirty_movable = am
 		dirty_movable.wash(CLEAN_ALL)

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -151,16 +151,16 @@
 	else
 		visible_message(span_notice("[src]'s gate slides open. The glowing yellow lights dim to a gentle green."))
 	var/list/things_to_clear = list() //Done this way since using GetAllContents on the SSU itself would include circuitry and such.
-	for(var/am in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
-		var/atom/movable/dirty_movable = am
-		dirty_movable.wash(CLEAN_ALL)
-	open_machine(0)
 	if(occupant)
 		things_to_clear += occupant
 		things_to_clear += occupant.GetAllContents()
 		dump_mob()
 	if(contents.len)
 		things_to_clear += contents
+	for(var/am in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
+		var/atom/movable/dirty_movable = am
+		dirty_movable.wash(CLEAN_ALL)
+	open_machine(0)
 
 /obj/machinery/decontamination_unit/proc/shock(mob/user)
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread


### PR DESCRIPTION
The clearing loop was above the list of objects, so basically it was clearing nothing

# Document the changes in your pull request
Fix decontamination unit not clearing contamination from objects
Fix icon flickering


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix decontamination unit not clearing contamination from objects
bugfix: Fix icon flickering
/:cl:
