### PR TITLE
"Station adrift" station trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -354,3 +354,4 @@
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
+#define STATION_TRAIT_STATION_ADRIFT "station_trait_station_adrift"

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -126,6 +126,11 @@
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
+/atom/movable/screen/plane_master/parallax/Initialize(mapload)
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_STATION_ADRIFT))
+		SpinAnimation(15 MINUTES)
+
 /atom/movable/screen/plane_master/parallax_white
 	name = "parallax whitifier plane master"
 	plane = PLANE_SPACE

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -59,3 +59,11 @@
 /datum/station_trait/announcement_medbot/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/medbot
+
+/datum/station_trait/station_adrift
+	name = "Adrift station"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 2
+	show_in_report = TRUE
+	report_message = "Your station's gravitational anchor has malfunctioned. You are now drifting freely in space."
+	trait_to_give = STATION_TRAIT_STATION_ADRIFT


### PR DESCRIPTION
We're leaving together
But still it's farewell
And maybe we'll come back
To Earth, who can tell?

# Document the changes in your pull request

Space parallax (if your parallax is on) will slowly rotate with this trait active

It is very pretty imo

Can be a bit trippy aswell

![](https://thumbs.gfycat.com/ScalyWiltedAmethystinepython-max-1mb.gif)

# Changelog

:cl:  
rscadd: Added "Station adrift" station trait"
/:cl:
