### PR TITLE
Adds Flight Potion to all flight capable species' uplinks

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2140,7 +2140,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "We mixed a bird and a human and we somehow made a potion that turns you into a holy creature."
 	cost = 5
 	item = /obj/item/reagent_containers/glass/bottle/potion/flight/syndicate
-	restricted_species = list("human")
+	restricted_species = list("human", "lizard", "moth", "skeleton", "preternis", "ipc")
 
 /datum/uplink_item/race_restricted/hammerimplant
 	name = "Vxtvul Hammer Implant"


### PR DESCRIPTION
# Document the changes in your pull request

The lizards said they would hurt me if I didn't do this

# Changelog

:cl:  
tweak: All species that can fly can now buy Flight Potions from the uplink
/:cl:
