### PR TITLE
substantially reduces foam lag

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -49,7 +49,7 @@
 		T.air_update_turf()
 
 /obj/effect/particle_effect/foam/firefighting/kill_foam()
-	STOP_PROCESSING(SSfastprocess, src)
+	STOP_PROCESSING(SSprocessing, src)
 
 	if(absorbed_plasma)
 		var/obj/effect/decal/cleanable/plasma/P = (locate(/obj/effect/decal/cleanable/plasma) in get_turf(src))
@@ -92,7 +92,7 @@
 /obj/effect/particle_effect/foam/Initialize()
 	. = ..()
 	create_reagents(1000) //limited by the size of the reagent holder anyway.
-	START_PROCESSING(SSfastprocess, src)
+	START_PROCESSING(SSprocessing, src)
 	playsound(src, 'sound/effects/bubbles2.ogg', 80, 1, -3)
 	applied_atoms = list()
 
@@ -102,13 +102,13 @@
 		AddComponent(/datum/component/slippery, 100)
 
 /obj/effect/particle_effect/foam/Destroy()
-	STOP_PROCESSING(SSfastprocess, src)
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 
 /obj/effect/particle_effect/foam/proc/kill_foam()
 	set waitfor = FALSE
-	STOP_PROCESSING(SSfastprocess, src)
+	STOP_PROCESSING(SSprocessing, src)
 	switch(metal)
 		if(ALUMINUM_FOAM)
 			new /obj/structure/foamedmetal(get_turf(src))
@@ -120,7 +120,7 @@
 	QDEL_IN(src, 5)
 
 /obj/effect/particle_effect/foam/smart/kill_foam() //Smart foam adheres to area borders for walls
-	STOP_PROCESSING(SSfastprocess, src)
+	STOP_PROCESSING(SSprocessing, src)
 	if(metal)
 		var/turf/T = get_turf(src)
 		if(isspaceturf(T)) //Block up any exposed space


### PR DESCRIPTION
hmm today i will create HUNDREDS of effects and then have them on FAST PROCESS and have them FUCK WITH ATMOS every single tick <- WORDS OF A FUCKING PSYCHOPATH

from testing this makes the atmos SS go from like a permanent 300ms generated after stationwide foam to about 25ms, as well as obviously eliminating a ton of work from the fast processing SS

# Changelog

:cl:  
tweak: foam lags the server less
/:cl:
