### PR TITLE
Rebuffs Ethereal

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -88,7 +88,7 @@
 		var/healthpercent = max(H.health, 0) / 100
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		ethereal_light.set_light_range_power_color(1 + (2 * healthpercent), 1 + (1 * healthpercent), current_color)
+		ethereal_light.set_light_range_power_color(1 + (4 * healthpercent), 1 + (1 * healthpercent), current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else


### PR DESCRIPTION
With the lighting change ethereals got nerfed back to previous numbers
Since lighting works differently this time i've only buffed the radius and not the power
Currently the light range is pitifully small, i've also made it linked with health more so a full health ethereal is notably brighter than a hurt ethereal.

:cl:  
tweak: Rebuffs Ethereals
/:cl:
