### PR TITLE
Caps Softcap for Rad Collector Attempt 2 - Making 115k Credits per collector is NOT intended.

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -9,6 +9,7 @@
 #define RAD_COLLECTOR_STORED_OUT 0.1	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
 #define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.000125 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
 #define RAD_COLLECTOR_OUTPUT min(stored_power, (stored_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
+#define RAD_COLLECTOR_PAYOUT_SCALE 300
 
 /obj/machinery/power/rad_collector
 	name = "Radiation Collector Array"
@@ -107,7 +108,7 @@
 				if(D)
 					var/payout = output/8000
 					stored_power -= min(payout*20000, stored_power)
-					creditpayout= clamp(payout, 0, 1200)
+					creditpayout = log(1 + (payout / RAD_COLLECTOR_PAYOUT_SCALE)) * (RAD_COLLECTOR_PAYOUT_SCALE / log(2))
 					D.adjust_money(creditpayout)
 					last_output = payout
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -45,7 +45,7 @@
 	// Higher power bonus will give more power
 	var/power_bonus = 0
 	// Balance amount of money given to crew
-	var/balancevalue = 0.05
+	var/creditpayout = 0
 
 	var/obj/item/radio/radio
 	var/obj/item/tank/internals/plasma/loaded_tank = null
@@ -106,9 +106,9 @@
 				var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 				if(D)
 					var/payout = output/8000
-					stored_power -= min(payout*200, stored_power)
-					payout = payout * balancevalue
-					D.adjust_money(payout)
+					stored_power -= min(payout*20000, stored_power)
+					creditpayout= clamp(payout, 0, 1200)
+					D.adjust_money(creditpayout)
 					last_output = payout
 
 /obj/machinery/power/rad_collector/interact(mob/user)
@@ -267,7 +267,7 @@
 		else if(mode == SCIENCE)
 			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE]</b>, and producing [last_output*60] research points per minute.</span>"
 		else if(mode == MONEY)
-			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE] credits</b>, and producing [last_output*60] credits per minute.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE] credits</b>, and producing [creditpayout] credits per minute.</span>"
 	else
 		if(mode == POWER)
 			. += "<span class='notice'><b>[src]'s display displays the words:</b> \"Power production mode. Please insert <b>Plasma</b>. Use a multitool to change production modes.\"</span>"


### PR DESCRIPTION
Adds a softcap to rad collectors where you get diminishing returns. This will "softly" cap it 1200-2000 credits a minute for INSANE power. See here:

https://www.desmos.com/calculator/txnkzdj0sw

Green: What's current
Red: what it will be instead

:cl:  SapphicOverload, JamieD12
bugfix: Softcaps rad collectors maximum credits per minute.
/:cl:
