### PR TITLE
what the guh??? mechs for uplinked erts???

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -55,8 +55,12 @@
 	force = 50
 	max_equip = 5
 
+/obj/mecha/combat/marauder/seraph/unloaded
+
 /obj/mecha/combat/marauder/seraph/Initialize()
 	. = ..()
+	if(istype(src,/obj/mecha/combat/marauder/seraph/unloaded))
+		return
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2810,6 +2810,94 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/ammo_box/magazine/wt550m9/wtr
 	cost = 1
 
+/datum/uplink_item/nt/mech
+	category = "Exosuits"
+	required_ert_uplink = NT_ERT_ENGINEER
+
+/datum/uplink_item/nt/mech/marauder
+	name = "Marauder exosuit"
+	desc = "A heavy-duty exosuit for when the going gets tough. Armed with three smoke bombs, and capable of mounting three pieces of equipment."
+	item = /obj/mecha/combat/marauder
+	cost = 12
+
+/datum/uplink_item/nt/mech/seraph
+	name = "Seraph exosuit"
+	desc = "An ultra-heavy exosuit designed for destroying armies. Faster, tougher, and stronger than it's Marauder cousin."
+	item = /obj/mecha/combat/marauder/seraph/unloaded
+	cost = 30
+
+/datum/uplink_item/nt/mech/laser
+	name = "CH-PS Laser"
+	desc = "A mounted laser cannon. Fires standard lasers."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
+	cost = 2
+
+/datum/uplink_item/nt/mech/hades
+	name = "FNX-99 Carbine"
+	desc = "A mounted incendiary cannon. Fires bullets that do little damage, but light targets on fire."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
+	cost = 4
+
+/datum/uplink_item/nt/mech/scattershot
+	name = "LBX AC 10"
+	desc = "A mounted shotgun. Fires a larger variant of buckshot, making it devastating at close range."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot
+	cost = 4
+
+/datum/uplink_item/nt/mech/lmg
+	name = "Ultra AC 2"
+	desc = "A mounted machine gun, fires in three round bursts."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
+	cost = 4
+
+/datum/uplink_item/nt/mech/missile_launcher
+	name = "SRM-8"
+	desc = "A mounted missile rack."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
+	cost = 4
+
+/datum/uplink_item/nt/mech/pulse
+	name = "eZ-13"
+	desc = "A mounted heavy pulse cannon capable of firing heavy pulses, which can destroy multiple walls at once as well as decimating soft targets."
+	item = /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
+	cost = 10
+
+/datum/uplink_item/nt/mech/droid
+	name = "Repair droid"
+	desc = "A repair droid that will patch up most damage to a mech. Consumes a lot of power in the process."
+	item = /obj/item/mecha_parts/mecha_equipment/repair_droid
+	cost = 2
+
+/datum/uplink_item/nt/mech/tesla
+	name = "Tesla relay"
+	desc = "A remote, passive recharger for mechs. Very, very slow."
+	item = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	cost = 1
+
+/datum/uplink_item/nt/mech/hadesammo
+	name = "FNX-99 Ammunition"
+	desc = "An ammo box for the FNX-99 carbine."
+	item = /obj/item/mecha_ammo/incendiary
+	cost = 1
+
+/datum/uplink_item/nt/mech/scattershotammo
+	name = "LBX AC 10 Ammunition"
+	desc = "An ammo box for the LBX AC 10."
+	item = /obj/item/mecha_ammo/scattershot
+	cost = 1
+
+/datum/uplink_item/nt/mech/ultrammo
+	name = "Ultra AC 2 Ammunition"
+	desc = "An ammo box for the Ultra AC 2"
+	item = /obj/item/mecha_ammo/lmg
+	cost = 1
+
+/datum/uplink_item/nt/mech/missiles
+	name = "SRM-8 Missiles"
+	desc = "Additional missiles for the SRM-8 missile launcher."
+	item = /obj/item/mecha_ammo/missiles_he
+	cost = 1
+
 /datum/uplink_item/nt/cqc
 	category = "Close Quarters Combat"
 


### PR DESCRIPTION
may or may not have been requested by a certain ynot01 (i cant tell you because that would be leaking)

adds mechs to the engineer so they actually have interesting stuff to do as an alternative to being bob the builder
the mechs have no equipment as it must be purchased separately
most mech weapons are 4wcs, except the eZ-13 which is 10
marauder is 12wc (making it accessible to blues, although barely and when combined with ammo and a weapon leaves you with no wc) and seraph is 30wc so its really only deathsquad accessible
all ammos are 1wc per ammo box

yes these are pretty cheap but they are also more or less useless against non xenomorphs because melted in 0.5 seconds with emps (uncounterable) also there's a huge gap between red ert and deathsquad which is pretty difficult to accommodate 

# Changelog

:cl:  
rscadd: mechs for uplink erts
/:cl:
