### PR TITLE
Prevent people that are unable to speak from opening the Say prompt

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -137,8 +137,11 @@
 
 // Cannot talk
 
+/mob/living/simple_animal/hostile/statue/IsVocal()
+	return FALSE
+
 /mob/living/simple_animal/hostile/statue/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	return 0
+	return FALSE
 
 // Turn to dust when gibbed
 

--- a/yogstation/code/modules/keybindings/bindings_mob.dm
+++ b/yogstation/code/modules/keybindings/bindings_mob.dm
@@ -5,7 +5,10 @@
 /mob/key_down(datum/keyinfo/I, client/user)
 	switch(I.action)
 		if(ACTION_SAY)
-			get_say()
+			if(can_speak())
+				get_say()
+			else
+				to_chat(src, span_warning("You cannot speak!"))
 			return
 		if(ACTION_ME)
 			me_verb()


### PR DESCRIPTION
# Document the changes in your pull request

This is mostly just to prevent people from showing chat bubbles while unable to speak (like living statues which aren't meant to show signs of living) but also lets people (especially new players) know that they're muted so they don't waste time typing

# Changelog

:cl:  
tweak: Things that are unable to speak or are muted no longer get access to the Say prompt
/:cl:
