### PR TITLE
Makes crew monitor venry smol

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -148,7 +148,7 @@ export const HealthStat = props => {
   return (
     <Box
       inline
-      width={4}
+      width={2}
       color={COLORS.damageType[type]}
       textAlign="center">
       {value}
@@ -167,8 +167,8 @@ export const CrewConsole = (props, context) => {
   return (
     <Window
       title="Crew Monitor"
-      width={1000}
-      height={800}
+      width={750}
+      height={400}
       resizable>
       <Window.Content scrollable>
         <CrewConsoleContent />
@@ -223,7 +223,10 @@ export const CrewConsoleContent = (props, context) => {
               )}
             </Table.Row>
             {sensors.map(sensor => (
-              <Table.Row key={sensor.name}>
+              <Table.Row key={sensor.name} fontSize={0.85} style={{
+                'border': '1px solid',
+                'border-color': '#303030',
+              }}>
                 <Table.Cell
                   bold={jobIsHead(sensor.ijob)}
                   color={jobToColor(sensor.ijob)}>

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -226,6 +226,7 @@ export const CrewConsoleContent = (props, context) => {
               <Table.Row key={sensor.name} fontSize={0.85} style={{
                 'border': '1px solid',
                 'border-color': '#303030',
+                'font-family': 'Verdana, sans-serif',
               }}>
                 <Table.Cell
                   bold={jobIsHead(sensor.ijob)}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -225,7 +225,7 @@ export const CrewConsoleContent = (props, context) => {
             {sensors.map(sensor => (
               <Table.Row key={sensor.name} fontSize={0.85} style={{
                 'border': '1px solid',
-                'border-color': '#303030',
+                'border-color': '#202020',
                 'font-family': 'Verdana, sans-serif',
               }}>
                 <Table.Cell

--- a/tgui/packages/tgui/interfaces/NtosCrewMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCrewMonitor.js
@@ -6,8 +6,8 @@ export const NtosCrewMonitor = (props, context) => {
   const { act, data } = useBackend(context);
   return (
     <NtosWindow
-      width={1000}
-      height={800}
+      width={775}
+      height={415}
       resizable>
       <NtosWindow.Content scrollable>
         <CrewConsoleContent />


### PR DESCRIPTION
# Document the changes in your pull request

Crew monitor no longer taking up your entire screen on rounds with more than 20 people

![](https://i.imgur.com/sIoctmi.png)

# Changelog

:cl:  
tweak: Made crew monitor UI more compact
/:cl:
