### PR TITLE
shooting a darkspawn with an incendiary shotgun round instantly dusts them

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -20,6 +20,12 @@
 	name = "incendiary slug"
 	damage = 20
 
+/obj/item/projectile/bullet/incendiary/shotgun/on_hit(atom/target, blocked = FALSE)
+	if(istype(target, /mob/living/carbon/human)
+		if(isdarkspawn(target)
+			target.Dust()
+		
+
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
 	damage = 5


### PR DESCRIPTION
darkspawn op and needs a nerf. this is balanced and can be countered, just carry a fire extinguisher.