### PR TITLE
Fix lavaland mob spawning rate

### DIFF
--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -141,16 +141,17 @@
 
 			var/can_spawn = TRUE
 
-			// prevents tendrils spawning in each other's collapse range
-			if(ispath(picked_mob, /obj/structure/spawner/lavaland))
+			//avoid spawning if there's another hostile nearby within 12 tiles
+			for(var/mob/living/simple_animal/hostile/asteroid/mob_blocker in urange(12, new_turf))
+				can_spawn = FALSE
+				break
+
+			// prevents mobs from spawning within 2 tiles of a spawner
+			if(can_spawn)
 				for(var/obj/structure/spawner/lavaland/spawn_blocker in range(2, new_turf))
 					can_spawn = FALSE
 					break
-			//if the random is a standard mob, avoid spawning if there's another one within 12 tiles
-			else if(ispath(picked_mob, /mob/living/simple_animal/hostile/asteroid))
-				for(var/mob/living/simple_animal/hostile/asteroid/mob_blocker in range(12, new_turf))
-					can_spawn = FALSE
-					break
+
 			//if there's a megafauna within standard view don't spawn anything at all (This isn't really consistent, I don't know why we do this. you do you tho)
 			if(can_spawn)
 				for(var/mob/living/simple_animal/hostile/megafauna/found_fauna in range(7, new_turf))


### PR DESCRIPTION
# Document the changes in your pull request

Lavaland mob spawning rate got broken by https://github.com/yogstation13/Yogstation/pull/17208. Apparantly the old logic "bugged" which causes a lot less mobs to spawn. This PR replicates this broken behaviour back to restore the old spawning rate.

:cl:  
bugfix: Lavaland mob spawning rate should be back to normal
/:cl:
