### PR TITLE
Resting now only will avoid projectiles from adjacent shooters

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -598,7 +598,7 @@
 	else
 		var/mob/living/L = target
 		if(!direct_target)
-			if(!CHECK_BITFIELD(L.mobility_flags, MOBILITY_STAND) && (L in range(2, starting))) //if we're shooting over someone who's prone and nearby bc formations are cool and not going to be unbalanced
+			if(!CHECK_BITFIELD(L.mobility_flags, MOBILITY_STAND) && (L in range(1, starting))) //if we're shooting over someone who's prone and nearby bc formations are cool and not going to be unbalanced
 				return FALSE
 			if(!CHECK_BITFIELD(L.mobility_flags, MOBILITY_USE | MOBILITY_STAND | MOBILITY_MOVE) || !(L.stat == CONSCIOUS))		//If they're able to 1. stand or 2. use items or 3. move, AND they are not softcrit,  they are not stunned enough to dodge projectiles passing over.
 				return FALSE


### PR DESCRIPTION
I'm getting tired of people resting and just easily dodging projectiles all the time mid-combat. If you're within MELEE range sure but a tile away should be enough to shoot you.



# Wiki Documentation

If it's mentioned, it only applies to adjacent people now.

# Changelog

:cl:  

tweak: Resting only allows you to avoid projectiles from adjacent shooters

/:cl:
