### PR TITLE
remove ion rifle emp protection

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -12,9 +12,6 @@
 	flight_x_offset = 17
 	flight_y_offset = 9
 
-/obj/item/gun/energy/ionrifle/emp_act(severity)
-	return
-
 /obj/item/gun/energy/ionrifle/carbine
 	name = "ion carbine"
 	desc = "The MK.II Prototype Ion Projector is a lightweight carbine version of the larger ion rifle, built to be ergonomic and efficient."


### PR DESCRIPTION
adds counterplay for mechs (people will actually use the heavy ion cannon now) as well as punishing you for rushing in and emping yourself

# Changelog

:cl:  
tweak: ion rifle (and carbine) are no longer fully immune to all emps
/:cl:
