### PR TITLE
Returns tails to draconids and ashwalkers 2: Jamie said it was probably ok edition

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -97,7 +97,7 @@
 	name = "Ash Walker"
 	id = "ashlizard"
 	limbs_id = "lizard"
-	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE)
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE,HAS_TAIL)
 	inherent_traits = list(TRAIT_NOGUNS) //yogs start - ashwalkers have special lungs and actually breathe
 	mutantlungs = /obj/item/organ/lungs/ashwalker
 	breathid = "n2" // yogs end
@@ -122,7 +122,7 @@
 	id = "draconid"
 	limbs_id = "lizard"
 	fixed_mut_color = "A02720" 	//Deep red
-	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE)
+	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE,HAS_TAIL)
 	inherent_traits = list(TRAIT_RESISTHEAT)	//Dragons like fire
 	burnmod = 0.8
 	brutemod = 0.9 //something something dragon scales


### PR DESCRIPTION
Yeah turns out nobody bothered to give them the HAS_TAIL trait which fucked up a few things. Tragically this has gone from a 1-line pr to a 2-line pr oh noooo.

# Changelog


:cl:  

bugfix: Lizard tails now properly exist on all lizards

/:cl:
