### PR TITLE
buffs 10mm incind and emp

### DIFF
--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -48,13 +48,13 @@
 
 /obj/item/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"
-	damage = 20
+	damage = 25
 	fire_stacks = 2
 
 /obj/item/projectile/bullet/c10mm/emp
 	name = "10mm EMP bullet"
-	damage = 20
+	damage = 25
 
 /obj/item/projectile/bullet/c10mm/emp/on_hit(atom/target, blocked = FALSE)
 	..()
-	empulse(target, -1, 0) //Only EMPs whatever's hit
+	empulse(target, 0, 1) //Heavy EMP on target, light EMP in tiles around


### PR DESCRIPTION
# Document the changes in your pull request

they cost the same as the glorious 10mm ap so why do they suck as much as they do (I'm to blame)

adds 5 damage to both and makes it so the emp bullet actually heavy emps its tile and does a light emp at a range of 1

does this absolutely delete ipcs yes but so do emp grenades or the emp implant

# Wiki Documentation

10mm incind damage to 25 from 20
10mm EMP damage to 25 from 20, also maybe note its emp strength

# Changelog

:cl:  
tweak: 10mm incind and EMP now both do 25 damage instead of 20
tweak: 10mm EMP heavy EMPs the tile it hits and does a light EMP in the tile around rather than just a light EMP on its own tile so it actually counters sec
/:cl:
