### PR TITLE
Fix boh bombing creating a non existent singulo

### DIFF
--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -98,7 +98,7 @@
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 		
 		var/obj/singularity/ohshit = new /obj/singularity(loccheck)
-		ohshit.expand(STAGE_THREE)
+		ohshit.energy = 800
 		qdel(W)
 		qdel(A)
 		return

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -97,8 +97,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 		
-		var/obj/singularity/ohshit = new /obj/singularity(loccheck)
-		ohshit.energy = 800
+		var/obj/singularity/ohshit = new /obj/singularity(loccheck, 800)
 		qdel(W)
 		qdel(A)
 		return

--- a/yogstation/code/datums/components/storage/storage.dm
+++ b/yogstation/code/datums/components/storage/storage.dm
@@ -97,7 +97,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] detonated a bag of holding at [ADMIN_VERBOSEJMP(loccheck)].")
 		log_game("[key_name(user)] detonated a bag of holding at [loc_name(loccheck)].")
 		
-		var/obj/singularity/ohshit = new /obj/singularity(loccheck, 800)
+		new /obj/singularity(loccheck, 800)
 		qdel(W)
 		qdel(A)
 		return


### PR DESCRIPTION
#16916 was merged but seems untested


Singulo was intended to be at stage 3 by boh bombing but it was created at stage 1 because of low energy so it disappeared after that

# Document the changes in your pull request


Fix boh bombing creating a non existent singulo



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix boh bombing creating a non existent singulo
/:cl:
