### PR TITLE
buffs ling chems

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -21,10 +21,10 @@
 	var/dna_max = 6 //How many extra DNA strands the changeling can store for transformation.
 	var/absorbedcount = 0
 	var/trueabsorbs = 0//dna gained using absorb, not dna sting
-	var/chem_charges = 20
-	var/chem_storage = 75
-	var/chem_recharge_rate = 1
-	var/chem_recharge_slowdown = 0
+	var/chem_charges = 50 // chems we have on spawn
+	var/chem_storage = 150 // max chems
+	var/chem_recharge_rate = 5 // how fast we restore chems
+	var/chem_recharge_slowdown = 0 // how much is our chem restore rate hampered (keep at 0)
 	var/sting_range = 2
 	var/changelingID = "Changeling"
 	var/geneticdamage = 0

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -12,7 +12,7 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling.mimicing)
 		changeling.mimicing = ""
-		changeling.chem_recharge_slowdown -= 0.5
+		changeling.chem_recharge_slowdown -= 1
 		to_chat(user, span_notice("We return our vocal glands to their original position."))
 		return
 
@@ -21,7 +21,7 @@
 		return
 	..()
 	changeling.mimicing = mimic_voice
-	changeling.chem_recharge_slowdown += 0.5
+	changeling.chem_recharge_slowdown += 1
 	to_chat(user, span_notice("We shape our glands to take the voice of <b>[mimic_voice]</b>, this will slow down regenerating chemicals while active."))
 	to_chat(user, span_notice("Use this power again to return to our original voice and return chemical production to normal levels."))
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -473,7 +473,7 @@
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
 	suit_name_simple = "flesh shell"
 	helmet_name_simple = "space helmet"
-	recharge_slowdown = 0.5
+	recharge_slowdown = 1
 	blood_on_castoff = 1
 
 /obj/item/clothing/suit/space/changeling
@@ -521,7 +521,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = 1
-	recharge_slowdown = 0.25
+	recharge_slowdown = 0.5
 	xenoling_available = FALSE
 
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
+++ b/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
@@ -17,11 +17,11 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(!receptors_active)
 		to_chat(user, span_warning("We search for the scent of any nearby changelings."))
-		changeling.chem_recharge_slowdown += 0.5
+		changeling.chem_recharge_slowdown += 1
 		user.apply_status_effect(/datum/status_effect/agent_pinpointer/changeling)
 	else
 		to_chat(user, span_notice("We stop searching for now."))
-		changeling.chem_recharge_slowdown -= 0.5
+		changeling.chem_recharge_slowdown -= 1
 		user.remove_status_effect(/datum/status_effect/agent_pinpointer/changeling)
 
 	receptors_active = !receptors_active


### PR DESCRIPTION
# Document the changes in your pull request

Changelings have an out-of-place chokehold on their resource management compared to any other antagonist.

As a changeling, you can expect to use maybe 2-3 abilities in a given fight before running out. Fleshmend, armblade, and adrenaline cuts you down from full chems to 5 chems left.

You then, after running the bare minimum of your kit, have to go and wait for several minutes just to get back to full charge.

Fuck you if you want to retract and armblade and pull it back out for whatever reason, half your chems are *zoop*. There is no wiggle room and it serves to make changeling one of the most needlessly difficult antagonists to play. Having more chems isn't going to make them significantly stronger, they will just have more elasticity to make their plays.

This change

- doubles max default chem storage 75->150
- quintuples default chem restoration rate 1->5
- doubles most if not all chem restoration hinderances (pheromones, space suit, vocal coords)

# Changelog

:cl:  
tweak: significantly buffed ling chems
/:cl:
