### PR TITLE
Nuclear particles can power radiation collectors

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -327,8 +327,8 @@
 /obj/machinery/power/rad_collector/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
 		rad_act(P.irradiate * P.damage) // equivalent of a 2000 strength rad pulse for each particle
-		return
-	. = ..()
+		P.damage = 0
+	..()
 
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -324,6 +324,12 @@
 		flick("ca_deactive", src)
 	update_icon()
 
+/obj/machinery/power/rad_collector/bullet_act(obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+		rad_act(P.irradiate * P.damage) // equivalent of a 2000 strength rad pulse for each particle
+		return
+	. = ..()
+
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT
 #undef RAD_COLLECTOR_STORED_OUT


### PR DESCRIPTION
# Document the changes in your pull request

Radiation collectors can now be powered by nuclear particles, producing 192 kilojoules of energy each.

# Changelog

:cl:  
rscadd: nuclear particles can power radiation collectors
/:cl:
