### PR TITLE
IPC lungs mechfab print

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -923,7 +923,7 @@
 	category = list("IPC Components")
 
 /datum/design/ipc_lungs
-	name = "Auditory Sensors"
+	name = "Cooling Radiator"
 	id = "ipc_lungs"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/lungs/ipc


### PR DESCRIPTION
Lungs were labelled as ears

:cl:  
bugfix: Properly named IPC organ printing
/:cl:
