### PR TITLE
Changeling adrenal chem now reduces stamina damage (1->30)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1310,7 +1310,7 @@
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
 	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-1, 0)
+	M.adjustStaminaLoss(-30, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

The hero reads a most unsettling passage

I did a similar thing in #8254 but missed this

Lingkt adrenals are now good for resisting disabler spam

# Changelog

:cl:  
tweak: Changeling adrenals now heal more stamina damage
/:cl:
