### PR TITLE
Makes Completed Techshells Printable

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -395,13 +395,13 @@
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/frag12
-	name = "FRAG-12 Shell"
+	name = "FRAG-12 Slug"
 	result = /obj/item/ammo_casing/shotgun/frag12
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
 				/datum/reagent/glycerol = 5,
 				/datum/reagent/toxin/acid/fluacid = 5)
 	tools = list(TOOL_SCREWDRIVER)
-	time = 5
+	time = 0.5 SECONDS
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
@@ -428,7 +428,7 @@
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/depleteduraniumslug
-	name = "Depleted Uranium Slug Shell"
+	name = "Depleted Uranium Slug"
 	result = /obj/item/ammo_casing/shotgun/uraniumpenetrator
 	reqs = list(/obj/item/ammo_casing/shotgun/techshell = 1,
 				/obj/item/stack/sheet/mineral/uranium = 2,

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -121,7 +121,7 @@
 
 /obj/item/ammo_casing/shotgun/laserbuckshot
 	name = "laser buckshot"
-	desc = "An advanced shotgun shell that uses  micro lasers to replicate the effects of a laser weapon in a ballistic package."
+	desc = "An advanced shotgun shell that uses micro lasers to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/laser/buckshot
 	pellets = 5

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -120,7 +120,7 @@
 	desc = "A high-explosive breaching round for a 12 gauge shotgun."
 	id = "heslug"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 7500) //More inefficient because you don't have to put it together manually
+	materials = list(/datum/material/iron = 7500, /datum/material/plasma = 500) //More inefficient because you don't have to put it together manually
 	build_path = /obj/item/ammo_casing/shotgun/frag12
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -85,6 +85,86 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/pulse_slug
+	name = "Pulse Slug"
+	desc = "A primed energy shell that releases a single projectile that is capable of significantly damaging structures."
+	id = "pslug"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 500, /datum/material/uranium = 100) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/pulseslug
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/dragonbreath_shell
+	name = "Dragonbreath Shell"
+	desc = "A shotgun shell which fires a spread of incendiary pellets."
+	id = "Ishell"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4500, /datum/material/glass = 400) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/dragonsbreath
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/ion_shell
+	name = "Ion Shell"
+	desc = "A primed energy shell that releases several pellets that replicate the effects of ion projectiles."
+	id = "ionshell"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4500, /datum/material/glass = 1500, /datum/material/silver = 300, /datum/material/gold = 300, /datum/material/uranium = 100) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/ion
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/frag12_slug
+	name = "FRAG-12 Slug"
+	desc = "A high-explosive breaching round for a 12 gauge shotgun."
+	id = "heslug"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 7500) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/frag12
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/laser_buckshot_shell
+	name = "Laser Buckshot Shell"
+	desc = "An advanced shotgun shell that uses micro lasers to replicate the effects of a laser weapon in a ballistic package."
+	id = "lasershell"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4500, /datum/material/glass = 400) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/laserbuckshot
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/thundershot_shell
+	name = "Thundershot Shell"
+	desc = "An advanced shotgun shell that uses stored electrical energy to discharge a massive shock on impact, arcing to nearby targets."
+	id = "thundershell"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 400, /datum/material/gold = 200) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/thundershot
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/du_slug
+	name = "Depleted Uranium Slug"
+	desc = "A relatively low-tech shell with very impressive armor penetration capabilities."
+	id = "duslug"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 5000, /datum/material/uranium = 6000) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/uraniumpenetrator
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
+/datum/design/cryo_shell
+	name = "Cryoshot Shell"
+	desc = "A state-of-the-art shell that snap freezes targets without causing them much harm."
+	id = "cryoshell"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4500, /datum/material/glass = 400) //More inefficient because you don't have to put it together manually
+	build_path = /obj/item/ammo_casing/shotgun/cryoshot
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
+
 /datum/design/pin_testing
 	name = "Test-Range Firing Pin"
 	desc = "This safety firing pin allows firearms to be operated within proximity to a firing range."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -728,6 +728,14 @@
 	design_ids = list("techshotshell", "c38_hotshot", "c38_iceblox", "c38_gutterpunch")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
+/datum/techweb_node/experimental_shells
+	id = "experimental_shells"
+	display_name = "Experimental Shells"
+	description = "A set of experimental techshells, already assembled for quick usage."
+	prereq_ids = list("exotic_ammo")
+	design_ids = list("pslug", "Ishell", "ionshell", "heslug", "lasershell", "thundershell", "duslug", "cryoshell")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+
 /datum/techweb_node/gravity_gun
 	id = "gravity_gun"
 	display_name = "One-point Bluespace-gravitational Manipulator"

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -503,6 +503,10 @@
 	ui_x = -704
 	ui_y = -672
 
+/datum/techweb_node/experimental_shells
+	ui_x = -786
+	ui_y = -736
+
 /datum/techweb_node/gravity_gun
 	ui_x = -320
 	ui_y = -288


### PR DESCRIPTION
# Document the changes in your pull request

A really stupid idea but I hate to see so many cool ammo types go unused, ever, period. Balance can come after the fact, since almost none of these have actually seen the light of day so balancing them is kinda difficult without any actual practical reports of how effective they are

Basically adds a new research node to make the already-existing shells more accessible beyond meticulously grabbing meticulously specific items and then crafting each one by hand which means they're never made. The research requires exotic ammo, which gives the empty shells, but the new one costs 10000

The list of printable ammo is as follows (all of these recipes are more inefficient than their crafted recipes by a significant margin, minus required reagents because protolathes can't take reagents [he lied]):

Standard shell (buckshot, slug, w/e) normally costs 4000 Iron

- Pulse Slug: 5000 Iron, 500 Glass, 100 Uranium
- Dragonsbreath Shell: 4500 Iron, 400 Glass
- Ion Shell: 4500 Iron, 1500 Glass, 300 Silver, 300 Gold, 100 Uranium
- FRAG-12 Slug: 7500 Iron, 500 Plasma
- Laser Buckshot Shell: 4500 Iron, 400 Glass
- Thundershot Shell: 5000 Iron, 400 Glass, 200 Gold
- Depleted Uranium Slug: 5000 Iron, 6000 Uranium (yes, the original recipe calls for a total of 4000)
- Cryoshot Shell: 4500 Iron, 400 Glass

# Wiki Documentation

Technological shells will need new phrasing on Guide to Combat. Research nodes and design specifications should be added to proper R&D pages

# Changelog

:cl:  
tweak: New research node after Exotic Ammo called Experimental Shells, for 10000 research points. Permits access to inefficient printings of techshells. Empty techshells and crafting recipes still remain.
/:cl:
