### PR TITLE
Switching to semi-automatic sets accuracy to default gun accuracy

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -41,7 +41,8 @@
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
-	var/spread = 5						//Spread induced by the gun itself.
+	var/spread = 5						//Spread induced by the gun itself. SEE LINE BELOW.
+	var/default_spread = 5				//MUST be equal to the value above; used to calculate adjustments for if semi-auto is used on a burst weapon.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -42,14 +42,17 @@
 
 /obj/item/gun/ballistic/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr
+	var/spread_difference = initial(spread) - 5 //Set this way so laser sights work properly. Default value of 0
 	select = !select
 	if(!select)
 		burst_size = 1
 		fire_delay = 0
+		spread -= spread_difference //Has to be subtraction because laser sight
 		to_chat(user, span_notice("You switch to semi-automatic."))
 	else
 		burst_size = initial(burst_size)
 		fire_delay = initial(fire_delay)
+		spread += spread_difference //Has to be addition because laser sight
 		to_chat(user, span_notice("You switch to [burst_size]-rnd burst."))
 
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
@@ -166,11 +169,13 @@
 
 /obj/item/gun/ballistic/automatic/m90/burst_select()
 	var/mob/living/carbon/human/user = usr
+	var/spread_difference = initial(spread) - 5 //It shouldn't need this but just in case someone decides to nerf the M90-gl's accuracy for whatever reason
 	switch(select)
 		if(0)
 			select = 1
 			burst_size = initial(burst_size)
 			fire_delay = initial(fire_delay)
+			spread += spread_difference
 			to_chat(user, span_notice("You switch to [burst_size]-rnd burst."))
 		if(1)
 			select = 2
@@ -179,6 +184,7 @@
 			select = 0
 			burst_size = 1
 			fire_delay = 0
+			spread -= spread_difference
 			to_chat(user, span_notice("You switch to semi-auto."))
 	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 	update_icon()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -42,7 +42,7 @@
 
 /obj/item/gun/ballistic/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr
-	var/spread_difference = initial(spread) - 5 //Set this way so laser sights work properly. Default value of 0
+	var/spread_difference = initial(spread) - default_spread //Set this way so laser sights work properly. Default value of 0
 	select = !select
 	if(!select)
 		burst_size = 1
@@ -169,7 +169,7 @@
 
 /obj/item/gun/ballistic/automatic/m90/burst_select()
 	var/mob/living/carbon/human/user = usr
-	var/spread_difference = initial(spread) - 5 //It shouldn't need this but just in case someone decides to nerf the M90-gl's accuracy for whatever reason
+	var/spread_difference = initial(spread) - default_spread //It shouldn't need this but just in case someone decides to nerf the M90-gl's accuracy for whatever reason
 	switch(select)
 		if(0)
 			select = 1


### PR DESCRIPTION
# Document the changes in your pull request

Super super niche code but I remember someone mentioning it being nice once. Realistically on most weapons losing out on the lethality versus your accuracy doesn't matter, but I've got a little something in the works which will make this more of a viable thing. Plus it's just... generally quality and semi auto kinda sux

Specifically coded so that it should be agreeable with attachments and laser sights, tested it on the tommy gun, seemed to work fine

# Changelog

:cl:  
tweak: If a gun is more inaccurate than most other guns AND it fires in bursts, setting it to semi-automatic sets its inaccuracy to normal (for any gun)
/:cl:
