### PR TITLE
Ghosts can analyze gas mixes

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,7 +1,8 @@
-#define SCAN_CHEM 	(1<<0)
+#define SCAN_CHEM (1<<0)
 #define SCAN_HEALTH (1<<1)
-#define SCAN_NANITE	(1<<2)
-#define SCAN_WOUND	(1<<3)
+#define SCAN_NANITE (1<<2)
+#define SCAN_WOUND (1<<3)
+#define SCAN_GAS (1<<4)
 
 /mob/dead/observer/DblClickOn(atom/A, params)
 	if(check_click_intercept(params, A))
@@ -56,7 +57,9 @@
 	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user) & COMPONENT_NO_ATTACK_HAND)
 		return TRUE
 	if(user.client)
-		if(IsAdminGhost(user))
+		if(user.scanmode & SCAN_GAS && atmosanalyzer_scan(user, src))
+			return TRUE
+		else if(IsAdminGhost(user))
 			attack_ai(user)
 		else if(user.client.prefs.inquisitive_ghost)
 			user.examinate(src)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -363,6 +363,9 @@
 	else
 		return null
 
+/atom/proc/return_analyzable_air()
+	return null
+
 ///Return the air if we can analyze it
 ///Check if this atoms eye is still alive (probably)
 /atom/proc/check_eye(mob/user)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -942,6 +942,9 @@
 		return cabin_air
 	return ..()
 
+/obj/mecha/return_analyzable_air()
+	return cabin_air
+
 /obj/mecha/proc/return_pressure()
 	var/datum/gas_mixture/t_air = return_air()
 	if(t_air)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -745,11 +745,15 @@ GENE SCANNER
 			amount += inaccurate
 	return DisplayTimeText(max(1,amount))
 
-/proc/atmosanalyzer_scan(mixture, mob/living/user, atom/target = src)
+/proc/atmosanalyzer_scan(mob/user, atom/target, silent=FALSE)
+	var/mixture = target.return_analyzable_air()
+	if(!mixture)
+		return FALSE
+
 	var/list/combined_msg = list()
 	var/icon = target
-	if(!isobserver(user))
-		user.visible_message("[user] has used the analyzer on [icon2html(icon, viewers(user))] [target].", span_notice("You use the analyzer on [icon2html(icon, user)] [target]."))
+	if(!silent && isliving(user))
+		user.visible_message("[user] has used the analyzer on [icon2html(icon, viewers(user))] [target].", "<span class='notice'>You use the analyzer on [icon2html(icon, user)] [target].</span>")
 	combined_msg += span_boldnotice("Results of analysis of [icon2html(icon, user)] [target].")
 
 	var/list/airs = islist(mixture) ? mixture : list(mixture)
@@ -785,7 +789,7 @@ GENE SCANNER
 			combined_msg += span_boldnotice("Large amounts of free neutrons detected in the air indicate that a fusion reaction took place.")
 			combined_msg += span_notice("Instability of the last fusion reaction: [instability].")
 	to_chat(user, examine_block(combined_msg.Join("\n")))
-	return
+	return TRUE
 
 //slime scanner
 

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -133,9 +133,11 @@
 	else
 		return ..()
 
-/obj/item/flamethrower/analyzer_act(mob/living/user, obj/item/I)
+/obj/item/flamethrower/return_analyzable_air()
 	if(ptank)
-		ptank.analyzer_act(user, I)
+		return ptank.return_analyzable_air()
+	else
+		return null
 
 
 /obj/item/flamethrower/attack_self(mob/user)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -112,9 +112,6 @@
 
 		qdel(src)
 
-/obj/item/tank/analyzer_act(mob/living/user, obj/item/I)
-	atmosanalyzer_scan(air_contents, user, src)
-
 /obj/item/tank/deconstruct(disassembled = TRUE)
 	if(!disassembled)
 		var/turf/T = get_turf(src)
@@ -210,6 +207,9 @@
 	return air_contents.remove(amount)
 
 /obj/item/tank/return_air()
+	return air_contents
+
+/obj/item/tank/return_analyzable_air()
 	return air_contents
 
 /obj/item/tank/assume_air(datum/gas_mixture/giver)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -323,10 +323,8 @@
 		to_chat(M, "[src] is now skinned as '[choice].'")
 
 /obj/analyzer_act(mob/living/user, obj/item/I)
-	var/turf/T = get_turf(src)
-	if(T)
-		if(atmosanalyzer_scan(T.return_air(), user, src))
-			return TRUE
+	if(atmosanalyzer_scan(user, src))
+		return TRUE
 	return ..()
 
 /obj/proc/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -36,3 +36,9 @@
 		return tank.air_contents
 	else
 		return loc.return_air()
+
+/obj/structure/closet/crate/critter/return_analyzable_air()
+	if(tank)
+		return tank.return_analyzable_air()
+	else
+		return null

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -159,6 +159,9 @@
 /obj/structure/transit_tube_pod/return_air()
 	return air_contents
 
+/obj/structure/transit_tube_pod/return_analyzable_air()
+	return air_contents
+
 /obj/structure/transit_tube_pod/assume_air(datum/gas_mixture/giver)
 	return air_contents.merge(giver)
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -232,7 +232,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 	var/turf/T = get_turf(mob)
 	if(!isturf(T))
 		return
-	show_air_status_to(T, usr)
+	atmosanalyzer_scan(usr, T, TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Air Status In Location") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_robotize(mob/M in GLOB.mob_list)

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -1,25 +1,10 @@
-/proc/show_air_status_to(turf/target, mob/user)
-	var/datum/gas_mixture/env = target.return_air()
-	var/burning = FALSE
-	if(isopenturf(target))
-		var/turf/open/T = target
-		if(T.active_hotspot)
-			burning = TRUE
-
-	var/list/lines = list(span_adminnotice("[AREACOORD(target)]: [env.return_temperature()] K ([env.return_temperature() - T0C] C), [env.return_pressure()] kPa[(burning)?(", <font color='red'>burning</font>"):(null)]"))
-	for(var/id in env.get_gases())
-		var/moles = env.get_moles(id)
-		if (abs(moles) >= 0.00001)
-			lines += "[GLOB.meta_gas_info[id][META_GAS_NAME]]: [moles] mol"
-	to_chat(usr, lines.Join("\n"))
-
 /client/proc/air_status(turf/target)
 	set category = "Misc.Server Debug"
 	set name = "Display Air Status"
 
 	if(!isturf(target))
 		return
-	show_air_status_to(target, usr)
+	atmosanalyzer_scan(usr, target, TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Air Status") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/fix_next_move()

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -57,9 +57,6 @@
 		return TRUE
 
 
-/obj/item/onetankbomb/analyzer_act(mob/living/user, obj/item/I)
-	bombtank.analyzer_act(user, I)
-
 /obj/item/onetankbomb/attack_self(mob/user) //pressing the bomb accesses its assembly
 	bombassembly.attack_self(user, TRUE)
 	add_fingerprint(user)
@@ -198,3 +195,9 @@
 		return
 	T.assume_air(removed)
 	air_update_turf()
+
+/obj/item/onetankbomb/return_analyzable_air()
+	if(bombtank)
+		return bombtank.return_analyzable_air()
+	else
+		return null

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -84,6 +84,9 @@
 	RETURN_TYPE(/datum/gas_mixture)
 	return air
 
+/turf/open/return_analyzable_air()
+	return return_air()
+
 /turf/temperature_expose()
 	if(temperature > heat_capacity)
 		to_be_destroyed = TRUE

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -158,5 +158,5 @@
 
 // Tool acts
 
-/obj/machinery/atmospherics/components/analyzer_act(mob/living/user, obj/item/I)
-	atmosanalyzer_scan(airs, user, src)
+/obj/machinery/atmospherics/components/return_analyzable_air()
+	return airs

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -57,6 +57,10 @@
 	if(parent)
 		return parent.air
 
+/obj/machinery/atmospherics/pipe/return_analyzable_air()
+	if(parent)
+		return parent.air
+
 /obj/machinery/atmospherics/pipe/remove_air(amount)
 	if(parent)
 		return parent.air.remove(amount)
@@ -68,9 +72,6 @@
 		meter.setAttachLayer(piping_layer)
 	else
 		return ..()
-
-/obj/machinery/atmospherics/pipe/analyzer_act(mob/living/user, obj/item/I)
-	atmosanalyzer_scan(parent.air, user, src)
 
 /obj/machinery/atmospherics/pipe/examine(mob/dead/observer/user)
 	if(istype(user))

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -51,6 +51,9 @@
 /obj/machinery/portable_atmospherics/return_air()
 	return air_contents
 
+/obj/machinery/portable_atmospherics/return_analyzable_air()
+	return air_contents
+
 /obj/machinery/portable_atmospherics/proc/connect(obj/machinery/atmospherics/components/unary/portables_connector/new_port)
 	//Make sure not already connected to something else
 	if(connected_port || !new_port || new_port.connected_device)
@@ -149,9 +152,6 @@
 				update_icon()
 	else
 		return ..()
-
-/obj/machinery/portable_atmospherics/analyzer_act(mob/living/user, obj/item/I)
-	atmosanalyzer_scan(air_contents, user, src)
 
 /obj/machinery/portable_atmospherics/attacked_by(obj/item/I, mob/user)
 	if(I.force < 10 && !(stat & BROKEN))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -65,7 +65,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	add_verb(src, list(
 		/mob/dead/observer/proc/dead_tele,
 		/mob/dead/observer/proc/open_spawners_menu,
-		/mob/dead/observer/proc/view_gas,
 		/mob/dead/observer/proc/tray_view,
 		/mob/dead/observer/proc/possess_mouse_verb))
 
@@ -424,14 +423,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	usr.forceMove(pick(L))
 	update_parallax_contents()
 
-/mob/dead/observer/proc/view_gas()
-	set category = "Ghost"
-	set name = "View Gases"
-	set desc= "View the atmospheric conditions in a location"
-
-	var/turf/loc = get_turf(src)
-	show_air_status_to(loc, usr)
-
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"
 	set name = "Orbit" // "Haunt"
@@ -767,6 +758,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	scanmode ^= SCAN_WOUND
 	to_chat(src, span_notice("Wound scan [scanmode & SCAN_WOUND ? "enabled" : "disabled"]."))
+
+/mob/dead/observer/verb/toggle_gas_scan()
+	set name = "Toggle Gas Scan"
+	set desc = "Toggles whether you analyze gas contents on click"
+	set category = "Ghost"
+
+	scanmode ^= SCAN_GAS
+	to_chat(src, span_notice("Gas scan [scanmode & SCAN_GAS ? "enabled" : "disabled"]."))
 
 /mob/dead/observer/verb/restore_ghost_appearance()
 	set name = "Restore Ghost Character"

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -251,9 +251,11 @@
 
 	to_chat(user, "<span class='warning'>You set the [src] mode to [mode] production.</span>")
 
-/obj/machinery/power/rad_collector/analyzer_act(mob/living/user, obj/item/I)
+/obj/machinery/power/rad_collector/return_analyzable_air()
 	if(loaded_tank)
-		loaded_tank.analyzer_act(user, I)
+		return loaded_tank.return_analyzable_air()
+	else
+		return null
 
 /obj/machinery/power/rad_collector/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
This lets ghosts toggle a gas scanner when observing (like the current health scanner toggle.) Just click whatever you want to scan when it is enabled. It will scan turfs, too.

Ported from https://github.com/tgstation/tgstation/pull/43502

# Changelog

:cl: Willox
add: Added 'Toggle Gas Scan' verb to allow observers to analyze gas mixtures
tweak: Mechs, critter closets, and transmit-tube-pods can be analyzed with analyzers
/:cl:
