### PR TITLE
Fixes air shoes implant exploit using boost while hardcrit or dead

### DIFF
--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -214,7 +214,8 @@
 	holder = user
 
 /datum/action/innate/boost/IsAvailable()
-	if(COOLDOWN_FINISHED(src, dash_cooldown) && holder.stat < UNCONSCIOUS)
+	. = ..()
+	if(COOLDOWN_FINISHED(src, dash_cooldown))
 		return TRUE
 	else
 		to_chat(holder, span_warning("The implant's internal propulsion needs to recharge still!"))

--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -214,7 +214,7 @@
 	holder = user
 
 /datum/action/innate/boost/IsAvailable()
-	if(COOLDOWN_FINISHED(src, dash_cooldown))
+	if(COOLDOWN_FINISHED(src, dash_cooldown) && holder.stat < UNCONSCIOUS)
 		return TRUE
 	else
 		to_chat(holder, span_warning("The implant's internal propulsion needs to recharge still!"))

--- a/code/modules/surgery/organs/augment_legs.dm
+++ b/code/modules/surgery/organs/augment_legs.dm
@@ -214,9 +214,8 @@
 	holder = user
 
 /datum/action/innate/boost/IsAvailable()
-	. = ..()
 	if(COOLDOWN_FINISHED(src, dash_cooldown))
-		return TRUE
+		return ..()
 	else
 		to_chat(holder, span_warning("The implant's internal propulsion needs to recharge still!"))
 		return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Can no longer use it in hardcrit
Can still use it in softcrit bc im nice

# Changelog

:cl:  
bugfix: Can no longer use air shoes jump boost in hardcrit or death
/:cl:
