### PR TITLE
fixes neural network nanite program not being unlocked when it should be

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -998,7 +998,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites")
+	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000, TECHWEB_POINT_TYPE_NANITES = 2000)
 
 /datum/techweb_node/nanite_combat

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -134,7 +134,3 @@
 	prereq_ids = list("shuttle_route_upgrade_hyper", "alientech")
 	design_ids = list("engine_void", "disk_shuttle_route_void")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
-
-
-/datum/techweb_node/nanite_harmonic
-	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -137,4 +137,4 @@
 
 
 /datum/techweb_node/nanite_harmonic
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
+	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")


### PR DESCRIPTION
# Document the changes in your pull request

I'm killing you. I'm _killing_ you. I don't care about ANYTHING else. 

# Changelog

:cl:  
bugfix: neural networks have been considered "fair use" by corporate copy protection and are now unlocked by harmonic nanites (as intended)
/:cl:
