### PR TITLE
Fixes frenzy holoparasite spam (again)

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -83,3 +83,4 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		span_italics("You hear a fast wooosh."))
 	guardian.AttackingTarget()
 	target.throw_at(get_edge_target_turf(guardian, get_dir(guardian, target)), world.maxx / 6, 5, guardian, TRUE)
+	Finished()


### PR DESCRIPTION
Now with less sidewinder

# Changelog

:cl:  

bugfix: Frenzy holoparasite ome wa mu shinderu ability no longer spammable

/:cl:
