### PR TITLE
Makes recharger blue when it is fully charged

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -176,14 +176,20 @@
 	if(charging)
 		var/mutable_appearance/scan = mutable_appearance(icon, "[initial(icon_state)]filled")
 		var/obj/item/stock_parts/cell/C = charging.get_cell()
+		var/num = 0
 		if(C)
-			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), round(C.charge/C.maxcharge, 0.01))
+			num = round(C.charge/C.maxcharge, 0.01)
 		if(istype(charging, /obj/item/ammo_box/magazine/recharge))
 			var/obj/item/ammo_box/magazine/recharge/R = charging
-			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), round(R.stored_ammo.len/R.max_ammo, 0.01))
+			num = round(R.stored_ammo.len/R.max_ammo, 0.01)
 		if(istype(charging, /obj/item/ammo_box/magazine/m308/laser))
 			var/obj/item/ammo_box/magazine/m308/laser/R = charging
-			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), round(R.stored_ammo.len/R.max_ammo, 0.01))
+			num = round(R.stored_ammo.len/R.max_ammo, 0.01)
+		
+		if(num >= 1)
+			scan.color = "#58d0ff"
+		else
+			scan.color = gradient(list(0, "#ff0000", 0.99, "#00ff00", 1, "#cece00"), num)
 		add_overlay(scan)
 
 /obj/machinery/recharger/wallrecharger


### PR DESCRIPTION
# Document the changes in your pull request

I am colorblind, I stare at recharger for 20 minutes before I can tell it's fully charged

More accessibility :)

This is color

![](https://i.imgur.com/dAxxcxo.png)

# Changelog

:cl:  
tweak: Rechargers turn blue when they are fully charged
/:cl:
