### PR TITLE
Fixes negative explosions giving near-infinite research points and causing runtime errors

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	var/next_announce = 0
 	var/integrated = FALSE
 	var/max_dist = 150
+	var/allow_all = FALSE //lets the doppler array process any kind of bomb, in case admins want to be funny
 	verb_say = "states coldly"
 
 /obj/machinery/doppler_array/Initialize()
@@ -107,11 +108,13 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	var/point_gain = 0
 
 	/*****The Point Calculator*****/
-
-	if(orig_light_range > -TOXINS_RESEARCH_LAMBDA && orig_light_range < 10)
+	if(orig_light_range < 0 && !allow_all) // Sarah-proofs the doppler array
+		say("WARNING: NEGATIVE TACHYON DENSITY DETECTED.")
+		point_gain = TOXINS_RESEARCH_MAX
+	else if(orig_light_range < 10 && !allow_all)
 		say("Explosion not large enough for research calculations.")
 		return
-	else if(orig_light_range <= -INFINITY || orig_light_range >= INFINITY) // Colton-proofs the doppler array
+	else if(orig_light_range >= INFINITY && !allow_all) // Colton-proofs the doppler array
 		say("WARNING: INFINITE DENSITY OF TACHYONS DETECTED.")
 		point_gain = TOXINS_RESEARCH_MAX
 	else
@@ -127,7 +130,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		if(D)
 			D.adjust_money(point_gain)
 			linked_techweb.add_stored_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
-			say("Explosion details and mixture analyzed and sold to the highest bidder for $[point_gain], with a reward of [point_gain] points to be processed by research servers.")
+			var/msg = (orig_light_range < 0) ? "Implosion" : "Explosion"
+			say(msg + " details and mixture analyzed and sold to the highest bidder for $[point_gain], with a reward of [point_gain] points to be processed by research servers.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")


### PR DESCRIPTION
# Document the changes in your pull request

Due to the way research points are calculated, negative explosions are capable of producing a near-infinite amount of research points, and causes a runtime error when the light radius is exactly -3940 from it attempting to divide by zero.

![image](https://user-images.githubusercontent.com/93578146/212568477-986930c7-6c42-4ae8-9436-866cf535ef43.png)

Negative explosions can occur if an endothermic fusion reaction happens inside a tank immediately after it reaches the pressure required to explode, cooling the contents significantly and making the pressure differential used in the bomb size calculation negative which causes the explosion radius to be negative as well. This is highly unreliable due to the chaotic nature of fusion, but it *is* possible.

![image](https://user-images.githubusercontent.com/93578146/212568806-c2caf291-0d83-4683-a3eb-691662f65235.png)

I've also added a variable to the doppler array that can remove the restriction (and a few other restrictions). It's turned off by default, but admins can set it to true for testing purposes or if they want to be funny.

# Changelog

:cl:  
bugfix: fixes negative bombs giving near-infinite research and causing runtime errors
/:cl:
