### PR TITLE
Adjusts the bluespace bodybag breakout timer

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -82,6 +82,11 @@
 		return
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
+	to_chat(user, span_notice("You claw at the fabric of [src], trying to tear it open..."))
+	to_chat(loc, span_warning("Someone starts trying to break free of [src]!"))
+	if(!do_after(user, 5 SECONDS, src, stayStill = FALSE))
+		to_chat(loc, span_warning("The pressure subsides. It seems that they've stopped resisting..."))
+		return
 	loc.visible_message(span_warning("[user] suddenly appears in front of [loc]!"), span_userdanger("[user] breaks free of [src]!"))
 	qdel(src)
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -82,11 +82,6 @@
 		return
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
-	to_chat(user, span_notice("You claw at the fabric of [src], trying to tear it open..."))
-	to_chat(loc, span_warning("Someone starts trying to break free of [src]!"))
-	if(!do_after(user, 3 SECONDS, src))
-		to_chat(loc, span_warning("The pressure subsides. It seems that they've stopped resisting..."))
-		return
 	loc.visible_message(span_warning("[user] suddenly appears in front of [loc]!"), span_userdanger("[user] breaks free of [src]!"))
 	qdel(src)
 

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -84,7 +84,7 @@
 	user.last_special = world.time + CLICK_CD_BREAKOUT
 	to_chat(user, span_notice("You claw at the fabric of [src], trying to tear it open..."))
 	to_chat(loc, span_warning("Someone starts trying to break free of [src]!"))
-	if(!do_after(user, 20 SECONDS, src))
+	if(!do_after(user, 3 SECONDS, src))
 		to_chat(loc, span_warning("The pressure subsides. It seems that they've stopped resisting..."))
 		return
 	loc.visible_message(span_warning("[user] suddenly appears in front of [loc]!"), span_userdanger("[user] breaks free of [src]!"))


### PR DESCRIPTION
# Document the changes in your pull request

Removes the ability of SOME people to surprise bodybag people to easily take them out of fights.

The bluespace bodybag is effectively a 20 second stun, this lowers it to a much more reasonable value of 5 seconds and hopefully fixes the dropping bug.

Yes this is an ided, tag it.

# Changelog

:cl:  
tweak: The bluespace bodybag breakout timer is significantly shorter now
/:cl:
