### PR TITLE
Moves .38 speed loaders to armory lathe, autolathe .38 now only prints single bullets when hacked

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -628,14 +628,6 @@
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("initial", "Security")
 
-/datum/design/c38
-	name = "Speed Loader (.38)"
-	id = "c38"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20000)
-	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
-
 /datum/design/recorder
 	name = "Universal Recorder"
 	id = "recorder"
@@ -910,6 +902,14 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
+	category = list("hacked", "Security")
+
+/datum/design/c38
+	name = ".38 Bullet"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 3000)
+	build_path = /obj/item/ammo_casing/c38
 	category = list("hacked", "Security")
 
 /datum/design/a357

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -2,11 +2,15 @@
 /////////////////Weapons/////////////////
 /////////////////////////////////////////
 
-/datum/design/c38/sec
+/datum/design/c38_sec
+	name = "Speed Loader (.38)"
+	desc = "Designed to quickly reload revolvers."
 	id = "sec_38"
 	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 20000)
+	build_path = /obj/item/ammo_box/c38
 	category = list("Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 
 /datum/design/c38_hotshot
 	name = "Speed Loader (.38 Hot Shot)"


### PR DESCRIPTION
# Document the changes in your pull request

The .38 is exclusively lethal now rather than less-than-lethal, why is it in the normal lathe?

Same goes for it being simply available at autolathes. To mirror the .357 and to prevent detectives from hoarding .38 loaders without warden/hos clearance, you can only print single bullets now which are much harder to carry (OR you could do it when you need to refill bullets)

I realize this makes that one bounty much harder to do however bounties are stupid and the "security" bounty should theoretically require input from security personally I would just tear up the whole system but it's w/e, there are much better and easier ways to make money

# Wiki Documentation

Significant changes to the Detective page should be made regarding the acquisition and usage of ammunition for the revolver

# Changelog

:cl:  
tweak: Protolathe .38 speed loader design moved to armory lathe
tweak: .38 printed at an autolathe can only be done while hacked, also only prints single bullets
/:cl:
