### PR TITLE
Makes geiger counter not bludgeon

### DIFF
--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -18,6 +18,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = NOBLUDGEON
 	materials = list(/datum/material/iron = 150, /datum/material/glass = 150)
 
 	var/grace = RAD_GRACE_PERIOD


### PR DESCRIPTION
# Document the changes in your pull request
If you use the geiger counter on someone, it will play the hitting/bludgeon animation. This happens even if you are on help intent

# Changelog

:cl:  
bugfix: You will now stop hitting people when using the geiger counter
/:cl:
