### PR TITLE
Lets Revenants see like the ghosts they are

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -24,7 +24,7 @@
 	layer = GHOST_LAYER
 	healable = FALSE
 	spacewalk = TRUE
-	sight = SEE_SELF
+	sight = SEE_MOBS | SEE_OBJS | SEE_TURFS | SEE_SELF
 	throwforce = 0
 
 	see_in_dark = 8


### PR DESCRIPTION
Revenant is not a strong antag in any manner, their entire thing relies on them being at the right place at the right time, but being unable to see beyond the room they are in just makes it feel tedious and unfun.
Not to mention the flavour of them being just an angry ghost is lost when for some reason becoming angry makes them lose the ability to see through walls.

:cl:  
tweak: Gives revenant X-ray vision
/:cl:
