### PR TITLE
Various traitor Dark HONK fixes

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -300,6 +300,24 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/tearstache()//The mousetrap mortar was not up-to-snuff.
 	ME.attach(src)
 
+/obj/mecha/combat/honker/dark/crew
+	operation_req_access = list()
+	internals_req_access = list()
+	wreckage = /obj/structure/mecha_wreckage/honker/dark/crew
+
+/obj/mecha/combat/honker/dark/crew/loaded/Initialize()
+	. = ..()
+	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/honker()
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana()//Needed more offensive weapons.
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang/tearstache()//The mousetrap mortar was not up-to-snuff.
+	ME.attach(src)
+
 /obj/structure/mecha_wreckage/honker/dark
 	name = "\improper Dark H.O.N.K wreckage"
 	icon_state = "darkhonker-broken"
+	orig_mecha = /obj/mecha/combat/honker/dark
+
+/obj/structure/mecha_wreckage/honker/dark/crew
+	orig_mecha = /obj/mecha/combat/honker/dark/crew

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2211,7 +2211,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/honker
 	name = "Dark H.O.N.K."
 	desc = "A clown combat mech equipped with bombanana peel and tearstache grenade launchers, as well as the ubiquitous HoNkER BlAsT 5000."
-	item = /obj/mecha/combat/honker/dark/loaded
+	item = /obj/mecha/combat/honker/dark/crew/loaded
 	cost = 20
 	restricted_roles = list("Clown")
 	manufacturer = /datum/corporation/traitor/waffleco


### PR DESCRIPTION
# Document the changes in your pull request

This gets ahelped a lot

# Changelog

:cl:  
bugfix: Fixed Dark H.O.N.K. wreckage not reconstructing into a Dark H.O.N.K.
bugfix: Fixed traitor Dark H.O.N.K. requiring nukie access
/:cl:
