### PR TITLE
[ADMIN] ert uplinks are less likely to get you admin complainted for using

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -1,7 +1,9 @@
 GLOBAL_LIST_EMPTY(uplinks)
 
 #define PEN_ROTATIONS 2
-
+#define NT_ERT_TROOPER 1
+#define NT_ERT_MEDIC 2
+#define NT_ERT_ENGINEER 3
 /**
  * Uplinks
  *
@@ -33,6 +35,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	///Instructions on how to access the uplink based on location
 	var/unlock_text
 	var/list/previous_attempts
+	var/nt_uplink_type = null //for NT uplinks to enforce team variety.
 
 /datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, datum/game_mode/_gamemode, starting_tc = TELECRYSTALS_DEFAULT)
 	if(!isitem(parent))
@@ -177,6 +180,10 @@ GLOBAL_LIST_EMPTY(uplinks)
 							break
 					if(is_inaccessible)
 						continue
+			if(istype(I, /datum/uplink_item/nt))
+				var/datum/uplink_item/nt/M = I
+				if(nt_uplink_type != null && M.required_ert_uplink != null && nt_uplink_type != M.required_ert_uplink) //Different roles in ERT uplinks have different equipment avaliable
+					continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.manufacturer && user.mind.is_employee(I.manufacturer) ? CEILING(I.cost * 0.8, 1) : I.cost,
@@ -360,3 +367,14 @@ GLOBAL_LIST_EMPTY(uplinks)
 	name = "nanotrasen uplink"
 	js_ui = "NTUplink"
 	currency = /obj/item/stack/ore/bluespace_crystal/refined/nt
+
+/datum/component/uplink/nanotrasen/trooper
+	nt_uplink_type = NT_ERT_TROOPER
+/datum/component/uplink/nanotrasen/medic
+	nt_uplink_type = NT_ERT_MEDIC
+/datum/component/uplink/nanotrasen/engineer
+	nt_uplink_type = NT_ERT_ENGINEER
+
+#undef NT_ERT_TROOPER
+#undef NT_ERT_MEDIC
+#undef NT_ERT_ENGINEER

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -114,7 +114,7 @@
 
 /datum/ert/uplinked
 	leader_role = /datum/antagonist/ert/common/leader
-	roles = list(/datum/antagonist/ert/common)
+	roles = list(/datum/antagonist/ert/common/trooper,/datum/antagonist/ert/common/medic,/datum/antagonist/ert/common/engineer)
 	rename_team = "Uplinked Emergency Response Team"
 	polldesc = "an Uplink-Equipped ERT"
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -582,6 +582,13 @@
 
 				// Equip uplink
 				var/obj/item/ntuplink/upl = new ertemplate.uplinktype(ERTOperative, ERTOperative.key)
+				if(istype(ert_antag, /datum/antagonist/ert/common/trooper))
+					upl.nt_datum = /datum/component/uplink/nanotrasen/trooper
+				else if(istype(ert_antag, /datum/antagonist/ert/common/medic))
+					upl.nt_datum = /datum/component/uplink/nanotrasen/medic
+				else if(istype(ert_antag, /datum/antagonist/ert/common/engineer))
+					upl.nt_datum = /datum/component/uplink/nanotrasen/engineer
+				upl.finalize()
 				if(istype(upl))
 					ERTOperative.equip_to_slot_or_del(upl, SLOT_IN_BACKPACK)
 					ert_team.uplink_type = ertemplate.uplinktype // Type path

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -112,6 +112,16 @@
 /datum/antagonist/ert/common
 	outfit = /datum/outfit/ert
 
+/datum/antagonist/ert/common/trooper
+	outfit = /datum/outfit/ert
+
+/datum/antagonist/ert/common/medic
+	outfit = /datum/outfit/ert
+	name = "Emergency Response Medic"
+
+/datum/antagonist/ert/common/engineer
+	name = "Emergency Response Engineer"
+
 /datum/antagonist/ert/common/leader
 	name = "Emergency Response Commander"
 	role = "Commander"

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -91,12 +91,16 @@
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_SMALL
-
+	var/nt_datum = /datum/component/uplink/nanotrasen //Component for the uplink to use.
 	var/wc_start = 20 // Starting warpcrystal amount
+	var/datum_owner //i dont know what this does and i'm too afraid to ask
 
 /obj/item/ntuplink/Initialize(mapload, owner)
 	. = ..()
-	AddComponent(/datum/component/uplink/nanotrasen, owner, FALSE, TRUE, null, wc_start)
+	datum_owner = owner
+	
+/obj/item/ntuplink/proc/finalize()
+	AddComponent(nt_datum, datum_owner, FALSE, TRUE, null, wc_start)
 
 /obj/item/ntuplink/official
 	name = "centcom official uplink"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2584,32 +2584,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /// NT Uplink items
 /datum/uplink_item/nt
-	category = "Warpcrystals"
 	surplus = 0 // Chance of being included in the surplus crate.
 	include_uplinks = list("NTUplink")
 	illegal_tech = FALSE
-
-/datum/uplink_item/nt/telecrystal
-	name = "1 Raw Warpcrystal"
-	desc = "A warpcrystal in its rawest and purest form; can be utilized on active uplinks to increase their warpcrystal count."
-	item = /obj/item/stack/ore/bluespace_crystal/refined/nt
-	cost = 1
-	purchase_log_vis = FALSE
-	cant_discount = TRUE
-
-/datum/uplink_item/nt/telecrystal/five
-	name = "5 Raw Warpcrystals"
-	desc = "Five warpcrystals in their rawest and purest form; can be utilized on active uplinks to increase their warpcrystal count."
-	item = /obj/item/stack/ore/bluespace_crystal/refined/nt/five
-	cost = 5
-	cant_discount = TRUE
-
-/datum/uplink_item/nt/telecrystal/twenty
-	name = "20 Raw Warpcrystals"
-	desc = "Twenty warpcrystals in their rawest and purest form; can be utilized on active uplinks to increase their warpcrystal count."
-	item = /obj/item/stack/ore/bluespace_crystal/refined/nt/twenty
-	cost = 20
-	cant_discount = TRUE
+	cant_discount = TRUE //no i dont want amber erts with tasers thanks
+	var/required_ert_uplink = null //Do we need a specific uplink? Defaults to universal.
 
 /datum/uplink_item/nt/energy_weps
 	category = "Energy Weapons"
@@ -2619,14 +2598,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A standard energy gun with disable and laser modes equipped."
 	item = /obj/item/gun/energy/e_gun
 	cost = 3
-	limited_stock = 3
+	limited_stock = 2 //One for you and a friend, no infinite guns though
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/energy_weps/tac_egun
 	name = "Tactical Energy Gun"
 	desc = "A military-grade augmented energy gun, fitted with a tasing mode."
 	item = /obj/item/gun/energy/e_gun/stun
-	cost = 8
-	limited_stock = 2
+	cost = 20
+	limited_stock = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/energy_weps/mini_egun
 	name = "Miniature Energy Gun"
@@ -2641,19 +2622,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/gun/ballistic/automatic/laser
 	cost = 8
 	limited_stock = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/energy_weps/m1911
 	name = "Spur"
 	desc = "A legendary slowly self-charging pistol with massive recoil that deals more damage the more charge it has."
 	item = /obj/item/gun/energy/polarstar/spur
 	cost = 10
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/energy_weps/pulsecarbine
 	name = "Pulse Carbine"
 	desc = "A severely lethal energy carbine that fires additionaly fires pulse rounds. Must be recharged instead of reloaded."
 	item = /obj/item/gun/energy/pulse/carbine
 	cost = 45
-	cant_discount = TRUE
+	required_ert_uplink = 1 //Medics and engies can buy pulse pistols
 
 /datum/uplink_item/nt/energy_weps/pulsepistol
 	name = "Pulse Pistol"
@@ -2661,17 +2644,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Must be recharged instead of reloaded."
 	item = /obj/item/gun/energy/pulse/pistol
 	cost = 35
-	cant_discount = TRUE
 
 /datum/uplink_item/nt/energy_weps/pulsedestroyer
 	name = "Pulse Destroyer"
 	desc = "LOG-ENTRY ERROR. DEATH. DEATH. DEATH. KILL. DESTROY. NONE LEFT ALIVE."
 	item = /obj/item/gun/energy/pulse/destroyer
 	cost = 100
-	cant_discount = TRUE
 
 /datum/uplink_item/nt/ball_weps
 	category = "Ballistic Weapons"
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/ball_weps/boarder
 	name = "NT-ARG 'Boarder' Rifle"
@@ -2698,12 +2680,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A classic 2-round burst carbine with a number of ammo options. Chambered in 4.6x30mm."
 	item = /obj/item/gun/ballistic/automatic/wt550
 	cost = 5
+	required_ert_uplink = null
 
 /datum/uplink_item/nt/ball_weps/m1911
 	name = "M1911"
 	desc = "A classic .45 sidearm with a small magazine capacity."
 	item = /obj/item/gun/ballistic/automatic/pistol/m1911
 	cost = 3
+	required_ert_uplink = null
 
 /datum/uplink_item/nt/ball_weps/tommygun
 	name = "Thompson SMG"
@@ -2714,12 +2698,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/nt/ammo
 	category = "Ammunition"
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/ammo/recharger
 	name = "Weapon Recharger"
 	desc = "Standard issue energy weapon recharger. Must be anchored in an APC-powered area."
 	item = /obj/machinery/recharger
 	cost = 2
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/ammo/powerpack
 	name = "Power Pack"
@@ -2779,7 +2765,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = ".45 Handgun Magazine"
 	desc = "An additional 8-round .45 magazine; suitable for use with the M1911."
 	item = /obj/item/ammo_box/magazine/m45
-	cost = 1
+	cost = 2
+	required_ert_uplink = null
 
 /datum/uplink_item/nt/ammo/saberammo
 	name = "9mm Magazine"
@@ -2802,24 +2789,26 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "4.6x30mm Magazine"
 	desc = "An additional 22-round 4.6x30mm magazine; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9
-	cost = 1
+	cost = 2
+	required_ert_uplink = null
 
 /datum/uplink_item/nt/ammo/wt/ap
 	name = "4.6x30mm AP Magazine"
 	desc = "An additional 22-round 4.6x30mm magazine loaded with armor-piercing rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtap
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/nt/ammo/wt/ic
 	name = "4.6x30mm Incendiary Magazine"
 	desc = "An additional 22-round 4.6x30mm magazine loaded with incendiary rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtic
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/nt/ammo/wt/r
 	name = "4.6x30mm Rubber Shot Magazine"
 	desc = "An additional 22-round 4.6x30mm magazine loaded with less-lethal rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtr
+	cost = 1
 
 /datum/uplink_item/nt/cqc
 	category = "Close Quarters Combat"
@@ -2830,18 +2819,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			pocketed when inactive."
 	item = /obj/item/melee/transforming/energy/sword/saber
 	cost = 8
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/eshield
 	name = "Energy Shield"
 	desc = "A shield that blocks all energy projectiles but is useless against physical attacks."
 	item = /obj/item/shield/energy
 	cost = 16
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/ntmantisblade
 	name = "H.E.P.H.A.E.S.T.U.S. Mantis Blades"
 	desc = "A pair of retractable arm-blade implants. Activating both will let you double-attack."
 	item = /obj/item/storage/briefcase/nt_mantis
-	cost = 7
+	cost = 14
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/sblade
 	name = "Switchblade"
@@ -2854,24 +2846,27 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A manual that teaches a single user tactical Close-Quarters Combat before self-destructing."
 	item = /obj/item/book/granter/martial/cqc
 	cost = 13
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/teleshield
 	name = "Telescopic Shield"
 	desc = "A foldable shield that blocks attacks when active but can break."
 	item = /obj/item/shield/riot/tele
 	cost = 3
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/stunbaton
 	name = "Stun Baton"
 	desc = "A robust charged baton that will swiftly take down most criminals."
 	item = /obj/item/melee/baton/loaded
 	cost = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/cqc/telebaton
 	name = "Telescopic Baton"
 	desc = "A foldable baton that doesn't run on charge. Takes more hits to down, but swings faster."
 	item = /obj/item/melee/classic_baton/telescopic
-	cost = 1
+	cost = 1 //Engies and medics can buy these, like normal ERTs!
 
 /datum/uplink_item/nt/cqc/flash
 	name = "Flash"
@@ -2889,6 +2884,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			minimum setting of 10 seconds."
 	item = /obj/item/grenade/plastic/c4
 	cost = 1
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/support/medkit
 	name = "Medic Kit"
@@ -2904,6 +2900,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			and other supplies helpful for a field medic."
 	item = /obj/item/storage/firstaid/tactical
 	cost = 4
+	required_ert_uplink = 2 //Only real medics get the good stuff
 
 /datum/uplink_item/nt/support/medbeam
 	name = "Medbeam Gun"
@@ -2918,30 +2915,35 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Comes pre-stocked with every engineering tool you'll ever need."
 	item = /obj/item/storage/belt/utility/full/engi
 	cost = 1
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/support/rcd
 	name = "Rapid Construction Device"
 	desc = "Standard RCD that can repair or destroy structures very quickly. Holds up to 160 matter units."
 	item = /obj/item/construction/rcd/loaded
 	cost = 2
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/support/combatrcd
 	name = "Industrial RCD"
 	desc = "Heavy combat RCD that holds up to 500 matter units."
 	item = /obj/item/construction/rcd/combat
 	cost = 4
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/support/rcdammo
 	name = "Compressed Matter Cartridge"
 	desc = "Highly compressed matter that restores 160 matter units on an RCD."
 	item = /obj/item/rcd_ammo
 	cost = 1
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/support/foamnades
 	name = "Box of Smart Metal Foam Grenades"
 	desc = "A box of 7 smart metal foam grenades to patch hull breaches with."
 	item = /obj/item/storage/box/smart_metal_foam
 	cost = 1
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/hardsuit
 	category = "Armor & Hardsuits"
@@ -2975,12 +2977,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A bulky suit that protects you againt melee attacks but not much else."
 	item = /obj/item/clothing/suit/armor/riot
 	cost = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/hardsuit/riothelmet
 	name = "Riot Helmet"
 	desc = "A helmet that protects you againt melee attacks but not much else."
 	item = /obj/item/clothing/head/helmet/riot
 	cost = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/hardsuit/cmd
 	name = "ERT Commander Hardsuit"
@@ -2994,18 +2998,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Make them fear the long arm of law."
 	item = /obj/item/clothing/suit/space/hardsuit/ert/sec
 	cost = 5
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/hardsuit/engi
 	name = "ERT Engineering Hardsuit"
 	desc = "HOW DID YOU DELAMINATE THE SM 5 MINUTES IN?"
 	item = /obj/item/clothing/suit/space/hardsuit/ert/engi
 	cost = 5
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/hardsuit/med
 	name = "ERT Medical Hardsuit"
 	desc = "Dying is illegal."
 	item = /obj/item/clothing/suit/space/hardsuit/ert/med
 	cost = 5
+	required_ert_uplink = 2
 
 /datum/uplink_item/nt/hardsuit/ds
 	name = "MK.III SWAT Suit"
@@ -3029,18 +3036,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Standard issue security gear, all in a stylish belt."
 	item = /obj/item/storage/belt/security/full
 	cost = 2
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/gear/flashbangs
 	name = "Box of Flashbangs"
 	desc = "A box of 7 flashbangs to make the crew hate you."
 	item = /obj/item/storage/box/flashbangs
 	cost = 2
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/gear/handcuffs
 	name = "Box of Handcuffs"
 	desc = "A box of 7 pairs of handcuffs to keep prisoners in line."
 	item = /obj/item/storage/box/handcuffs
 	cost = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/gear/bowman
 	name = "Bowman Headset"
@@ -3053,18 +3063,21 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pair of sunglasses fitted with a security HUD."
 	item = /obj/item/clothing/glasses/hud/security/sunglasses 
 	cost = 1
+	required_ert_uplink = 1
 
 /datum/uplink_item/nt/gear/medhud
 	name = "Medical HUDglasses"
 	desc = "A pair of sunglasses fitted with a medical HUD."
 	item = /obj/item/clothing/glasses/hud/health/sunglasses
 	cost = 1
+	required_ert_uplink = 2
 
 /datum/uplink_item/nt/gear/mesonhud
 	name = "Meson Sunglasses"
 	desc = "A pair of sunglasses fitted with meson technology."
 	item = /obj/item/clothing/glasses/meson/sunglasses
 	cost = 1
+	required_ert_uplink = 3
 
 /datum/uplink_item/nt/gear/thermalhud
 	name = "Optical Thermal Scanner"


### PR DESCRIPTION
# Document the changes in your pull request

normal erts have some semblance of balance, for one they can't get 1 dollar taser guns, traitor martial arts and energy swords. they're also designed to have different roles, eg medics engineers soldiers and commanders are all seperate.

basically, now the role separation exists for uplinked erts, a lot of the dumb overpowered stuff is now limited to the troopers, who in exchange cannot buy medical or engineering stuff. this is to prevent hit squads of tasers from rolling down and shitting on everything because tasers tend to do that.

discounts deleted completely because they were stupid and random chance on a fucking admin spawn is pretty frustrating for an admin who's trying to create a balanced opposition, 20 motherfuckers with cqc and eswords is not a balanced opposition.

some prices also changed, notably placing tasers at 20wc so only really red can get them, which is intended. mantis blades also increased in price because they're a stupid meta item due to powercreep and i hate them.

# Changelog

:cl:  
tweak: different roles added to uplinked ERTs, your role determines what you can and cannot buy
tweak: some op shit has had its price increased for uplinked erts
tweak: uplinked erts can no longer get discounts, period.
tweak: uplinked erts can't eject wcs from their uplinks anymore
/:cl:
