### PR TITLE
Fixes exploit being able to supersede NT-USP power pack max ammo

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -139,6 +139,8 @@
 			if(R.stored_ammo.len < R.max_ammo)
 				for(var/i in 1 to recharge_coeff) //So it actually gives more ammo when upgraded
 					R.stored_ammo += new R.ammo_type(R)
+					if(R.stored_ammo.len <= R.max_ammo)
+						break
 				use_power(200 * recharge_coeff)
 			update_icon()
 			return


### PR DESCRIPTION
# Document the changes in your pull request

Upgraded rechargers would ignore the max ammo count for a single charge loop which means you can get up to 3 extra bullets in your magazine

# Changelog

:cl:  
bugfix: fixed having more NT-USP ammo than intended
/:cl:
