### PR TITLE
Fix typo in hop skillcape

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcapes.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcapes.dm
@@ -74,7 +74,7 @@
 	item_state = "cap-trimmed"
 
 /obj/item/clothing/neck/skillcape/hop
-	name = "cape of the head of personel"
+	name = "cape of the head of persomnel"
 	desc = "A slick, blue cape. The owner must have granted passage to many."
 	icon_state = "hop-skillcape"
 	item_state = "hop-skillcape"

--- a/code/modules/clothing/neck/skillcapes/skillcapes.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcapes.dm
@@ -74,7 +74,7 @@
 	item_state = "cap-trimmed"
 
 /obj/item/clothing/neck/skillcape/hop
-	name = "cape of the head of persomnel"
+	name = "cape of the head of personnel"
 	desc = "A slick, blue cape. The owner must have granted passage to many."
 	icon_state = "hop-skillcape"
 	item_state = "hop-skillcape"


### PR DESCRIPTION
# Document the changes in your pull request

Fixes #17424

# Changelog

:cl:  ynot01, Moltijoe
spellcheck: fixed head of personel in HoP skillcape
/:cl:
