### PR TITLE
Replaces all foam events with smoke events

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -107,6 +107,7 @@
 
 
 /obj/effect/particle_effect/foam/proc/kill_foam()
+	set waitfor = FALSE
 	STOP_PROCESSING(SSfastprocess, src)
 	switch(metal)
 		if(ALUMINUM_FOAM)
@@ -181,6 +182,7 @@
 	return 1
 
 /obj/effect/particle_effect/foam/proc/spread_foam()
+	set waitfor = FALSE
 	var/turf/t_loc = get_turf(src)
 	for(var/turf/T in t_loc.GetAtmosAdjacentTurfs())
 		var/obj/effect/particle_effect/foam/foundfoam = locate() in T //Don't spread foam where there's already foam!

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -107,7 +107,6 @@
 
 
 /obj/effect/particle_effect/foam/proc/kill_foam()
-	set waitfor = FALSE
 	STOP_PROCESSING(SSfastprocess, src)
 	switch(metal)
 		if(ALUMINUM_FOAM)
@@ -182,7 +181,6 @@
 	return 1
 
 /obj/effect/particle_effect/foam/proc/spread_foam()
-	set waitfor = FALSE
 	var/turf/t_loc = get_turf(src)
 	for(var/turf/T in t_loc.GetAtmosAdjacentTurfs())
 		var/obj/effect/particle_effect/foam/foundfoam = locate() in T //Don't spread foam where there's already foam!

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -40,10 +40,10 @@
 			else
 				R.add_reagent(pick(saferChems), reagentsAmount)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.one_apply_per_object = TRUE
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+			var/datum/effect_system/smoke_spread/chem/smokey = new
+			smokey.attach(vent)
+			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.start()
 
 		CHECK_TICK
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -45,6 +45,11 @@
 			smokey.set_up(R, 8, get_turf(vent), TRUE)
 			smokey.start()
 
+			var/datum/effect_system/foam_spread/foam = new
+			foam.one_apply_per_object = TRUE
+			foam.set_up(200, get_turf(vent), R)
+			foam.start()
+
 		CHECK_TICK
 
 /datum/round_event_control/vent_clog/threatening
@@ -106,11 +111,6 @@
 			foam.one_apply_per_object = TRUE
 			foam.set_up(200, get_turf(vent), R)
 			foam.start()
-
-			var/datum/effect_system/smoke_spread/chem/smokey = new
-			smokey.attach(vent)
-			smokey.set_up(R, 8, get_turf(vent), TRUE)
-			smokey.start()
 		CHECK_TICK
 
 /datum/round_event/vent_clog/cleaner

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -42,7 +42,7 @@
 
 			var/datum/effect_system/smoke_spread/chem/smokey = new
 			smokey.attach(vent)
-			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.set_up(R, 10, get_turf(vent), TRUE)
 			smokey.start()
 		CHECK_TICK
 
@@ -103,7 +103,7 @@
 
 			var/datum/effect_system/smoke_spread/chem/smokey = new
 			smokey.attach(vent)
-			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.set_up(R, 10, get_turf(vent), TRUE)
 			smokey.start()
 		CHECK_TICK
 
@@ -122,7 +122,7 @@
 
 			var/datum/effect_system/smoke_spread/chem/smokey = new
 			smokey.attach(vent)
-			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.set_up(R, 10, get_turf(vent), TRUE)
 			smokey.start()
 		CHECK_TICK
 
@@ -133,6 +133,6 @@
 	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
 		if(vent && vent.loc)
 			var/datum/effect_system/smoke_spread/freezing/decon/smoke = new
-			smoke.set_up(7, get_turf(vent), 7)
+			smoke.set_up(10, get_turf(vent), 7)
 			smoke.start()
 		CHECK_TICK

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -44,12 +44,6 @@
 			smokey.attach(vent)
 			smokey.set_up(R, 8, get_turf(vent), TRUE)
 			smokey.start()
-
-			var/datum/effect_system/foam_spread/foam = new
-			foam.one_apply_per_object = TRUE
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
-
 		CHECK_TICK
 
 /datum/round_event_control/vent_clog/threatening
@@ -77,7 +71,7 @@
 	reagentsAmount = 250
 
 /datum/round_event_control/vent_clog/beer
-	name = "Foamy beer stationwide"
+	name = "Smokey beer stationwide"
 	typepath = /datum/round_event/vent_clog/beer
 	max_occurrences = 0
 
@@ -107,10 +101,10 @@
 			R.my_atom = vent
 			R.add_reagent(/datum/reagent/consumable/ethanol/beer, reagentsAmount)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.one_apply_per_object = TRUE
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+			var/datum/effect_system/smoke_spread/chem/smokey = new
+			smokey.attach(vent)
+			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.start()
 		CHECK_TICK
 
 /datum/round_event/vent_clog/cleaner
@@ -126,9 +120,10 @@
 			R.my_atom = vent
 			R.add_reagent(/datum/reagent/space_cleaner, reagentsAmount)
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+			var/datum/effect_system/smoke_spread/chem/smokey = new
+			smokey.attach(vent)
+			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.start()
 		CHECK_TICK
 
 /datum/round_event/vent_clog/plasma_decon/announce()

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -106,6 +106,11 @@
 			foam.one_apply_per_object = TRUE
 			foam.set_up(200, get_turf(vent), R)
 			foam.start()
+
+			var/datum/effect_system/smoke_spread/chem/smokey = new
+			smokey.attach(vent)
+			smokey.set_up(R, 8, get_turf(vent), TRUE)
+			smokey.start()
 		CHECK_TICK
 
 /datum/round_event/vent_clog/cleaner


### PR DESCRIPTION
Foam affects server performance a lot, using it for stationwide can cause a lot of time dialations. Smoke is less impact on server performance, plus smoke doesnt break lighting anymore
Closes #16221
# Document the changes in your pull request
Replaces all foam events with smoke events

# Wiki document
Replaces all foam events with smoke events


# Changelog
🆑
tweak: Replaces all foam events with smoke events
/🆑