### PR TITLE
Allows purchasing of air scubbers & pumps

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister/generic, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("portable pump", /obj/machinery/portable_atmospherics/pump, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("portable scrubber", /obj/machinery/portable_atmospherics/scrubber, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
 	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -53,7 +53,6 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	null, \
 	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister/generic, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("portable pump", /obj/machinery/portable_atmospherics/pump, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("portable scrubber", /obj/machinery/portable_atmospherics/scrubber, 10, time = 15, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe("floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
 	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -863,34 +863,25 @@
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/engineering/portable_pumps
-	name = "Portable Air Pumps"
+	name = "Portable Pumps"
 	desc = "A set of spare portable pumps. Perfect for larger atmospheric projects or restocking after a toxins problem goes wrong."
 	cost = 1500
 	contains = list(
 		/obj/machinery/portable_atmospherics/pump,
 		/obj/machinery/portable_atmospherics/pump
 	)
-	crate_name = "portable air pump crate"
+	crate_name = "portable pump crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/engineering/portable_scrubbers
-	name = "Portable Air Scrubbers"
+	name = "Portable Scrubbers"
 	desc = "A set of spare portable scrubbers. Perfect for when plasma 'accidentally' gets into the air supply."
 	cost = 1500
 	contains = list(
 		/obj/machinery/portable_atmospherics/scrubber,
 		/obj/machinery/portable_atmospherics/scrubber
 	)
-	crate_name = "portable air scrubber crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/engineering/huge_scrubber
-	name = "Huge Air Scrubber"
-	desc = "A huge air scrubber. Perfect for cleaning up after you fail to make fusion."
-	cost = 5000
-	access_view = ACCESS_CE
-	contains = list(/obj/machinery/portable_atmospherics/scrubber/huge)
-	crate_name = "huge air scrubber crate"
+	crate_name = "portable scrubber crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/engineering/shuttle_engine

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -862,6 +862,28 @@
 	crate_name = "power cell crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
+/datum/supply_pack/engineering/portable_pumps
+	name = "Portable Pumps"
+	desc = "A set of spare portable pumps. Perfect for larger atmospheric projects or restocking after a toxins problem goes wrong."
+	cost = 1500
+	contains = list(
+		/obj/machinery/portable_atmospherics/pump,
+		/obj/machinery/portable_atmospherics/pump
+	)
+	crate_name = "portable pump crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/engineering/portable_scrubbers
+	name = "Portable Scrubbers"
+	desc = "A set of spare portable scrubbers. Perfect for when plasma 'accidentally' gets into the air supply."
+	cost = 1500
+	contains = list(
+		/obj/machinery/portable_atmospherics/scrubber,
+		/obj/machinery/portable_atmospherics/scrubber
+	)
+	crate_name = "portable scrubber crate"
+	crate_type = /obj/structure/closet/crate/large
+
 /datum/supply_pack/engineering/shuttle_engine
 	name = "Shuttle Engine Crate"
 	desc = "Through advanced bluespace-shenanigans, our engineers have managed to fit an entire shuttle engine into one tiny little crate. Requires CE access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -863,25 +863,34 @@
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
 /datum/supply_pack/engineering/portable_pumps
-	name = "Portable Pumps"
+	name = "Portable Air Pumps"
 	desc = "A set of spare portable pumps. Perfect for larger atmospheric projects or restocking after a toxins problem goes wrong."
 	cost = 1500
 	contains = list(
 		/obj/machinery/portable_atmospherics/pump,
 		/obj/machinery/portable_atmospherics/pump
 	)
-	crate_name = "portable pump crate"
+	crate_name = "portable air pump crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/engineering/portable_scrubbers
-	name = "Portable Scrubbers"
+	name = "Portable Air Scrubbers"
 	desc = "A set of spare portable scrubbers. Perfect for when plasma 'accidentally' gets into the air supply."
 	cost = 1500
 	contains = list(
 		/obj/machinery/portable_atmospherics/scrubber,
 		/obj/machinery/portable_atmospherics/scrubber
 	)
-	crate_name = "portable scrubber crate"
+	crate_name = "portable air scrubber crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/engineering/huge_scrubber
+	name = "Huge Air Scrubber"
+	desc = "A huge air scrubber. Perfect for cleaning up after you fail to make fusion."
+	cost = 5000
+	access_view = ACCESS_CE
+	contains = list(/obj/machinery/portable_atmospherics/scrubber/huge)
+	crate_name = "huge air scrubber crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/engineering/shuttle_engine


### PR DESCRIPTION
# Document the changes in your pull request

I don't know why this hasn't been added before. There is currently no way to get more air scrubbers. This PR adds the ability to order them (+ pumps) from cargo.

# Changelog

:cl:  
rscadd: Portable scrubbers and pumps can now be ordered from cargo
/:cl:
