### PR TITLE
Unlocks the keys to reality

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -108,10 +108,10 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 
 	/*****The Point Calculator*****/
 
-	if(orig_light_range < 10)
+	if(orig_light_range > -TOXINS_RESEARCH_LAMBDA && orig_light_range < 10)
 		say("Explosion not large enough for research calculations.")
 		return
-	else if(orig_light_range >= INFINITY) // Colton-proofs the doppler array
+	else if(orig_light_range <= -INFINITY || orig_light_range >= INFINITY) // Colton-proofs the doppler array
 		say("WARNING: INFINITE DENSITY OF TACHYONS DETECTED.")
 		point_gain = TOXINS_RESEARCH_MAX
 	else


### PR DESCRIPTION
# Documentation

Tachyon-doppler array will no longer reject bombs small enough to significant net point gain

<img width='300' height='400' src='https://user-images.githubusercontent.com/28408322/212217476-06135620-7bb0-40a4-bf13-397d2019202b.png'>
<img width='400' height='400' src='https://user-images.githubusercontent.com/28408322/212217502-357b1ddc-34ce-4799-a48f-c3eabc8183eb.png'>


# Changelog
:cl:  
bugfix: The tachyon-doppler array will now properly respect sufficiently sized negative bombs
/:cl:
