### PR TITLE
PR template and github issue template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -50,7 +50,15 @@ body:
     label: BYOND Username
     description: Also known as ckey, its the username you use to login on BYOND.
     placeholder: "Player1702"
-  
+
+- type: dropdown
+  attributes:
+    label: Was this done on a locally hosted or non-Yogstation hosted server?
+    description: This information is important so we can better determine if it is an issue caused on our end or on your local branch.
+    options:
+      - Yes
+      - No
+
 - type: textarea
   attributes:
     label: Additional information

--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -56,8 +56,8 @@ body:
     label: Was this done on a locally hosted or non-Yogstation hosted server?
     description: This information is important so we can better determine if it is an issue caused on our end or on your local branch.
     options:
-      - Yes
-      - No
+      - "Yes"
+      - "No"
 
 - type: textarea
   attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,8 @@ Important documentation information includes, but is not limited to: any numeric
 
 # Changelog
 
-<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR.
-If you add a name after the ':cl', that name will be used in the changelog. Leave it empty to use your GitHub name. -->
+<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
+If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->
 
 :cl:  
 rscadd: Added new things  


### PR DESCRIPTION
# Document the changes in your pull request

Opening an issue on github now asks a user if the issue they are experiencing is occurring on a non-Yog hosted server or a local server instead of the actual server.

PR template now mentions changelogs shouldn't exist if there are non-player facing changes
