### PR TITLE
Modernize gas filters (multiple filters & consistent movement)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1288,10 +1288,8 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
 "pj" = (
-/obj/machinery/atmospherics/components/trinary/filter/on{
-	dir = 1;
-	filter_type = "n2";
-	name = "Nitrogen Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -1977,10 +1975,8 @@
 /turf/closed/wall,
 /area/mine/living_quarters)
 "zZ" = (
-/obj/machinery/atmospherics/components/trinary/filter/on{
-	dir = 1;
-	filter_type = "o2";
-	name = "Oxygen Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8

--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
@@ -1162,7 +1162,7 @@
 "do" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8;
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -756,7 +756,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8;
-	filter_type = "h2o"
+	filter_type = list(/datum/gas/water_vapor)
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,

--- a/_maps/RandomRuins/StationRuins/MetaStation/meta_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/MetaStation/meta_sm.dmm
@@ -51,7 +51,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -23348,10 +23348,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "co2";
-	name = "CO2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -25153,10 +25151,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "n2o";
-	name = "N2O Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -28357,10 +28353,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "plasma";
-	name = "Plasma Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -59323,10 +59317,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 8;
-	filter_type = "n2";
-	name = "N2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -72589,10 +72581,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 8;
-	filter_type = "o2";
-	name = "O2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -19220,8 +19220,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical/n2{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1;
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -13051,10 +13051,8 @@
 /area/security/prison)
 "gnF" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 4;
-	filter_type = "n2o";
-	name = "N2O Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -14934,10 +14932,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "plasma";
-	name = "Plasma Fitler"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -19225,9 +19220,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 1;
-	filter_type = "n2"
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical/n2{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -41646,10 +41640,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "o2";
-	name = "O2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -43142,10 +43133,8 @@
 /area/crew_quarters/bar)
 "vMD" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 4;
-	filter_type = "co2";
-	name = "CO2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -44069,10 +44058,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "n2";
-	name = "N2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},

--- a/_maps/map_files/IceBox/IceBox.dmm
+++ b/_maps/map_files/IceBox/IceBox.dmm
@@ -43744,10 +43744,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bLg" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "co2";
-	name = "CO2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
@@ -44090,17 +44088,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bMa" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "n2";
-	name = "N2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bMb" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "n2o";
-	name = "N2O Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
@@ -44422,10 +44415,7 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos_distro)
 "bMR" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "o2";
-	name = "O2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "bMS" = (
@@ -44450,10 +44440,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "bMT" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "plasma";
-	name = "Plasma Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
@@ -49946,7 +49934,7 @@
 "bYl" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8;
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -74506,7 +74506,7 @@
 "czo" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8;
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{

--- a/_maps/map_files/Omegastation/omegastation.dmm
+++ b/_maps/map_files/Omegastation/omegastation.dmm
@@ -33574,7 +33574,7 @@
 	},
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1;
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -13556,10 +13556,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "o2";
-	name = "O2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -28148,10 +28145,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "co2";
-	name = "CO2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -36694,10 +36689,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "plasma";
-	name = "Plasma Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -37560,10 +37553,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 1;
-	filter_type = "n2o";
-	name = "N2O Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -57712,10 +57703,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	filter_type = "n2";
-	name = "N2 Filter"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
 "tOZ" = (

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -9348,7 +9348,7 @@
 	},
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 4;
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16505,7 +16505,7 @@
 /area/engine/atmospherics_engine)
 "aCi" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	filter_type = "n2";
+	filter_type = list(/datum/gas/nitrogen)
 	name = "nitrogen filter"
 	},
 /obj/effect/turf_decal/tile/yellow{

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -53742,10 +53742,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 4;
-	filter_type = "plasma";
-	name = "Plasma Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -57849,10 +57847,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 4;
-	filter_type = "n2o";
-	name = "N2O Fitler"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -60493,10 +60489,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 4;
-	filter_type = "co2";
-	name = "CO2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -68792,10 +68786,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 8;
-	filter_type = "o2";
-	name = "O2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -79822,10 +79814,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped{
-	dir = 8;
-	filter_type = "n2";
-	name = "N2 Filter"
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -313,3 +313,27 @@ get_true_breath_pressure(pp) --> gas_pp = pp/breath_pp*total_moles()
 
 		return TRUE
 	return FALSE
+
+/datum/gas_mixture/proc/remove_specific_ratio(gas_id, ratio)
+	if(ratio <= 0)
+		return null
+	ratio = min(ratio, 1)
+
+	var/datum/gas_mixture/removed = new
+
+	removed.set_temperature(return_temperature())
+
+	var/current_moles = get_moles(gas_id)
+	var/moles_to_remove = QUANTIZE(current_moles * ratio)
+	var/moles_left = current_moles - moles_to_remove
+
+	// sanitize moles to ensure we aren't writing any invalid or tiny values
+	moles_left = clamp(moles_left, 0, current_moles)
+	if (moles_left < MINIMUM_MOLE_COUNT)
+		moles_left = 0
+		moles_to_remove = current_moles
+
+	removed.set_moles(gas_id, moles_to_remove)
+	set_moles(gas_id, moles_left)
+
+	return removed

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -238,38 +238,38 @@
 	on = TRUE
 	icon_state = "filter_on-0"
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2
-	name = "nitrogen filter"
+	name = "Nitrogen filter (N2)"
 	filter_type = list(/datum/gas/nitrogen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2
-	name = "oxygen filter"
+	name = "Oxygen filter (O2)"
 	filter_type = list(/datum/gas/oxygen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2
-	name = "carbon dioxide filter"
+	name = "Carbon dioxide filter (CO2)"
 	filter_type = list(/datum/gas/carbon_dioxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o
-	name = "nitrous oxide filter"
+	name = "Nitrous oxide filter (N2O)"
 	filter_type = list(/datum/gas/nitrous_oxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma
-	name = "plasma filter"
+	name = "Plasma filter"
 	filter_type = list(/datum/gas/plasma)
 
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped //This feels wrong, I know
 	icon_state = "filter_on-0_f"
 	flipped = TRUE
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2
-	name = "nitrogen filter"
+	name = "Nitrogen filter (N2)"
 	filter_type = list(/datum/gas/nitrogen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2
-	name = "oxygen filter"
+	name = "Oxygen filter (O2)"
 	filter_type = list(/datum/gas/oxygen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2
-	name = "carbon dioxide filter"
+	name = "Carbon dioxide filter (CO2)"
 	filter_type = list(/datum/gas/carbon_dioxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o
-	name = "nitrous oxide filter"
+	name = "Nitrous oxide filter (N2O)"
 	filter_type = list(/datum/gas/nitrous_oxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma
-	name = "plasma filter"
+	name = "Plasma filter"
 	filter_type = list(/datum/gas/plasma)
 
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -7,7 +7,8 @@
 
 	can_unwrench = TRUE
 	var/transfer_rate = MAX_TRANSFER_RATE
-	var/filter_type = null
+	///What gases are we filtering, by typepath
+	var/list/filter_type = list()
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
 
@@ -70,43 +71,55 @@
 	var/datum/gas_mixture/air2 = airs[2]
 	var/datum/gas_mixture/air3 = airs[3]
 
-	var/output_starting_pressure = air3.return_pressure()
-
-	if(output_starting_pressure >= MAX_OUTPUT_PRESSURE)
-		//No need to transfer if target is already full!
-		return
-
 	var/transfer_ratio = transfer_rate/air1.return_volume()
-
-	//Actually transfer the gas
 
 	if(transfer_ratio <= 0)
 		return
 
+	// Attempt to transfer the gas.
+
+	// If the main output is full, we try to send filtered output to the side port (air2).
+	// If the side output is full, we try to send the non-filtered gases to the main output port (air3).
+	// Any gas that can't be moved due to its destination being too full is sent back to the input (air1).
+
+	var/side_output_full = air2.return_pressure() >= MAX_OUTPUT_PRESSURE
+	var/main_output_full = air3.return_pressure() >= MAX_OUTPUT_PRESSURE
+
+	// If both output ports are full, there's nothing we can do. Don't bother removing anything from the input.
+	if (side_output_full && main_output_full)
+		return
+
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)
 
-	if(!removed)
+	if(!removed || !removed.total_moles())
 		return
 
 	var/filtering = TRUE
-	if(!ispath(filter_type))
-		if(filter_type)
-			filter_type = gas_id2path(filter_type) //support for mappers so they don't need to type out paths
-		else
-			filtering = FALSE
+	if(!filter_type.len)
+		filtering = FALSE
 
-	if(filtering && removed.get_moles(filter_type))
+	// Process if we have a filter set.
+	// If no filter is set, we just try to forward everything to air3 to avoid gas being outright lost.
+	if(filtering)
 		var/datum/gas_mixture/filtered_out = new
 
-		filtered_out.set_temperature(removed.return_temperature())
-		filtered_out.set_moles(filter_type, removed.get_moles(filter_type))
+		for(var/gas in removed.get_gases() & filter_type)
+			var/datum/gas_mixture/removing = removed.remove_specific_ratio(gas, 1)
+			if(removing)
+				filtered_out.merge(removing)
+		// Send things to the side output if we can, return them to the input if we can't.
+		// This means that other gases continue to flow to the main output if the side output is blocked.
+		if (side_output_full)
+			air1.merge(filtered_out)
+		else
+			air2.merge(filtered_out)
 
-		removed.set_moles(filter_type, 0)
-
-		var/datum/gas_mixture/target = (air2.return_pressure() < MAX_OUTPUT_PRESSURE ? air2 : air1) //if there's no room for the filtered gas; just leave it in air1
-		target.merge(filtered_out)
-
-	air3.merge(removed)
+	// Send things to the main output if we can, return them to the input if we can't.
+	// This lets filtered gases continue to flow to the side output in a manner consistent with the main output behavior.
+	if (main_output_full)
+		air1.merge(removed)
+	else
+		air3.merge(removed)
 
 	update_parents()
 
@@ -127,10 +140,9 @@
 	data["max_rate"] = round(MAX_TRANSFER_RATE)
 
 	data["filter_types"] = list()
-	data["filter_types"] += list(list("name" = "Nothing", "path" = "", "selected" = !filter_type))
 	for(var/path in GLOB.meta_gas_info)
 		var/list/gas = GLOB.meta_gas_info[path]
-		data["filter_types"] += list(list("name" = gas[META_GAS_NAME], "id" = gas[META_GAS_ID], "selected" = (path == gas_id2path(filter_type))))
+		data["filter_types"] += list(list("name" = gas[META_GAS_NAME], "gas_id" = gas[META_GAS_ID], "enabled" = (path in filter_type)))
 
 	return data
 
@@ -159,15 +171,18 @@
 				transfer_rate = clamp(rate, 0, MAX_TRANSFER_RATE)
 				investigate_log("was set to [transfer_rate] L/s by [key_name(usr)]", INVESTIGATE_ATMOS)
 				investigate_log("was set to [transfer_rate] L/s by [key_name(usr)]", INVESTIGATE_SUPERMATTER) // yogs - make supermatter invest useful
-		if("filter")
-			filter_type = null
-			var/filter_name = "nothing"
-			var/gas = gas_id2path(params["mode"])
-			if(gas in GLOB.meta_gas_info)
-				filter_type = gas
-				filter_name	= GLOB.meta_gas_info[gas][META_GAS_NAME]
-			investigate_log("was set to filter [filter_name] by [key_name(usr)]", INVESTIGATE_ATMOS)
-			investigate_log("was set to filter [filter_name] by [key_name(usr)]", INVESTIGATE_SUPERMATTER) // yogs - make supermatter invest useful
+		if("toggle_filter")
+			if(!gas_id2path(params["val"]))
+				return TRUE
+			filter_type ^= gas_id2path(params["val"])
+			var/change
+			if(gas_id2path(params["val"]) in filter_type)
+				change = "added"
+			else
+				change = "removed"
+			var/gas_name = GLOB.meta_gas_info[gas_id2path(params["val"])][META_GAS_NAME]
+			investigate_log("[key_name(usr)] [change] [gas_name] from the filter type.", INVESTIGATE_ATMOS)
+			investigate_log("[key_name(usr)] [change] [gas_name] from the filter type.", INVESTIGATE_SUPERMATTER) // yogs - make supermatter invest useful
 			. = TRUE
 	update_icon()
 
@@ -224,38 +239,38 @@
 	icon_state = "filter_on-0"
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2
 	name = "nitrogen filter"
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2
 	name = "oxygen filter"
-	filter_type = "o2"
+	filter_type = list(/datum/gas/oxygen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2
 	name = "carbon dioxide filter"
-	filter_type = "co2"
+	filter_type = list(/datum/gas/carbon_dioxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o
 	name = "nitrous oxide filter"
-	filter_type = "n2o"
+	filter_type = list(/datum/gas/nitrous_oxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma
 	name = "plasma filter"
-	filter_type = "plasma"
+	filter_type = list(/datum/gas/plasma)
 
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped //This feels wrong, I know
 	icon_state = "filter_on-0_f"
 	flipped = TRUE
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2
 	name = "nitrogen filter"
-	filter_type = "n2"
+	filter_type = list(/datum/gas/nitrogen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2
 	name = "oxygen filter"
-	filter_type = "o2"
+	filter_type = list(/datum/gas/oxygen)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2
 	name = "carbon dioxide filter"
-	filter_type = "co2"
+	filter_type = list(/datum/gas/carbon_dioxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o
 	name = "nitrous oxide filter"
-	filter_type = "n2o"
+	filter_type = list(/datum/gas/nitrous_oxide)
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma
 	name = "plasma filter"
-	filter_type = "plasma"
+	filter_type = list(/datum/gas/plasma)
 
 // These two filter types have critical_machine flagged to on and thus causes the area they are in to be exempt from the Grid Check event.
 

--- a/tgui/packages/tgui/interfaces/AtmosFilter.js
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.js
@@ -8,8 +8,8 @@ export const AtmosFilter = (props, context) => {
   const filter_types = data.filter_types || [];
   return (
     <Window
-      width={450}
-      height={187}>
+      width={420}
+      height={227}>
       <Window.Content>
         <Section>
           <LabeledList>

--- a/tgui/packages/tgui/interfaces/AtmosFilter.js
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.js
@@ -5,10 +5,10 @@ import { Window } from '../layouts';
 
 export const AtmosFilter = (props, context) => {
   const { act, data } = useBackend(context);
-  const filterTypes = data.filter_types || [];
+  const filter_types = data.filter_types || [];
   return (
     <Window
-      width={390}
+      width={450}
       height={187}>
       <Window.Content>
         <Section>
@@ -40,14 +40,15 @@ export const AtmosFilter = (props, context) => {
                   rate: 'max',
                 })} />
             </LabeledList.Item>
-            <LabeledList.Item label="Filter">
-              {filterTypes.map(filter => (
+            <LabeledList.Item label="Filters">
+              {filter_types.map(filter => (
                 <Button
                   key={filter.id}
-                  selected={filter.selected}
-                  content={getGasLabel(filter.id, filter.name)}
-                  onClick={() => act('filter', {
-                    mode: filter.id,
+                  icon={filter.enabled ? 'check-square-o' : 'square-o'}
+                  content={getGasLabel(filter.gas_id, filter.gas_name)}
+                  selected={filter.enabled}
+                  onClick={() => act('toggle_filter', {
+                    val: filter.gas_id,
                   })} />
               ))}
             </LabeledList.Item>


### PR DESCRIPTION
# Document the changes in your pull request

Main changes:
- Gas filters now allow multiple gasses to be filtered
  - Ideally this logic should be handled in C++ land, however I made it in BYOND for now since we might switch to Katmos soon
- Replaced all gas-specific gas filters with the right filter type (``filter_type = "n2";`` -> ``filter/atmos/n2``)
- Makes gas movement more consistent
- Makes the gas filter window actually fit all the gasses without having to scroll

![image](https://user-images.githubusercontent.com/24573384/210083341-fdb39c70-4afa-4c4c-9cec-e5aa840dc718.png)

Based on these 2 PRs:
- https://github.com/tgstation/tgstation/pull/62177
- https://github.com/tgstation/tgstation/pull/62237

# Changelog

:cl: 
rscadd: Gas filters now allow multiple gasses to be filtered at once
tweak: Gas should move more consistently through gas filters
/:cl:
