### PR TITLE
halves .38 boolet metal cost

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -908,7 +908,7 @@
 	name = ".38 Bullet"
 	id = "c38"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 3000)
+	materials = list(/datum/material/iron = 1500)
 	build_path = /obj/item/ammo_casing/c38
 	category = list("hacked", "Security")
 


### PR DESCRIPTION
# Document the changes in your pull request

so apparently .357 bullets are 2000 metal now (based) but .38 bullets were 3000 meh-tal so they're now cheaper because .357 is BIGGER than .38

# Changelog

:cl:  
tweak: makes bullet size:metal cost ratio consistent for revolver ammo at the autolathe
/:cl:
