### PR TITLE
Gas reaction priority sorting fix

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -185,6 +185,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		reactions += SSair.gas_reactions[I]
 	if(!length(reactions))
 		return
+	if (length(reactions) > 1)
+		reactions = sortTim(reactions, /proc/cmp_gas_reaction)
 	reaction_results = new
 	var/temp = return_temperature()
 	var/ener = thermal_energy()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -58,6 +58,9 @@ nobliumformation = 1001
 			maxb = R.priority
 	return maxb - maxa
 
+/proc/cmp_gas_reaction(datum/gas_reaction/a, datum/gas_reaction/b) // compares the priority of two gas reactions
+	return b.priority - a.priority
+
 /datum/gas_reaction
 	//regarding the requirements lists: the minimum or maximum requirements must be non-zero.
 	//when in doubt, use MINIMUM_MOLE_COUNT.


### PR DESCRIPTION
# Document the changes in your pull request

Fixes gas reaction priority not being sorted which let to hypernoblium stopping its own formation and not stopping fire, among other things.

# Changelog

:cl:  
bugfix: fixes gas reaction priority not working correctly
/:cl:
