### PR TITLE
Fixes Green Stockings not having a sprite

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -1886,7 +1886,7 @@
 
 /datum/sprite_accessory/socks/stockings_green
 	name = "Stockings (Green)"
-	icon_state = "stockings_black"
+	icon_state = "stockings_green"
 
 /datum/sprite_accessory/socks/stockings_orange
 	name = "Stockings (Orange)"


### PR DESCRIPTION
Where the fuck is the black stockings greeny!?

# Document the changes in your pull request

The green stockings pointed to a nonexistent sprite so I changed it back to what it was supposed to be after this was left alone for 4 years.

# Spriting

![image](https://user-images.githubusercontent.com/107460718/208343216-8be25972-76a6-4d4c-8bdc-89b5bc68077a.png)


# Changelog

:cl:  
bugfix: Green Stockings should be worn to work now 
/:cl:
