### PR TITLE
corrects sausage snipping to not work if you are snipping it while holding it

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -288,7 +288,7 @@
 			if(!do_after(user, 1 SECONDS, src)) {
 				return
 			}
-			new /obj/item/reagent_containers/food/snacks/sausage/american(get_turf(user))
+			new /obj/item/reagent_containers/food/snacks/sausage/american(loc)
 			to_chat(user, span_notice("You snip [src]."))
 			qdel(src)
 		else

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -284,9 +284,8 @@
 /obj/item/reagent_containers/food/snacks/sausage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/kitchen/knife))
 		if(isturf(loc)) //CHECK IF ITS ON A TABLE OR OTHER SURFACE FOR THE LOVE OF GOD
-			if(!do_after(user, 1 SECONDS, src)) {
+			if(!do_after(user, 1 SECONDS, src))
 				return
-			}
 			new /obj/item/reagent_containers/food/snacks/sausage/american(loc)
 			to_chat(user, span_notice("You snip [src]."))
 			qdel(src)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -284,12 +284,16 @@
 
 /obj/item/reagent_containers/food/snacks/sausage/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/kitchen/knife))
-		if(!do_after(user, 1 SECONDS, src)) {
+		if(isturf(loc)) //CHECK IF ITS ON A TABLE OR OTHER SURFACE FOR THE LOVE OF GOD
+			if(!do_after(user, 1 SECONDS, src)) {
+				return
+			}
+			new /obj/item/reagent_containers/food/snacks/sausage/american(get_turf(user))
+			to_chat(user, span_notice("You snip [src]."))
+			qdel(src)
+		else
+			to_chat(user, span_warning("You need to put [src] on a surface to snip it!"))
 			return
-		}
-		new /obj/item/reagent_containers/food/snacks/sausage/american(loc)
-		to_chat(user, span_notice("You snip [src]."))
-		qdel(src)
 	else
 		..()
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -117,9 +117,8 @@
 /obj/item/reagent_containers/food/snacks/raw_meatball/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/kitchen/rollingpin))
 		if(isturf(loc))
-			if(!do_after(user, 1 SECONDS, src)) {
+			if(!do_after(user, 1 SECONDS, src))
 				return
-			}
 			new patty_type(loc)
 			to_chat(user, span_notice("You flatten [src]."))
 			qdel(src)


### PR DESCRIPTION
# Document the changes in your pull request
You can no longer snip a sausage into an american sausage if you are holding it in your hand.

I blame @ToasterBiome for the disappearance of a countless numbers of sausages from the station

fixes #17201 

# Changelog

:cl:  
bugfix: adds sanity check to sausage code 
/:cl:
