### PR TITLE
Adds GPS support to Elite fauna

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -24,11 +24,15 @@
 	var/list/attack_action_types = list()
 	var/can_talk = FALSE
 	var/obj/loot_drop = null
-
+	var/obj/item/gps/internal
+	var/internal_type
+	var/true_spawn = TRUE // If this elite fauna should have a signal, same gps system used in megafauna.
 
 //Gives player-controlled variants the ability to swap attacks
 /mob/living/simple_animal/hostile/asteroid/elite/Initialize(mapload)
 	. = ..()
+	if(internal_type && true_spawn)
+		internal = new internal_type(src)
 	for(var/action_type in attack_action_types)
 		var/datum/action/innate/elite_attack/attack_action = new action_type()
 		attack_action.Grant(src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -39,6 +39,7 @@
 	move_to_delay = 5
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
 	mouse_opacity = MOUSE_OPACITY_ICON
+	internal_type = /obj/item/gps/internal/broodmother
 	deathmessage = "explodes into gore!"
 	loot_drop = /obj/item/crusher_trophy/broodmother_tongue
 
@@ -155,6 +156,16 @@
 			child.forceMove(T)
 			playsound(src, 'sound/effects/bamf.ogg', 100, 1)
 
+/obj/item/gps/internal/broodmother
+	icon_state = null
+	gpstag = "Brooding Signal"
+	desc = "7.5/10 too many tentacles."
+	invisibility = 100
+
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother/death()
+	QDEL_NULL(internal) // removes signal from a deceased elite.
+	. = ..()
+
 //The goliath's children.  Pretty weak, simple mobs which are able to put a single tentacle under their target when at range.
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child
 	name = "baby goliath"
@@ -182,6 +193,7 @@
 	deathmessage = "falls to the ground."
 	status_flags = CANPUSH
 	var/mob/living/simple_animal/hostile/asteroid/elite/broodmother/mother = null
+	true_spawn = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/OpenFire(target)
 	ranged_cooldown = world.time + 40

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -36,6 +36,7 @@
 	speed = 4
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
+	internal_type = /obj/item/gps/internal/herald
 	deathsound = 'sound/magic/demon_dies.ogg'
 	deathmessage = "begins to shudder as it becomes transparent..."
 	loot_drop = /obj/item/clothing/neck/cloak/herald_cloak
@@ -189,6 +190,16 @@
 	my_mirror.my_master = src
 	my_mirror.faction = faction.Copy()
 
+/obj/item/gps/internal/herald
+	icon_state = null
+	gpstag = "Reverent Signal"
+	desc = "Mirrors inside mirrors inside mirrors inside mirrors."
+	invisibility = 100
+
+/mob/living/simple_animal/hostile/asteroid/elite/herald/death()
+	QDEL_NULL(internal) // removes signal from a deceased elite.
+	. = ..()
+
 /mob/living/simple_animal/hostile/asteroid/elite/herald/mirror
 	name = "herald's mirror"
 	desc = "This fiendish work of magic copies the herald's attacks.  Seems logical to smash it."
@@ -201,6 +212,7 @@
 	del_on_death = TRUE
 	is_mirror = TRUE
 	var/mob/living/simple_animal/hostile/asteroid/elite/herald/my_master = null
+	true_spawn = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/mirror/Initialize()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -37,6 +37,7 @@
 	speed = 0
 	move_to_delay = 3
 	mouse_opacity = MOUSE_OPACITY_ICON
+	internal_type = /obj/item/gps/internal/legionnaire
 	deathsound = 'sound/magic/curse.ogg'
 	deathmessage = "'s arms reach out before it falls apart onto the floor, lifeless."
 	loot_drop = /obj/item/crusher_trophy/legionnaire_spine
@@ -213,6 +214,16 @@
 	smoke.set_up(2, T)
 	smoke.start()
 
+/obj/item/gps/internal/legionnaire
+	icon_state = null
+	gpstag = "Wailing Signal"
+	desc = "One vs many."
+	invisibility = 100
+
+/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/death()
+	QDEL_NULL(internal) // removes signal from a deceased elite.
+	. = ..()
+
 //The legionnaire's head.  Basically the same as any legion head, but we have to tell our creator when we die so they can generate another head.
 /mob/living/simple_animal/hostile/asteroid/elite/legionnairehead
 	name = "legionnaire head"
@@ -238,6 +249,7 @@
 	faction = list()
 	ranged = FALSE
 	var/mob/living/simple_animal/hostile/asteroid/elite/legionnaire/body = null
+	true_spawn = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/elite/legionnairehead/death()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -36,6 +36,7 @@
 	speed = 4
 	move_to_delay = 10
 	mouse_opacity = MOUSE_OPACITY_ICON
+	internal_type = /obj/item/gps/internal/pandora
 	deathsound = 'sound/magic/repulse.ogg'
 	deathmessage = "'s lights flicker, before its top part falls down."
 	loot_drop = /obj/item/clothing/accessory/pandora_hope
@@ -168,6 +169,17 @@
 		if(get_dist(t, T) == ring)
 			new /obj/effect/temp_visual/hierophant/blast/pandora(t, src)
 	addtimer(CALLBACK(src, .proc/aoe_squares_2, T, (ring + 1), max_size), 2)
+
+/obj/item/gps/internal/pandora
+	icon_state = null
+	gpstag = "Chaotic Signal"
+	desc = "You opened the box."
+	invisibility = 100
+
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/death()
+	QDEL_NULL(internal) // removes signal from a deceased elite.
+	. = ..()
+
 
 //The specific version of hiero's squares pandora uses
 /obj/effect/temp_visual/hierophant/blast/pandora


### PR DESCRIPTION
For when the elites wander too far from their nests.

# Document the changes in your pull request

Adds GPS tracking support for the Elites with the same system used by the Megafauna. It clutters the GPS a bit by showcasing the original spawn point and where the Elite itself is, lesser mobs spawned by elites but are not Elite themselves like the legionnaire head, broodmother babies, and the herald's mirror do not have a GPS.

# Wiki Documentation

Chaotic Signal ---> Pandora
Wailing Signal ---> Legionnaire
Brooding Signal -> Broodmother 
Reverent Signal --> Herald

# Changelog

:cl:  
rscadd: Adds GPS Signals to Tumor Fauna
/:cl:
