### PR TITLE
Gives CMO a syringe gun in their locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -70,6 +70,7 @@
 	new /obj/item/clipboard/yog/paperwork/cmo(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/med/chief(src)
 	new /obj/item/storage/lockbox/medal/med(src)
+	new /obj/item/gun/syringe(src)
 
 
 /obj/structure/closet/secure_closet/paramedic


### PR DESCRIPTION
Security having exclusive access to the syringe guns is weird considering only medical can really use them.
It being locked to CMO means medical still has access if something goes wrong, but shouldn't allow for easy validhunting.

:cl:  
rscadd: CMO gets a syringe gun in their locker
/:cl:
