### PR TITLE
Fixes a funny potential (by potential I mean literally no one in their right mind would use it) source of DDoSing.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -153,6 +153,14 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	switch(href_list["action"])
 		if("openLink")
 			src << link(href_list["link"])
+		//YOGS START: adds "refresh_admin_ticket_list" from another file.
+		if("refresh_admin_ticket_list")
+			var/client/C = usr.client
+			var/flag = href_list["flag"]
+			if(!flag)
+				flag = TICKET_FLAG_LIST_ALL
+			C.view_tickets_main(flag)
+		//YOGS END
 	if (hsrc)
 		var/datum/real_src = hsrc
 		if(QDELETED(real_src))

--- a/yogstation/code/modules/admin/verbs/adminhelp.dm
+++ b/yogstation/code/modules/admin/verbs/adminhelp.dm
@@ -176,7 +176,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	_interactions = list()
 
 	if(is_bwoink)
-		AddInteraction("[usr.client?.ckey] PM'd [initiator_key_name]") 
+		AddInteraction("[usr.client?.ckey] PM'd [initiator_key_name]")
 		message_admins("<font color='blue'>Ticket [TicketHref("#[id]")] created</font>")
 	else
 		MessageNoRecipient(msg)
@@ -245,7 +245,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 						type = MESSAGE_TYPE_ADMINLOG,
 						html = msg,
 						confidential = TRUE)
-				
+
 		if(world.time > last_bwoinking)
 			last_bwoinking = world.time + 1 SECONDS
 			for(var/client/X in GLOB.permissions.admins)
@@ -683,7 +683,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	//client may of have disconnected by the time this proc gets called
 	if(!src)
 		return
-		
+
 	if(!locate(/client/verb/adminhelp) in src.verbs)
 		add_verb(src, /client/verb/adminhelp)
 
@@ -864,17 +864,6 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	usr << browse(null, "window=ViewTickets")
 	usr << browse(html, "window=ViewTickets")
-
-/client/Topic(href, href_list, hsrc)
-	..()
-
-	if(href_list["action"] == "refresh_admin_ticket_list")
-		var/client/C = usr.client
-		var/flag = href_list["flag"]
-		if(!flag)
-			flag = TICKET_FLAG_LIST_ALL
-
-		C.view_tickets_main(flag)
 
 // Used for methods where input via arg doesn't work
 /client/proc/get_adminhelp()


### PR DESCRIPTION


# Document the changes in your pull request

All client topic calls are spam checked to prevent DDoSing or whatever. This one section of code isn't because of an oversight. I don't think a DDoS via this method is feasible unless you get like 20 clients to do it. You'd have to be connected to the server too. 


# Changelog

:cl:  BurgerBB
bugfix: Fixes a funny potential (by potential I mean literally no one in their right mind would use it) DDoS bug.
/:cl:
