### PR TITLE
Fix air alarm not returning to normal state when meeting the normal threshold

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -453,18 +453,16 @@
 			. = TRUE
 		if("alarm")
 			var/area/A = get_area(src)
-			if(A.atmosalert(2, src))
-				post_alert(2)
 			for(var/obj/machinery/airalarm/AA in A)
-				AA.manual_alarm = !AA.manual_alarm
+				AA.manual_alarm = TRUE
+				AA.post_alert(2)
 				AA.update_icon()
 			. = TRUE
 		if("reset")
 			var/area/A = get_area(src)
-			if(A.atmosalert(0, src))
-				post_alert(0)
 			for(var/obj/machinery/airalarm/AA in A)
-				AA.manual_alarm = !AA.manual_alarm
+				AA.manual_alarm = FALSE
+				AA.post_alert(0)
 				AA.update_icon()
 			. = TRUE
 	update_icon()
@@ -691,13 +689,15 @@
 		gas_dangerlevel = max(gas_dangerlevel, cur_tlv.get_danger_level(environment.get_moles(gas_id) * partial_pressure))
 
 
-	var/old_danger_level = danger_level
+	var/old_danger_level = initial(danger_level)
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
 	if(old_danger_level != danger_level)
 		apply_danger_level()
+		post_alert(2)
 	else if((old_danger_level == danger_level) && !manual_alarm)
 		apply_danger_level()
+		post_alert(0)
 
 	if(mode == AALARM_MODE_REPLACEMENT && environment_pressure < ONE_ATMOSPHERE * 0.05)
 		mode = AALARM_MODE_SCRUBBING
@@ -718,11 +718,13 @@
 	if(alert_level==2)
 		alert_signal.data["alert"] = "severe"
 		A.set_vacuum_alarm_effect()
+		A.atmosalert(2, src)
 	else if (alert_level==1)
 		alert_signal.data["alert"] = "minor"
 	else if (alert_level==0)
 		alert_signal.data["alert"] = "clear"
 		A.unset_vacuum_alarm_effect()
+		A.atmosalert(0, src)
 
 	frequency.post_signal(src, alert_signal, range = -1)
 
@@ -734,8 +736,6 @@
 		AA.manual_alarm = FALSE
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
-	if(A.atmosalert(new_area_danger_level,src)) //if area was in normal state or if area was in alert state
-		post_alert(new_area_danger_level)
 
 	update_icon()
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -82,6 +82,9 @@
 	var/danger_level = 0
 	var/mode = AALARM_MODE_SCRUBBING
 
+	///manual alarm for when you want to have permanently blue lights
+	var/manual_alarm = FALSE
+
 	var/locked = TRUE
 	var/aidisabled = 0
 	var/shorted = 0
@@ -452,11 +455,17 @@
 			var/area/A = get_area(src)
 			if(A.atmosalert(2, src))
 				post_alert(2)
+			for(var/obj/machinery/airalarm/AA in A)
+				AA.manual_alarm = !AA.manual_alarm
+				AA.update_icon()
 			. = TRUE
 		if("reset")
 			var/area/A = get_area(src)
 			if(A.atmosalert(0, src))
 				post_alert(0)
+			for(var/obj/machinery/airalarm/AA in A)
+				AA.manual_alarm = !AA.manual_alarm
+				AA.update_icon()
 			. = TRUE
 	update_icon()
 
@@ -687,6 +696,9 @@
 
 	if(old_danger_level != danger_level)
 		apply_danger_level()
+	else if((old_danger_level == danger_level) && !manual_alarm)
+		apply_danger_level()
+
 	if(mode == AALARM_MODE_REPLACEMENT && environment_pressure < ONE_ATMOSPHERE * 0.05)
 		mode = AALARM_MODE_SCRUBBING
 		apply_mode(src)
@@ -719,6 +731,7 @@
 
 	var/new_area_danger_level = 0
 	for(var/obj/machinery/airalarm/AA in A)
+		AA.manual_alarm = FALSE
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
 	if(A.atmosalert(new_area_danger_level,src)) //if area was in normal state or if area was in alert state


### PR DESCRIPTION
Fix #14344


This is very inconnvenience for ai, borgs, engineers and atmos techs have to go near the air alarm and manually turn off the atmos alert

The station alert consoles and station alert programs are still buggy because they use same old codes pretty broken, and i don't know how to fix that, i only fixing air alarm. I will list an issue with atmos alert console here if someone wants to fix it #17106

<details><summary>bug image</summary>

![image](https://user-images.githubusercontent.com/89688125/208233644-a805bfb8-e025-4cc4-81ab-60dc1ce13194.png)
</details>

# Document the changes in your pull request
Fix air alarm not returning to normal state when meeting the normal threshold


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix air alarm not returning to normal state when meeting the normal threshold
/:cl:
