### PR TITLE
Revert "Changeling adrenal chem now reduces stamina damage (1->30)"

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1310,7 +1310,7 @@
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
 	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-30, 0)
+	M.adjustStaminaLoss(-1, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
Reverts yogstation13/Yogstation#17204

Adrenals already provides a massive stamina heal on being used, and with the chem buff this can just be used several times so having constant passive stamina regeneration isn't particularly necessary or limited