### PR TITLE
The Great Enthickening

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
@@ -8,6 +8,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACE
 	armor = list(MELEE = 50, BULLET = 60, LASER = 0, ENERGY = 0, BOMB = 60, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/clockwork/Initialize()
 	. = ..()
@@ -69,6 +70,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list(MELEE = 60, BULLET = 60, LASER = 0, ENERGY = 0, BOMB = 60, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	allowed = list(/obj/item/clockwork, /obj/item/clothing/glasses/wraith_spectacles, /obj/item/clothing/glasses/judicial_visor, /obj/item/mmi/posibrain/soul_vessel)
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/clockwork/Initialize()
 	. = ..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -166,6 +166,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flash_protect = 2
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch
 	name = "ominous armor"
@@ -178,6 +179,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	// slightly better than normal cult robes
 	armor = list(MELEE = 50, BULLET = 50, LASER = 50,ENERGY = 50, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
+	clothing_flags = THICKMATERIAL
 
 /obj/item/reagent_containers/glass/beaker/eldritch
 	name = "flask of eldritch essence"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -90,7 +90,8 @@
 	armor = list(MELEE = 15, BULLET = 60, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 5)
 	can_flashlight = TRUE
 	dog_fashion = null
-
+	clothing_flags = THICKMATERIAL
+	
 /obj/item/clothing/head/helmet/old
 	name = "degrading helmet"
 	desc = "Standard issue security helmet. Due to degradation the helmet's visor obstructs the users ability to see long distances."
@@ -120,6 +121,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/riot/raised/Initialize()
 	. = ..()

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -132,7 +132,8 @@
 	strip_delay = 80
 	equip_delay_other = 60
 	slowdown = 0.33
-
+	clothing_flags = THICKMATERIAL
+	
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"
 	desc = "A tribal armor plate, crafted from animal bone."
@@ -188,7 +189,8 @@
 	armor = list(MELEE = 15, BULLET = 60, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 20)
 	strip_delay = 70
 	equip_delay_other = 50
-
+	clothing_flags = THICKMATERIAL
+	
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflective jacket"
 	desc = "A jacket that excels in protecting the wearer against energy projectiles, as well as occasionally reflecting them."


### PR DESCRIPTION
# Document the changes in your pull request
Adds syringe protection to a few select armors who should probably protect you from a roundstart non antag item which if your hit once by your fucked.

for traitor chemists concerned you have a 4tc item which ignores this called the dart gun.

Currently the protected armors are:
Heretic Ominous Armor, Bulletproof vest and helmet, Riot vest and helmet and clock cult suit and helm.

I WOULD GREATLY APPRECIATE YOUR SUGGESTIONS ON ARMORS.
# Wiki Documentation
Edit the relevant armor descriptions on wiki to inform of the new protection
# Changelog

:cl:  
tweak: Ominous Armor(heretic) now protects from normal syringes
tweak: Riot armor now protects from normal syringes
tweak: Bullet Proof armor now protects from normal syringes
tweak: Clockcults giant suits of armor now protects from normal syringes
/:cl:
