### PR TITLE
Preternis only need 10x as much stimulum to have an effect instead of 50x

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -81,7 +81,7 @@
 	icon_state = "lungs-c"
 	safe_oxygen_min = 12
 	safe_toxins_max = 10
-	gas_stimulation_min = 0.1 //fucking filters removing my stimulants
+	gas_stimulation_min = 0.01 //fucking filters removing my stimulants
 
 	cold_level_1_threshold = 280 //almost room temperature
 	cold_level_1_damage = 2


### PR DESCRIPTION
# Document the changes in your pull request

Preternis are exceptionally weak to stamina damage and stimulum is one of the only ways to deal with that. However, they need 50x as much stimulum for it to have any effect on them, which is quite literally unobtainable as it requires a higher kPa at room temperature than internal tanks will go up to, without taking into account that you need oxygen as well. The solution would seem to be to cool it down for more moles each breath, but preternis lungs can't even handle a few degrees below room temperature making it still unusable without strong passive healing, of which preternis only have a tiny handful of options due to their mechanical limbs.

This PR makes stimulum actually usable by preternis by reducing the mole requirement from 50x the default down to 10x, which is still significantly higher than normal but possible to achieve.

# Changelog

:cl:  
tweak: preternis need 10x as much stimulum instead of 50x
/:cl:
