### PR TITLE
what if we put maint access to cloning on box that would be weird 😳

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -21342,6 +21342,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"erS" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "erX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23162,6 +23167,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"fcI" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera{
+	c_tag = "Genetics Cloning Lab";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "fcY" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -32059,14 +32077,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"iOO" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "iOP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -37065,6 +37075,17 @@
 /area/construction)
 "ldW" = (
 /turf/template_noop,
+/area/maintenance/aft)
+"leh" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Genetics Maintenance";
+	req_access_txt = "5;9;68"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "leo" = (
 /obj/structure/window/reinforced{
@@ -48424,14 +48445,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"pSS" = (
-/obj/effect/landmark/start/geneticist,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "pSY" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -54510,6 +54523,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"szN" = (
+/obj/effect/landmark/start/geneticist,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "sAl" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
@@ -60334,6 +60362,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uUo" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "uUH" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -62074,16 +62106,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"vHw" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning Lab";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "vHH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -62153,14 +62175,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vIh" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "vIj" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -109382,7 +109396,7 @@ hUj
 gru
 lEC
 kYK
-oOo
+wUw
 ufj
 bNd
 saZ
@@ -109637,9 +109651,9 @@ oBk
 nLu
 gVP
 ruc
-vHw
+fcI
 kYK
-wUw
+vYi
 ufj
 bNd
 irH
@@ -109894,9 +109908,9 @@ uHA
 mIj
 pEC
 ruc
-vIh
-kYK
-vYi
+uUo
+leh
+bAw
 ufj
 bNd
 pQc
@@ -110151,7 +110165,7 @@ fQz
 uvN
 gxA
 ruc
-pSS
+szN
 kYK
 wLA
 ufj
@@ -110410,7 +110424,7 @@ bnG
 edM
 oob
 kYK
-iOO
+erS
 ufj
 bNd
 bNd


### PR DESCRIPTION
# Document the changes in your pull request

genetics lost maint access on boxstation when they added the large hallway all the way to xenobio. this makes it so certain assaults on genetics are cucked massively making genetics and cloning virtually unassailable.

![image](https://user-images.githubusercontent.com/5091394/209899903-0503c6df-0a66-4480-96dc-b1ac47a277dd.png)

yes im aware this isnt into genetics but cloning, and that there is a door 6 tiles away. this removes a door from the equation. there's not really a way to give access to genetics (in any useful way) from maint with this setup unless cloning and genetics were flipped 😳 (maybe later) so this is hte next best solution.

if I get ratio'd then so be it

# Wiki Documentation

maint door in cloning on box

# Changelog

:cl:  
mapping: Boxstation cloning is now accessible from maint
/:cl:
