### PR TITLE
Blood cult can no longer create runes on lavaland + Other changes.

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -620,7 +620,7 @@ GLOBAL_LIST_INIT(runed_metal_recipes, list ( \
 		return
 	var/turf/T = get_turf(user) //we may have moved. adjust as needed...
 	var/area/A = get_area(user)
-	if((!is_station_level(T.z) && !is_mining_level(T.z) && !is_reebe(T.z)) || (A && !A.blob_allowed))
+	if((!is_station_level(T.z) && !is_reebe(T.z)) || (A && !A.blob_allowed)) //Yogstation change: Can't make runes on lavaland anymore.
 		to_chat(user, span_warning("The veil is not weak enough here."))
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/clockcult/clock_items/replica_fabricator.dm
+++ b/code/modules/antagonists/clockcult/clock_items/replica_fabricator.dm
@@ -93,7 +93,7 @@
 		fabrication_values["power_cost"] = 0
 
 	var/turf/Y = get_turf(user)
-	if(!Y || (!is_centcom_level(Y.z) && !is_station_level(Y.z) && !is_mining_level(Y.z)))
+	if(!Y || (!is_centcom_level(Y.z) && !is_station_level(Y.z))) //Yogstation change: Added penalty for being on lavaland base.
 		fabrication_values["operation_time"] *= 2
 		if(fabrication_values["power_cost"] > 0)
 			fabrication_values["power_cost"] *= 2

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(scripture_states,scripture_states_init_value()) //list of clock
 
 /datum/clockwork_scripture/proc/check_offstation_penalty()
 	var/turf/T = get_turf(invoker)
-	if(!T || (!is_centcom_level(T.z) && !is_station_level(T.z) && !is_mining_level(T.z) && !is_reebe(T.z)))
+	if(!T || (!is_centcom_level(T.z) && !is_station_level(T.z) && !is_reebe(T.z))) //Yogstation change: Added penalty for being on lavaland base.
 		channel_time *= 2
 		power_cost *= 2
 		return TRUE

--- a/code/modules/antagonists/cult/ritual.dm
+++ b/code/modules/antagonists/cult/ritual.dm
@@ -150,7 +150,7 @@ This file contains the cult dagger and rune list code
 		to_chat(user, span_cult("There is already a rune here."))
 		return FALSE
 	var/area/A = get_area(T)
-	if((!is_station_level(T.z) && !is_mining_level(T.z)) || (A && !A.blob_allowed))
+	if((!is_station_level(T.z)) || (A && !A.blob_allowed)) //Yogstation change: Can't make runes on lavaland anymore.
 		to_chat(user, span_warning("The veil is not weak enough here."))
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/cult/rune_spawn_action.dm
+++ b/code/modules/antagonists/cult/rune_spawn_action.dm
@@ -28,7 +28,7 @@
 	if(locate(/obj/effect/rune) in T)
 		to_chat(owner, span_cult("There is already a rune here."))
 		return FALSE
-	if(!is_station_level(T.z) && !is_mining_level(T.z) && !is_reebe(T.z))
+	if(!is_station_level(T.z) && !is_reebe(T.z)) //Yogstation change: Can't make runes on lavaland anymore.
 		to_chat(owner, span_warning("The veil is not weak enough here."))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Blood cult can no longer create runes on lavaland.
You can no longer craft things with runed metal on lavaland.
Clockwork scriptures get a double cost and time penalty on lavaland.
Clockwork fabricators get a double cost and time penalty on lavaland.

# Justification

Lavaland Cult is just genuinely too strong / bad for the server for the following reasons:

## Visibility
You basically have a location that is completely isolated from the rest of the station. The only role that ever checks cams there is quatermaster, and quartermasters that actually check on miners are extremely rare. No one ever physically goes there either except mining medics, and miners, both roles which, and quite frankly, frequently have players who have all antag roles set to max. While the AI can check the mining base cameras, they usually don't because that requires changing camera networks and the only time they really ever do that is they suspect cult in the first place.

## Difficulty to Access
Lavaland has 2 entrance points via shuttle (Labor Camp, Mining Base). Lavaland has their own power supply that you can't cut off without going there, their own oxygen supply that you can't cut off without going there, and near unlimited meds because of how cheap miner medipens and kits are. If cult also decide to advance on the station, they can easily take over cargo pretty easily. It is entirely possible for cult to break the shuttle, requiring repairs and/or eva suits to actually get down to lavaland. The labor camp is also quite a bit of a distance away from the main mining base so reaching it is pretty difficult.

## Progression
Lavaland Cult rounds are usually 45 minutes to an hour long because they tend to remain undetected for so long with a large focus on obtaining lavaland loot and converts. Rounds where literally nothing happens and then everything happens at once is usually extremely boring and unfun for the crew. Dynamic and/or admins tend to spawn extra traitors to compensate for this, which shouldn't need to happen.

## Cheese
Lavaland contains a lot of strong equipment (even with the nerfs) and a lot of potential for cheese with ghost role spawners such as ashwalkers and other spawns.

## The v i s i o n
I don't know the server's direction or vision with respect to mining, but from what I can understand from a few devs/contributors, they don't like how isolated lavaland is from the station as well as the fact that Shaft Miners and Mining Medics have a huge advantage compared to other traitors when it comes to access to potential bases and other crazy stuff.

## Random list of things that aren't "allowed" to be on lavaland.
Clockwork Cult console teleportation targets.
Communications Consoles
Slaughter Demons
Blobs
Malf Doomsday Activation
Many Malf abilities, including APC shunting.
AI Data Cores
Downloading the AI
AI Hijacking
AI Cogging
Alarm notices (Camera, Atmos, etc)
Many Gang abilities, like area claiming.

Despite all this, cult seems to be the exception of the "please do your bullshitery on the station" rule that most of the code has.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Blood_Cult
https://wiki.yogstation.net/wiki/Clockwork_Cult

# Changelog

:cl:  BurgerBB
tweak: Blood cult can no longer create runes on lavaland.
tweak: Clockwork fabricators and scriptures cost twice as much power and twice as much energy to use on lavaland.
/:cl:
