### PR TITLE
Reduce the chance that an EMP'd leg implant will break your leg

### DIFF
--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -34,7 +34,7 @@
 	L.set_disabled(TRUE)	//disable the bodypart
 	addtimer(CALLBACK(src, .proc/reenableleg), 5 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
-	if(severity & EMP_HEAVY && prob(20))	//10% chance on getting hit by a heavy emp to break your leg (technically more since you have two)
+	if(severity & EMP_HEAVY && prob(5))	//put probabilities into a calculator before you try fucking with this
 		to_chat(owner, span_warning("The EMP causes your [src] to thrash your [L] around wildly breaking it!"))	
 		var/datum/wound/blunt/severe/breakdown = new
 		breakdown.apply_wound(L)


### PR DESCRIPTION
Yeah, i probably should have put it into a calculator rather than just guesstimating a good number.
20% chance to be near permanently crippled when hit by an emp is ridiculous
i've reduced it to 5% chance, since often death is preferable over wounds with how bad they currently are.

:cl:  
tweak: Leg Implants are less likely to break your leg if EMP'd
/:cl:
