### PR TITLE
Cleaving Saw buff + Saw Bleed passive damage

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -463,6 +463,7 @@
 		qdel(src)
 	else
 		add_bleed(-1)
+		owner.apply_damage(10)
 
 /datum/status_effect/saw_bleed/proc/add_bleed(amount)
 	owner.cut_overlay(bleed_overlay)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -462,8 +462,11 @@
 	if(owner.stat == DEAD)
 		qdel(src)
 	else
+		if(faction_check(owner.faction, list("mining", "boss")))
+			owner.apply_damage(10)
+		else //This is so that it doesn't murder humans drastically as there are none in either faction.
+			owner.apply_damage(2)
 		add_bleed(-1)
-		owner.apply_damage(10)
 
 /datum/status_effect/saw_bleed/proc/add_bleed(amount)
 	owner.cut_overlay(bleed_overlay)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -955,10 +955,10 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 
 	if(B.needs_to_bleed)
 		to_chat(user, span_notice("You drink the blood spilled from [target] healing your wounds!"))
-		user.adjustBruteLoss(-8)
-		user.adjustFireLoss(-8)
-		user.adjustToxLoss(-8)
-		user.blood_volume += 8
+		user.adjustBruteLoss(-10)
+		user.adjustFireLoss(-10)
+		user.adjustToxLoss(-10)
+		user.blood_volume += 10
 
 /obj/item/melee/transforming/cleaving_saw/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!active || swiping || !target.density || get_turf(target) == get_turf(user))

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -900,8 +900,8 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 
 /obj/item/melee/transforming/cleaving_saw/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It is [active ? "open, will cleave enemies in a wide arc and deal additional damage to fauna":"closed, and can be used for rapid consecutive attacks that cause fauna to bleed"].\n"+\
-	"Both modes will build up existing bleed effects, doing a burst of high damage if the bleed is built up high enough.\n"+\
+	. += "<span class='notice'>It is [active ? "open, will cleave enemies in a wide arc and deal additional damage to fauna, while getting you blood-drunk":"closed, and can be used for rapid consecutive attacks that cause fauna to bleed, dealing passive damage"].\n"+\
+	"Both modes will build up existing bleed effects, doing a burst of high damage and healing you if the bleed is built up high enough.\n"+\
 	"Transforming it immediately after an attack causes the next attack to come out faster.</span>"
 
 /obj/item/melee/transforming/cleaving_saw/suicide_act(mob/user)
@@ -921,9 +921,9 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 /obj/item/melee/transforming/cleaving_saw/transform_messages(mob/living/user, supress_message_text)
 	if(!supress_message_text)
 		if(active)
-			to_chat(user, span_notice("You open [src]. It will now cleave enemies in a wide arc and deal additional damage to fauna."))
+			to_chat(user, span_notice("You open [src]. It will now cleave enemies in a wide arc and deal additional damage to fauna, getting you drunk on blood."))
 		else
-			to_chat(user, span_notice("You close [src]. It will now attack rapidly and cause fauna to bleed."))
+			to_chat(user, span_notice("You close [src]. It will now attack rapidly and cause fauna to bleed, letting you drink their blood to heal."))
 	playsound(user, 'sound/magic/clockwork/fellowship_armory.ogg', 35, TRUE, frequency = 90000 - (active * 30000))
 
 /obj/item/melee/transforming/cleaving_saw/clumsy_transform_effect(mob/living/user)
@@ -931,10 +931,17 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		to_chat(user, span_warning("You accidentally cut yourself with [src], like a doofus!"))
 		user.take_bodypart_damage(10)
 
-/obj/item/melee/transforming/cleaving_saw/melee_attack_chain(mob/user, atom/target, params)
+/obj/item/melee/transforming/cleaving_saw/melee_attack_chain(mob/living/user, atom/target, params)
 	..()
 	if(!active)
 		user.changeNext_move(CLICK_CD_MELEE * 0.5) //when closed, it attacks very rapidly
+	else
+		if(iscarbon(target) && prob(25)) //RNG wound application regardless of armor.
+			var/mob/living/carbon/carbon_target = target
+			var/obj/item/bodypart/bodypart = pick(carbon_target.bodyparts)
+			var/datum/wound/slash/moderate/crit_wound = new
+			user.visible_message(span_boldwarning("[user] cleaves [target] delivering a viscious wound!"))
+			crit_wound.apply_wound(bodypart)
 
 /obj/item/melee/transforming/cleaving_saw/nemesis_effects(mob/living/user, mob/living/target)
 	var/datum/status_effect/saw_bleed/B = target.has_status_effect(STATUS_EFFECT_SAWBLEED)
@@ -942,7 +949,16 @@ GLOBAL_LIST_EMPTY(bloodmen_list)
 		if(!active) //This isn't in the above if-check so that the else doesn't care about active
 			target.apply_status_effect(STATUS_EFFECT_SAWBLEED)
 	else
+		if(active && prob(33)) //This isn't in an else check above so that it doesn't care if they're not bleeding.
+			user.apply_status_effect(STATUS_EFFECT_BLOODDRUNK)
 		B.add_bleed(B.bleed_buildup)
+
+	if(B.needs_to_bleed)
+		to_chat(user, span_notice("You drink the blood spilled from [target] healing your wounds!"))
+		user.adjustBruteLoss(-8)
+		user.adjustFireLoss(-8)
+		user.adjustToxLoss(-8)
+		user.blood_volume += 8
 
 /obj/item/melee/transforming/cleaving_saw/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!active || swiping || !target.density || get_turf(target) == get_turf(user))


### PR DESCRIPTION
Delicious blood drinking mmmm.

# Document the changes in your pull request

- Cleaving Saw now has a 33% to apply the Blood-Drunk effect while in cleave mode.
- Cleaving Saw heals the user 10 points of Brute, Burn, and Toxin Damage, and gives the user 10 blood when the target bleeds.
- Cleaving Saw has a 25% chance to ignore armor and inflict a wound on the target if they are carbon.
- Saw Bleed effect now deals 10 damage per tick on the afflicted "mining" or "boss" mob, dealing 2 to everything else.
- Description changes to tell the user about added effects.

I heard it was underperforming despite its raw damage output so I thought this would help, and the other fact of it not doing so well against anything with armor despite it looking like it would do so. Might revisit and allow all simple mobs to be afflicted by bleed if that fits its liking.

# Wiki Documentation

All of the above.

# Changelog

:cl:  
rscadd: Saw Bleed now kills the target passively
tweak: Bleeding heals the user when it hits the bleed threshold
tweak: Cleave mode now has a chance to apply Blood-Drunk to the user when used against lavaland mobs
tweak: Cleave mode now has a chance to inflict wounds on human targets regardless of armor
spellcheck: Description reflects added effects
/:cl:
