### PR TITLE
Flowering bud countdown rounded

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -180,5 +180,5 @@
 		return
 	if(!bud.finish_time)
 		return -1
-	var/time_left = max(0, (bud.finish_time - world.time) / 10)
+	var/time_left = CEILING(max(0, (bud.finish_time - world.time) / 10), 1)
 	return time_left


### PR DESCRIPTION
# Document the changes in your pull request

Decimal places would make the number get cut off

# Changelog

:cl:  
spellcheck: Rounded the countdown display on flower buds so it doesn't get cut off as hard
/:cl:
