### PR TITLE
Adds Atmospherics Simulator console to every maps turbine area

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -18572,22 +18572,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fpC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "fpJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26657,6 +26641,26 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ibw" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
+	dir = 4;
+	name = "Toxins Lab APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_sim{
+	dir = 8;
+	mode = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "ibT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -33425,13 +33429,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ksu" = (
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "ksz" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
@@ -64367,6 +64364,17 @@
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"uLx" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/computer/atmos_sim{
+	dir = 1;
+	mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "uLP" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/bluespace,
@@ -113146,7 +113154,7 @@ aOl
 dIS
 oHB
 wUw
-fpC
+ibw
 rhV
 usj
 eqh
@@ -122426,7 +122434,7 @@ afF
 uKx
 cOK
 nMs
-ksu
+uLx
 afF
 gAc
 ihY

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -18975,6 +18975,21 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"jzv" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
+/obj/machinery/computer/atmos_sim{
+	dir = 8;
+	mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "jzY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -36556,17 +36571,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
-"suo" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "sus" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
@@ -66243,7 +66247,7 @@ fZQ
 kMQ
 myw
 fFT
-suo
+jzv
 ahZ
 xWa
 mcs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -24265,6 +24265,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fCl" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/computer/atmos_sim{
+	dir = 3;
+	mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "fCu" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -37217,6 +37225,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"lic" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "lip" = (
 /obj/machinery/light{
 	dir = 1
@@ -40642,11 +40657,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"mBg" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "mBi" = (
 /obj/machinery/air_sensor{
 	id_tag = "n2_sensor"
@@ -56471,12 +56481,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tly" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "tlN" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -108142,7 +108146,7 @@ ldW
 ldW
 ldW
 cmd
-tly
+lic
 bVC
 dfL
 tEp
@@ -108656,7 +108660,7 @@ ldW
 ldW
 ldW
 cmd
-mBg
+fCl
 owJ
 etJ
 ufo

--- a/_maps/map_files/YogsDelta/YogsDelta.dmm
+++ b/_maps/map_files/YogsDelta/YogsDelta.dmm
@@ -19558,20 +19558,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"aGU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "aGV" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -125343,6 +125329,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
+"pWH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/computer/atmos_sim{
+	dir = 3;
+	mode = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "pWT" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -153507,7 +153511,7 @@ axp
 aDl
 avZ
 aHX
-aGU
+pWH
 aNc
 dmO
 auK

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -336,10 +336,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/maintenance/starboard)
-"aaW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "aaY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57910,6 +57906,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"iIL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/atmos_sim{
+	dir = 4;
+	mode = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "iJJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -120715,7 +120719,7 @@ jWF
 bZE
 mKO
 qbK
-aaW
+iIL
 bxI
 byG
 bZE


### PR DESCRIPTION



Atmos simulators are pretty cool, why doesnt atmos techs get the consoles atleast for turbine????

Adds the atmos simulator console to turbine across every in rotation map and adds it to asteroid toxins

# Spriting

# Wiki Documentation

maybe new pictures but 🤷 

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

mapping: added atmos sims to turbines on all maps in rotation and added one to asteroid toxins

/:cl:
