### PR TITLE
Fix runtime in give keybind

### DIFF
--- a/yogstation/code/modules/keybindings/bindings_mob.dm
+++ b/yogstation/code/modules/keybindings/bindings_mob.dm
@@ -61,8 +61,8 @@
 			user.body_l_leg()
 			return
 		if(ACTION_GIVE)
-			var/mob/living/carbon/O = src
-			if(O)
+			if (iscarbon(src))
+				var/mob/living/carbon/O = src
 				O.give()
 			return
 


### PR DESCRIPTION
# Document the changes in your pull request

If you press the ``give`` keybind as a ghost, it will cause a runtime.


# Changelog

:cl:  
bugfix: Fixed a runtime in the 'give' keybind
/:cl:
