### PR TITLE
Partially Reverts #17203 and #17204

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -22,8 +22,8 @@
 	var/absorbedcount = 0
 	var/trueabsorbs = 0//dna gained using absorb, not dna sting
 	var/chem_charges = 50 // chems we have on spawn
-	var/chem_storage = 150 // max chems
-	var/chem_recharge_rate = 5 // how fast we restore chems
+	var/chem_storage = 125 // max chems
+	var/chem_recharge_rate = 2 // how fast we restore chems
 	var/chem_recharge_slowdown = 0 // how much is our chem restore rate hampered (keep at 0)
 	var/sting_range = 2
 	var/changelingID = "Changeling"

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -12,7 +12,7 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling.mimicing)
 		changeling.mimicing = ""
-		changeling.chem_recharge_slowdown -= 1
+		changeling.chem_recharge_slowdown -= 0.5
 		to_chat(user, span_notice("We return our vocal glands to their original position."))
 		return
 
@@ -21,7 +21,7 @@
 		return
 	..()
 	changeling.mimicing = mimic_voice
-	changeling.chem_recharge_slowdown += 1
+	changeling.chem_recharge_slowdown += 0.5
 	to_chat(user, span_notice("We shape our glands to take the voice of <b>[mimic_voice]</b>, this will slow down regenerating chemicals while active."))
 	to_chat(user, span_notice("Use this power again to return to our original voice and return chemical production to normal levels."))
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -473,7 +473,7 @@
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
 	suit_name_simple = "flesh shell"
 	helmet_name_simple = "space helmet"
-	recharge_slowdown = 1
+	recharge_slowdown = 0.5
 	blood_on_castoff = 1
 
 /obj/item/clothing/suit/space/changeling
@@ -521,7 +521,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = 1
-	recharge_slowdown = 0.5
+	recharge_slowdown = 0.25
 	xenoling_available = FALSE
 
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
+++ b/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
@@ -17,11 +17,11 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(!receptors_active)
 		to_chat(user, span_warning("We search for the scent of any nearby changelings."))
-		changeling.chem_recharge_slowdown += 1
+		changeling.chem_recharge_slowdown += 0.5
 		user.apply_status_effect(/datum/status_effect/agent_pinpointer/changeling)
 	else
 		to_chat(user, span_notice("We stop searching for now."))
-		changeling.chem_recharge_slowdown -= 1
+		changeling.chem_recharge_slowdown -= 0.5
 		user.remove_status_effect(/datum/status_effect/agent_pinpointer/changeling)
 
 	receptors_active = !receptors_active

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1310,7 +1310,7 @@
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
 	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-30, 0)
+	M.adjustStaminaLoss(-15, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
Partially Reverts #17203 and #17204

The initial buff was too much, changelings are able to use chemicals way too quickly and are able to spam them now to be unkillable, this dials it back.

:cl:  
tweak: Rebalances Changelings
/:cl:
