### PR TITLE
Targeted black powder nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -94,7 +94,7 @@
 	description = "Explodes. Violently."
 	reagent_state = LIQUID
 	color = "#000000"
-	metabolization_rate = 0.05
+	metabolization_rate = REAGENTS_METABOLISM * 2.5	//Yogs change - faster metabolization
 	taste_description = "salt"
 
 /datum/reagent/blackpowder/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -100,7 +100,7 @@
 	name = "Black Powder Kaboom"
 	id = "blackpowder_explosion"
 	required_reagents = list(/datum/reagent/blackpowder = 1)
-	required_temp = 474
+	required_temp = 737		//Yogs change - 464 C, actual ignition temp
 	strengthdiv = 6
 	modifier = 1
 


### PR DESCRIPTION
Increases the required explosion temperature to 737 K (464 C, the actual ignition temperature) and increases the metabolization rate of black powder to 1/tick. This should effectively neuter semi-instant-death black powder bomb syringes without dunking on black powder grenades or monkey bombs. Black powder syringes should be a lot easier to survive now if you act quickly.

Yes I realize this is made during the feature freeze, I can wait. It's just a number change.

# Wiki Documentation
See changelog


# Changelog

:cl:  
tweak: Black powder metabolization rate increased (0.05 -> 1) 
tweak: Black powder explosion temp required increased (474 -> 737)
/:cl:
