### PR TITLE
Flamethrower Rework Part 2: Electric Boogaloo

### DIFF
--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -198,6 +198,8 @@
 			// See /proc/default_ignite
 			var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(0.05)
 			var/damage = air_transfer.get_moles(/datum/gas/plasma) * 16
+			damage += air_transfer.get_moles(/datum/gas/tritium) * 24
+			damage += air_transfer.get_moles(/datum/gas/hydrogen) * 32
 			damage = min(damage, 16)
 			if(damage < 4)
 				// Turn off because we're out
@@ -232,32 +234,42 @@
 /obj/item/flamethrower/proc/default_ignite(turf/target, release_amount = 0.05)
 	//Fetch and remove 5% of current tank air contents
 	var/datum/gas_mixture/air_transfer = ptank.air_contents.remove_ratio(release_amount)
+	//var/oxygen_consumption = (air_transfer.get_moles(/datum/gas/plasma) * 2) + (air_transfer.get_moles(/datum/gas/tritium) / 2) + (air_transfer.get_moles(/datum/gas/hydrogen) / 2)
+
+	// Return of the stimball flamethrower, wear radiation protection when using this or you're just as likely to die as your target
+	if(air_transfer.get_moles(/datum/gas/plasma) >= STIM_BALL_MOLES_REQUIRED && air_transfer.get_moles(/datum/gas/stimulum) >= STIM_BALL_MOLES_REQUIRED && air_transfer.get_moles(/datum/gas/pluoxium) >= STIM_BALL_MOLES_REQUIRED)
+		var/balls_shot = round(min(air_transfer.get_moles(/datum/gas/stimulum), air_transfer.get_moles(/datum/gas/pluoxium), STIM_BALL_MAX_REACT_RATE / STIM_BALL_MOLES_REQUIRED))
+		var/angular_increment = 360/balls_shot
+		var/random_starting_angle = rand(0,360)
+		for(var/i in 1 to balls_shot)
+			target.fire_nuclear_particle((i*angular_increment+random_starting_angle))
+		air_transfer.adjust_moles(/datum/gas/plasma, -balls_shot * STIM_BALL_GAS_AMOUNT) // No free extra damage for you, conservation of mass go brrrrr
 
 	// 8 damage at 0.5 mole transfer or having 10 moles in the tank
 	// 16 damage at 1 mole transfer or having 20 moles in the tank
 	var/damage = air_transfer.get_moles(/datum/gas/plasma) * 16
 	// harder to achieve than plasma
-	damage += air_transfer.get_moles(/datum/gas/tritium) * 32
+	damage += air_transfer.get_moles(/datum/gas/tritium) * 24 // Lower damage than hydrogen, causes minor radiation
 	damage += air_transfer.get_moles(/datum/gas/hydrogen) * 32
-	// still capped
-	damage = min(damage, 16)
-	if(damage < 4)
-		visible_message(span_danger("\The [src] lets out a sighed hiss and automatically shuts off."))
+	// Maximum damage restricted by the available oxygen, with a hard cap at 16
+	var/datum/gas_mixture/turf_air = target.return_air()
+	damage = min(damage, turf_air.get_moles(/datum/gas/oxygen) + air_transfer.get_moles(/datum/gas/oxygen), 16)
+	if(damage < 4) // If there's not enough fuel and/or oxygen to do more than 4 damage, shut itself off
+		visible_message(span_danger("\The [src] lets out a sighed hiss as it dies out."))
 		lit = FALSE
 		set_light(0)
 		playsound(loc, deac_sound, 50, TRUE)
 		STOP_PROCESSING(SSobj,src)
+		update_icon()
 		return FALSE
-
-	var/datum/gas_mixture/turf_air = target.return_air()
-	if(turf_air.get_moles(/datum/gas/oxygen) < 10) // Not enough oxygen to ignite
-		return TRUE
 
 	//Burn it
 	var/list/hit_list = list()
 	hit_list += src
 	new /obj/effect/hotspot(target)
-	target.hotspot_expose(damage*50,damage*25,1)
+	target.hotspot_expose(FIRE_MINIMUM_TEMPERATURE_TO_EXIST+damage*25,damage*25,1)
+	if(air_transfer.get_moles(/datum/gas/tritium)) // Tritium fires cause a bit of radiation
+		radiation_pulse(target, air_transfer.get_moles(/datum/gas/tritium) * FIRE_HYDROGEN_ENERGY_RELEASED / TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 	for(var/mob/living/L in target.contents)
 		if(L in hit_list)
 			continue


### PR DESCRIPTION
# Document the changes in your pull request

The recent flamethrower rework was ultimately a good thing for the game but it has a few oversights that this PR corrects, and I've also added a bit more complexity to them that allows a sufficiently skilled atmospheric technician to increase their effectiveness.

1) Hotspots made are now at least the temperature required to create fire.

2) Flamethrowers' damage is now capped by the number of moles of available oxygen, still capped at 16 damage.

3) Oxygen in the flamethrower fuel now counts toward the available oxygen, adding some allows you to use it in lower oxygen environments but reduces the amount of fuel you can fit into the tank.

4) Tritium is now less effective than hydrogen, but can now also irradiate you. This gives you around 10 or so rads for each mole of tritium consumed.

5) Re-adds the stimball reaction to flamethrowers.

6) Fixes the flamethrower icon not updating when it shuts off.

7) Tritium and hydrogen fuel now correctly damage blobs.

# Changelog

:cl:  
rscadd: return of the stimball flamethrower
rscadd: tritium now causes a bit of radiation when used it flamethrowers
tweak: tritium does less damage in flamethrowers
tweak: oxygen in flamethrower fuel counts toward available oxygen
tweak: flamethrower damage now limited by available oxygen
bugfix: fixes flamethrower icon not updating
bugfix: tritium and hydrogen now damage blobs properly
/:cl:
