### PR TITLE
Fix disabler doing 30 stamina damage instead of 25

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -83,7 +83,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 25
 	damage_type = STAMINA
 	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
# Document the changes in your pull request

Seem like at some point in time someone made them do 30 stamina again, probably some unnoticed change that slipped in due to someone's branch being very old maybe. I wonder who could do such a silly mistake but it's okay since we are fixing it :)

# Changelog

:cl:  
bugfix: disabler beam do 25 stamina again
/:cl:
