### PR TITLE
Plasmeme can no longer get husked

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -4,7 +4,7 @@
 	say_mod = "rattles"
 	sexes = FALSE
 	meat = /obj/item/stack/sheet/mineral/plasma
-	species_traits = list(NOBLOOD,NOTRANSSTING,HAS_BONE, AGENDER)
+	species_traits = list(NOBLOOD,NOTRANSSTING, HAS_BONE, AGENDER, NOHUSK)
 	// plasmemes get hard to wound since they only need a severe bone wound to dismember, but unlike skellies, they can't pop their bones back into place.
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_NOHUNGER,TRAIT_CALCIUM_HEALER,TRAIT_ALWAYS_CLEAN,TRAIT_HARDLY_WOUNDED)
 	inherent_biotypes = list(MOB_UNDEAD, MOB_HUMANOID)


### PR DESCRIPTION
QoL for the poor plasmeme that dies and gets cloned and husked infinitely
Realistically, how does a skeleton even get husked?

:cl:  
tweak: Plasmeme can no longer get husked
/:cl:
