### PR TITLE
Fitted sprite fix

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -849,6 +849,7 @@
 	icon_state = "weiner"
 	item_state = "weiner"
 	can_adjust = FALSE
+	fitted = FEMALE_UNIFORM_TOP
 
 // Ashwalker Clothes
 /obj/item/clothing/under/chestwrap
@@ -857,6 +858,7 @@
 	icon_state = "chestwrap"
 	has_sensor = NO_SENSORS
 	body_parts_covered = CHEST|GROIN
+	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/raider_leather
 	name = "scavenged rags"
@@ -887,7 +889,6 @@
 	body_parts_covered = CHEST|GROIN
 	has_sensor = NO_SENSORS
 	can_adjust = FALSE
-	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/ash_robe/young
 	name = "tribal rags"


### PR DESCRIPTION
Tweaks the female fitting for two jumpsuits and removes a redundant line.

Fixes that one weird looking pixel.
![image](https://user-images.githubusercontent.com/43766432/208536530-3918b8df-830e-4f48-9fad-9162a49a145f.png)
![image](https://user-images.githubusercontent.com/43766432/208536676-5ea1918f-9905-4c52-b3e7-9faa96955e45.png)

# Changelog

:cl:  

imageadd: Fixes a wonky pixel for two uniforms

/:cl:
