### PR TITLE
Fixes bag of holding inhands and mob sprites

### DIFF
--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -6,8 +6,7 @@
 	var/cut = FALSE
 	var/appears_split = FALSE
 
-/obj/item/storage/backpack/holding/build_worn_icon(var/state = "", var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
-	state = item_state
+/obj/item/storage/backpack/holding/build_worn_icon(var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
 	if(default_icon_file == 'icons/mob/clothing/head/head.dmi')
 		default_icon_file = 'yogstation/icons/mob/clothing/head/head.dmi' // thats a fun dilemma.... how to keep the tg sprites when doing back but do yogs sprites when worn on head.
 	return ..()
@@ -172,10 +171,6 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
-
-/obj/item/disabled_boh/build_worn_icon(var/state = "", var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
-	state = "brokenpack"
-	return ..()
 
 //Nick's snail shit
 

--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -6,7 +6,6 @@
 	var/cut = FALSE
 	var/appears_split = FALSE
 
-/obj/item/storage/backpack/holding/build_worn_icon(var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
 	if(default_icon_file == 'icons/mob/clothing/head/head.dmi')
 		default_icon_file = 'yogstation/icons/mob/clothing/head/head.dmi' // thats a fun dilemma.... how to keep the tg sprites when doing back but do yogs sprites when worn on head.
 	return ..()
@@ -171,6 +170,10 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
+
+/obj/item/disabled_boh/build_worn_icon(var/state = "", var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
+	state = "brokenpack"
+	return ..()
 
 //Nick's snail shit
 

--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -6,6 +6,7 @@
 	var/cut = FALSE
 	var/appears_split = FALSE
 
+/obj/item/storage/backpack/holding/build_worn_icon(var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
 	if(default_icon_file == 'icons/mob/clothing/head/head.dmi')
 		default_icon_file = 'yogstation/icons/mob/clothing/head/head.dmi' // thats a fun dilemma.... how to keep the tg sprites when doing back but do yogs sprites when worn on head.
 	return ..()
@@ -170,10 +171,6 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
-
-/obj/item/disabled_boh/build_worn_icon(var/state = "", var/default_layer = 0, var/default_icon_file = null, var/isinhands = FALSE, var/femaleuniform = NO_FEMALE_UNIFORM)
-	state = "brokenpack"
-	return ..()
 
 //Nick's snail shit
 


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #17081
Fixes #14996 (dupe issue)

Need to preface this, I have no idea what the state var is doing, only that it shouldn't be there, and that there are no other instances where this proc is specfically called using the state var. Was this meant to be something like an out parameter in c#? Why was it the first argument, especially when you can't overload procs like in c#? Was this code tested? I have zero idea to any of these questions, only that removing it doesn't seem to break anything.

# Spriting
N/A
# Wiki Documentation

N/A

# Changelog
:cl:   
bugfix: Bag of holdings should now appear in your hands, on your back and... head. 
/:cl:
