### PR TITLE
Abductor plasma gland now vomits miasma instead of plasma.

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -402,7 +402,7 @@
 
 /obj/effect/spawner/lootdrop/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot
-	
+
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_FILLED_MAINT))
 		lootcount = FLOOR(lootcount * 1.5, 1)
 
@@ -456,7 +456,7 @@
 		/obj/item/organ/heart/gland/egg = 7,
 		/obj/item/organ/heart/gland/chem = 5,
 		/obj/item/organ/heart/gland/mindshock = 5,
-		/obj/item/organ/heart/gland/plasma = 7,
+		/obj/item/organ/heart/gland/gas = 7, //Yogstation change: plasma -> gas
 		/obj/item/organ/heart/gland/pop = 5,
 		/obj/item/organ/heart/gland/slime = 4,
 		/obj/item/organ/heart/gland/spiderman = 5,

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -478,8 +478,8 @@
 /obj/item/organ/heart/gland/plasma/proc/vomit_plasma()
 	if(!owner)
 		return
-	owner.visible_message(span_danger("[owner] vomits a cloud of plasma!"))
+	owner.visible_message(span_danger("[owner] vomits a cloud of miasma!")) //Yogstation change: plasma -> miasma
 	var/turf/open/T = get_turf(owner)
 	if(istype(T))
-		T.atmos_spawn_air("plasma=50;TEMP=[T20C]")
+		T.atmos_spawn_air("miasma=50;TEMP=[T20C]") //Yogstation change: plasma -> miasma
 	owner.vomit()

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -462,7 +462,7 @@
 	owner.adjustToxLoss(-5, TRUE, TRUE)
 	..()
 
-/obj/item/organ/heart/gland/plasma
+/obj/item/organ/heart/gland/gas //Yogstation change: plasma -> gas
 	true_name = "effluvium sanguine-synonym emitter"
 	cooldown_low = 2 MINUTES
 	cooldown_high = 3 MINUTES
@@ -470,12 +470,12 @@
 	mind_control_uses = 1
 	mind_control_duration = 80 SECONDS
 
-/obj/item/organ/heart/gland/plasma/activate()
+/obj/item/organ/heart/gland/gas/activate() //Yogstation change: plasma -> gas
 	to_chat(owner, span_warning("You feel bloated."))
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, owner, span_userdanger("A massive stomachache overcomes you.")), 15 SECONDS)
-	addtimer(CALLBACK(src, .proc/vomit_plasma), 20 SECONDS)
+	addtimer(CALLBACK(src, .proc/vomit_gas), 20 SECONDS) //Yogstation change: plasma -> gas
 
-/obj/item/organ/heart/gland/plasma/proc/vomit_plasma()
+/obj/item/organ/heart/gland/gas/proc/vomit_gas() //Yogstation change: plasma -> gas
 	if(!owner)
 		return
 	owner.visible_message(span_danger("[owner] vomits a cloud of miasma!")) //Yogstation change: plasma -> miasma

--- a/yogstation/code/modules/ruins/lavaland_ruin_code.dm
+++ b/yogstation/code/modules/ruins/lavaland_ruin_code.dm
@@ -106,7 +106,7 @@
 				/obj/item/organ/heart/gland/egg = 8,
 				/obj/item/organ/heart/gland/electric = 8,
 				/obj/item/organ/heart/gland/chem = 8,
-				/obj/item/organ/heart/gland/plasma = 8)
+				/obj/item/organ/heart/gland/gas = 8) //Yogstation change: plasma -> gas
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space // Weird typo fix override
 	flavour_text = "Monitor enemy activity as best you can. Try to keep a low profile. Use the communication equipment to provide support to any field agents. Sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands."


### PR DESCRIPTION

# Document the changes in your pull request

Abductor plasma gland now vomits miasma instead of plasma.

This is done because plasma on yogs is strong and can seriously mess up the ~~emergency shuttle~~ an enclosed room if there is an ignition source.


# Wiki Documentation

https://wiki.yogstation.net/wiki/Abductor needs to be updated

# Changelog

:cl:  BurgerBB
tweak: Abductor plasma gland now vomits miasma instead of plasma.
/:cl:
