### PR TITLE
Fixes bookbinder only using last written passage when binding books

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -459,7 +459,7 @@ GLOBAL_LIST_EMPTY(checkouts)
 			visible_message("[src] whirs as it prints and binds a new book.")
 			var/obj/item/book/B = new(src.loc)
 			for(var/datum/langtext/L in P.written)
-				B.dat = L.text
+				B.dat += L.text
 			var/title = "Print Job #" + "[rand(100, 999)]"
 			B.name = title
 			B.title = title


### PR DESCRIPTION
# Document the changes in your pull request
Fixes  #17057


# Spriting
N/A

# Wiki Documentation
N/A

# Changelog

:cl:  
bugfix: The bookbinder should now print off the entire contents of the paper it gets inserted with. What do you mean you never use the bookbinder?
/:cl:
