### PR TITLE
Insulated gloves now have nodrop so you can't steal them as easy

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -2,7 +2,6 @@
 	dying_key = DYE_REGISTRY_GLOVES
 
 /obj/item/clothing/gloves/color/yellow
-/obj/item/clothing/gloves/color/yellow
 	desc = "These gloves will protect the wearer from electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
@@ -10,6 +9,10 @@
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 	resistance_flags = NONE
+
+/obj/item/clothing/gloves/color/yellow/Initialize
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, "fuck you assistant mains")
 
 /obj/item/clothing/gloves/color/fyellow                             //Cheap Chinese Crap
 	desc = "These gloves are cheap knockoffs of the coveted ones - no way this can end badly."

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -10,7 +10,7 @@
 	permeability_coefficient = 0.05
 	resistance_flags = NONE
 
-/obj/item/clothing/gloves/color/yellow/Initialize
+/obj/item/clothing/gloves/color/yellow/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, "fuck you assistant mains")
 


### PR DESCRIPTION
# Document the changes in your pull request

If you want my gloves you're going to have to pry them from my COLD, DEAD HANDS

# Wiki Documentation

Insulated gloves cannot be taken off once you have equipped them, barring dismemberment

# Changelog

:cl:  
rscadd: engineers have begun to lace the inside of their gloves with gorilla glue in the advent of a massive increase in glove-related thefts
bugfix: fixes insulated gloves being given a path twice, apparently?
/:cl:
