### PR TITLE
Revert "Forces Drone to Stay on the Station"

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -62,7 +62,7 @@
 	var/laws = {"\
 1. You may not involve yourself in the matters of another being, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.
 2. You may not harm any being, regardless of intent or circumstance.
-3. Your goals are to build, maintain, repair, improve, and provide power to your assigned station to the best of your abilities, You must never actively work against these goals or leave your assigned station.\
+3. Your goals are to build, maintain, repair, improve, and provide power to the best of your abilities, You must never actively work against these goals.\
 "}
 	var/heavy_emp_damage = 25 //Amount of damage sustained if hit by a heavy EMP pulse
 	var/alarms = list("Atmosphere" = list(), "Fire" = list(), "Power" = list())


### PR DESCRIPTION
Reverts yogstation13/Yogstation#17113 because it was selfmerged with missing rationale and overwhelmingly negative reception after Jamie removed the "Missing/Inadequate Rationale" and "Closing after 24h" tags that Bibby placed

:cl:
tweak: Drones can be off-station again
/:cl: