### PR TITLE
Stand users are drawn towards other stand users

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 #define GUARDIAN_HANDS_LAYER 1
 #define GUARDIAN_TOTAL_LAYERS 1
+#define GUARDIAN_SCAN_DISTANCE 50
 
 /mob/living/simple_animal/hostile/guardian
 	name = "Guardian Spirit"
@@ -394,6 +395,51 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 	src.log_talk(input, LOG_SAY, tag="guardian")
 
+/mob/living/proc/finduser()
+	set name = "Find another user"
+	set category = "Guardian"
+	set desc = "Search for the rough location of another person with a Guardian."
+	var/turf/my_loc = get_turf(owner)
+	var/closest_dist = 9999
+	var/mob/living/closest_user
+
+	to_chat(owner, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
+	sleep(5 SECONDS)
+	var/list/datum/mind/users = list()
+	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
+		if(all_carbons == owner) //don't track ourselves!
+			continue
+		if(!all_carbons.mind)
+			continue
+		var/datum/mind/carbon_minds = all_carbons.mind
+		if(carbon_minds.has_antag_datum(/datum/antagonist/guardian))
+		users += carbon_minds
+
+	for(var/datum/mind/user_minds in users)
+		if(!user_minds.current || user_minds.current == owner) // || !get_turf(M.current) || !get_turf(owner))
+			continue
+		for(var/antag_datums in user_minds.antag_datums)
+			var/datum/antagonist/antag_datum = antag_datums
+			if(!istype(antag_datum))
+				continue
+			var/their_loc = get_turf(user_minds.current)
+			var/distance = get_dist_euclidian(my_loc, their_loc)
+			/// Found One: Closer than previous/max distance
+			if(distance < closest_dist && distance <= GUARDIAN_SCAN_DISTANCE)
+				closest_dist = distance
+				closest_user = user_minds.current
+				/// Stop searching through my antag datums and go to the next guy
+				break
+
+	/// Found one!
+	if(closest_user)
+		var/distString = closest_dist <= GUARDIAN_SCAN_DISTANCE / 4 ? "<b>somewhere nearby!</b>" : "somewhere in the distance."
+		to_chat(owner, span_warning("You detect signs of a user [distString]"))
+
+	/// Will yield a "?"
+	else
+		to_chat(owner, span_notice("There are no users nearby."))
+
 //FORCE RECALL/RESET
 
 /mob/living/proc/guardian_recall()
@@ -572,7 +618,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 	add_verb(user, list(/mob/living/proc/guardian_comm, \
 						/mob/living/proc/guardian_recall, \
-						/mob/living/proc/guardian_reset))
+						/mob/living/proc/guardian_reset, \
+						/mob/living/proc/finduser))
 	G?.client.init_verbs()
 
 /obj/item/guardiancreator/choose

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -404,7 +404,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/mob/living/closest_user
 
 	to_chat(owner, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
-	sleep(5 SECONDS)
+	if(!do_after(owner, 5 SECONDS))
+		return FALSE
 	var/list/datum/mind/users = list()
 	var/list/guardians = hasparasites()
 	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
@@ -444,7 +445,6 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		to_chat(owner, span_notice("There are no users nearby."))
 
 //FORCE RECALL/RESET
-
 /mob/living/proc/guardian_recall()
 	set name = "Recall Guardian"
 	set category = "Guardian"

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -406,15 +406,18 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	to_chat(owner, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
 	sleep(5 SECONDS)
 	var/list/datum/mind/users = list()
+	var/list/guardians = hasparasites()
 	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
 		if(all_carbons == owner) //don't track ourselves!
 			continue
 		if(!all_carbons.mind)
 			continue
 		var/datum/mind/carbon_minds = all_carbons.mind
-		if(carbon_minds.has_antag_datum(/datum/antagonist/guardian))
-		users += carbon_minds
-
+		for(var/para in guardians)
+			var/mob/living/simple_animal/hostile/guardian/G = para
+			if(G.summoner?.current.ckey == owner.ckey)
+				users += carbon_minds
+	
 	for(var/datum/mind/user_minds in users)
 		if(!user_minds.current || user_minds.current == owner) // || !get_turf(M.current) || !get_turf(owner))
 			continue

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 
 #define GUARDIAN_HANDS_LAYER 1
 #define GUARDIAN_TOTAL_LAYERS 1
+#define GUARDIAN_SCAN_DISTANCE 50
 
 /mob/living/simple_animal/hostile/guardian
 	name = "Guardian Spirit"
@@ -216,7 +217,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 		UnregisterSignal(summoner.current, COMSIG_MOVABLE_MOVED)
 	cut_barriers()
 	var/mob/living/carbon/H = summoner.current
-	remove_verb(H, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset))
+	remove_verb(H, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset, /mob/living/proc/finduser))
 	berserk = TRUE
 	summoner = null
 	maxHealth = 750
@@ -612,6 +613,51 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 
 	src.log_talk(input, LOG_SAY, tag="guardian")
 
+/mob/living/proc/finduser()
+	set name = "Find another user"
+	set category = "Guardian"
+	set desc = "Search for the rough location of another person with a Guardian."
+	var/turf/my_loc = get_turf(src)
+	var/closest_dist = 9999
+	var/mob/living/closest_user
+
+	to_chat(src, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
+	sleep(5 SECONDS)
+	var/list/datum/mind/users = list()
+	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
+		if(all_carbons == src) //don't track ourselves!
+			continue
+		if(!all_carbons.mind)
+			continue
+		var/datum/mind/carbon_minds = all_carbons.mind
+		if(carbon_minds.has_antag_datum(/datum/antagonist/guardian))
+			users += carbon_minds
+
+	for(var/datum/mind/user_minds in users)
+		if(!user_minds.current || user_minds.current == src)
+			continue
+		for(var/antag_datums in user_minds.antag_datums)
+			var/datum/antagonist/antag_datum = antag_datums
+			if(!istype(antag_datum))
+				continue
+			var/their_loc = get_turf(user_minds.current)
+			var/distance = get_dist_euclidian(my_loc, their_loc)
+			/// Found One: Closer than previous/max distance
+			if(distance < closest_dist && distance <= GUARDIAN_SCAN_DISTANCE)
+				closest_dist = distance
+				closest_user = user_minds.current
+				/// Stop searching through my antag datums and go to the next guy
+				break
+
+	/// Found one!
+	if(closest_user)
+		var/distString = closest_dist <= GUARDIAN_SCAN_DISTANCE / 4 ? "<b>somewhere nearby!</b>" : "somewhere in the distance."
+		to_chat(src, span_warning("You detect signs of a user [distString]"))
+
+	/// Will yield a "?"
+	else
+		to_chat(src, span_notice("There are no users nearby."))
+
 /mob/living/simple_animal/hostile/guardian/verb/Battlecry()
 	set name = "Set Battlecry"
 	set category = "Guardian"
@@ -680,7 +726,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 /mob/living/proc/revive_guardian()
 	var/list/guardians = hasparasites()
 	if (LAZYLEN(guardians))
-		add_verb(src, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset))
+		add_verb(src, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset, /mob/living/proc/finduser))
 		for (var/mob/living/simple_animal/hostile/guardian/jojo in guardians)
 			jojo.forceMove(src)
 			jojo.RegisterSignal(src, COMSIG_MOVABLE_MOVED, /mob/living/simple_animal/hostile/guardian.proc/OnMoved)
@@ -719,7 +765,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 /datum/mind/proc/transfer_parasites()
 	var/list/guardians = hasparasites()
 	if (LAZYLEN(guardians))
-		add_verb(current, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset))
+		add_verb(current, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset, /mob/living/proc/finduser))
 		for (var/mob/living/simple_animal/hostile/guardian/jojo in guardians)
 			jojo.forceMove(current)
 			jojo.RegisterSignal(current, COMSIG_MOVABLE_MOVED, /mob/living/simple_animal/hostile/guardian.proc/OnMoved)

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -624,14 +624,18 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	to_chat(src, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
 	sleep(5 SECONDS)
 	var/list/datum/mind/users = list()
+	var/list/guardians = hasparasites()
 	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)
 		if(all_carbons == src) //don't track ourselves!
 			continue
 		if(!all_carbons.mind)
 			continue
 		var/datum/mind/carbon_minds = all_carbons.mind
-		if(carbon_minds.has_antag_datum(/datum/antagonist/guardian))
-			users += carbon_minds
+		for(var/para in guardians)
+			var/mob/living/simple_animal/hostile/guardian/G = para
+			if(G.summoner?.current.ckey == src.ckey)
+				users += carbon_minds
+				
 
 	for(var/datum/mind/user_minds in users)
 		if(!user_minds.current || user_minds.current == src)
@@ -657,7 +661,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	/// Will yield a "?"
 	else
 		to_chat(src, span_notice("There are no users nearby."))
-
+		
 /mob/living/simple_animal/hostile/guardian/verb/Battlecry()
 	set name = "Set Battlecry"
 	set category = "Guardian"

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -622,7 +622,8 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	var/mob/living/closest_user
 
 	to_chat(src, span_notice("You take a moment to think, focusing yourself to try and discern any nearby users."))
-	sleep(5 SECONDS)
+	if(!do_after(src, 5 SECONDS))
+		return FALSE
 	var/list/datum/mind/users = list()
 	var/list/guardians = hasparasites()
 	for(var/mob/living/carbon/all_carbons in GLOB.alive_mob_list)

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -216,7 +216,7 @@
 				to_chat(user, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font> has been summoned!"))
 			if ("carp")
 				to_chat(user, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font> has been caught!"))
-		add_verb(user, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset))
+		add_verb(user, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset, /mob/living/proc/finduser))
 		user.update_sight()
 		//surprise another check in case you tried to get around the first one and now you have no holoparasite :)
 		for (var/obj/H in all_items)

--- a/yogstation/code/modules/guardian/standarrow.dm
+++ b/yogstation/code/modules/guardian/standarrow.dm
@@ -171,7 +171,7 @@
 		users[G] = TRUE
 		log_game("[key_name(H)] has summoned [key_name(G)], a holoparasite, via the stand arrow.")
 		to_chat(H, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font> has been summoned!"))
-		add_verb(H, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset))
+		add_verb(H, list(/mob/living/proc/guardian_comm, /mob/living/proc/guardian_recall, /mob/living/proc/guardian_reset, /mob/living/proc/finduser))
 		H.update_sight()
 		uses--
 		in_use = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

![ho-anime (1)](https://user-images.githubusercontent.com/74586965/212400117-27c4bf6c-ad52-40b4-9dff-c74e5f50c0bc.gif)

![jotaro-no-bw](https://user-images.githubusercontent.com/74586965/212400132-3e3a3d44-5eaf-4e76-a949-bc3fdd3a810d.gif)


Stand users, All 3 types, now have the ability to detect the presence of nearby stand users

Thank you redd for debugging because i didnt feel like it 😎 

<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Stand users can now discern the location of nearby other stand users, vaguely
/:cl:
