### PR TITLE
Short and Long Telomeres Quirks

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -228,6 +228,9 @@
 #define TRAIT_MESONS			"mesons"
 #define TRAIT_MAGBOOTS			"magboots"
 #define TRAIT_BADMAIL			"badmail"	//Your mail is going to be worse than average
+#define TRAIT_SHORT_TELOMERES	"short_telomeres" //You cannot be CLOONED
+#define TRAIT_LONG_TELOMERES	"long_telomeres" //You get CLOONED faster!!!
+
 /// This person is crying
 #define TRAIT_CRYING "crying"
 

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -292,3 +292,10 @@
 	if(prefs.pref_species && istype(prefs.pref_species, /datum/species/ipc)) // IPCs are already cybernetic
 		return "You already have cybernetic organs!"
 	return FALSE
+
+/datum/quirk/telomeres_long
+	name = "Long Telomeres"
+	desc = "You haven't been cloned much, if at all. Your DNA's telomeres are still largely unaffected by repeated cloning, enabling cloners to work faster."
+	value = 3
+	mob_trait = TRAIT_LONG_TELOMERES
+	medical_record_text = "DNA analysis indicates that the patient's DNA telomeres are still naturally long."

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -296,6 +296,11 @@
 /datum/quirk/telomeres_long
 	name = "Long Telomeres"
 	desc = "You haven't been cloned much, if at all. Your DNA's telomeres are still largely unaffected by repeated cloning, enabling cloners to work faster."
-	value = 3
+	value = 2
 	mob_trait = TRAIT_LONG_TELOMERES
 	medical_record_text = "DNA analysis indicates that the patient's DNA telomeres are still naturally long."
+
+/datum/quirk/telomeres_long/check_quirk(datum/preferences/prefs)
+	if(prefs.pref_species && (NO_DNA_COPY in prefs.pref_species.species_traits)) //Can't pick if you have no DNA bruv.
+		return "You have no DNA!"
+	return FALSE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -860,3 +860,10 @@
 	desc = "You are a complete nobody, no one would ever send you anything worthwhile in the mail."
 	value = -1
 	mob_trait = TRAIT_BADMAIL
+
+/datum/quirk/telomeres_short 
+	name = "Short Telomeres"
+	desc = "Due to hundreds of cloning cycles, your DNA's telomeres are dangerously shortened. Your DNA can't support cloning without expensive DNA restructuring, and what's worse- you work for Nanotrasen."
+	value = -1
+	mob_trait = TRAIT_SHORT_TELOMERES
+	medical_record_text = "DNA analysis indicates that the patient's DNA telomeres are artificially shortened from previous cloner usage."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -864,6 +864,12 @@
 /datum/quirk/telomeres_short 
 	name = "Short Telomeres"
 	desc = "Due to hundreds of cloning cycles, your DNA's telomeres are dangerously shortened. Your DNA can't support cloning without expensive DNA restructuring, and what's worse- you work for Nanotrasen."
-	value = -1
+	value = -2
 	mob_trait = TRAIT_SHORT_TELOMERES
 	medical_record_text = "DNA analysis indicates that the patient's DNA telomeres are artificially shortened from previous cloner usage."
+
+/datum/quirk/telomeres_short/check_quirk(datum/preferences/prefs)
+	if(prefs.pref_species && (NO_DNA_COPY in prefs.pref_species.species_traits)) //Can't pick if you have no DNA bruv.
+		return "You have no DNA!"
+	return FALSE
+	

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -338,7 +338,8 @@ GLOBAL_VAR_INIT(clones, 0)
 			mob_occupant.Unconscious(80)
 			var/dmg_mult = CONFIG_GET(number/damage_multiplier)
 			 //Slowly get that clone healed and finished.
-			mob_occupant.adjustCloneLoss(-((speed_coeff / 2) * dmg_mult))
+			var/telomere_boost = HAS_TRAIT(mob_occupant,TRAIT_LONG_TELOMERES) ? 1.2 : 1.0 //clone 20% faster with long telomere quirk
+			mob_occupant.adjustCloneLoss(-((speed_coeff / 2) * dmg_mult * telomere_boost))
 			var/progress = CLONE_INITIAL_DAMAGE - mob_occupant.getCloneLoss()
 			// To avoid the default cloner making incomplete clones
 			progress += (100 - MINIMUM_HEAL_LEVEL)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -535,6 +535,11 @@
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return 
 
+	if(HAS_TRAIT(mob_occupant,TRAIT_SHORT_TELOMERES))
+		say("Error: Scan indicates occupant's DNA telomeres are too short to properly scan. Aborting.")
+		return
+
+
 	var/datum/data/record/R = new()
 	if(dna.species)
 		// We store the instance rather than the path, because some


### PR DESCRIPTION
# Document the changes in your pull request

Two new quirks:


**Short Telomeres**: Due to hundreds of cloning cycles, your DNA's telomeres are dangerously shortened. Your DNA can't support cloning without expensive DNA restructuring, and what's worse- you work for Nanotrasen.
**Value**: -2

You cannot be scanned the cloner no matter what upgrades it has, and consequently - you cannot be cloned through the cloner.

**Long Telomeres**: You haven't been cloned much, if at all. Your DNA's telomeres are still largely unaffected by repeated cloning, enabling cloners to work faster.
**Value**: 2

Makes you clone 20% faster.

Cannot take either if you have no DNA (IPC)

# Wiki Documentation

https://wiki.yogstation.net/wiki/Quirks

Need to be added to this page.

# Changelog

:cl:  
rscadd: Adds two new quirks - Short and Long Telomeres, either making you unable to be cloned or boosting your clone speed.
/:cl:
