### PR TITLE
Makes AI Download 50% Faster

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -110,7 +110,7 @@
 	//Can we (simple) examine humans?
 	var/canExamineHumans = FALSE
 	//Reduces/Increases download speed by this modifier
-	var/downloadSpeedModifier = 1
+	var/downloadSpeedModifier = 1.5
 
 	var/login_warned_temp = FALSE
 


### PR DESCRIPTION
Makes AI Download 50% Faster

At the moment it takes ages to download the AI if you are a traitor for example and have the steal AI objective. Which forces you to either have to make your own or find a different way of doing this. Failing this, maybe we could have an item which traitors can get which makes it silent or perhaps doubles the speed?

:cl:  
tweak: Makes AI Download 50% Faster
/:cl:
