### PR TITLE
Makes AI Download 50% Faster

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(ai_project_categories, list(
 ))
 
 ///How much is the AI download progress increased by per tick? Multiplied by a modifer on the AI if they have upgraded. Need to reach 100 to be downloaded
-#define AI_DOWNLOAD_PER_PROCESS 0.75
+#define AI_DOWNLOAD_PER_PROCESS 1.125
 ///Check for tracked individual coming into view every X ticks
 #define AI_CAMERA_MEMORY_TICKS 15
 

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -226,7 +226,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 	if(downloading)
 		if(!silent)
 			to_chat(downloading, span_userdanger("Download stopped."))
-		downloading.can_download = FALSE //can be downloaded again
+		downloading.can_download = TRUE //can be downloaded again
 		downloading = null
 		user_downloading = null
 		download_progress = 0

--- a/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/management/ai_controlpanel.dm
@@ -226,6 +226,7 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 	if(downloading)
 		if(!silent)
 			to_chat(downloading, span_userdanger("Download stopped."))
+		downloading.can_download = FALSE //can be downloaded again
 		downloading = null
 		user_downloading = null
 		download_progress = 0
@@ -360,11 +361,13 @@ GLOBAL_VAR_INIT(ai_control_code, random_nukecode(6))
 			if(!istype(target.loc, /obj/machinery/ai/data_core))
 				return
 			if(!target.can_download)
+				to_chat(usr, span_warning("Error! This AI can not be downloaded."))
 				return
 			if(!is_station_level(z))
 				to_chat(usr, span_warning("No connection. Try again later."))
 				return
 			downloading = target
+			target.can_download = FALSE //can only be downloaded from one place at once
 			to_chat(downloading, span_userdanger("Warning! Someone is attempting to download you from [get_area(src)]! (<a href='?src=[REF(downloading)];instant_download=1;console=[REF(src)]'>Click here to finish download instantly</a>)"))
 			user_downloading = usr
 			download_progress = 0


### PR DESCRIPTION
> Makes AI Download 50% Faster
> 
> At the moment it takes ages to download the AI if you are a traitor for example and have the steal AI objective. Which forces you to either have to make your own or find a different way of doing this. Failing this, maybe we could have an item which traitors can get which makes it silent or perhaps doubles the speed?

Jamie's busy with more important stuff to update #17221 so i decided to just do it myself

:cl:  
tweak: Makes AI Download 50% Faster
/:cl:
