### PR TITLE
clock scarabs no longer screw over clock cults

### DIFF
--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -253,7 +253,7 @@
 	var/servants = length(GLOB.all_clockwork_mobs)
 	for(var/I in GLOB.player_list)
 		var/mob/M = I
-		if(M.stat != DEAD)
+		if(M.stat != DEAD && !istype(M,/mob/living/simple_animal/drone/cogscarab))
 			++alive
 	var/ratio = servants/alive
 	if(ratio >= SERVANT_HARDMODE_PERCENT)


### PR DESCRIPTION
scarabs being spawned in can bring the threshold of cult size above 20% which can cause the slow teleport thing to activate before any cultists can place brass tiles or convert people

# Changelog

:cl:  
bugfix: clockwork scarabs being created will not interfere with the clock cult's teleportation time
/:cl:
