### PR TITLE
fixes crafting blacklists not working at all

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -82,7 +82,7 @@
 		var/needed_amount = R.reqs[requirement_path]
 		for(var/content_item_path in contents)
 			// Right path and not blacklisted
-			if(!ispath(content_item_path, requirement_path) || R.blacklist.Find(requirement_path))
+			if(!ispath(content_item_path, requirement_path) || R.blacklist.Find(content_item_path))
 				continue
 
 			needed_amount -= contents[content_item_path]


### PR DESCRIPTION
# Document the changes in your pull request

turns out these were checking the path in the recipe, not the path of the item being checked

# Changelog

:cl:  
bugfix: items blacklisted from crafting recipes can no longer be used in those crafting recipes
/:cl:
