### PR TITLE
Revert "No more making golem shells with atmos"

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -473,6 +473,7 @@ GLOBAL_LIST_INIT(abductor_recipes, list ( \
 GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 10, res_amount = 1),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 5, res_amount = 1),
+	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=20, res_amount=1),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/twohanded/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1),
 	))
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -473,7 +473,7 @@ GLOBAL_LIST_INIT(abductor_recipes, list ( \
 GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 10, res_amount = 1),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 5, res_amount = 1),
-	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=20, res_amount=1),
+	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=13, res_amount=1),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/twohanded/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1),
 	))
 


### PR DESCRIPTION
MEtallic hydrogen can no longer spam hundreds of golems anymore since open tile metallic hydrogen is nerfed to balls not even 5 metallic hydrogen bar could be made, crystallizer however is the only efficient way to make this and it requires a stable temp, more bz and hydrogen are needed to make one single bar. So making one single golem requires a lot of efforts now, plus atmos golems are extremely useful to help engineers building, etc.. Getting one golem for engineering is pretty rare now as no one gonna bother xenobio for one
# Changelog
🆑
tweak: metallic hydrogen can make golem shells again with 13 metallic hydrogen
/🆑