### PR TITLE
Changes apcs to turn off lighting first at 40% then equipment at 15%

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1324,9 +1324,9 @@
 			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			area.poweralert(0, src)
-		else if(cell.percent() < 30 && longtermpower < 0)			// <30%, turn off equipment
-			equipment = autoset(equipment, 2)
-			lighting = autoset(lighting, 1)
+		else if(cell.percent() < 40 && longtermpower < 0)			// <40%, turn off Lighting
+			equipment = autoset(equipment, 1)
+			lighting = autoset(lighting, 2)
 			environ = autoset(environ, 1)
 			area.poweralert(0, src)
 		else									// otherwise all can be on


### PR DESCRIPTION
No one cares about lighting as much as usual shit like medbay machines and brig timers are alot more needed instead of some lights.

:cl:  
rscadd: Changes APCs to turn off Lighting first
/:cl:
