### PR TITLE
MC changes on correct SSinput

### DIFF
--- a/yogstation/code/controllers/subsystem/input.dm
+++ b/yogstation/code/controllers/subsystem/input.dm
@@ -5,6 +5,7 @@ SUBSYSTEM_DEF(input)
 	flags = SS_TICKER
 	priority = FIRE_PRIORITY_INPUT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
+	init_stage = INITSTAGE_EARLY
 
 	var/list/macro_sets
 
@@ -17,7 +18,7 @@ SUBSYSTEM_DEF(input)
 	initialized = TRUE
 	refresh_client_macro_sets()
 
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

previous MC PR incorrectly made changes to SSinput Init Stage / Initialize in its disabled files instead of the ones in `yogstation/`

this fixes that by letting it properly early-init and suppressing the warning