### PR TITLE
Missing frenzy button ability doesn't make you reselect the button

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -67,14 +67,12 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		return
 	if (!isliving(target))
 		to_chat(guardian, span_italics(span_danger("[target] is not a living thing.")))
-		revert_cast()
 		return
 	if (!guardian.stats)
 		revert_cast()
 		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))
-		revert_cast()
 		return
 	remove_ranged_ability()
 	guardian.forceMove(get_step(get_turf(target), turn(target.dir, 180)))


### PR DESCRIPTION
# Document the changes in your pull request

This was so ass that I had to push it, I'm not waiting

If you miss it, it won't cancel the ability anymore

Clicking on someone out of range similarly won't cancel it

# Changelog

:cl:  
tweak: Missing the click on Frenzy teleport won't cancel the ability and force you to re-select the button
/:cl:
