### PR TITLE
Fixes chem machines swallowing multitools and wirecutters when the panel was open

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -357,8 +357,8 @@
 		if(HAS_TRAIT(I, TRAIT_NODROP))
 			to_chat(user, span_notice("[I] is stuck to your hand!"))
 			return
-		I.forceMove(src) // Force it out of our hands so we can put the old cell in it
 		if(istype(I, /obj/item/stock_parts/cell))
+			I.forceMove(src) // Force it out of our hands so we can put the old cell in it		
 			if(!user.put_in_hands(cell))
 				cell.forceMove(get_turf(src))
 			component_parts -= cell // Remove the old cell so the new one spawns when deconstructed


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #17047

# Spriting
N/A

# Wiki Documentation
N/A

# Changelog
:cl: 
bugfix: Chem machines no longer have a voracious desire for wirecutters, multitools or anything else you could use on it while the panel was open.
/:cl:
