### PR TITLE
Fixes NT-USP not having flashlight offset

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -31,6 +31,8 @@
 	mag_type = /obj/item/ammo_box/magazine/recharge/ntusp
 	can_suppress = FALSE
 	can_flashlight = TRUE
+	flight_x_offset = 16
+	flight_y_offset = 13
 	bolt_type = BOLT_TYPE_LOCKING
 	fire_sound = "sound/weapons/gunshot.ogg"
 	vary_fire_sound = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/28408322/211222453-076856e5-15c1-41d3-8932-ac3483a987f7.png)

![image](https://user-images.githubusercontent.com/28408322/211222457-0d00f375-9714-4fe8-a394-7702a81d81c0.png)


# Changelog

:cl:  
bugfix: fixed NT-USP not having flashlight offset
/:cl:
