### PR TITLE
Small hemophilia fix

### DIFF
--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -64,7 +64,7 @@
 		if(prob(5))
 			to_chat(victim, span_notice("You feel the [lowertext(name)] in your [limb.name] firming up from the cold!"))
 
-	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat != DEAD))
 		blood_flow += 0.5 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 
 	if(limb.current_gauze)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -102,7 +102,7 @@
 
 	blood_flow = min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW)
 
-	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat !+ DEAD))
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat != DEAD))
 		blood_flow += 0.5 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 	if(limb.current_gauze)
 		if(clot_rate > 0)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -102,7 +102,7 @@
 
 	blood_flow = min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW)
 
-	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat !+ DEAD))
 		blood_flow += 0.5 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
 	if(limb.current_gauze)
 		if(clot_rate > 0)


### PR DESCRIPTION
# Document the changes in your pull request

Stops TRAIT_BLOODY_MESS from increasing bleeding rate while you're dead.
I'll make a bigger change to this that doesn't count as a bug fix once the feature freeze is done that makes it REASONABLE and not "paper cuts turn you into a raisin"

# Changelog

:cl:  

bugfix: Hemophilia/heparin no longer making bleeding worse when you're already dead

/:cl:
