### PR TITLE
Diseases can have double cures

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -296,12 +296,21 @@
 		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
 		if(res == oldres)
 			return
-		cures = list(pick(advance_cures[res]))
+		
+		if(prob(res * 7)) // Double cure
+			var/list/not_used = advance_cures[res].Copy()
+			cures = list(pick_n_take(not_used), pick_n_take(not_used))
+			// Get the cure name from the cure_id
+			var/datum/reagent/D1 = GLOB.chemical_reagents_list[cures[1]]
+			var/datum/reagent/D2 = GLOB.chemical_reagents_list[cures[2]]
+			cure_text = "[D1.name] and [D2.name]"
+		else // Single cure
+			cures = list(pick(advance_cures[res]))
+			// Get the cure name from the cure_id
+			var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
+			cure_text = D.name
+		
 		oldres = res
-
-		// Get the cure name from the cure_id
-		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
-		cure_text = D.name
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level, ignore_mutable = FALSE)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -298,7 +298,8 @@
 			return
 		
 		if(prob(res * 7)) // Double cure
-			var/list/not_used = advance_cures[res].Copy()
+			var/list/the_cures = advance_cures[res]
+			var/list/not_used = the_cures.Copy()
 			cures = list(pick_n_take(not_used), pick_n_take(not_used))
 			// Get the cure name from the cure_id
 			var/datum/reagent/D1 = GLOB.chemical_reagents_list[cures[1]]

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -297,7 +297,7 @@
 		if(res == oldres)
 			return
 		
-		if(prob(res * 7)) // Double cure
+		if(prob(82 - (res * 7))) // Double cure
 			var/list/the_cures = advance_cures[res]
 			var/list/not_used = the_cures.Copy()
 			cures = list(pick_n_take(not_used), pick_n_take(not_used))


### PR DESCRIPTION
# Document the changes in your pull request

General virus buff but targeted at sentient virus to help reduce meta

Any disease without a preset cure will have a chance based on low resistance to have two cures instead of one, like a sentient virus

The higher resistance a virus is, the lower the chance is for multiple cures, because double cure at the higher tiers can be very very bad

Refer to the wiki table for cures at resistance levels 

![](https://i.imgur.com/Jl8mMv1.png)

# Wiki

Chance is (82 - (7 * resistance))%

1: 75%
2: 68%
3: 61%
4: 54%
5: 47%
6: 40%
7: 33%
8: 26%
9: 19%
10: 12%
11: 5%

# Changelog

:cl:  
tweak: Advanced viruses now have a chance to have two cures instead of one
/:cl:
