### PR TITLE
The glowie mutation will now cause gradual eye damage to the user.

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -198,6 +198,19 @@
 	var/current_nullify_timer // For veil yogstation\code\modules\antagonists\shadowling\shadowling_abilities.dm
 	power_coeff = 1
 	conflicts = list(/datum/mutation/human/glow/anti)
+//Yogstation change start: Glowie now causes gradual eye damage.
+	synchronizer_coeff = 1
+	var/list/eye_damage_messages = list(
+		"Your eyes water from the light coming from your skin..."
+		"The inside of your eyelids grow bright when you blink...",
+		"You squint as the light from your eyelids glow brightly.."
+	)
+
+
+/datum/mutation/human/glow/on_life()
+	if(glow > 0 && prob(1 + 5 * GET_MUTATION_SYNCHRONIZER(src) && owner.adjustOrganLoss(ORGAN_SLOT_EYES,1 + rand(1,3) *  GET_MUTATION_POWER(src)))
+		to_chat(owner,span_warning(pick(eye_damage_messages)))
+//Yogstation change end: Glowie now causes gradual eye damage.
 
 /datum/mutation/human/glow/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -208,7 +208,7 @@
 
 
 /datum/mutation/human/glow/on_life()
-	if(glow > 0 && prob(1 + 5 * GET_MUTATION_SYNCHRONIZER(src) && owner.adjustOrganLoss(ORGAN_SLOT_EYES,1 + rand(1,3) *  GET_MUTATION_POWER(src)))
+	if(glow > 0 && prob(1 + 5 * GET_MUTATION_SYNCHRONIZER(src)) && owner.adjustOrganLoss(ORGAN_SLOT_EYES,1 + rand(1,3) *  GET_MUTATION_POWER(src)))
 		to_chat(owner,span_warning(pick(eye_damage_messages)))
 //Yogstation change end: Glowie now causes gradual eye damage.
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -201,7 +201,7 @@
 //Yogstation change start: Glowie now causes gradual eye damage.
 	synchronizer_coeff = 1
 	var/list/eye_damage_messages = list(
-		"Your eyes water from the light coming from your skin..."
+		"Your eyes water from the light coming from your skin...",
 		"The inside of your eyelids grow bright when you blink...",
 		"You squint as the light from your eyelids glow brightly.."
 	)


### PR DESCRIPTION


# Document the changes in your pull request

The glowie mutation will now cause gradual eye damage to the user. The effect can be reduced by reducing power or increasing the synchronizer value.

# Justification

You think having your skin glow brighter than a flashlight won't cause any issues to your eyes? (Your eyelids are skin!)

While shadowlings do get some way to nullify glowie, it is still very strong to use against them and can effectively shut them down if the crew manages to get their hands on mass glowie production. This will make it so that crew will have to get help from the chemist if they want to be practically shielded from Darkspawn.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Guide_to_Genetics needs to be updated.



# Changelog

:cl: BurgerBB (Not a shadowling thrall)
tweak: The glowie mutation will now cause gradual eye damage to the user. The effect can be reduced by reducing power or increasing the synchronizer value.
/:cl:
