### PR TITLE
lets preternis and ethereals be affected by trait_eat_more and trait_eat_less

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -169,7 +169,14 @@
 
 /obj/item/organ/stomach/ethereal/on_life()
 	..()
-	adjust_charge(-ETHEREAL_CHARGE_FACTOR)
+	var/chargemod = 1
+	if(HAS_TRAIT(owner, TRAIT_EAT_LESS))
+		chargemod *= 0.75 //power consumption rate reduced by about 25%
+	if(HAS_TRAIT(owner, TRAIT_EAT_MORE))
+		chargemod *= 3 //hunger rate tripled
+	if(HAS_TRAIT(owner, TRAIT_BOTTOMLESS_STOMACH))
+		crystal_charge = min(crystal_charge, ETHEREAL_CHARGE_ALMOSTFULL) //capped, can never be truly full
+	adjust_charge(-(ETHEREAL_CHARGE_FACTOR * chargemod))
 
 /obj/item/organ/stomach/ethereal/Insert(mob/living/carbon/M, special = 0)
 	..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -245,7 +245,13 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		H.jitteriness -= 100
 
 /datum/species/preternis/proc/handle_charge(mob/living/carbon/human/H)
-	charge = clamp(charge - power_drain,PRETERNIS_LEVEL_NONE,PRETERNIS_LEVEL_FULL)
+	var/chargemod = 1 //TRAIT_BOTTOMLESS_STOMACH isn't included because preternis charge doesn't work that way
+	if(HAS_TRAIT(H, TRAIT_EAT_LESS))
+		chargemod *= 0.75 //power consumption rate reduced by about 25%
+	if(HAS_TRAIT(H, TRAIT_EAT_MORE))
+		chargemod *= 3 //hunger rate tripled
+	charge = clamp(charge - (power_drain * chargemod),PRETERNIS_LEVEL_NONE,PRETERNIS_LEVEL_FULL)
+
 	if(charge == PRETERNIS_LEVEL_NONE)
 		to_chat(H,span_danger("Warning! System power criti-$#@$"))
 		H.death()


### PR DESCRIPTION
Preternis use their own janky form of hunger, this means traits that speed up or slow down hunger don't affect them
Ethereals don't get affected by these either because they rely on a weird stomach variable

This means efficient metabolism doesn't work on either of them, and a gluttony demon doesn't get "hungry" faster

IPC _does_ get affected by these because they just use nutrition

Changing either of these to rely on nutrition instead would take significant rewrites of their code and would have little benefits to my knowledge as of this moment.

Not entirely sure if this is a bugfix or a tweak

:cl:  
bugfix: lets preternis and ethereals be affected by trait_eat_more and trait_eat_less
/:cl:
