### PR TITLE
Removes toxin damage from drinking welding fuel as IPC or Preternis

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1068,7 +1068,7 @@
 	..()
 
 /datum/reagent/fuel/on_mob_life(mob/living/carbon/M)
-	if(!ispreternis(M) || !isipc(M))
+	if(!(ispreternis(M) || isipc(M)))
 		M.adjustToxLoss(1, 0)
 	..()
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1068,7 +1068,8 @@
 	..()
 
 /datum/reagent/fuel/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(1, 0)
+	if(!ispreternis(M) || !isipc(M))
+		M.adjustToxLoss(1, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
Welding fuel was made to tox every mob that drinks it including preternis and IPC themselves which is bad because preternis organ could process welding fuel to heal them so it shouldn't get toxin from it (Pretty sure someone ported preternis forgot about this or something), for IPC they are inorganic so they shouldn't get tox from it

# Document the changes in your pull request

IPC and Preternis no longer take toxin damage from drinking welding fuel


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Removes toxin damage from drinking welding fuel as IPC or Preternis
/:cl:
