### PR TITLE
Makes hydrogen burns less stupid

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -132,7 +132,8 @@ nobliumformation = 1001
 	var/initial_trit = air.get_moles(/datum/gas/tritium)// Yogs
 	if(air.get_moles(/datum/gas/oxygen) < initial_trit || MINIMUM_TRIT_OXYBURN_ENERGY > (temperature * old_heat_capacity))// Yogs -- Maybe a tiny performance boost? I'unno
 		burned_fuel = air.get_moles(/datum/gas/oxygen)/TRITIUM_BURN_OXY_FACTOR
-		if(burned_fuel > initial_trit) burned_fuel = initial_trit //Yogs -- prevents negative moles of Tritium
+		if(burned_fuel > initial_trit) 
+			burned_fuel = initial_trit //Yogs -- prevents negative moles of Tritium
 		air.adjust_moles(/datum/gas/tritium, -burned_fuel)
 	else
 		burned_fuel = initial_trit // Yogs -- Conservation of Mass fix
@@ -635,7 +636,7 @@ nobliumformation = 1001
 
 	if(burned_fuel)
 		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)
-		air.adjust_moles(/datum/gas/water_vapor, (burned_fuel / HYDROGEN_BURN_OXY_FACTOR))
+		air.adjust_moles(/datum/gas/water_vapor, burned_fuel)
 
 		cached_results["fire"] += burned_fuel
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -135,6 +135,7 @@ nobliumformation = 1001
 		if(burned_fuel > initial_trit) 
 			burned_fuel = initial_trit //Yogs -- prevents negative moles of Tritium
 		air.adjust_moles(/datum/gas/tritium, -burned_fuel)
+		air.adjust_moles(/datum/gas/tritium, -burned_fuel / 2)	//Yogs - no infinite tiny trit burn please
 	else
 		burned_fuel = initial_trit // Yogs -- Conservation of Mass fix
 		air.set_moles(/datum/gas/tritium, air.get_moles(/datum/gas/tritium) * (1 - 1/TRITIUM_BURN_TRIT_FACTOR)) // Yogs -- Maybe a tiny performance boost? I'unno
@@ -626,12 +627,16 @@ nobliumformation = 1001
 	cached_results["fire"] = 0
 	var/turf/open/location = isturf(holder) ? holder : null
 	var/burned_fuel = 0
+	var/initial_hydrogen = air.get_moles(/datum/gas/hydrogen)	//Yogs
 	if(air.get_moles(/datum/gas/oxygen) < air.get_moles(/datum/gas/hydrogen) || MINIMUM_H2_OXYBURN_ENERGY > air.thermal_energy())
 		burned_fuel = (air.get_moles(/datum/gas/oxygen)/HYDROGEN_BURN_OXY_FACTOR)
+		if(burned_fuel > initial_hydrogen)
+			burned_fuel = initial_hydrogen	//Yogs - prevents negative mols of h2
 		air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)
+		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2) 	//Yogs - only takes half a mol of O2 for a mol of H2O
 	else
-		burned_fuel = (air.get_moles(/datum/gas/hydrogen) * HYDROGEN_BURN_H2_FACTOR)
-		air.adjust_moles(/datum/gas/hydrogen, -(air.get_moles(/datum/gas/hydrogen) / HYDROGEN_BURN_H2_FACTOR))
+		burned_fuel = initial_hydrogen	//Yogs - conservation of mass fix 
+		air.set_moles(/datum/gas/hydrogen, air.get_moles(/datum/gas/hydrogen) * (1 - 1 / HYDROGEN_BURN_H2_FACTOR))	// Yogs - see trit burn
 		air.adjust_moles(/datum/gas/oxygen, -air.get_moles(/datum/gas/hydrogen))
 
 	if(burned_fuel)


### PR DESCRIPTION
Important note: tritium and hydrogen burns are still really stupid and could be made less stupid but I don't want to mess with the underlying mechanics of the COOL gas too much.

Basically, this makes hydrogen burns mimic tritium burns except with significantly lower temperature because it now also makes a metric buttload of water vapor while burning. In testing, temperatures seemed to reach around 12,000-13,000 degrees with a 50/50 mix (compared to tritium's >100,000). Toxins mains can now DESPAIR because their funny super high temperature burn stupidity has been made REASONABLE! Use exotic gases to make funny bombs not the most abundant element in the universe! Why are we even researching plasma if hydrogen is better?!



# Wiki Documentation

Uhhhh something about hydrogen being just worse non-radioactive tritium (or tritium being spicier hydrogen i guess)

# Changelog

:cl:  

tweak: Hydrogen is now just shittier tritium as it should be
bugfix: hydrogen/tritium burns will now actually consume oxygen instead of fabricating it out of thin air (haha get it because it's a gas)

/:cl:
