### PR TITLE
Uncapitalizes crystallizer output items

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -230,7 +230,7 @@
 		if(55 to 64)
 			quality_control = "average"
 		if(35 to 54)
-			quality_control = "ok"
+			quality_control = "okay"
 		if(15 to 34)
 			quality_control = "poor"
 		if(5 to 14)

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -220,25 +220,25 @@
 	var/quality_control
 	switch(total_quality)
 		if(100)
-			quality_control = "Masterwork"
+			quality_control = "masterwork"
 		if(95 to 99)
-			quality_control = "Supreme"
+			quality_control = "supreme"
 		if(75 to 94)
-			quality_control = "Good"
+			quality_control = "good"
 		if(65 to 74)
-			quality_control = "Decent"
+			quality_control = "decent"
 		if(55 to 64)
-			quality_control = "Average"
+			quality_control = "average"
 		if(35 to 54)
-			quality_control = "Ok"
+			quality_control = "ok"
 		if(15 to 34)
-			quality_control = "Poor"
+			quality_control = "poor"
 		if(5 to 14)
-			quality_control = "Ugly"
+			quality_control = "ugly"
 		if(1 to 4)
-			quality_control = "Cracked"
+			quality_control = "cracked"
 		if(0)
-			quality_control = "Oh God why"
+			quality_control = "terrible"
 
 	for(var/path in selected_recipe.products)
 		var/amount_produced = selected_recipe.products[path]

--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -67,14 +67,12 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		return
 	if (!isliving(target))
 		to_chat(guardian, span_italics(span_danger("[target] is not a living thing.")))
-		revert_cast()
 		return
 	if (!guardian.stats)
 		revert_cast()
 		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))
-		revert_cast()
 		return
 	remove_ranged_ability()
 	guardian.forceMove(get_step(get_turf(target), turn(target.dir, 180)))

--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -67,12 +67,14 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		return
 	if (!isliving(target))
 		to_chat(guardian, span_italics(span_danger("[target] is not a living thing.")))
+		revert_cast()
 		return
 	if (!guardian.stats)
 		revert_cast()
 		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))
+		revert_cast()
 		return
 	remove_ranged_ability()
 	guardian.forceMove(get_step(get_turf(target), turn(target.dir, 180)))


### PR DESCRIPTION
# Document the changes in your pull request

stop capitalizing item names

also replaces "Oh God Why" rating with "terrible"

# Changelog

:cl:  
spellcheck: Uncapitalized crystallizer output items
spellcheck: Replaced crystallizer "oh god why" rating with "terrible"
/:cl:
