### PR TITLE
Emagged defibs knockdown instead of paralyze

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -473,7 +473,7 @@
 	M.visible_message(span_danger("[user] has touched [M] with [src]!"), \
 			span_userdanger("[user] has touched [M] with [src]!"))
 	M.adjustStaminaLoss(50)
-	M.Paralyze(100)
+	M.Knockdown(100)
 	M.updatehealth() //forces health update before next life tick //isn't this done by adjustStaminaLoss anyway?
 	playsound(src,  'sound/machines/defib_zap.ogg', 50, 1, -1)
 	M.emote("gasp")


### PR DESCRIPTION
It's an instant 10 second stun that you can't really mitigate like you can batons. A knockdown still makes it useful, just not quite the instant win it was before. This is specifically the disarm intent effect.

# Wiki Documentation

Emagged/combat defibs knockdown instead of stun.

# Changelog


:cl:  

tweak: Emagged/combat defibs knockdown instead of stun

/:cl:
