### PR TITLE
Chameleon glasses no longer provide armor

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -348,7 +348,6 @@
 	icon_state = "meson"
 	item_state = "meson"
 	resistance_flags = NONE
-	body_parts_covered = HEAD
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -348,7 +348,7 @@
 	icon_state = "meson"
 	item_state = "meson"
 	resistance_flags = NONE
-	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 


### PR DESCRIPTION
They have armor, sure. Intended bonus armor, maybe. Glasses SHOULDN'T give extra armor to the head for armor stacking reasons because there are NO other items that go on your eye slot that give you armor and it's kinda weird to make an exception like this.


# Changelog

:cl:  

tweak: Chameleon glasses no longer provide armor

/:cl:
