### PR TITLE
Fixes decal examine runtimes and prevents them from ever happening again

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -269,7 +269,7 @@
 		to_chat(user, span_notice("[target] is not a tile!"))
 		return
 	if(use_paint(user))
-		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, color, null, null, alpha)
+		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, FALSE, stored_dir, color, null, null, alpha)
 
 /obj/item/airlock_painter/decal/attack_self(mob/user)
 	. = ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -456,7 +456,7 @@
 
 	if(result.len)
 		for(var/i in 1 to (length(result) - 1))
-			result[i] += "\n"
+			result[i] = "[result[i]]\n"
 
 	to_chat(src, examine_block("<span class='infoplain'>[result.Join()]</span>"))
 	SEND_SIGNAL(src, COMSIG_MOB_EXAMINATE, A)


### PR DESCRIPTION
# Document the changes in your pull request

Decal args were misplaced, leading `examinate()` to try to concatenate `210` (the intended alpha of the decal) and `\n`, leading to a runtime.

Instead of concatenating a potentially non-string value it now typecasts it which will prevent a runtime and show the examine to the player which will probably look weird and get reported and debugged faster.

# Changelog

:cl:  
bugfix: fixed not being able to examine decal floors
bugfix: fixed decal floors not being partially transparent
/:cl:
