### PR TITLE
Makes it so every convert isn't instantly made a ridiculously robust species on war clockies

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -93,10 +93,7 @@ Credit where due:
 	if(.)
 		var/datum/antagonist/clockcult/servant = .
 		var/datum/team/clockcult/cult = servant.get_team()
-		cult.check_size()	
-		if (GLOB.ratvar_approaches)
-			L.set_species(/datum/species/golem/clockwork/no_scrap)
-			to_chat(L, "<span class='heavy_brass'>The beacon is active! You are reformed in Ratvar's image.</span>")
+		cult.check_size()
 	
 	if(!silent && L)
 		if(.)


### PR DESCRIPTION
# Document the changes in your pull request

Not a technical revert PR because the power buff is actually a good thing

# Wiki Documentation

Clockie page should be changed if the war part for convert were ever changed (don't think it was)

# Changelog

:cl:  
tweak: War clockies no longer get to make converts into their ridiculously powerful species type
/:cl:
