### PR TITLE
adds a variation of the BM speedwagon that doesnt obliterate people it crashes into

### DIFF
--- a/code/modules/vehicles/speedbike.dm
+++ b/code/modules/vehicles/speedbike.dm
@@ -45,6 +45,7 @@
 	icon_state = "speedwagon"
 	layer = LYING_MOB_LAYER
 	var/static/mutable_appearance/overlay // Yogs -- fixes potential game crash or something
+	var/damage = TRUE
 	max_buckled_mobs = 4
 	var/crash_all = FALSE //CHAOS
 	pixel_y = -48
@@ -71,6 +72,8 @@
 /obj/vehicle/ridden/space/speedwagon/Bump(atom/A)
 	. = ..()
 	if(A.density && has_buckled_mobs())
+		if(!damage)
+			return
 		var/atom/throw_target = get_edge_target_turf(A, dir)
 		if(crash_all)
 			if(ismovable(A))
@@ -94,3 +97,7 @@
 		for(var/atom/A in range(2, src))
 			if(!(A in buckled_mobs))
 				Bump(A)
+
+/obj/vehicle/ridden/space/speedwagon/nodamage
+	damage = FALSE
+	


### PR DESCRIPTION
the BM speedwagon is funny but fucking annihilating anyone it crashes into with its giant fucking hitbox makes it terrifyingly deadly and having a version that doesnt do that would be nice

# Changelog

:cl:  
rscadd: a variation of the BM speedwagon except it doesnt obliterate people it crashes into (admin only like the normal speedwagon)
/:cl:
