### PR TITLE
Chameleon armor applies correctly and cham HIDE flags now update

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -225,6 +225,8 @@
 			var/obj/item/clothing/PCL = picked_item
 			CL.flags_cover = initial(PCL.flags_cover)
 			CL.flags_inv = initial(PCL.flags_inv)
+			if(istype(CL, /obj/item/clothing/mask/chameleon))
+				CL.flags_inv |= HIDEFACE // We always want the chameleon mask hiding the face!
 	if(istype(target, /obj/item/clothing/suit/space/hardsuit/infiltration)) //YOGS START
 		var/obj/item/clothing/suit/space/hardsuit/infiltration/I = target
 		var/obj/item/clothing/suit/space/hardsuit/HS = picked_item
@@ -342,6 +344,7 @@
 	icon_state = "meson"
 	item_state = "meson"
 	resistance_flags = NONE
+	body_parts_covered = HEAD
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -224,6 +224,7 @@
 			var/obj/item/clothing/CL = I
 			var/obj/item/clothing/PCL = picked_item
 			CL.flags_cover = initial(PCL.flags_cover)
+			CL.flags_inv = initial(PCL.flags_inv)
 	if(istype(target, /obj/item/clothing/suit/space/hardsuit/infiltration)) //YOGS START
 		var/obj/item/clothing/suit/space/hardsuit/infiltration/I = target
 		var/obj/item/clothing/suit/space/hardsuit/HS = picked_item
@@ -306,6 +307,7 @@
 	icon_state = "armor"
 	item_state = "armor"
 	blood_overlay_type = "armor"
+	body_parts_covered = CHEST
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -143,6 +143,7 @@
 	var/chameleon_type = null
 	var/chameleon_name = "Item"
 	var/emp_timer
+	var/current_disguise = null
 
 /datum/action/item_action/chameleon/change/Grant(mob/M)
 	if(M && (owner != M))
@@ -226,7 +227,9 @@
 			CL.flags_cover = initial(PCL.flags_cover)
 			CL.flags_inv = initial(PCL.flags_inv)
 			if(istype(CL, /obj/item/clothing/mask/chameleon))
-				CL.flags_inv |= HIDEFACE // We always want the chameleon mask hiding the face!
+				var/obj/item/clothing/mask/chameleon/CH = CL
+				if(CH.vchange)
+					CH.flags_inv |= HIDEFACE // We want the chameleon mask hiding the face to retain voice changing!
 	if(istype(target, /obj/item/clothing/suit/space/hardsuit/infiltration)) //YOGS START
 		var/obj/item/clothing/suit/space/hardsuit/infiltration/I = target
 		var/obj/item/clothing/suit/space/hardsuit/HS = picked_item
@@ -238,6 +241,7 @@
 		//YOGS END
 	target.icon = initial(picked_item.icon)
 	target.on_chameleon_change()
+	current_disguise = picked_item
 
 /datum/action/item_action/chameleon/change/Trigger()
 	if(!IsAvailable())
@@ -497,7 +501,10 @@
 /obj/item/clothing/mask/chameleon/attack_self(mob/user)
 	vchange = !vchange
 	to_chat(user, span_notice("The voice changer is now [vchange ? "on" : "off"]!"))
-
+	if(vchange)
+		flags_inv |= HIDEFACE
+	else if(current_disguise)
+		flags_inv = initial(current_disguise.flags_inv)
 
 /obj/item/clothing/mask/chameleon/drone
 	//Same as the drone chameleon hat, undroppable and no protection

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -503,8 +503,8 @@
 	to_chat(user, span_notice("The voice changer is now [vchange ? "on" : "off"]!"))
 	if(vchange)
 		flags_inv |= HIDEFACE
-	else if(current_disguise)
-		flags_inv = initial(current_disguise.flags_inv)
+	else if(chameleon_action.current_disguise)
+		flags_inv = initial(chameleon_action.current_disguise.flags_inv)
 
 /obj/item/clothing/mask/chameleon/drone
 	//Same as the drone chameleon hat, undroppable and no protection

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -503,8 +503,9 @@
 	to_chat(user, span_notice("The voice changer is now [vchange ? "on" : "off"]!"))
 	if(vchange)
 		flags_inv |= HIDEFACE
-	else if(chameleon_action.current_disguise)
-		flags_inv = initial(chameleon_action.current_disguise.flags_inv)
+	else if(chameleon_action.current_disguise && isitem(chameleon_action.current_disguise))
+		var/obj/item/I = chameleon_action.current_disguise
+		flags_inv = initial(I.flags_inv)
 
 /obj/item/clothing/mask/chameleon/drone
 	//Same as the drone chameleon hat, undroppable and no protection


### PR DESCRIPTION
# Document the changes in your pull request

Chameleon suits (over-armor) now cover the chest (only) instead of nothing

Chameleon glasses now cover the head instead of nothing

##

Chameleon items (most infamously the mask) would retain their HIDE flags no matter their disguise (but updating their coverage flags??). This would lead to things like wearing a cigarette but the facial hair, headset, and any glasses would be hidden, making it incredibly obvious that the person was using chameleon gear but being toed between metashielding and have to deal with that inner turmoil.

Now chameleon items will update their HIDE flags on disguise. Chameleon masks will retain HIDEFACE if the voice changer is on or turned on. Turning off the voice changer will remove HIDEFACE if it is not present on the disguise selected.

# Changelog

:cl:  
bugfix: Chameleon armor and glasses now provide armor correctly
bugfix: Chameleon items will no longer hide parts of your face or body if the disguised item does not. Chameleon masks will always hide your face (but not always headset, glasses, etc) if the voice changer is on.
/:cl:
