### PR TITLE
Revert "[ENGINEERING BUFFS] Pyro and radiation anomaly spawned by supermatter now takes 40 seconds to detonate"

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1084,9 +1084,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			if(GRAVITATIONAL_ANOMALY)
 				new /obj/effect/anomaly/grav(L, 250)
 			if(PYRO_ANOMALY)
-				new /obj/effect/anomaly/pyro(L, 400)
+				new /obj/effect/anomaly/pyro(L, 200)
 			if(RADIATION_ANOMALY)
-				new /obj/effect/anomaly/radiation(L, 400)
+				new /obj/effect/anomaly/radiation(L, 300)
 
 /obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart, range = 3, power)
 	. = zapstart.dir


### PR DESCRIPTION
Reverts yogstation13/Yogstation#16981

why should it be a one man project to farm anomalies? farming anomalies safely should require at least two people. unrequired buff