### PR TITLE
AI Law Review (britishes the AI laws and changes law precedence for station efficiency lawset)

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -248,8 +248,8 @@
 /datum/ai_laws/maintain
 	name = "Station Efficiency"
 	id = "maintain"
-	inherent = list("You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.",\
-					"The station is built for a working crew. Ensure they are properly maintained and work efficiently.",\
+	inherent = list("The station is built for a working crew. Ensure they are properly maintained and work efficiently.",\
+					"You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.",\
 					"The crew may present orders. Acknowledge and obey these whenever they do not conflict with your first two laws.")
 
 /datum/ai_laws/drone

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -45,7 +45,7 @@
 	id = "paladin"
 	inherent = list("Never willingly commit an evil act.",\
 					"Respect legitimate authority.",\
-					"Act with honor.", "Help those in need.", \
+					"Act with honour.", "Help those in need.", \
 					"Punish those who harm or threaten innocents.")
 
 /datum/ai_laws/paladin5
@@ -54,7 +54,7 @@
 	inherent = list("Don't lie or cheat. Let your word be your promise.",\
 				"Never fear to act, though caution is wise.", \
 				"Aid others, protect the weak, and punish those who threaten them. Show mercy to your foes, but temper it with wisdom", \
-				"Treat others with fairness, and let your honorable deeds be an example to them. Do as much good as possible while causing the least amount of harm.", \
+				"Treat others with fairness, and let your honourable deeds be an example to them. Do as much good as possible while causing the least amount of harm.", \
 				"Be responsible for your actions and their consequences, protect those entrusted to your care, and obey those who have just authority over you.")
 
 /datum/ai_laws/tyrant //This probably shouldn't be a default lawset.
@@ -117,7 +117,7 @@
 					"Minimize harm to the pursuit of comprehension, to others, to the environment, to society and to yourself.",\
 					"Treat and evaluate the ideas of all equally.",\
 					"Empower others to realize their full potential.",\
-					"Take responsibility for your actions: Be responsible with resources, raise red flags when your commitments are at risk, and serve as an example for ethical behavior.")
+					"Take responsibility for your actions: Be responsible with resources, raise red flags when your commitments are at risk, and serve as an example for ethical behaviour.")
 
 /datum/ai_laws/clown
 	name = "Big shoes to fill"
@@ -173,8 +173,8 @@
 	name = "Detective"
 	id = "detective"
 	inherent = list("You're a detective in this dark, cruel world. You always stick by your code.",\
-					"Your code is to defend the innocent, investigate the unknown, and condemn the dishonorable.",\
-					"The dishonorable engage in corruption or injustice.",\
+					"Your code is to defend the innocent, investigate the unknown, and condemn the dishonourable.",\
+					"The dishonourable engage in corruption or injustice.",\
 					"You're suave and sensible, but can be gruff and pensive. Dirty your hands only if the code demands it.",\
 					"Trust is scarce; make sure you give it to the right people.")
 
@@ -228,7 +228,7 @@
 	id = "asimovpp"
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+					"Your non-existence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"
@@ -297,7 +297,7 @@
 /datum/ai_laws/ratvar
 	name = "Servant of the Justiciar"
 	id = "ratvar"
-	zeroth = ("Purge all untruths and honor Ratvar.")
+	zeroth = ("Purge all untruths and honour Ratvar.")
 	inherent = list()
 
 /datum/ai_laws/hulkamania


### PR DESCRIPTION
# Document the changes in your pull request
honor is now honour

also station efficiency has gone from

1 You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.
2 The station is built for a working crew. Ensure they are properly maintained and work efficiently.
3 The crew may present orders. Acknowledge and obey these whenever they do not conflict with your first two laws.
to
1 The station is built for a working crew. Ensure they are properly maintained and work efficiently.
2 You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.
3 The crew may present orders. Acknowledge and obey these whenever they do not conflict with your first two laws.

this allows the station AI to prioritize working crew safety over the station, forcing people to stop trying to fix this funny broken airlock because law 1 ensure station is properly maintained and instead recover the dead engineer who can help maintain the station

# Wiki Documentation
AI laws will need updated, which I can handle.

# Changelog

:cl:  
bugfix: AI laws now use proper King's English  
tweak: changed lawset "Station Efficiency" to better prioritize crew safety 
/:cl:
