### PR TITLE
Fix security gun dupe exploit 2023

### DIFF
--- a/code/modules/vending/security_armaments.dm
+++ b/code/modules/vending/security_armaments.dm
@@ -32,7 +32,7 @@
 	if(istype(C) && (ACCESS_SECURITY in C.access) && (ACCESS_WEAPONS in C.access) && !(ACCESS_HOS in C.access))
 		allowed = TRUE
 	// Hasn't claimed a weapon yet
-	if(!C?.registered_account?.sec_weapon_claimed)
+	if(C?.registered_account && !C.registered_account.sec_weapon_claimed)
 		can_claim = TRUE
 
 	if(!allowed)

--- a/code/modules/vending/security_armaments.dm
+++ b/code/modules/vending/security_armaments.dm
@@ -111,7 +111,7 @@
 	if(istype(C) && (ACCESS_SECURITY in C.access) && (ACCESS_WEAPONS in C.access) && !(ACCESS_HOS in C.access))
 		allowed = TRUE
 	// Hasn't claimed a weapon yet
-	if(!C?.registered_account?.sec_weapon_claimed)
+	if(C?.registered_account && !C.registered_account.sec_weapon_claimed)
 		can_claim = TRUE
 
 	data["allowed"] = allowed


### PR DESCRIPTION
# Document the changes in your pull request

No account = no gun!!!

Fixes #17400

# Changelog

:cl:  
bugfix: You can no longer dupe guns at the armaments dispenser
/:cl:
