### PR TITLE
Tritium/Hydrogen combustion tweaks and bugfixes

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -7,7 +7,7 @@
 #define PLASMA_MINIMUM_OXYGEN_NEEDED		2
 #define PLASMA_MINIMUM_OXYGEN_PLASMA_RATIO	30
 #define FIRE_CARBON_ENERGY_RELEASED			100000	//Amount of heat released per mole of burnt carbon into the tile
-#define FIRE_HYDROGEN_ENERGY_RELEASED		560000  //Yogs -- Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope). Doubled due to Consv. of Mass fix causing shittier fires
+#define FIRE_HYDROGEN_ENERGY_RELEASED		2800000  //Yogs -- Amount of heat released per mole of burnt hydrogen and/or tritium(hydrogen isotope). Increased significantly due to a bugfix leading to much lower burn temperatures.
 #define FIRE_PLASMA_ENERGY_RELEASED			3000000	//Amount of heat released per mole of burnt plasma into the tile
 //General assmos defines.
 #define WATER_VAPOR_FREEZE					200
@@ -31,7 +31,7 @@
 #define MINIMUM_TRIT_OXYBURN_ENERGY 		2000000	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
 //hydrogen reaction
 #define HYDROGEN_BURN_OXY_FACTOR			100
-#define HYDROGEN_BURN_H2_FACTOR				10
+#define HYDROGEN_BURN_H2_FACTOR				5		//Burns faster and with half the energy of tritium
 #define MINIMUM_H2_OXYBURN_ENERGY 			2000000	//This is calculated to help prevent singlecap bombs(Overpowered hydrogen/oxygen single tank bombs)
 //ammonia reaction
 #define AMMONIA_FORMATION_FACTOR			250

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -131,15 +131,13 @@ nobliumformation = 1001
 	var/burned_fuel = 0
 	var/initial_trit = air.get_moles(/datum/gas/tritium)// Yogs
 	if(air.get_moles(/datum/gas/oxygen) < initial_trit || MINIMUM_TRIT_OXYBURN_ENERGY > (temperature * old_heat_capacity))// Yogs -- Maybe a tiny performance boost? I'unno
-		burned_fuel = air.get_moles(/datum/gas/oxygen)/TRITIUM_BURN_OXY_FACTOR
-		if(burned_fuel > initial_trit) 
-			burned_fuel = initial_trit //Yogs -- prevents negative moles of Tritium
+		burned_fuel = min(air.get_moles(/datum/gas/oxygen) / TRITIUM_BURN_OXY_FACTOR, initial_trit) //Yogs -- prevents negative moles of Tritium
 		air.adjust_moles(/datum/gas/tritium, -burned_fuel)
-		air.adjust_moles(/datum/gas/tritium, -burned_fuel / 2)	//Yogs - no infinite tiny trit burn please
+		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)	//Yogs - now consumes oxygen as intended
 	else
-		burned_fuel = initial_trit // Yogs -- Conservation of Mass fix
-		air.set_moles(/datum/gas/tritium, air.get_moles(/datum/gas/tritium) * (1 - 1/TRITIUM_BURN_TRIT_FACTOR)) // Yogs -- Maybe a tiny performance boost? I'unno
-		air.adjust_moles(/datum/gas/oxygen, -air.get_moles(/datum/gas/tritium))
+		burned_fuel = initial_trit / TRITIUM_BURN_TRIT_FACTOR // Yogs -- Conservation of Mass fix
+		air.adjust_moles(/datum/gas/tritium, -burned_fuel) // Yogs -- Maybe a tiny performance boost? I'unno
+		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
 		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * (TRITIUM_BURN_TRIT_FACTOR - 1)) // Yogs -- Fixes low-energy tritium fires
 
 	if(burned_fuel)
@@ -629,15 +627,14 @@ nobliumformation = 1001
 	var/burned_fuel = 0
 	var/initial_hydrogen = air.get_moles(/datum/gas/hydrogen)	//Yogs
 	if(air.get_moles(/datum/gas/oxygen) < air.get_moles(/datum/gas/hydrogen) || MINIMUM_H2_OXYBURN_ENERGY > air.thermal_energy())
-		burned_fuel = (air.get_moles(/datum/gas/oxygen)/HYDROGEN_BURN_OXY_FACTOR)
-		if(burned_fuel > initial_hydrogen)
-			burned_fuel = initial_hydrogen	//Yogs - prevents negative mols of h2
+		burned_fuel = min(air.get_moles(/datum/gas/oxygen)/HYDROGEN_BURN_OXY_FACTOR, initial_hydrogen) //Yogs - prevents negative mols of h2
 		air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)
 		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2) 	//Yogs - only takes half a mol of O2 for a mol of H2O
 	else
-		burned_fuel = initial_hydrogen	//Yogs - conservation of mass fix 
-		air.set_moles(/datum/gas/hydrogen, air.get_moles(/datum/gas/hydrogen) * (1 - 1 / HYDROGEN_BURN_H2_FACTOR))	// Yogs - see trit burn
-		air.adjust_moles(/datum/gas/oxygen, -air.get_moles(/datum/gas/hydrogen))
+		burned_fuel = initial_hydrogen / HYDROGEN_BURN_H2_FACTOR	//Yogs - conservation of mass fix 
+		air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)	// Yogs - see trit burn
+		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
+		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * (HYDROGEN_BURN_H2_FACTOR - 1)) // Yogs -- burns twice as fast with half the energy
 
 	if(burned_fuel)
 		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)


### PR DESCRIPTION
# Document the changes in your pull request

1) Low-energy tritium combustion now correctly consumes oxygen instead of more tritium

2) Fixes high-energy tritium/hydrogen combustion consuming 18x as much oxygen as intended

3) Hydrogen now burns with half as much energy as tritium instead of 1/10 and burns twice as many moles per tick

# Changelog

:cl:  
bugfix: fixes low-energy tritium combustion not consuming oxygen
bugfix: fixed high-energy trit/h2 combustion consuming 18x more oxygen that it's supposed to
tweak: hydrogen burns with half the energy of tritium while consuming twice as many moles
/:cl:
