### PR TITLE
fixes coffins being worth substantially more than they should be

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -29,6 +29,7 @@
 	cost = 250//50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
+	exclude_types = list()
 
 /datum/export/large/reagent_dispenser
 	cost = 100 // +0-400 depending on amount of reagents left

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -2,7 +2,7 @@
 	cost = 500
 	unit_name = "crate"
 	export_types = list(/obj/structure/closet/crate)
-	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden, /obj/structure/closet/crate/secure/cheap, /obj/structure/closet/crate/secure/owned, /obj/structure/closet/crate/mail)
+	exclude_types = list(/obj/structure/closet/crate/large, /obj/structure/closet/crate/wooden, /obj/structure/closet/crate/secure/cheap, /obj/structure/closet/crate/secure/owned, /obj/structure/closet/crate/mail, /obj/structure/closet/crate/coffin)
 
 /datum/export/large/crate/total_printout(datum/export_report/ex, notes = TRUE) // That's why a goddamn metal crate costs that much.
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Turns out they weren't properly blacklisted from the generic crate export so they would count as crates rather than coffins

# Changelog


:cl:  
bugfix: The space IRS has clamped down on corporate tax evasion via coffins, reducing their export price to that of the standard coffin export price (250 credits)
/:cl:
