### PR TITLE
Moves things around, adds things to make seafood themed items to Fishing Biodome

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
@@ -144,21 +144,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ruin/powered/fishing/shop)
-"dT" = (
-/obj/effect/decal/cleanable/oil,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "dV" = (
 /obj/structure/rack,
 /obj/item/twohanded/fishingrod,
@@ -320,6 +305,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
+"iQ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing)
 "iX" = (
 /obj/machinery/light{
 	dir = 1
@@ -678,6 +677,17 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
+"rA" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "rQ" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -930,6 +940,18 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ruin/powered/fishing/tcom)
+"xB" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "xQ" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/firedoor/border_only{
@@ -945,18 +967,6 @@
 /obj/structure/chair/americandiner/black,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"yH" = (
-/obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "yZ" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -1062,6 +1072,20 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
+"Bb" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/hall)
 "Bj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/window/reinforced/tinted,
@@ -1323,21 +1347,6 @@
 "Fr" = (
 /turf/closed/wall/r_wall,
 /area/ruin/powered/fishing/kitchen)
-"Fs" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/hall)
 "FC" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/brute{
@@ -1468,23 +1477,6 @@
 "HJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/water/safe,
-/area/ruin/powered/fishing)
-"HR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/dark,
 /area/ruin/powered/fishing)
 "It" = (
 /obj/machinery/microwave{
@@ -2596,9 +2588,9 @@ US
 "}
 (16,1,1) = {"
 US
-yH
+rA
 FM
-HR
+iQ
 eT
 eT
 eT
@@ -2621,9 +2613,9 @@ ly
 zI
 LV
 LV
-Fs
+Bb
 QF
-dT
+xB
 US
 "}
 (17,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
@@ -389,6 +389,45 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/fishing/kitchen)
+"kE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/cultivator{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/shovel/spade{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/structure/window/reinforced/tinted{
+	damage_deflection = 21;
+	dir = 8;
+	max_integrity = 600
+	},
+/obj/item/hatchet/wooden,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/item/seeds/nettle{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/seeds/nettle{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "kG" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/machinery/shower{
@@ -478,6 +517,25 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/fishing/bedroom)
+"mQ" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer{
+	name = "fish freezer"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/fish/bass,
+/obj/item/reagent_containers/food/snacks/fish/bass,
+/obj/item/reagent_containers/food/snacks/fish/salmon,
+/obj/item/reagent_containers/food/snacks/fish/salmon,
+/obj/item/reagent_containers/food/snacks/fish/squid,
+/obj/item/reagent_containers/food/snacks/fish/shrimp,
+/obj/item/reagent_containers/food/snacks/fish/puffer,
+/obj/item/reagent_containers/food/snacks/fish/tuna,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "mU" = (
 /obj/machinery/light{
 	dir = 1
@@ -506,37 +564,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"ok" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/cultivator{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/shovel/spade{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/structure/window/reinforced/tinted{
-	damage_deflection = 21;
-	dir = 8;
-	max_integrity = 600
-	},
-/obj/item/hatchet/wooden,
-/obj/item/storage/box/disks_plantgene,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "pj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
@@ -765,15 +792,6 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/fishing/bedroom)
-"vN" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
-/obj/item/book/manual/chef_recipes,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "vV" = (
 /obj/machinery/light{
 	dir = 4
@@ -1154,16 +1172,6 @@
 /obj/effect/turf_decal/pool/innercorner,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"CD" = (
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/brown/filled/end,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered/fishing/kitchen)
 "CJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -1215,6 +1223,20 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"DF" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/brown/filled/end,
+/obj/structure/table,
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 6
+	},
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/powered/fishing/kitchen)
 "DV" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -1527,16 +1549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
-"Kv" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "Kx" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -1773,21 +1785,6 @@
 "Sz" = (
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/hall)
-"SB" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "SK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -1853,6 +1850,23 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
+"UU" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "Va" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1962,6 +1976,11 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"WS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "Xf" = (
 /obj/structure/mirror{
 	pixel_x = 29;
@@ -2378,7 +2397,7 @@ bA
 kR
 RB
 Fr
-Kv
+mQ
 Uq
 Fr
 aa
@@ -2409,7 +2428,7 @@ jM
 RJ
 kr
 dc
-CD
+DF
 IM
 kB
 Fr
@@ -2475,7 +2494,7 @@ GS
 dc
 aF
 IM
-vN
+WS
 Fr
 aa
 "}
@@ -2506,7 +2525,7 @@ Wr
 DV
 ZU
 Fr
-SB
+UU
 eC
 Fr
 US
@@ -2633,7 +2652,7 @@ gZ
 qQ
 av
 aG
-ok
+kE
 rh
 lD
 gZ

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
@@ -63,27 +63,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/hall)
-"aU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/structure/window/reinforced/tinted{
-	damage_deflection = 21;
-	dir = 8;
-	max_integrity = 600
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "aY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 23
@@ -159,18 +138,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"dF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/wood,
-/area/ruin/powered/fishing/kitchen)
 "dS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -539,6 +506,37 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"ok" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/cultivator{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/shovel/spade{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/structure/window/reinforced/tinted{
+	damage_deflection = 21;
+	dir = 8;
+	max_integrity = 600
+	},
+/obj/item/hatchet/wooden,
+/obj/item/storage/box/disks_plantgene,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "pj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
@@ -709,52 +707,6 @@
 /obj/effect/turf_decal/pool/corner,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"ue" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/shovel/spade{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/hatchet/wooden,
-/obj/item/cultivator{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/disks_plantgene,
-/obj/item/seeds/nettle{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/seeds/nettle{
-	pixel_x = -1;
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
-"uo" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "uy" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 8
@@ -813,6 +765,15 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/fishing/bedroom)
+"vN" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 6
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "vV" = (
 /obj/machinery/light{
 	dir = 4
@@ -1193,6 +1154,16 @@
 /obj/effect/turf_decal/pool/innercorner,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"CD" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/brown/filled/end,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/powered/fishing/kitchen)
 "CJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -1556,6 +1527,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
+"Kv" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
+"Kx" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "KH" = (
 /obj/effect/turf_decal/pool,
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
@@ -1654,19 +1649,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"OF" = (
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/brown/filled/end,
-/obj/structure/table,
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered/fishing/kitchen)
 "OG" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -1791,6 +1773,21 @@
 "Sz" = (
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/hall)
+"SB" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "SK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -1800,11 +1797,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
-"SL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "SM" = (
 /obj/structure/window/reinforced/spawner/east,
 /mob/living/simple_animal/hostile/carp/cayenne{
@@ -1849,23 +1841,6 @@
 "Uq" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
-"UB" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/food/snacks/fish/bass,
-/obj/item/reagent_containers/food/snacks/fish/bass,
-/obj/item/reagent_containers/food/snacks/fish/salmon,
-/obj/item/reagent_containers/food/snacks/fish/salmon,
-/obj/item/reagent_containers/food/snacks/fish/shrimp,
-/obj/item/reagent_containers/food/snacks/fish/squid,
-/obj/item/reagent_containers/food/snacks/fish/puffer,
-/obj/item/reagent_containers/food/snacks/fish/tuna,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/fishing/kitchen)
 "UL" = (
@@ -2403,7 +2378,7 @@ bA
 kR
 RB
 Fr
-UB
+Kv
 Uq
 Fr
 aa
@@ -2434,7 +2409,7 @@ jM
 RJ
 kr
 dc
-OF
+CD
 IM
 kB
 Fr
@@ -2494,13 +2469,13 @@ ZT
 ZT
 YV
 yD
-dF
+jM
 RJ
 GS
 dc
 aF
 IM
-SL
+vN
 Fr
 aa
 "}
@@ -2531,7 +2506,7 @@ Wr
 DV
 ZU
 Fr
-uo
+SB
 eC
 Fr
 US
@@ -2658,7 +2633,7 @@ gZ
 qQ
 av
 aG
-aU
+ok
 rh
 lD
 gZ
@@ -2722,7 +2697,7 @@ xQ
 xn
 LV
 wg
-ue
+Kx
 Ay
 OG
 gZ

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_fishing.dmm
@@ -63,6 +63,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/hall)
+"aU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/structure/window/reinforced/tinted{
+	damage_deflection = 21;
+	dir = 8;
+	max_integrity = 600
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
 "aY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 23
@@ -138,6 +159,18 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"dF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "fishing lockdown"
+	},
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/wood,
+/area/ruin/powered/fishing/kitchen)
 "dS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -506,37 +539,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"ok" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/cultivator{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/shovel/spade{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "fishing lockdown"
-	},
-/obj/structure/window/reinforced/tinted{
-	damage_deflection = 21;
-	dir = 8;
-	max_integrity = 600
-	},
-/obj/item/hatchet/wooden,
-/obj/item/storage/box/disks_plantgene,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "pj" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
@@ -707,6 +709,52 @@
 /obj/effect/turf_decal/pool/corner,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"ue" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/shovel/spade{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/hatchet/wooden,
+/obj/item/cultivator{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/seeds/nettle{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/seeds/nettle{
+	pixel_x = -1;
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/powered/fishing/hall)
+"uo" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "uy" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 8
@@ -765,15 +813,6 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/fishing/bedroom)
-"vN" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
-/obj/item/book/manual/chef_recipes,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "vV" = (
 /obj/machinery/light{
 	dir = 4
@@ -1154,16 +1193,6 @@
 /obj/effect/turf_decal/pool/innercorner,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
-"CD" = (
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/brown/filled/end,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/powered/fishing/kitchen)
 "CJ" = (
 /obj/machinery/light{
 	dir = 4
@@ -1527,30 +1556,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
-"Kv" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
-"Kx" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel,
-/area/ruin/powered/fishing/hall)
 "KH" = (
 /obj/effect/turf_decal/pool,
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
@@ -1649,6 +1654,19 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/ruin/powered/fishing)
+"OF" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/brown/filled/end,
+/obj/structure/table,
+/obj/machinery/reagentgrinder/kitchen{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/powered/fishing/kitchen)
 "OG" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -1773,21 +1791,6 @@
 "Sz" = (
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/hall)
-"SB" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/powered/fishing/kitchen)
 "SK" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -1797,6 +1800,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/powered/fishing/shop)
+"SL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
 "SM" = (
 /obj/structure/window/reinforced/spawner/east,
 /mob/living/simple_animal/hostile/carp/cayenne{
@@ -1841,6 +1849,23 @@
 "Uq" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/fishing/kitchen)
+"UB" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/fish/bass,
+/obj/item/reagent_containers/food/snacks/fish/bass,
+/obj/item/reagent_containers/food/snacks/fish/salmon,
+/obj/item/reagent_containers/food/snacks/fish/salmon,
+/obj/item/reagent_containers/food/snacks/fish/shrimp,
+/obj/item/reagent_containers/food/snacks/fish/squid,
+/obj/item/reagent_containers/food/snacks/fish/puffer,
+/obj/item/reagent_containers/food/snacks/fish/tuna,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/fishing/kitchen)
 "UL" = (
@@ -2378,7 +2403,7 @@ bA
 kR
 RB
 Fr
-Kv
+UB
 Uq
 Fr
 aa
@@ -2409,7 +2434,7 @@ jM
 RJ
 kr
 dc
-CD
+OF
 IM
 kB
 Fr
@@ -2469,13 +2494,13 @@ ZT
 ZT
 YV
 yD
-jM
+dF
 RJ
 GS
 dc
 aF
 IM
-vN
+SL
 Fr
 aa
 "}
@@ -2506,7 +2531,7 @@ Wr
 DV
 ZU
 Fr
-SB
+uo
 eC
 Fr
 US
@@ -2633,7 +2658,7 @@ gZ
 qQ
 av
 aG
-ok
+aU
 rh
 lD
 gZ
@@ -2697,7 +2722,7 @@ xQ
 xn
 LV
 wg
-Kx
+ue
 Ay
 OG
 gZ


### PR DESCRIPTION
Fishy Fish

# Document the changes in your pull request

- Adds Fish crate freezer filled with 2 Bass, 2 Salmons, a Squid, a Shrimp, a Pufferfish, and a Tuna
- Adds 2 Nettle Seeds
- Moves the Food Processor, Cook Book, and Condimaster to make the more useful one more noticeable

I know this technically gives the Fishermen access to Death Nettles but it's either that or an entire Chem Dispenser that doesn't fit in well at all. This is all in order to make Soysauce which needs Sulfuric Acid for some reason. Oh, and the rarer fish would make good loot for hungry people.

![image](https://user-images.githubusercontent.com/107460718/212920862-2f6f5cb8-c117-4351-a76c-5a4805259d89.png)

# Wiki Documentation

Image Outdated, Documentation of above.

# Changelog

:cl:  
mapping: Adds 2 Nettle Seeds to Fishing Biodome
mapping: Adds Fish Freezer to Fishing Biodome
mapping: Swapped the Grinder and Condimaster, moved the Cook Book
mapping: Removes double doors doubled Cyclelink Helpers
/:cl:
