### PR TITLE
Nerfs and Reworks Ninja

### DIFF
--- a/code/datums/actions/ninja.dm
+++ b/code/datums/actions/ninja.dm
@@ -1,46 +1,48 @@
 /datum/action/item_action/initialize_ninja_suit
 	name = "Toggle ninja suit"
 
+//Current ninja cell is 20000.
+
 /datum/action/item_action/ninjasmoke
-	name = "Smoke Bomb"
+	name = "Smoke Bomb (100E)" //0.5%
 	desc = "Blind your enemies momentarily with a well-placed smoke bomb."
 	button_icon_state = "smoke"
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 
 /datum/action/item_action/ninjaboost
 	check_flags = NONE
-	name = "Adrenaline Boost"
+	name = "Adrenaline Boost (250E)" //1.25%
 	desc = "Inject a secret chemical that will counteract all movement-impairing effect."
 	button_icon_state = "repulse"
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 
 /datum/action/item_action/ninjapulse
-	name = "EM Burst (25E)"
+	name = "EM Burst (5000E)" // 25%
 	desc = "Disable any nearby technology with an electro-magnetic pulse."
 	button_icon_state = "emp"
 	icon_icon = 'icons/mob/actions/actions_spells.dmi'
 
 /datum/action/item_action/ninjastar
-	name = "Create Throwing Stars (3E)"
+	name = "Create Throwing Stars (500E)" //2.5%
 	desc = "Creates some throwing stars"
 	button_icon_state = "throwingstar"
 	icon_icon = 'icons/obj/weapons/misc.dmi'
 
 /datum/action/item_action/ninjanet
-	name = "Energy Net (25E)"
-	desc = "Captures a fallen opponent in a net of energy. Will teleport them to a holding facility after 30 seconds."
+	name = "Energy Net (1000E)" //5%
+	desc = "Captures a fallen opponent in a net of energy."
 	button_icon_state = "energynet"
 	icon_icon = 'icons/effects/effects.dmi'
 
 /datum/action/item_action/ninja_sword_recall
-	name = "Recall Energy Katana (Variable Cost)"
+	name = "Recall Energy Katana (200E per tile)" //1% per tile.
 	desc = "Teleports the Energy Katana linked to this suit to its wearer, cost based on distance."
 	button_icon_state = "energy_katana"
 	icon_icon = 'icons/obj/weapons/swords.dmi'
 
 /datum/action/item_action/ninja_stealth
 	name = "Toggle Stealth"
-	desc = "Toggles stealth mode on and off."
+	desc = "Toggles stealth mode on and off. Only works in darkness."
 	button_icon_state = "ninja_cloak"
 	icon_icon = 'icons/mob/actions/actions_minor_antag.dmi'
 

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -10,11 +10,6 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	var/give_objectives = TRUE
 	var/give_equipment = TRUE
 
-/datum/antagonist/ninja/New()
-	if(helping_station)
-		can_hijack = HIJACK_PREVENT
-	. = ..()
-
 /datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	for(var/obj/item/implant/explosive/E in M.implants)
@@ -101,9 +96,7 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by right clicking on it, to use abilities like stealth)!")
 	to_chat(owner.current, "I am not allied to the Syndicate nor NanoTrasen. I am not complete my objectives without drawing too much attention.")
 	to_chat(owner.current, "<b>If you are new to playing the Space Ninja, please review the <a href='https://wiki.yogstation.net/wiki/Space_Ninja'>Space Ninja</a> wiki entry for explanations and abilities.</b>") //Yogs
-	if(helping_station) {
-		to_chat(owner.current, "<b>As a Ninja, you are beholden to <a href='https://forums.yogstation.net/help/rules/#rule-3_1_1'>rule 3.1.1</a>: Do not murderbone.</b>")
-	}
+	to_chat(owner.current, "<b>As a Ninja, you are beholden to <a href='https://forums.yogstation.net/help/rules/#rule-3_1_1'>rule 3.1.1</a>: Do not murderbone.</b>")
 	owner.announce_objectives()
 	return
 
@@ -144,8 +137,6 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 			adj = "objectiveless"
 		else
 			return
-	if(helping_station)
-		can_hijack = HIJACK_PREVENT
 	new_owner.assigned_role = ROLE_NINJA
 	new_owner.special_role = ROLE_NINJA
 	new_owner.add_antag_datum(src)

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -7,7 +7,6 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
 	antag_moodlet = /datum/mood_event/focused
-	var/helping_station = FALSE
 	var/give_objectives = TRUE
 	var/give_equipment = TRUE
 
@@ -36,80 +35,53 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 /datum/antagonist/ninja/proc/addMemories()
 	antag_memory += "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!<br>"
 	antag_memory += "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by clicking the initialize UI button, to use abilities like stealth)!<br>"
-	antag_memory += "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.<br>"
-	name = "[helping_station?"Nanotrasen Ninja":"Syndicate Ninja"]" // yogs - ninja disposition
+	antag_memory += "I am not allied to the Syndicate nor NanoTrasen. I am not complete my objectives without drawing too much attention."
+	name = "Spider Clan Ninja"
 
-/datum/antagonist/ninja/proc/addObjectives(quantity = 6)
-	var/list/possible_targets = list()
-	for(var/datum/mind/M in SSticker.minds)
-		if(M.current && M.current.stat != DEAD)
-			if(ishuman(M.current))
-				if(M.special_role)
-					possible_targets[M] = 0						//bad-guy
-				else if(M.assigned_role in GLOB.command_positions)
-					possible_targets[M] = 1						//good-guy
+/datum/antagonist/ninja/proc/addObjectives(quantity = 4)
 
-	var/list/possible_objectives = list(1,2,3,4)
+	var/list/possible_objectives = list(1,2,2,2,3,3,4)
 
 	while(objectives.len < quantity)
 		switch(pick_n_take(possible_objectives))
 			if(1)	//research
-				var/datum/objective/download/O = new /datum/objective/download()
+				var/datum/objective/download/O = new
 				O.owner = owner
 				O.gen_amount_goal()
 				objectives += O
 
 			if(2)	//steal
-				var/datum/objective/steal/special/O = new /datum/objective/steal/special()
+				var/datum/objective/steal/special/O = new
 				O.owner = owner
 				O.find_target()
 				objectives += O
 
-			if(3)	//protect/kill
-				if(!possible_targets.len)	continue
-				var/index = rand(1,possible_targets.len)
-				var/datum/mind/M = possible_targets[index]
-				var/is_bad_guy = possible_targets[M]
-				possible_targets.Cut(index,index+1)
-
-				if(is_bad_guy ^ helping_station)			//kill (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/assassinate/O = new /datum/objective/assassinate()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Slay \the [M.current.real_name], the [M.assigned_role]."
-					objectives += O
-				else										//protect
-					var/datum/objective/protect/O = new /datum/objective/protect()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Protect \the [M.current.real_name], the [M.assigned_role], from harm."
-					objectives += O
+			if(3)	//kill
+				var/datum/objective/assassinate/A = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
+				A = new A
+				A.owner = owner
+				A.find_target()
+				objectives += A
+				if(A.target && prob(20))
+					var/datum/objective/minor/deadpics/D = new
+					D.owner = owner
+					D.target = A.target
+					objectives += D
 			if(4)	//debrain/capture
-				if(!possible_targets.len)	continue
-				var/selected = rand(1,possible_targets.len)
-				var/datum/mind/M = possible_targets[selected]
-				var/is_bad_guy = possible_targets[M]
-				possible_targets.Cut(selected,selected+1)
-
-				if(is_bad_guy ^ helping_station)			//debrain (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/debrain/O = new /datum/objective/debrain()
-					O.owner = owner
-					O.target = M
-					O.explanation_text = "Steal the brain of [M.current.real_name]."
-					objectives += O
-				else										//capture
-					var/datum/objective/capture/O
-					if(helping_station) {
-						O = new /datum/objective/capture()
-					} else {
-						O = new /datum/objective/capture/living()
-					}
-					O.owner = owner
-					O.gen_amount_goal()
-					objectives += O
-			else
+				var/datum/objective/protect/P = new
+				P.owner = owner
+				P.find_target()
+				objectives += P
+				if(P.target && prob(20))
+					var/datum/objective/maroon/M = new
+					M.owner = owner
+					M.target = P.target
+					objectives += M
+			else //Failsafe.
 				break
-	var/datum/objective/O = new /datum/objective/survive()
+
+	var/datum/objective/O = pick(/datum/objective/martyr,/datum/objective/survive)
+	O = new O
 	O.owner = owner
 	objectives += O
 
@@ -128,10 +100,10 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	SEND_SOUND(owner.current, sound('sound/effects/ninja_greeting.ogg'))
 	to_chat(owner.current, "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!")
 	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by right clicking on it, to use abilities like stealth)!")
-	to_chat(owner.current, "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.")
+	to_chat(owner.current, "I am not allied to the Syndicate nor NanoTrasen. I am not complete my objectives without drawing too much attention.")
 	to_chat(owner.current, "<b>If you are new to playing the Space Ninja, please review the <a href='https://wiki.yogstation.net/wiki/Space_Ninja'>Space Ninja</a> wiki entry for explanations and abilities.</b>") //Yogs
 	if(helping_station) {
-		to_chat(owner.current, "<b>As a Nanotrasen ninja, you are beholden to <a href='https://forums.yogstation.net/help/rules/#rule-3_1_1'>rule 3.1.1</a>: Do not murderbone.</b>")
+		to_chat(owner.current, "<b>As a Ninja, you are beholden to <a href='https://forums.yogstation.net/help/rules/#rule-3_1_1'>rule 3.1.1</a>: Do not murderbone.</b>")
 	}
 	owner.announce_objectives()
 	return
@@ -164,16 +136,10 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 
 /datum/antagonist/ninja/admin_add(datum/mind/new_owner,mob/admin)
 	var/adj
-	switch(input("What kind of ninja?", "Ninja") as null|anything in list("Random","Syndicate","Nanotrasen","No objectives"))
-		if("Random")
-			helping_station = pick(TRUE,FALSE)
-			adj = ""
-		if("Syndicate")
-			helping_station = FALSE
-			adj = "syndie"
-		if("Nanotrasen")
-			helping_station = TRUE
-			adj = "friendly"
+	switch(input("What kind of ninja?", "Ninja") as null|anything in list("Normal", "No objectives"))
+		if("Normal")
+			give_objectives = TRUE
+			adj = "normal"
 		if("No objectives")
 			give_objectives = FALSE
 			adj = "objectiveless"

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -80,8 +80,7 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 			else //Failsafe.
 				break
 
-	var/datum/objective/O = pick(/datum/objective/martyr,/datum/objective/survive)
-	O = new O
+	var/datum/objective/survive/O = new
 	O.owner = owner
 	objectives += O
 

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -21,13 +21,8 @@ Contents:
 	var/success_spawn = 0
 	role_name = "space ninja"
 	minimum_required = 1
-
-	var/helping_station
 	var/spawn_loc
 	var/give_objectives = TRUE
-
-/datum/round_event/ghost_role/ninja/setup()
-	helping_station = rand(0,1)
 
 /datum/round_event/ghost_role/ninja/kill()
 	if(!success_spawn && control)
@@ -66,7 +61,6 @@ Contents:
 	var/mob/living/carbon/human/Ninja = create_space_ninja(spawn_loc)
 	Mind.transfer_to(Ninja)
 	var/datum/antagonist/ninja/ninjadatum = new
-	ninjadatum.helping_station = pick(TRUE,FALSE)
 	Mind.add_antag_datum(ninjadatum)
 
 	var/datum/language_holder/H = Ninja.get_language_holder() //yogs start

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -21,5 +21,4 @@
 		var/obj/item/clothing/suit/space/space_ninja/S = H.wear_suit
 		if(istype(H.belt, belt))
 			S.energyKatana = H.belt
-		S.randomize_param()
 

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -20,9 +20,7 @@ It is possible to destroy the net by the occupant or someone else.
 	buckle_prevents_pull = TRUE
 	var/mob/living/carbon/affecting//Who it is currently affecting, if anyone.
 	var/mob/living/carbon/master//Who shot web. Will let this person know if the net was successful or failed.
-	var/check = 15//30 seconds before teleportation. Could be extended I guess.
-	var/success = FALSE
-
+	var/check = 15 //30 seconds before teleportation. Could be extended I guess.
 
 /obj/structure/energy_net/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -35,8 +33,6 @@ It is possible to destroy the net by the occupant or someone else.
 	if(!success)
 		if(!QDELETED(affecting))
 			affecting.visible_message("[affecting.name] was recovered from the energy net!", "You were recovered from the energy net!", span_italics("You hear a grunt."))
-		if(!QDELETED(master))//As long as they still exist.
-			to_chat(master, "[span_userdanger("ERROR")]: unable to initiate capture protocol. Procedure terminated.")
 	return ..()
 
 /obj/structure/energy_net/process()
@@ -48,31 +44,7 @@ It is possible to destroy the net by the occupant or someone else.
 		check--
 		return
 
-	success = TRUE
 	qdel(src)
-	if(ishuman(affecting))
-		var/mob/living/carbon/human/H = affecting
-		for(var/obj/item/W in H)
-			if(W == H.w_uniform)
-				continue//So all they're left with are shoes and uniform.
-			if(W == H.shoes)
-				continue
-			H.dropItemToGround(W)
-
-	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
-	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)
-
-	visible_message("[affecting] suddenly vanishes!")
-	affecting.forceMove(pick(GLOB.holdingfacility)) //Throw mob in to the holding facility.
-	GLOB.ninja_capture += affecting
-	to_chat(affecting, span_danger("You appear in a strange place. You feel very trapped."))
-
-	if(!QDELETED(master))//As long as they still exist.
-		to_chat(master, span_notice("<b>SUCCESS</b>: capture procedure of [affecting] complete."))
-	do_sparks(5, FALSE, affecting)
-	playsound(affecting, 'sound/effects/phasein.ogg', 25, 1)
-	playsound(affecting, 'sound/effects/sparks2.ogg', 50, 1)
-	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
 /obj/structure/energy_net/attack_paw(mob/user)
 	return attack_hand()

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
@@ -2,7 +2,7 @@
 //Movement impairing would indicate drugs and the like.
 /obj/item/clothing/suit/space/space_ninja/proc/ninjaboost()
 
-	if(!ninjacost(0,N_ADRENALINE))
+	if(!ninjacost(250,N_ADRENALINE))
 		var/mob/living/carbon/human/H = affecting
 		H.SetUnconscious(0)
 		H.SetStun(0)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_cost_check.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_cost_check.dm
@@ -3,13 +3,12 @@
 //Cost function for suit Procs/Verbs/Abilities
 /obj/item/clothing/suit/space/space_ninja/proc/ninjacost(cost = 0, specificCheck = 0)
 	var/mob/living/carbon/human/H = affecting
-	var/actualCost = cost*10
-	if(cost && cell.charge < actualCost)
-		to_chat(H, span_danger("Not enough energy."))
+	if(cost && cell.charge < cost)
+		to_chat(H, span_danger("Not enough energy!"))
 		return 1
 	else
 		//This shit used to be handled individually on every proc.. why even bother with a universal check proc then?
-		cell.charge-=(actualCost)
+		cell.charge -= cost
 
 	switch(specificCheck)
 		if(N_STEALTH_CANCEL)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_empulse.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_empulse.dm
@@ -3,7 +3,7 @@
 //Disables nearby tech equipment.
 /obj/item/clothing/suit/space/space_ninja/proc/ninjapulse()
 
-	if(!ninjacost(250,N_STEALTH_CANCEL))
+	if(!ninjacost(5000,N_STEALTH_CANCEL))
 		var/mob/living/carbon/human/H = affecting
 		playsound(H.loc, 'sound/effects/empulse.ogg', 60, 2)
 		empulse(H, 4, 6) //Procs sure are nice. Slightly weaker than wizard's disable tch.

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
@@ -31,7 +31,7 @@
 	if(istype(C, /mob/dead/observer))
 		to_chat(H, span_warning("You may not use an energy net on ghosts!"))
 		return
-	if(!ninjacost(250,N_STEALTH_CANCEL)) //25 energy, 25% of base cell.
+	if(!ninjacost(1000,N_STEALTH_CANCEL)) //25 energy, 25% of base cell.
 		H.Beam(C,"n_beam",time=15)
 		H.say("Get over here!", forced = "ninja net")
 		var/obj/structure/energy_net/E = new /obj/structure/energy_net(C.drop_location())

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_smoke.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_smoke.dm
@@ -3,7 +3,7 @@
 //Smoke bomb
 /obj/item/clothing/suit/space/space_ninja/proc/ninjasmoke()
 
-	if(!ninjacost(0,N_SMOKE_BOMB))
+	if(!ninjacost(100,N_SMOKE_BOMB))
 		var/mob/living/carbon/human/H = affecting
 		var/datum/effect_system/smoke_spread/bad/smoke = new
 		smoke.set_up(4, H.loc)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -2,7 +2,7 @@
 
 //Creates a throwing star for 3 energy, 3% of the base power cell.
 /obj/item/clothing/suit/space/space_ninja/proc/ninjastar()
-	if(!ninjacost(30))
+	if(!ninjacost(500))
 		var/mob/living/carbon/human/H = affecting
 		var/obj/item/throwing_star/ninja/N = new(H)
 		if(H.put_in_hands(N))

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_sword_recall.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_sword_recall.dm
@@ -15,7 +15,7 @@
 	var/distance = get_dist(H,energyKatana)
 
 	if(!(energyKatana in view(H)))
-		cost = distance //Actual cost is cost x 10, so 5 turfs is 50 cost.
+		cost = distance*200 // 5 turfs is 500 cost.
 		inview = 0
 
 	if(!ninjacost(cost))
@@ -24,7 +24,7 @@
 			C.transferItemToLoc(energyKatana, get_turf(energyKatana), TRUE)
 
 			//Yogs start -- Yogs vorecode
-			//Somebody swollowed my sword, probably the clown doing a circus act.	
+			//Somebody swollowed my sword, probably the clown doing a circus act.
 			if(energyKatana in C.stomach_contents)
 				C.stomach_contents -= energyKatana
 			//Yogs end

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -40,8 +40,8 @@ Contents:
 		//Main function variables.
 	var/s_initialized = 0//Suit starts off.
 	var/s_coold = 0//If the suit is on cooldown. Can be used to attach different cooldowns to abilities. Ticks down every second based on suit ntick().
-	var/s_cost = 5//Base energy cost each ntick.
-	var/s_acost = 25//Additional cost for additional powers active.
+	var/s_cost = 10//Base energy cost each ntick.
+	var/s_acost = 50//Additional cost for additional powers active.
 	var/s_delay = 40//How fast the suit does certain things, lower is faster. Can be overridden in specific procs. Also determines adverse probability.
 	var/a_transfer = 20//How much radium is used per adrenaline boost.
 	var/a_maxamount = 7//Maximum number of adrenaline boosts.
@@ -54,7 +54,7 @@ Contents:
 
 		//Ability function variables.
 	var/s_bombs = 10//Number of smoke bombs.
-	var/a_boost = 3//Number of adrenaline boosters.
+	var/a_boost = 5//Number of adrenaline boosters.
 
 
 /obj/item/clothing/suit/space/space_ninja/get_cell()
@@ -72,10 +72,8 @@ Contents:
 	stored_research = new()
 
 	//Cell Init
-	cell = new/obj/item/stock_parts/cell/high
-	cell.charge = 9000
-	cell.name = "black power cell"
-	cell.icon_state = "bscell"
+	//Yogs change, ninja suits get super capacity power cells.
+	cell = new/obj/item/stock_parts/cell/super
 
 //Simply deletes all the attachments and self, killing all related procs.
 /obj/item/clothing/suit/space/space_ninja/proc/terminate()
@@ -83,16 +81,6 @@ Contents:
 	qdel(n_gloves)
 	qdel(n_shoes)
 	qdel(src)
-
-
-//Randomizes suit parameters.
-/obj/item/clothing/suit/space/space_ninja/proc/randomize_param()
-	s_cost = rand(1,20)
-	s_acost = rand(20,100)
-	s_delay = rand(10,100)
-	s_bombs = rand(5,20)
-	a_boost = rand(1,7)
-
 
 //This proc prevents the suit from being taken off.
 /obj/item/clothing/suit/space/space_ninja/proc/lock_suit(mob/living/carbon/human/H)

--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -12,7 +12,10 @@
 			cell.charge -= s_cost//s_cost is the default energy cost each ntick, usually 5.
 			if(stealth)//If stealth is active.
 				cell.charge -= s_acost
-
+				var/turf/T = get_turf(U)
+				var/lums = T.get_lumcount()
+				if(lums > 0.5)
+					cancel_stealth()
 		else
 			cell.charge = 0
 			cancel_stealth()


### PR DESCRIPTION
# Justification

To me it doesn't really make sense that a mid-round ghost role can have so much power over affecting the round while being nearly untouchable. 
- Most players are uneasy about hunting Ninjas because it has a chance to be NanoTrasen aligned. While it really isn't against the rules to kill a NanoTrasen ninja because it's a ninja, people are still hesitant to do so anyways like they're hesitant to toolbox a Delta Station engineer who stumbles upon the station.
- Ninjas are super fast and incredibly stealthy. It is absurdly hard to catch one and is very close to wizard in terms of evasion. This is fine for a ninja, but it is really strong for a mid-round ghost role.
- Not only do Ninjas (potentially) have objectives to kill or protect heads, but they (potentially) have objectives to kill or protect antagonists, effectively outing them or shutting down their round. No mid-round ghost role should have a license to validhunt.
- Ninjas have a license to capture people and effectively keep them from the round entirely unless they die. This is pretty anti-fun and is honestly no different than round-removing random people.



# Document the changes in your pull request

- Ninjas no longer have an alliance (NanoTrasen aligned, Syndicate Aligned) and will always be Neutral.
- Ninjas can have up to 4 objectives chosen from a pool of objectives (See below).
- Ninja suit stats are no longer randomized.
- Energy nets no longer teleport players to GBJ (shoutout to SimpleFlips!), but rather trap them for 30 seconds.
- Stealth mode require less than 0.5 lumens (0 is completely dark, 1 is completely fullbright) to work.
- Increases the battery cell of the suit from a cell that gives 9000 energy to a cell that gives 20000 energy.
- Increases the energy cost of EMP from 2500 to 5000.
- Increases the energy cost of Adrenaline from 0 to 250.
- Decreases the energy cost of Nets from 2500 to 1000.
- Increases the energy cost of Smoke Bombs from 0 to 100.
- Increases the energy cost of Shuriken from 300 to 500.
- Increases the energy cost of Sword Recall from 100 per turf to 200 per turf.
- Increases the suit passive energy cost from 5 per tick to 10 per tick.
- Increases the suit stealth energy cost from 25 per tick to 50 per tick.
- Increases the amount of adrenal boosters from 3 to 5.

Current Ninja objectives (4 randomly chosen, can have duplicates).
- Steal research nodes.
- Steal important item.
- Kill (anyone, previously it was limited to heads/antags). Has a 20% chance to additionally add an "extract with a photo of the body" objective.
- Protect (anyone, previously it was limited to heads/antags). Has a 20% chance to additionally add a "prevent the target from escaping" objective.

With a guaranteed 

- Survive until the end of the round.



# Wiki Documentation

https://wiki.yogstation.net/wiki/Space_Ninja Needs to be updated.

# Changelog

:cl:  BurgerBB
tweak: Rebalances Ninja and their objectives.
/:cl:
