### PR TITLE
bullet wound buff (just for pistols and revolvers)

### DIFF
--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -3,6 +3,7 @@
 /obj/item/projectile/bullet/c9mm
 	name = "9mm bullet"
 	damage = 20
+	wound_bonus = -10
 
 /obj/item/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
@@ -19,6 +20,7 @@
 /obj/item/projectile/bullet/c10mm
 	name = "10mm bullet"
 	damage = 30
+	wound_bonus = -30
 
 /obj/item/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -3,12 +3,16 @@
 /obj/item/projectile/bullet/n762
 	name = "7.62x38mmR bullet"
 	damage = 20
+	wound_bonus = -5
+	wound_falloff_tile = -2.5
 
 // .50AE (Desert Eagle)
 
 /obj/item/projectile/bullet/a50AE
 	name = ".50AE bullet"
 	damage = 40
+	wound_bonus = -35
+	wound_falloff_tile = -2.5
 
 // .38 (Detective's Gun)
 
@@ -17,6 +21,7 @@
 	damage = 25 //High damaging but...
 	armour_penetration = -40 //Almost doubles the armor of any bullet armor it hits
 	wound_bonus = -10
+	wound_falloff_tile = -2.5
 	bare_wound_bonus = 10
 
 /obj/item/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
@@ -74,7 +79,9 @@
 /obj/item/projectile/bullet/a357
 	name = ".357 bullet"
 	damage = 40
-	wound_bonus = -70
+	armour_penetration = 15
+	wound_bonus = -45
+	wound_falloff_tile = -2.5
 
 /obj/item/projectile/bullet/pellet/a357_ironfeather
 	name = ".357 Ironfeather pellet"
@@ -87,7 +94,7 @@
 /obj/item/projectile/bullet/a357/nutcracker
 	name = ".357 Nutcracker bullet"
 	damage = 20 //Twice the damage of a breaching slug
-	wound_bonus = -60
+	wound_bonus = -10
 
 /obj/item/projectile/bullet/a357/nutcracker/on_hit(atom/target) //Basically breaching slug with 1.5x damage
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
@@ -97,6 +104,7 @@
 /obj/item/projectile/bullet/a357/metalshock
 	name = ".357 Metalshock bullet"
 	damage = 10
+	wound_bonus = -5
 
 /obj/item/projectile/bullet/a357/metalshock/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -106,14 +114,14 @@
 /obj/item/projectile/bullet/a357/heartpiercer
 	name = ".357 Heartpiercer bullet"
 	damage = 35
-	armour_penetration = 30 //Not as good AP-wise relative to the stechy - both are a 5-hit against bulletproof armor, whereas this 3-hits normal armor versus 4 hits. Revolver has much lower RoF, too
+	armour_penetration = 45
 	penetrating = TRUE //Goes through a single mob before ending on the next target
 	penetrations = 1
 
 /obj/item/projectile/bullet/a357/wallstake
 	name = ".357 Wallstake bullet"
 	damage = 36 //Almost entirely a meme round at this point. 36 damage barely four-shots standard armor
-	wound_bonus = -60 //Minor chance of dislocation from the bullet itself
+	wound_bonus = -40
 	sharpness = SHARP_NONE //Blunt
 
 /obj/item/projectile/bullet/a357/wallstake/on_hit(atom/target, blocked = FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

Makes all wound bonuses for pistol and revolver ammo types (mostly 10mm and .357 notably) actually not dogwater so secoffs should maybe be scared now

As of rn buying a stechkin/revolver is like throwing TC into the wind so making them have more oomf while not necessarily being instantly more deadly should force secoffs to go to medbay more often or GO TO MEDBAY before they bleed out

I also somehow forgot to completely mention that .357 now has innate 15 AP, so, yay?

# Wiki Documentation

Revolver ammunition types probably warrant being noted as having less wound falloff, .357 has innate minor AP now

# Changelog

:cl:  
tweak: .357 has innate 15 AP now, Heartpiercer buffed to compensate
tweak: All pistol and revolver ammunition types have scarier wound bonuses that should be semi-relevant so you can't just shrug off being SHOT
tweak: All revolver ammo types have half the normal wound chance falloff
/:cl:
