### PR TITLE
Fucking pixelshifters mane

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -228,18 +228,3 @@
 
 /datum/keybinding/mob/prevent_movement/up(client/user)
 	user.movement_locked = FALSE
-
-
-/datum/keybinding/mob/pixel_shift
-	hotkey_keys = list("CtrlShift")
-	name = "pixel_shift"
-	full_name = "Pixel shift"
-	description = "Allows you to shift your characters by a few pixels"
-
-/datum/keybinding/mob/pixel_shift/down(client/user)
-	user.movement_locked = TRUE // we also set this to ensure we don't move
-	user.pixel_shifting = TRUE
-
-/datum/keybinding/mob/pixel_shift/up(client/user)
-	user.movement_locked = FALSE
-	user.pixel_shifting = FALSE

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -15,9 +15,10 @@
 	if((movement_dir & EAST) && (movement_dir & WEST))
 		movement_dir &= ~(EAST|WEST)
 
-	if (user.pixel_shifting)
-		setShift(movement_dir)
-	else if(user.movement_locked)
-		setDir(movement_dir)
+	if(user.movement_locked)
+		if (user.keys_held["Shift"])
+			setShift(movement_dir)
+		else
+			setDir(movement_dir)
 	else
 		user.Move(get_step(src, movement_dir), movement_dir)


### PR DESCRIPTION
# Document the changes in your pull request
Having conflicting keybinds like this WILL break stuff. Pixel-shifting is now hardcoded to "Block movement" + shift (Ctrl + Shift by default)
