### PR TITLE
Fix unnable to talk on departmental channel on bounce radio

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -65,42 +65,17 @@
 		return .
 
 	if(message_mods[MODE_HEADSET])
-		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
-			radio.talk_into(src, message, , spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, , spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-		for (var/obj/item/radio/intercom/I in view(1, null))
-			if(I)
-				I.talk_into(src, message, , spans, language, message_mods)
-				return ITALICS | REDUCE_RANGE
 	else if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT)
-		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
-			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-		for (var/obj/item/radio/intercom/I in view(1, null))
-			if(I)
-				I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-				return ITALICS | REDUCE_RANGE
 	else if(GLOB.radiochannels[message_mods[RADIO_EXTENSION]])
-		var/obj/item/radio/radio = locate() in src
-		if((get_item_by_slot(SLOT_BELT) == radio) || (get_active_held_item() == radio) || (get_item_by_slot(SLOT_R_STORE) == radio) || (get_item_by_slot(SLOT_L_STORE) == radio) || (get_item_by_slot(SLOT_S_STORE) == radio))	
-			radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
 		if(ears)
 			ears.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
-		for (var/obj/item/radio/intercom/I in view(1, null))
-			if(I)
-				I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-				return ITALICS | REDUCE_RANGE
-
 	return 0
 
 /mob/living/carbon/human/get_alt_name()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -386,6 +386,23 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 			imp.radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 
+	var/list/storage_item = list(get_active_held_item(), get_item_by_slot(SLOT_BELT), get_item_by_slot(SLOT_R_STORE), get_item_by_slot(SLOT_L_STORE), get_item_by_slot(SLOT_S_STORE))
+	for(var/obj/item/radio/hand in storage_item)
+		if(message_mods[MODE_HEADSET])
+			hand.talk_into(src, message, , spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || (message_mods[RADIO_EXTENSION] in hand.channels))
+			hand.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+
+	for (var/obj/item/radio/intercom/I in view(1, null))
+		if(message_mods[MODE_HEADSET])
+			I.talk_into(src, message, , spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+		if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || (message_mods[RADIO_EXTENSION] in I.channels))
+			I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
+			return ITALICS | REDUCE_RANGE
+			
 	switch(message_mods[RADIO_EXTENSION])
 		if(MODE_R_HAND)
 			for(var/obj/item/r_hand in get_held_items_for_side("r", all = TRUE))


### PR DESCRIPTION
Technically you still can but you gotta reequip/remove the other radio for it, which is annoying. Now it will just use either  radio that has the channel access. Also during tcomms blackout, if you a bounce radio in your pocket or belt it will use that one instead of keep using the headset one.

Also clean up codes

**In case of you wondering if this is tested, yes i did and it is now working better than before no more wonky radio shit**

# Document the changes in your pull request

Fix unnable to talk on departmental channel on bounce radio



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix unnable to talk on departmental channel on bounce radio
/:cl:
