### PR TITLE
Moves insuls and belt back onto clockies when they spawn in

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -279,8 +279,10 @@ Credit where due:
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	back = /obj/item/storage/backpack
 	ears = /obj/item/radio/headset
+	gloves = /obj/item/clothing/gloves/color/yellow //Take them off if you want
+	belt = /obj/item/storage/belt/utility/servant //Take this off and pour it into a toolbox if you want
 	backpack_contents = list(/obj/item/storage/box/engineer = 1, \
-	/obj/item/clockwork/replica_fabricator = 1, /obj/item/stack/tile/brass/fifty = 1, /obj/item/paper/servant_primer = 1, /obj/item/clothing/gloves/color/yellow = 1, /obj/item/storage/belt/utility/servant = 1)
+	/obj/item/clockwork/replica_fabricator = 1, /obj/item/stack/tile/brass/fifty = 1, /obj/item/paper/servant_primer = 1)
 	id = /obj/item/pda
 	var/plasmaman //We use this to determine if we should activate internals in post_equip()
 


### PR DESCRIPTION
# Document the changes in your pull request

#16384 was a good PR for reducing meta (bad) in adding people to the manifest however it seems moving the bulky belt into the bag where it isn't supposed to fit (!) means it just isn't spawning right now. Check belt code, and the belt still exists there, so it's just not properly manifesting in the bag.

This PR moves the gloves and belt back on to the cultist, anyone with a brain can just take them off if they desire, belt contents can be poured into the backpack. If random search and seeing an assistant with a bag is a problem, that's meta in of itself plus this highlights the problem of having sec level go to blue roundstart (screws over heretics too, also if a funky nuke core box spawns in your backpack then GG if you're caught in the hallway as soon as you get it)

# Changelog

:cl:  
tweak: Insuls and belt back in the bag
/:cl:
