### PR TITLE
 Remove pump outside incinerator on Yogsmeta

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -30993,14 +30993,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"bAX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Incinerator Output Pump"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/space,
-/area/maintenance/disposal/incinerator)
 "bAZ" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
@@ -38315,8 +38307,8 @@
 /area/medical/medbay/central)
 "ccb" = (
 /obj/machinery/light,
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/ppflowers,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "ccc" = (
@@ -55865,8 +55857,8 @@
 /turf/open/floor/plating,
 /area/medical/psych)
 "hjp" = (
-/mob/living/carbon/monkey,
 /obj/structure/sink/puddle,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "hjz" = (
@@ -64268,14 +64260,14 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/mob/living/simple_animal/bot/cleanbot/medical{
-	on = 0
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/mob/living/simple_animal/bot/cleanbot/medical{
+	on = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -64420,13 +64412,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mMP" = (
@@ -66240,11 +66232,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nYm" = (
@@ -66563,8 +66555,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "ojx" = (
@@ -70923,8 +70915,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rfv" = (
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
 "rfM" = (
@@ -74547,8 +74539,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/mob/living/carbon/monkey,
 /obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "tAl" = (
@@ -79733,8 +79725,8 @@
 	dir = 1
 	},
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/Runtime,
 /obj/item/toy/cattoy,
+/mob/living/simple_animal/pet/cat/Runtime,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/cmo)
 "wXx" = (
@@ -80068,13 +80060,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /mob/living/simple_animal/bot/medbot{
 	auto_patrol = 1;
 	desc = "A little medical robot, officially part of the Nanotrasen medical inspectorate. He looks somewhat underwhelmed.";
 	name = "Inspector Johnson"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -117922,7 +117914,7 @@ cBJ
 cAP
 cDs
 dvY
-hcK
+cmc
 hcK
 hcK
 jdB
@@ -120984,7 +120976,7 @@ waU
 cgv
 trp
 czR
-bAX
+cmc
 cmc
 cmc
 cmc


### PR DESCRIPTION
# Document the changes in your pull request

Why is there a pump on the output pipe of the incinerator? It's also set to the default 101kPa so it's a massive PITA.

![image](https://user-images.githubusercontent.com/24573384/209997854-02dec0c4-a8c0-4b9d-8f4e-434da807c479.png)


# Changelog
:cl:  
rscdel: Removed a pump outside the incinerator on Yogsmeta
/:cl:
