### PR TITLE
cloned sheltered people now retain sheltered on clone

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -715,6 +715,11 @@
 	lose_text = span_notice("You start to put together how to speak galactic common.")
 	medical_record_text = "Patient looks perplexed when questioned in galactic common."
 
+/datum/quirk/sheltered/on_clone(data)
+	var/mob/living/carbon/human/H = quirk_holder
+	H.remove_language(/datum/language/common, FALSE, TRUE)
+	if(!H.get_selected_language())
+		H.grant_language(/datum/language/japanese)
 
 /datum/quirk/sheltered/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder


### PR DESCRIPTION
# Document the changes in your pull request

This was reported as a bug in #7508 . This fixes it, and makes sense.

A cloner might fix a paraplegic's leg, but why would memory cloning teach them how to speak a whole language?

# Changelog

:cl:    
tweak: sheltered people are no longer given galactic common when cloned  
/:cl:
