### PR TITLE
Fix bloodsucker blood examines (masquerade and such)

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -492,6 +492,7 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 
 /// Whether we have succesfully hidden out blood level
 #define BLOODSUCKER_HIDE_BLOOD "hide_blood_volume"
+#define BLOODSUCKER_SHOW_BLOOD "show_blood_volume"
 /// 1 tile down
 #define ui_blood_display "WEST:6,CENTER-1:0"
 /// 2 tiles down

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
@@ -137,5 +137,6 @@
 	// Special check: Nosferatu will always be Pale Death
 	if(HAS_TRAIT(src, TRAIT_MASQUERADE))
 		return BLOODSUCKER_HIDE_BLOOD
+	return BLOODSUCKER_SHOW_BLOOD
 	// If a Bloodsucker is malnourished, AND if his temperature matches his surroundings (aka he hasn't fed recently and looks COLD)
 //	return blood_volume < BLOOD_VOLUME_OKAY // && !(bodytemperature <= get_temperature() + 2)

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_integration.dm
@@ -126,21 +126,16 @@
 /// Am I "pale" when examined? - Bloodsuckers on Masquerade will hide this.
 /mob/living/carbon/human/proc/ShowAsPaleExamine(mob/living/user, blood_volume)
 	if(!mind)
-		return BLOODSUCKER_HIDE_BLOOD
+		return BLOODSUCKER_SHOW_BLOOD
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	// Not a Bloodsucker?
 	if(!bloodsuckerdatum)
-		return BLOODSUCKER_HIDE_BLOOD
+		return BLOODSUCKER_SHOW_BLOOD
 	// Blood level too low to be hidden?
 	if(blood_volume <= BLOOD_VOLUME_BAD(user) || bloodsuckerdatum.frenzied)
-		return BLOODSUCKER_HIDE_BLOOD
+		return BLOODSUCKER_SHOW_BLOOD
 	// Special check: Nosferatu will always be Pale Death
 	if(HAS_TRAIT(src, TRAIT_MASQUERADE))
 		return BLOODSUCKER_HIDE_BLOOD
-	if(blood_volume <= BLOOD_VOLUME_SAFE(user)) // Not a lotta blood!
-		if(blood_volume > BLOOD_VOLUME_OKAY(user))
-			return "[p_they(TRUE)] [p_have()] pale skin.\n"
-		else
-			return "<b>[p_they(TRUE)] look[p_s()] like pale death.</b>\n"
 	// If a Bloodsucker is malnourished, AND if his temperature matches his surroundings (aka he hasn't fed recently and looks COLD)
 //	return blood_volume < BLOOD_VOLUME_OKAY // && !(bodytemperature <= get_temperature() + 2)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,7 +253,7 @@
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	// Fulp edit START - Bloodsuckers
 	var/bloodDesc = ShowAsPaleExamine(user, apparent_blood_volume)
-	if(bloodDesc == BLOODSUCKER_SHOW_BLOOD)
+	if(bloodDesc == BLOODSUCKER_SHOW_BLOOD) // BLOODSUCKER_SHOW_BLOOD: Explicitly show the correct blood amount
 		switch(get_blood_state())
 			if(BLOOD_OKAY)
 				msg += "[t_He] [t_has] pale skin.\n"
@@ -261,6 +261,8 @@
 				msg += "<b>[t_He] look[p_s()] like pale death.</b>\n"
 			if(BLOOD_DEAD to BLOOD_SURVIVE)
 				msg += "<span class='deadsay'><b>[t_He] resemble[p_s()] a crushed, empty juice pouch.</b></span>\n"
+	else if(bloodDesc != BLOODSUCKER_HIDE_BLOOD) // BLOODSUCKER_HIDE_BLOOD: Always show full blood
+		msg += bloodDesc // Else: Show custom blood message
 
 	if(bleedsuppress)
 		msg += "[t_He] [t_is] imbued with a power that defies bleeding.\n" // only statues and highlander sword can cause this so whatever

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,15 +253,14 @@
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	// Fulp edit START - Bloodsuckers
 	var/bloodDesc = ShowAsPaleExamine(user, apparent_blood_volume)
-	if(bloodDesc != BLOODSUCKER_HIDE_BLOOD)
-		msg += bloodDesc
-	else switch(get_blood_state())
-		if(BLOOD_OKAY)
-			msg += "[t_He] [t_has] pale skin.\n"
-		if(BLOOD_BAD)
-			msg += "<b>[t_He] look[p_s()] like pale death.</b>\n"
-		if(BLOOD_DEAD to BLOOD_SURVIVE)
-			msg += "<span class='deadsay'><b>[t_He] resemble[p_s()] a crushed, empty juice pouch.</b></span>\n"
+	if(bloodDesc == BLOODSUCKER_SHOW_BLOOD)
+		switch(get_blood_state())
+			if(BLOOD_OKAY)
+				msg += "[t_He] [t_has] pale skin.\n"
+			if(BLOOD_BAD)
+				msg += "<b>[t_He] look[p_s()] like pale death.</b>\n"
+			if(BLOOD_DEAD to BLOOD_SURVIVE)
+				msg += "<span class='deadsay'><b>[t_He] resemble[p_s()] a crushed, empty juice pouch.</b></span>\n"
 
 	if(bleedsuppress)
 		msg += "[t_He] [t_is] imbued with a power that defies bleeding.\n" // only statues and highlander sword can cause this so whatever


### PR DESCRIPTION
# Document the changes in your pull request

Wrapping my head around this seemingly nonsensical code was a chore

The way it used to work is it would basically just always return the bloodsucker's true blood. The code was very misdirecting returning `BLOODSUCKER_HIDE_BLOOD` when that meant to show true blood and when it wasn't returning `BLOODSUCKER_HIDE_BLOOD` it was returning normal blood examines based on your true blood. So basically it did nothing useful and was just confusing.

The way it works now is as follows:
Show true blood volume on examine when returning `BLOODSUCKER_SHOW_BLOOD` (not bloodsucker or not masqueraded)
Show 100% blood volume on examine when returning `BLOODSUCKER_HIDE_BLOOD` (When masqueraded and not low blood or frenzied)
Returning anything else will be treated as a custom message, for when we port Nosferatu or want to do anything else with this regarding custom blood examines

# Changelog

:cl:  
bugfix: Fix bloodsucker blood examines with masquerade
/:cl:
