### PR TITLE
reworks the ebow to be cooler and probably less overpowered

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10422,24 +10422,6 @@
 /obj/item/clothing/neck/stripedbluescarf,
 /turf/open/floor/grass,
 /area/centcom/testchamber)
-"awh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/kinetic_accelerator/crossbow/large{
-	pin = /obj/item/firing_pin;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/centcom/testchamber)
 "awi" = (
 /obj/structure/statue/diamond/captain,
 /turf/open/floor/holofloor/grass,
@@ -65244,7 +65226,7 @@ aQo
 aHE
 awS
 aWI
-awh
+aVC
 aWx
 aZw
 aQz

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -6,7 +6,3 @@
 
 /obj/item/ammo_casing/energy/bolt/halloween
 	projectile_type = /obj/item/projectile/energy/bolt/halloween
-
-/obj/item/ammo_casing/energy/bolt/large
-	projectile_type = /obj/item/projectile/energy/bolt/large
-	select_name = "heavy bolt"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -86,7 +86,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow
 	name = "mini energy crossbow"
-	desc = "A weapon favored by syndicate stealth specialists."
+	desc = "A weapon favored by syndicate stealth specialists. Each bolt injects a some poison into the victim."
 	icon_state = "crossbow"
 	item_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL
@@ -95,7 +95,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	weapon_weight = WEAPON_LIGHT
 	obj_flags = 0
-	overheat_time = 20
+	overheat_time = 20 SECONDS
 	holds_charge = TRUE
 	unique_frequency = TRUE
 	can_flashlight = FALSE
@@ -107,21 +107,6 @@
 	icon_state = "crossbow_halloween"
 	item_state = "crossbow"
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/halloween)
-
-/obj/item/gun/energy/kinetic_accelerator/crossbow/large
-	name = "energy crossbow"
-	desc = "A reverse engineered weapon using syndicate technology, substantially bulkier than its illegal counterpart."
-	icon_state = "crossbowlarge"
-	w_class = WEIGHT_CLASS_BULKY
-	materials = list(/datum/material/iron=4000)
-	suppressed = null
-	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
-	pin = null
-	holds_charge = FALSE
-	unique_frequency = FALSE
-	weapon_weight = WEIGHT_CLASS_HUGE
-	overheat_time = 10 SECONDS
-
 
 /obj/item/gun/energy/plasmacutter
 	name = "plasma cutter"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -86,7 +86,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow
 	name = "mini energy crossbow"
-	desc = "A weapon favored by syndicate stealth specialists. Each bolt injects a some poison into the victim."
+	desc = "A weapon favored by syndicate stealth specialists. Each bolt injects some poison into the victim."
 	icon_state = "crossbow"
 	item_state = "crossbow"
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -7,11 +7,11 @@
 /obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(ishuman(target))
-		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 10)
+		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 5)
 		target.reagents.add_reagent(/datum/reagent/toxin/mutagen, 8)
 		target.reagents.add_reagent(/datum/reagent/peaceborg/tire, 8)
 		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 8)
-		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 6)
+		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 4)
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,17 +1,18 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
-	damage_type = TOX
-	nodamage = FALSE
-	stamina = 60
-	eyeblur = 10
-	knockdown = 10
-	slur = 5
+	irradiate = 200
+	pass_flags = PASSGLASS
+
+/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
+	..()
+	if(ishuman(target))
+		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 10)
+		target.reagents.add_reagent(/datum/reagent/toxin/mutagen, 8)
+		target.reagents.add_reagent(/datum/reagent/peaceborg/tire, 8)
+		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 8)
+		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 6)
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"
-
-/obj/item/projectile/energy/bolt/large
-	damage = 30 //we already deal 60 stamina damage per hit

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -8,8 +8,7 @@
 	..()
 	if(ishuman(target))
 		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 5)
-		target.reagents.add_reagent(/datum/reagent/toxin/mutagen, 8)
-		target.reagents.add_reagent(/datum/reagent/peaceborg/tire, 8)
+		target.reagents.add_reagent(/datum/reagent/toxin/relaxant, 8)
 		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 8)
 		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 4)
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -416,6 +416,8 @@
 	..()
 
 /datum/reagent/toxin/polonium/ebow
+	name = "Potent Polonium"
+	description = "A more potent for of Polonium. It is purged quicker from the body, but it is also significantly more deadly."
 	metabolization_rate = 0.8 * REAGENTS_METABOLISM
 	radpower = 80
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -251,7 +251,7 @@
 
 /datum/reagent/toxin/relaxant/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)
-	L.next_move_modifier = L.next_move_modifier / 3
+	L.next_move_modifier /= 3
 
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -417,7 +417,7 @@
 
 /datum/reagent/toxin/polonium/ebow
 	name = "Potent Polonium"
-	description = "A more potent for of Polonium. It is purged quicker from the body, but it is also significantly more deadly."
+	description = "A more potent form of Polonium. It is purged more quickly from the body, but also significantly more deadly."
 	metabolization_rate = 0.8 * REAGENTS_METABOLISM
 	radpower = 80
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -239,6 +239,20 @@
 		M.hallucination += 5
 	return ..()
 
+/datum/reagent/toxin/relaxant
+	name = "Muscle Relaxant"
+	description = "A potent paralytic chemical that causes the patient to move and act slower."
+	toxpwr = 0
+
+/datum/reagent/toxin/relaxant/on_mob_metabolize(mob/living/L)
+	..()
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=2, blacklisted_movetypes=(FLYING|FLOATING))
+	L.next_move_modifier = L.next_move_modifier * 3
+
+/datum/reagent/toxin/relaxant/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(type)
+	L.next_move_modifier = L.next_move_modifier / 3
+
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
 	description = "A harmful toxic mixture to kill plantlife. Do not ingest!"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -395,10 +395,15 @@
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
 	process_flags = ORGANIC | SYNTHETIC
+	var/radpower = 40
 
 /datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/M)
-	M.radiation += 40
+	M.radiation += radpower
 	..()
+
+/datum/reagent/toxin/polonium/ebow
+	metabolization_rate = 0.8 * REAGENTS_METABOLISM
+	radpower = 80
 
 /datum/reagent/toxin/histamine
 	name = "Histamine"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -247,7 +247,7 @@
 /datum/reagent/toxin/relaxant/on_mob_metabolize(mob/living/L)
 	..()
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=2, blacklisted_movetypes=(FLYING|FLOATING))
-	L.next_move_modifier = L.next_move_modifier * 3
+	L.next_move_modifier *= 3
 
 /datum/reagent/toxin/relaxant/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -383,16 +383,6 @@
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/largecrossbow
-	name = "Energy Crossbow"
-	desc = "A reverse-engineered energy crossbow favored by syndicate infiltration teams and carp hunters."
-	id = "largecrossbow"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1500, /datum/material/uranium = 1500, /datum/material/silver = 1500)
-	build_path = /obj/item/gun/energy/kinetic_accelerator/crossbow/large
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
-
 /datum/design/hardlightbow
 	name = "Hardlight Bow"
 	desc = "A modern bow that can fabricate hardlight arrows using an internal energy."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1058,7 +1058,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "hardlightbow", "donksofttoyvendor", "donksoft_refill")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "hardlightbow", "donksofttoyvendor", "donksoft_refill")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -668,14 +668,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Miniature Energy Crossbow"
 	desc = "A short bow mounted across a tiller in miniature. \
 	Small enough to fit into a pocket or slip into a bag unnoticed. \
-	It will synthesize and fire bolts tipped with a debilitating \
-	toxin that will damage and disorient targets, causing them to \
-	slur as if inebriated. It can produce an infinite number \
+	It will synthesize and fire bolts tipped with some debilitating \
+	toxins that will irradiate and tire, causing them to \
+	be silenced. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
-	cost = 10
-	surplus = 50
-	limited_stock = 1
+	cost = 8
+	surplus = 30
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/origami_kit


### PR DESCRIPTION
ebow overpowered, ebow stun combat, stun combat bad. ebow only 10tc. ebow gives skrem an excuse to powercreep. ebow not good.

# Wiki Documentation

Instead of knocking down and doing direct damage, the energy crossbow injects poisons when it hits somebody, as well as dealing 200 radiation.
Specifically:
5u of ebow polonium, it metabolizes much faster but does double the amount of radiation damage per tick
8u of muscle relaxant, it makes you very slow and triples your next_move_multiplier, which most importantly affects how fast you can shoot and attack, making whoever you just shot a lot less good at fighting back.
8u mute toxin, now you can use the ebow as an actual stealthy assassination weapon, yay!
4u anacea, prevents gamers from carrying charcoal to instantly nullify your traitor weapon.

Ebow also has 20 second cooldown because stacking a million units of poison on someone is stupid
Big ebow deleted because it doesnt make sense with these changes

Ebow is also now only 8tc instead of 10, and you can buy more than one, if for some reason you want to.
# Changelog

:cl:  
tweak: ebow reworked to be cooler
rscdel: the big ebow, rip bozo
/:cl:
