### PR TITLE
Bomb cores will now only detonate on ex_act if in a bomb case

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -268,7 +268,8 @@
 	var/range_flame = 20
 
 /obj/item/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
-	detonate()
+	if(loc && istype(loc, /obj/machinery/syndicatebomb))
+		detonate()
 
 /obj/item/bombcore/microwave_act(obj/machinery/microwave/M)
 	detonate()


### PR DESCRIPTION
# Document the changes in your pull request

No more C4 pocket maxcaps

# Changelog

:cl:  
tweak: Bomb cores will no longer detonate when exploded unless in a bomb case
/:cl:
