### PR TITLE
Removes the Curator's space suit

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -98,15 +98,6 @@
 	new /obj/item/clothing/shoes/workboots/mining(src)
 	new /obj/item/melee/curator_whip(src)
 
-/obj/item/storage/box/hero/astronaut
-	name = "First Man on the Moon - 1960's."
-
-/obj/item/storage/box/hero/astronaut/PopulateContents()
-	new /obj/item/clothing/suit/space/nasavoid(src)
-	new /obj/item/clothing/head/helmet/space/nasavoid(src)
-	new /obj/item/tank/internals/oxygen(src)
-	new /obj/item/gps(src)
-
 /obj/item/storage/box/hero/scottish
 	name = "Braveheart, the Scottish rebel - 1300's."
 


### PR DESCRIPTION
# Document the changes in your pull request

Title self explanatory
The curator is there to curate the library, they shouldn't be going on space walks every round and leaving their precious books unattended.

As usual, I have no idea what I'm doing and this code is untested

# Spriting

N/A

# Wiki Documentation

I'm pretty sure we don't mention that the curator gets a voidsuit anywhere on the wiki

# Changelog

:cl:  
rscdel: Curators now have to curate their library instead of being Space Indiana Jones
/:cl:
