### PR TITLE
slight old gods sect clarification

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -342,7 +342,7 @@
 /datum/religion_sect/oldgods
 	name = "Gathering of the Old Ones"
 	desc = "A sect dedicated to the Old Gods."
-	convert_opener = "The great gods of old welcome you to their gathering, acolyte.<br>Bless slabs of meat on your altar and then sacrifice it in the name of the Old Gods."
+	convert_opener = "The great gods of old welcome you to their gathering, acolyte.<br>Bless slabs of meat on top of your altar and then sacrifice it in the name of the Old Gods."
 	alignment = ALIGNMENT_EVIL //kind of evil?
 	max_favor = 3000
 	desired_items = list(/obj/item/reagent_containers/food/snacks/meat/slab/blessed)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -441,7 +441,7 @@
 
 /datum/religion_rites/meatbless
 	name = "Meat Blessing"
-	desc = "Bless a piece of meat. Preps it for sacrifice"
+	desc = "Bless a piece of meat. Preps it for sacrifice. The meat must be on top of the altar."
 	ritual_length = 2 SECONDS
 	//no invoke message, this does a custom one down below in invoke_effect
 	///the piece of meat that will be blessed, only one per rite

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -268,6 +268,7 @@ Questions? Consult the Wiki: https://wiki.yogstation.net/wiki/Main_Page
 Questions? Consult the Mentors using the 'MHelp' system.
 Starving makes you move slower. Be sure to keep fed!
 As the Chaplain, You can use your bible on the "Altar of God" to choose a variety of religions with special rites.
+As the Chaplain, if you pick the Gathering of the Old Gods as your sect, you can gain the favor of your patron eldritch god for harvesting tools, healing fountains, and body transformation. To do this, climb ontop of your altar, drop pieces of meat, bless them through a rite, and then offer them.
 As a Changeling, your Regenerate Limbs power will quickly heal all of your wounds, but they'll still leave scars. Changelings can use Fleshmend to get rid of scars, or you can ingest Carpotoxin to get rid of them like a normal person.
 Stasis beds halt ALL passive life functions, including regeneration. If your patient isn't responding to treatment, especially with cut or burn wounds, try unbuckling them!
 Standard epipens contain a potent coagulant that not only slow bloodloss, but also help clot whichever of your wounds is bleeding the most! If you're suffering multiple bad bleeding wounds, make sure to seek out additional treatment ASAP!


### PR DESCRIPTION
Adds  some more clarification to the rite and sect opener that meat must be placed ON TOP of the altar to bless it. Also adds a tip of the round that mentions this.

# Changelog

:cl:  
rscadd: new tip of the round
tweak: old gods sect meat blessing clarified
/:cl:
