### PR TITLE
Malf AI core balance changes

### DIFF
--- a/code/game/gamemodes/malfunction/malf.dm
+++ b/code/game/gamemodes/malfunction/malf.dm
@@ -38,9 +38,20 @@
 /datum/game_mode/malf/post_setup()
 	for(var/mob/living/silicon/ai/AI in GLOB.ai_list) //triumvirate AIs ride for free. Oh well, it's basically an event in that case
 		AI.mind.add_antag_datum(/datum/antagonist/traitor/malf)
-
+	addtimer(CALLBACK(src, .proc/auto_call_shuttle), 30 MINUTES) // Auto call shuttle after 30 minutes, let the crew know whats up
 	gamemode_ready = TRUE
 	. = ..()
+
+/datum/game_mode/malf/proc/auto_call_shuttle()
+	var/all_dead = TRUE
+	for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
+		if(AI.stat != DEAD && is_traitor(AI)) // Is there a living malf? Call shuttle if so
+			all_dead = FALSE
+	if(all_dead) // Don't call shuttle if there in no living malf
+		return
+	priority_announce(readable_corrupted_text("Hostile runtimes detected in all station systems. Evacuation or deactivation of station AI recommended."))
+	if(EMERGENCY_IDLE_OR_RECALLED)
+		SSshuttle.emergency.request(null, set_coefficient=1)
 
 /datum/game_mode/malf/make_antag_chance()
 	return FALSE //no latejoins for you

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
 
 /datum/AI_Module/destructive/nuke_station/can_use(mob/living/silicon/ai/AI)
-	return !AI.mind.has_antag_datum(/datum/antagonist/hijacked_ai)
+	return FALSE //!AI.mind.has_antag_datum(/datum/antagonist/hijacked_ai)
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"

--- a/code/modules/antagonists/traitor/equipment/module_picker.dm
+++ b/code/modules/antagonists/traitor/equipment/module_picker.dm
@@ -60,6 +60,8 @@
 			"items" = (category == selected_cat ? list() : null))
 		for(var/module in possible_modules[category])
 			var/datum/AI_Module/AM = possible_modules[category][module]
+			if(istype(user, /mob/living/silicon/ai) && !AM.can_use(user))
+				continue
 			cat["items"] += list(list(
 				"name" = AM.name,
 				"cost" = AM.cost,
@@ -98,6 +100,8 @@
 	if(!AI || AI.stat == DEAD)
 		return
 	if(AM.cost > processing_time)
+		return
+	if(!AM.can_use(AI))
 		return
 
 	var/datum/action/innate/ai/action = locate(AM.power_type) in AI.actions


### PR DESCRIPTION
# Document the changes in your pull request

After a recent discussion, I realized that Malf AI had some flaws in its pursuances.

##

The AI is supposed to make the station uninhabitable, kill everyone, and ensure no one gets on the shuttle, but doomsday existing circumvents this.

Myself and a few others agreed that doomsday was plainly bad for the game. It basically runs the players against the clock to either kill AI or, through inaction, simply die and lose.

The value I take from Malf AI is those tense, eerie moments where the comms are dead, the halls are burning, and you're hobbling on your last legs through maint looking for survivors, and figuring out how you're going to make it home today. Doomsday circumvents this kind of interaction entirely.

##

The second change is forcing a shuttle call (with an obvious message) 30 minutes after the malf gamemode is finished setting up (so in reality it'll be called at like ~33 minutes)

This is to encourage AIs to act sooner rather than prolonging what is effectively extended, as well as restricting their time for hacking APCs.

##

reply to "this makes AI weaker!"

```
i really
do not give a shit
doomsday in any balance state is shitty
and extended in any balance state is shitty
them existing to buff the AI is not a valid argument
```

# Changelog

:cl:  
tweak: Disabled doomsday
tweak: Malf AI will now auto call shuttle 30 minutes into the round
/:cl:
