### PR TITLE
durand is no longer literally just the best combat mech

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -11,6 +11,8 @@
 	infra_luminosity = 8
 	force = 35
 	wreckage = /obj/structure/mecha_wreckage/durand
+	baseline_emp_damage = 80
+	baseline_equipment_disable = 6 SECONDS
 
 /obj/mecha/combat/durand/GrantActions(mob/living/user, human_occupant = 0)
 	..()

--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -63,7 +63,9 @@
 		return 0
 	if (targloc == curloc)
 		return 0
-	
+	if(chassis.equipment_disabled)
+		to_chat(chassis.occupant, "<span=warn>Error -- Equipment control unit is unresponsive.</span>")
+		return 0
 	
 	if(target == targloc && !(chassis.occupant.a_intent == INTENT_HELP) && cleave)	//If we are targetting a location, not an object or mob, and we're not in a passive stance
 		cleave_attack()

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -129,7 +129,8 @@
 
 	var/occupant_sight_flags = 0 //sight flags to give to the occupant (e.g. mech mining scanner gives meson-like vision)
 	var/mouse_pointer
-
+	var/baseline_emp_damage = 40
+	var/baseline_equipment_disable = 3 SECONDS
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
 
 /obj/item/radio/mech //this has to go somewhere

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -162,7 +162,7 @@
 		return
 	if(get_charge())
 		use_power((cell.charge/3)/(severity*2))
-		take_damage(40 / severity, BURN, ENERGY, 1)
+		take_damage(baseline_emp_damage / severity, BURN, ENERGY, 1)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	if(istype(src, /obj/mecha/combat))
@@ -171,7 +171,7 @@
 	if(!equipment_disabled && occupant) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupant, "<span=danger>Error -- Connection to equipment control unit has been lost.</span>")
 	overload_action.Activate(0)
-	addtimer(CALLBACK(src, /obj/mecha/proc/restore_equipment), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, /obj/mecha/proc/restore_equipment), baseline_equipment_disable, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = 1
 
 /obj/mecha/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -270,7 +270,7 @@
 	id = "durand_chassis"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/chassis/durand
-	materials = list(/datum/material/iron=25000)
+	materials = list(/datum/material/iron=55000,/datum/material/gold=10000,/datum/material/silver=10000,/datum/material/plasma=5000)
 	construction_time = 100
 	category = list("Durand")
 
@@ -279,7 +279,7 @@
 	id = "durand_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_torso
-	materials = list(/datum/material/iron=25000,/datum/material/glass=10000,/datum/material/silver=10000)
+	materials = list(/datum/material/iron=55000,/datum/material/glass=10000,/datum/material/silver=10000)
 	construction_time = 300
 	category = list("Durand")
 
@@ -288,7 +288,7 @@
 	id = "durand_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_head
-	materials = list(/datum/material/iron=10000,/datum/material/glass=15000,/datum/material/silver=2000)
+	materials = list(/datum/material/iron=30000,/datum/material/glass=15000,/datum/material/silver=4000,/datum/material/gold=3000)
 	construction_time = 200
 	category = list("Durand")
 
@@ -297,7 +297,7 @@
 	id = "durand_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_left_arm
-	materials = list(/datum/material/iron=10000,/datum/material/silver=4000)
+	materials = list(/datum/material/iron=20000,/datum/material/silver=4000,/datum/material/plasma=5000)
 	construction_time = 200
 	category = list("Durand")
 
@@ -306,7 +306,7 @@
 	id = "durand_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_right_arm
-	materials = list(/datum/material/iron=10000,/datum/material/silver=4000)
+	materials = list(/datum/material/iron=20000,/datum/material/silver=4000,/datum/material/plasma=5000)
 	construction_time = 200
 	category = list("Durand")
 
@@ -315,7 +315,7 @@
 	id = "durand_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_left_leg
-	materials = list(/datum/material/iron=15000,/datum/material/silver=4000)
+	materials = list(/datum/material/iron=15000,/datum/material/silver=4000,/datum/material/plasma=5000)
 	construction_time = 200
 	category = list("Durand")
 
@@ -324,7 +324,7 @@
 	id = "durand_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_right_leg
-	materials = list(/datum/material/iron=15000,/datum/material/silver=4000)
+	materials = list(/datum/material/iron=15000,/datum/material/silver=4000,/datum/material/plasma=5000)
 	construction_time = 200
 	category = list("Durand")
 
@@ -333,7 +333,7 @@
 	id = "durand_armor"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/durand_armor
-	materials = list(/datum/material/iron=30000,/datum/material/uranium=25000,/datum/material/titanium=20000)
+	materials = list(/datum/material/iron=30000,/datum/material/uranium=25000,/datum/material/titanium=20000,/datum/material/diamond=10000)
 	construction_time = 600
 	category = list("Durand")
 


### PR DESCRIPTION
currently there is no reason to build a gygax because durand is better
even a fucking phazon is outclassed by durand in many regards
durand is also dirt cheap and can be spammed like crazy (seeing 3-4 durands walk down the hallway makes me want to scream)

changes:
Durand costs way more materials to create to make the 'spam combat mechs' strategy less viable
Durand takes double damage from EMPs (80 on heavy, 40 on light)
Durand has equipment disabled for double the time of any other mech (six seconds) when EMPed

also fixes a whacky and silly bug where mech melee weapons ignored emps disabling equipment

# Changelog

:cl:  
bugfix: melee mech weapons no longer work while equipment is disabled
tweak: durand is worse against emps and more expensive to print
/:cl:
