### PR TITLE
add dir hints to ship dir

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -164,11 +164,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Maintenance - Generic
 
 /area/maintenance/aft
-	name = "Aft Maintenance"
+	name = "Aft (S) Maintenance"
 	icon_state = "amaint"
 
 /area/maintenance/aft/secondary
-	name = "Aft Maintenance"
+	name = "Aft (S) Maintenance"
 	icon_state = "amaint_2"
 
 /area/maintenance/central
@@ -181,51 +181,51 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	clockwork_warp_allowed = FALSE
 
 /area/maintenance/fore
-	name = "Fore Maintenance"
+	name = "Fore (N) Maintenance"
 	icon_state = "fmaint"
 
 /area/maintenance/fore/secondary
-	name = "Fore Maintenance"
+	name = "Fore (N) Maintenance"
 	icon_state = "fmaint_2"
 
 /area/maintenance/starboard
-	name = "Starboard Maintenance"
+	name = "Starboard (E) Maintenance"
 	icon_state = "smaint"
 
 /area/maintenance/starboard/central
-	name = "Central Starboard Maintenance"
+	name = "Central Starboard (E) Maintenance"
 	icon_state = "smaint"
 
 /area/maintenance/starboard/secondary
-	name = "Secondary Starboard Maintenance"
+	name = "Secondary Starboard (E) Maintenance"
 	icon_state = "smaint_2"
 
 /area/maintenance/starboard/aft
-	name = "Starboard Quarter Maintenance"
+	name = "Starboard Quarter (SE) Maintenance"
 	icon_state = "asmaint"
 
 /area/maintenance/starboard/aft/secondary
-	name = "Secondary Starboard Quarter Maintenance"
+	name = "Secondary Starboard Quarter (SE) Maintenance"
 	icon_state = "asmaint_2"
 
 /area/maintenance/starboard/fore
-	name = "Starboard Bow Maintenance"
+	name = "Starboard Bow (NE) Maintenance"
 	icon_state = "fsmaint"
 
 /area/maintenance/port
-	name = "Port Maintenance"
+	name = "Port (W) Maintenance"
 	icon_state = "pmaint"
 
 /area/maintenance/port/central
-	name = "Central Port Maintenance"
+	name = "Central Port (W) Maintenance"
 	icon_state = "maintcentral"
 
 /area/maintenance/port/aft
-	name = "Port Quarter Maintenance"
+	name = "Port Quarter (SW) Maintenance"
 	icon_state = "apmaint"
 
 /area/maintenance/port/fore
-	name = "Port Bow Maintenance"
+	name = "Port Bow (NW) Maintenance"
 	icon_state = "fpmaint"
 
 /area/maintenance/disposal
@@ -243,19 +243,19 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	minimap_color = "#8d8c68"
 
 /area/hallway/primary/aft
-	name = "Aft Primary Hallway"
+	name = "Aft (S) Primary Hallway"
 	icon_state = "hallA"
 
 /area/hallway/primary/fore
-	name = "Fore Primary Hallway"
+	name = "Fore (N) Primary Hallway"
 	icon_state = "hallF"
 
 /area/hallway/primary/starboard
-	name = "Starboard Primary Hallway"
+	name = "Starboard (E) Primary Hallway"
 	icon_state = "hallS"
 
 /area/hallway/primary/port
-	name = "Port Primary Hallway"
+	name = "Port (W) Primary Hallway"
 	icon_state = "hallP"
 
 /area/hallway/primary/central
@@ -263,7 +263,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "hallC"
 
 /area/hallway/primary/aft_starboard
-	name="Aft Starboard Primary Hallway"
+	name="Aft Starboard (SE) Primary Hallway"
 	icon_state = "hallAS"
 
 /area/hallway/secondary/command
@@ -613,43 +613,43 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_wires = /datum/wires/airlock/engineering
 
 /area/solar/fore
-	name = "Fore Solar Array"
+	name = "Fore (N) Solar Array"
 	icon_state = "yellow"
 
 /area/solar/aft
-	name = "Aft Solar Array"
+	name = "Aft (S) Solar Array"
 	icon_state = "yellow"
 
 /area/solar/aux/port
-	name = "Port Bow Auxiliary Solar Array"
+	name = "Port Bow (NW) Auxiliary Solar Array"
 	icon_state = "panelsA"
 
 /area/solar/aux/starboard
-	name = "Starboard Bow Auxiliary Solar Array"
+	name = "Starboard Bow (NE) Auxiliary Solar Array"
 	icon_state = "panelsA"
 
 /area/solar/starboard
-	name = "Starboard Solar Array"
+	name = "Starboard (E) Solar Array"
 	icon_state = "panelsS"
 
 /area/solar/starboard/aft
-	name = "Starboard Quarter Solar Array"
+	name = "Starboard Quarter (SE) Solar Array"
 	icon_state = "panelsAS"
 
 /area/solar/starboard/fore
-	name = "Starboard Bow Solar Array"
+	name = "Starboard Bow (NE) Solar Array"
 	icon_state = "panelsFS"
 
 /area/solar/port
-	name = "Port Solar Array"
+	name = "Port (W) Solar Array"
 	icon_state = "panelsP"
 
 /area/solar/port/aft
-	name = "Port Quarter Solar Array"
+	name = "Port Quarter (SW) Solar Array"
 	icon_state = "panelsAP"
 
 /area/solar/port/fore
-	name = "Port Bow Solar Array"
+	name = "Port Bow (NW) Solar Array"
 	icon_state = "panelsFP"
 
 
@@ -660,27 +660,27 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "yellow"
 
 /area/maintenance/solars/port
-	name = "Port Solar Maintenance"
+	name = "Port (W) Solar Maintenance"
 	icon_state = "SolarcontrolP"
 
 /area/maintenance/solars/port/aft
-	name = "Port Quarter Solar Maintenance"
+	name = "Port Quarter (SW) Solar Maintenance"
 	icon_state = "SolarcontrolAP"
 
 /area/maintenance/solars/port/fore
-	name = "Port Bow Solar Maintenance"
+	name = "Port Bow (NW) Solar Maintenance"
 	icon_state = "SolarcontrolFP"
 
 /area/maintenance/solars/starboard
-	name = "Starboard Solar Maintenance"
+	name = "Starboard (E) Solar Maintenance"
 	icon_state = "SolarcontrolS"
 
 /area/maintenance/solars/starboard/aft
-	name = "Starboard Quarter Solar Maintenance"
+	name = "Starboard Quarter (SE) Solar Maintenance"
 	icon_state = "SolarcontrolAS"
 
 /area/maintenance/solars/starboard/fore
-	name = "Starboard Bow Solar Maintenance"
+	name = "Starboard Bow (NE) Solar Maintenance"
 	icon_state = "SolarcontrolFS"
 
 //Teleporter
@@ -1145,11 +1145,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	minimap_color = "#c8c0ff"
 
 /area/storage/emergency/starboard
-	name = "Starboard Emergency Storage"
+	name = "Starboard (E) Emergency Storage"
 	icon_state = "emergencystorage"
 
 /area/storage/emergency/port
-	name = "Port Emergency Storage"
+	name = "Port (W) Emergency Storage"
 	icon_state = "emergencystorage"
 
 /area/storage/tech

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -46,7 +46,7 @@
 	icon_state = "mining_storage"
 
 /area/mine/production
-	name = "Mining Station Starboard Wing"
+	name = "Mining Station Starboard (E) Wing"
 	icon_state = "mining_production"
 
 /area/mine/abandoned

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -328,7 +328,7 @@
 	icon_state = "hallS"
 
 /area/ruin/space/derelict/hallway/primary/port
-	name = "Derelict Port Hallway"
+	name = "Derelict Port (W) Hallway"
 	icon_state = "hallFP"
 
 /area/ruin/space/derelict/arrival

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -367,11 +367,11 @@
 	icon_state = "chapel"
 
 /area/solar/derelict_starboard
-	name = "Derelict Starboard Solar Array"
+	name = "Derelict Starboard (E) Solar Array"
 	icon_state = "panelsS"
 
 /area/solar/derelict_aft
-	name = "Derelict Aft Solar Array"
+	name = "Derelict Aft (S) Solar Array"
 	icon_state = "yellow"
 
 /area/ruin/space/derelict/singularity_engine

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -10,11 +10,11 @@
 	icon_state = "away1"
 
 /area/awaymission/academy/academyfore
-	name = "Academy Fore Block"
+	name = "Academy Fore (N) Block"
 	icon_state = "away2"
 
 /area/awaymission/academy/academyaft
-	name = "Academy Aft Block"
+	name = "Academy Aft (S) Block"
 	icon_state = "away3"
 
 /area/awaymission/academy/academycellar

--- a/code/modules/ruins/spaceruin_code/crashedship.dm
+++ b/code/modules/ruins/spaceruin_code/crashedship.dm
@@ -8,7 +8,7 @@
 
 
 /area/awaymission/BMPship/Aft
-	name = "Aft Block"
+	name = "Aft (S) Block"
 	icon_state = "away1"
 	requires_power = TRUE
 
@@ -18,7 +18,7 @@
 	requires_power = TRUE
 
 /area/awaymission/BMPship/Fore
-	name = "Fore Block"
+	name = "Fore (N) Block"
 	icon_state = "away3"
 	requires_power = TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

I don't give a shit if there's no magnetization in space, no one actually knows on a whim which maint Port Bow is, even I don't even after changing all of these. People say "cargo maint" or some shit but departments aren't always arranged the same so compass directions will have to do.

# Changelog

:cl:  
tweak: Changed all ship directions to have compass direction hints e.g. Port will now say (W) as in "West"
/:cl:
