### PR TITLE
Armor is now 25% more effective against shotgun pellets

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun/slug
 	name = "12g shotgun slug"
 	speed = 0.5 //Shotgun = slower
-	damage = 46
+	damage = 46 //About 2/3's the damage of buckshot but doesn't suffer from damage falloff, negative AP, or spread
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
 
@@ -67,19 +67,20 @@
 
 /obj/item/projectile/bullet/pellet
 	speed = 0.5 //Shotgun = slower
+	armour_penetration = -20 //Armor is 25% stronger against pellets
 	var/tile_dropoff = 0.45
 	var/tile_dropoff_s = 0.35
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12
+	damage = 12 //Total of 72 (big)
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 	
 /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
 	name = "syndicate buckshot pellet"
-	damage = 15.5 //7 damage more and crit instantly assuming PBS
+	damage = 15.5 //3.5 more damage so it sucks less?
 	wound_bonus = 2
 	bare_wound_bonus = 2
 	wound_falloff_tile = -2.5
@@ -90,7 +91,7 @@
 	damage = 13
 	wound_bonus = 4
 	bare_wound_bonus = 4
-	armour_penetration = 40
+	armour_penetration = 40 //You're the exception of pellets not sucking against armor because ??
 	tile_dropoff = 0.35 //Ranged pellet because I guess?
 	wound_falloff_tile = -1
 
@@ -102,7 +103,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 14.5
+	stamina = 14.5 //Total of 87 (very big)
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/shotgun_cryoshot


### PR DESCRIPTION
# Document the changes in your pull request

Shouldn't have too drastic of a change on actual performance. Mostly just something to reel in pellets doing a crapton of damage

I should probably adjust the "illegal" syndicate buckshot but we'll see how this goes and if it makes the bulldog feel like a wet noodle again (not that anyone uses it)

(Flechette has remained unchanged because AP is kinda its gimmick)

# Wiki Documentation

Shotgun shell properties should be properly updated on the Guide to Combat

# Changelog

:cl:  
tweak: Armor is now 25% more effective against pellet-like shotgun projectiles
/:cl:
