### PR TITLE
Water tile no longer be turned into chasm when burned

### DIFF
--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -4,7 +4,7 @@
 	desc = "Shallow water."
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "riverwater_motion"
-	baseturfs = /turf/open/indestructible/grass/sand
+	baseturfs = /turf/open/chasm/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	planetary_atmos = TRUE
 	slowdown = 1
@@ -19,6 +19,7 @@
 /turf/open/water/safe
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 	planetary_atmos = FALSE
+	baseturfs = /turf/open/indestructible/grass/sand
 
 /turf/open/water/safe/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -4,7 +4,7 @@
 	desc = "Shallow water."
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "riverwater_motion"
-	baseturfs = /turf/open/chasm/lavaland
+	baseturfs = /turf/open/indestructible/grass/sand
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	planetary_atmos = TRUE
 	slowdown = 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89688125/207317631-8d89f963-8e4c-4d87-9635-4b40d6a55d5b.png)

# Document the changes in your pull request
Water tile no longer turned into chasm when burned

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Water tile no longer turned into chasm when burned
/:cl:
