### PR TITLE
Fixes plastic surgery only working via putting in pretty filter names

### DIFF
--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -37,7 +37,7 @@
 			"[user] finishes the operation on [target]'s face.")
 	else
 		var/chosen_name = stripped_input(user, "Choose a new name to assign.", "Plastic Surgery", null, MAX_NAME_LEN)
-		if(!chosen_name || !isnotpretty(chosen_name))
+		if(!chosen_name || isnotpretty(chosen_name))
 			return
 		var/oldname = target.real_name
 		target.real_name = chosen_name


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #17134

would notpretty() return false if it was not the case that notpretty() would not not return true on not inputting words that would not be in the prettyfilter list?

# Spriting
N/A

# Wiki Documentation

N/A

# Changelog

:cl:  
bugfix: You no longer need to practice racism or bigotry to finish plastic surgery
/:cl:
