### PR TITLE
Revert "Removes tasers from darkspawn"

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -144,12 +144,14 @@
 			if(!twinned)
 				target.visible_message(span_warning("[firer]'s [name] slam into [target], knocking them off their feet!"), \
 				span_userdanger("You're knocked off your feet!"))
+				L.Paralyze(20)
 				L.Knockdown(60)
 			else
 				target.throw_at(get_step_towards(firer, target), 7, 2) //pull them towards us!
 				target.visible_message(span_warning("[firer]'s [name] slam into [target] and drag them across the ground!"), \
 				span_userdanger("You're suddenly dragged across the floor!"))
-				L.Knockdown(80) //these can't hit people who are already on the ground but they can be spammed to all shit
+				L.Paralyze(30) //these can't hit people who are already on the ground but they can be spammed to all shit
+				L.Knockdown(80)
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, target, 'yogstation/sound/magic/pass_attack.ogg', 50, TRUE), 1)
 		else
 			var/mob/living/silicon/robot/R = target


### PR DESCRIPTION
Reverts https://github.com/yogstation13/Yogstation/pull/16986
this broke the pull from duality and likely existed to prevent that bug in the first place. 
also fucked over newer darkspawn who keep moving while trying to bead cause people are crawling and then get filled with flameshot.

not all stuns are bad people sometimes they exist for a reason.
### Changelog
🆑
tweak: Darkspawn tendrils will now apply their stun once more preventing pull being cancelled and newer darkspawn not being able to bead due to having to chase a moving target and messing up the bead letting them get away
/🆑