### PR TITLE
Gives Krokodil Addicts proper traits

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -92,6 +92,9 @@
 	id = "goofzombies"
 	limbs_id = "zombie" //They look like zombies
 	sexes = FALSE
+	species_traits = list(HAS_FLESH, HAS_BONE, AGENDER)
+	inherent_traits = list(TRAIT_EASILY_WOUNDED) //you have no skin
+	inherent_biotypes = list(MOB_UNDEAD, MOB_HUMANOID) //pretty much just rotting flesh, somehow still "technically" alive
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
 	mutanttongue = /obj/item/organ/tongue/zombie
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN


### PR DESCRIPTION
It was probably a derivative of zombie in the past and piggy backed off their traits.
This should make it so losing your skin no longer makes you immune to all wounds and properly gives the agender tag.

Doesn't fix the sprite draw error, that will be a different PR

:cl:  
bugfix: Krokodil addict no longer lacks all traits
/:cl:
