### PR TITLE
Removes frenzy dash throw (again)

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -43,7 +43,6 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		guardian.forceMove(get_step(get_turf(L), get_dir(L, guardian)))
 		guardian.target = L
 		guardian.AttackingTarget()
-		L.throw_at(get_edge_target_turf(L, get_dir(guardian, L)), world.maxx / 4, 4, guardian, TRUE)
 		next_rush = world.time + 3 SECONDS
 
 /datum/guardian_ability/major/frenzy/StatusTab()


### PR DESCRIPTION
This does NOT affect the point-click ability, just the 3 second cooldown short range dash they ALSO happen to get that does practically the same thing. Lets leave the long throws to the ability with a real cooldown.


# Changelog

:cl:  

rscdel: Frenzy holoparasite dash passive no longer flings you across 25% of the z-level

/:cl:
