### PR TITLE
Fixes clockwork tiles spacing for real this time

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -233,11 +233,6 @@
 	if(!dropped_brass)
 		new /obj/item/stack/tile/brass(src)
 		dropped_brass = TRUE
-	if(islist(baseturfs))
-		if(type in baseturfs)
-			return
-	else if(baseturfs == type)
-		return
 	return ..()
 
 /turf/open/floor/clockwork/narsie_act()

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -163,6 +163,7 @@
 	var/dropped_brass
 	var/uses_overlay = TRUE
 	var/obj/effect/clockwork/overlay/floor/realappearence
+	var/made_baseturf = FALSE
 
 /turf/open/floor/clockwork/Bless() //Who needs holy blessings when you have DADDY RATVAR?
 	return
@@ -191,6 +192,9 @@
 	START_PROCESSING(SSobj, src)
 
 /turf/open/floor/clockwork/process()
+	if(!made_baseturf)
+		made_baseturf = TRUE
+		assemble_baseturfs(/turf/open/floor/plating)
 	if(!healservants())
 		STOP_PROCESSING(SSobj, src)
 
@@ -233,6 +237,11 @@
 	if(!dropped_brass)
 		new /obj/item/stack/tile/brass(src)
 		dropped_brass = TRUE
+	if(islist(baseturfs))
+		if(type in baseturfs)
+			return
+	else if(baseturfs == type)
+		return
 	return ..()
 
 /turf/open/floor/clockwork/narsie_act()


### PR DESCRIPTION
# Document the changes in your pull request

Continuation of #16834

Tested this time

Bad code is bad]

I hate turfs I hate clockies

Doesn't work on Initialize

# Changelog

:cl:  
bugfix: clockwork tiles no longer space the station when pried off
/:cl:
