### PR TITLE
Adds a cap to stamina damage slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1409,7 +1409,7 @@ GLOBAL_LIST_EMPTY(mentor_races)
 			if(I.item_flags & SLOWS_WHILE_IN_HAND)
 				. += I.slowdown
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
-			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
+			var/health_deficiency = max(H.maxHealth - H.health, min(H.staminaloss, H.maxHealth))
 			if(HAS_TRAIT(H, TRAIT_REDUCED_DAMAGE_SLOWDOWN))
 				health_deficiency -= H.maxHealth * 0.2 //20% more damage required for slowdown
 			if(health_deficiency >= H.maxHealth * 0.4)


### PR DESCRIPTION
# Document the changes in your pull request

Adds a cap to stamina damage slowdown. The cap is based off of max health, so that any stamina damage beyond what would cause you go into crit will not further increase the slowdown. The reason for this cap is because with anti-stuns you can easily accumulate hundreds of stamina damage causing you to be practically immobilized, which kinda defeats the whole purpose of antistuns. So, I've added a limit to how much it can slow you that I believe to be reasonable.

NOTE: This cap will NOT affect anyone that isn't stun-immune, you'll go into stamina crit before the point that it actually starts to matter.

# Changelog

:cl:  
tweak: caps slowdown from stamina damage
/:cl:
