### PR TITLE
Allow demos to be disabled via config

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -531,3 +531,6 @@
 
 /// logs all timers in buckets on automatic bucket reset (Useful for timer debugging)
 /datum/config_entry/flag/log_timers_on_bucket_reset
+
+/// Whether demos are written, if not set demo SS never initializes
+/datum/config_entry/flag/demos_enabled

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -70,7 +70,7 @@ SUBSYSTEM_DEF(demo)
 		marked_dirty.Cut()
 		marked_new.Cut()
 		marked_turfs.Cut()
-		return ..()
+		return SS_INIT_SUCCESS
 
 	WRITE_LOG_NO_FORMAT(GLOB.demo_log, "demo version 1\n") // increment this if you change the format
 	if(GLOB.revdata)

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -64,6 +64,14 @@ SUBSYSTEM_DEF(demo)
 	last_chat_message = json_encoded
 
 /datum/controller/subsystem/demo/Initialize()
+	if(!CONFIG_GET(flag/demos_enabled))
+		flags |= SS_NO_FIRE
+		can_fire = FALSE
+		marked_dirty.Cut()
+		marked_new.Cut()
+		marked_turfs.Cut()
+		return ..()
+
 	WRITE_LOG_NO_FORMAT(GLOB.demo_log, "demo version 1\n") // increment this if you change the format
 	if(GLOB.revdata)
 		WRITE_LOG_NO_FORMAT(GLOB.demo_log, "commit [GLOB.revdata.commit || GLOB.revdata.originmastercommit]\n")
@@ -397,11 +405,15 @@ SUBSYSTEM_DEF(demo)
 	return ..(msg)
 
 /datum/controller/subsystem/demo/proc/mark_turf(turf/T)
+	if(!can_fire)
+		return
 	if(!isturf(T))
 		return
 	marked_turfs[T] = TRUE
 
 /datum/controller/subsystem/demo/proc/mark_new(atom/movable/M)
+	if(!can_fire)
+		return
 	if(!isobj(M) && !ismob(M))
 		return
 	if(M.gc_destroyed)
@@ -412,6 +424,8 @@ SUBSYSTEM_DEF(demo)
 
 // I can't wait for when TG ports this and they make this a #define macro.
 /datum/controller/subsystem/demo/proc/mark_dirty(atom/movable/M)
+	if(!can_fire)
+		return
 	if(!isobj(M) && !ismob(M))
 		return
 	if(M.gc_destroyed)
@@ -420,6 +434,8 @@ SUBSYSTEM_DEF(demo)
 		marked_dirty[M] = TRUE
 
 /datum/controller/subsystem/demo/proc/mark_destroyed(atom/movable/M)
+	if(!can_fire)
+		return
 	if(!isobj(M) && !ismob(M))
 		return
 	if(marked_new[M])

--- a/config/config.txt
+++ b/config/config.txt
@@ -125,6 +125,9 @@ LOG_VIRUS
 ## log cloning actions
 LOG_CLONING
 
+## Enable the demo subsystem
+# DEMOS_ENABLED
+
 ##Log camera pictures - Must have picture logging enabled
 # PICTURE_LOGGING_CAMERA
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -126,7 +126,7 @@ LOG_VIRUS
 LOG_CLONING
 
 ## Enable the demo subsystem
-# DEMOS_ENABLED
+DEMOS_ENABLED
 
 ##Log camera pictures - Must have picture logging enabled
 # PICTURE_LOGGING_CAMERA


### PR DESCRIPTION
# Document the changes in your pull request

Basically ports https://github.com/tgstation/tgstation/pull/50615

While replays have proven to be beloved tool by our admins, it adds no value when developing. Having to wait an extra ±20 seconds everytime I want to start YogStation is pretty annoying and it starts using a lot of disk space after a while.

This PR simply disables demos by default to not bother developers while it can stay enabled on the server. I don't know if the server config is synced with GitHub (it wasn't back in my day), if it is I can change it to be enabled by default.
