### PR TITLE
Recyclers no longer delete brains when emagged

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -111,6 +111,7 @@
 			var/obj/item/mmi/as_mmi = AM
 			if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /obj/item/dullahan_relay))
 				living_detected = TRUE
+				continue	//Lets not use an emagged recycler as a ghetto brain deleter please thanks
 			nom += AM
 		else if(isliving(AM) && !istype(AM, /mob/living/simple_animal/hostile/megafauna))
 			living_detected = TRUE


### PR DESCRIPTION
Yeah sure you can kill someone with the recycler but DID YOU KNOW if you then cut their head off and run it through again the brain gets deleted? If we wanted to do that we could just make it gib the whole damn body.

Stop completely deleting people from the round it's cringe.

# Wiki Documentation

I dunno if it needs to be mentioned that it wont delete brains but hey it could go in there if you want

# Changelog

:cl:  

tweak: The recycler has lost its taste for scrumptious freshly-removed heads and brains.

/:cl:
