### PR TITLE
Fix non-syndie cardboard cutouts not having a tint

### DIFF
--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -114,7 +114,7 @@
 	alpha = 255
 	icon = initial(icon)
 	if(!deceptive)
-		add_atom_colour("#FFD7A7", FIXED_COLOUR_PRIORITY)
+		add_atom_colour("#FFD7A7", ADMIN_COLOUR_PRIORITY)
 	switch(new_appearance)
 		if("Assistant")
 			name = "[pick(GLOB.first_names_male)] [pick(GLOB.last_names)]"


### PR DESCRIPTION
# Document the changes in your pull request

The WASHABLE_COLOUR_PRIORITY (applied from the spray can used to skin it) has higher priority than FIXED_COLOUR_PRIORITY

![](https://i.imgur.com/Fxd1ptK.png)

# Changelog

:cl:  
bugfix: fixed non-syndie cardboard cutouts not having a tint
/:cl:
