### PR TITLE
Makes syndi prisoner bag not bad & broken

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -296,21 +296,12 @@
 		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
 		if(res == oldres)
 			return
-		
-		if(prob(res * 7)) // Double cure
-			var/list/not_used = advance_cures[res].Copy()
-			cures = list(pick_n_take(not_used), pick_n_take(not_used))
-			// Get the cure name from the cure_id
-			var/datum/reagent/D1 = GLOB.chemical_reagents_list[cures[1]]
-			var/datum/reagent/D2 = GLOB.chemical_reagents_list[cures[2]]
-			cure_text = "[D1.name] and [D2.name]"
-		else // Single cure
-			cures = list(pick(advance_cures[res]))
-			// Get the cure name from the cure_id
-			var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
-			cure_text = D.name
-		
+		cures = list(pick(advance_cures[res]))
 		oldres = res
+
+		// Get the cure name from the cure_id
+		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
+		cure_text = D.name
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level, ignore_mutable = FALSE)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -296,12 +296,21 @@
 		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
 		if(res == oldres)
 			return
-		cures = list(pick(advance_cures[res]))
+		
+		if(prob(res * 7)) // Double cure
+			var/list/not_used = advance_cures[res].Copy()
+			cures = list(pick_n_take(not_used), pick_n_take(not_used))
+			// Get the cure name from the cure_id
+			var/datum/reagent/D1 = GLOB.chemical_reagents_list[cures[1]]
+			var/datum/reagent/D2 = GLOB.chemical_reagents_list[cures[2]]
+			cure_text = "[D1.name] and [D2.name]"
+		else // Single cure
+			cures = list(pick(advance_cures[res]))
+			// Get the cure name from the cure_id
+			var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
+			cure_text = D.name
+		
 		oldres = res
-
-		// Get the cure name from the cure_id
-		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
-		cure_text = D.name
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level, ignore_mutable = FALSE)

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -289,7 +289,7 @@
 	foldedbag_path = /obj/item/bodybag/environmental/prisoner/syndicate
 	weather_protection = list(WEATHER_ALL)
 	breakout_time = 8 MINUTES
-	sinch_time = 20 SECONDS
+	sinch_time = 4 SECONDS
 
 /obj/structure/closet/body_bag/environmental/prisoner/syndicate/Initialize()
 	. = ..()
@@ -297,7 +297,7 @@
 
 
 /obj/structure/closet/body_bag/environmental/prisoner/syndicate/update_airtightness()
-	if(sinched && !air_contents)
+	if(sinched)
 		refresh_air()
 	else if(!sinched && air_contents)
 		air_contents = null

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -304,7 +304,7 @@
 
 /obj/structure/closet/body_bag/environmental/prisoner/syndicate/proc/refresh_air()
 	air_contents = null
-	air_contents = new(50) //liters
+	air_contents = new(50) // liters
 	air_contents.set_temperature(T20C)
 	air_contents.set_moles(/datum/gas/oxygen, (ONE_ATMOSPHERE*50)/(R_IDEAL_GAS_EQUATION*T20C) * O2STANDARD)
 	air_contents.set_moles(/datum/gas/nitrous_oxide, (ONE_ATMOSPHERE*50)/(R_IDEAL_GAS_EQUATION*T20C) * N2STANDARD)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1861,7 +1861,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Syndicate Prisoner Transport Bag"
 	desc = "An alteration of Nanotrasen's environmental protection bag which has been used in several high-profile kidnappings. Designed to keep a victim unconscious, alive, and secured until they are transported to a required location."
 	item = /obj/item/bodybag/environmental/prisoner/syndicate
-	cost = 7
+	cost = 2
 
 /datum/uplink_item/device_tools/holo_sight
 	name = "Holographic Sight"


### PR DESCRIPTION
# Document the changes in your pull request
Changes tested locally
## Part 1: Made it not horrible to use

Two changes were made here
- The bag now only takes 4 seconds to zip instead of 20
  - Holy shit. 20 fucking seconds. If you have someone that refuses to move for 20 seconds, they're either dead or already asleep or AFK
- The bag now only costs 2TC from 7TC
  - Literal 7TC handcuffs & mute that takes longer to apply and is very obvious. The main attraction is from the fact that they will never get up (you can forget about them as long as they won't get found) and that you can step over them while taking them places. This does not make it worth anywhere near 7TC. I'm split between 2 and 3 TC, but I'd like to place this in 2TC heaven and see where people take it.

## Part 2: Fixed a bug where you die

Yeah it would just kill the guy
<img src='https://i.imgur.com/wQBlq7a.png' width=400 height=300>



# Changelog

:cl:  
bugfix: Syndicate prisoner bag no longer kills its victims
tweak: Syndicate prisoner bag costs 2TC
tweak: Syndicate prisoner bag zips up much quicker
/:cl:
