### PR TITLE
Makes darkspawn abilities work more like they should

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/dark_bead.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/dark_bead.dm
@@ -56,31 +56,35 @@
 		full_restore = FALSE
 		to_chat(user, span_warning("[L] has been veiled and will not produce as much psi as an unmodified victim."))
 	eating = TRUE
+	L.Stun(5 SECONDS)
+	user.Immobilize(1 SECONDS) // So they don't accidentally move while beading
+	ADD_TRAIT(L, TRAIT_PARALYSIS, "bead-trait")
 	if(user.loc != L)
 		user.visible_message(span_warning("[user] grabs [L] and leans in close..."), "<span class='velvet bold'>cera qo...</span><br>\
 		[span_danger("You begin siphoning [L]'s mental energy...")]")
 		to_chat(L, span_userdanger("<i>AAAAAAAAAAAAAA-</i>"))
-		L.Stun(50)
 		L.silent += 4
 		playsound(L, 'yogstation/sound/magic/devour_will.ogg', 65, FALSE) //T A S T Y   S O U L S
-		if(!do_mob(user, L, 30))
-			user.Knockdown(30)
+		if(!do_mob(user, L, 3 SECONDS))
+			REMOVE_TRAIT(L, TRAIT_PARALYSIS, "bead-trait")
+			user.Knockdown(3 SECONDS)
 			to_chat(L, span_boldwarning("All right. You're all right."))
-			L.Knockdown(30)
+			L.Knockdown(3 SECONDS)
 			qdel(src, force = TRUE)
 			return
 	else
 		L.visible_message("<span class='userdanger italics'>[L] suddenly howls and clutches as their face as violet light screams from their eyes!</span>", \
 		"<span class='userdanger italics'>AAAAAAAAAAAAAAA-</span>")
 		to_chat(user, span_velvet("<b>cera qo...</b><br>You begin siphoning [L]'s will..."))
-		L.Stun(50)
 		playsound(L, 'yogstation/sound/magic/devour_will_long.ogg', 65, FALSE)
-		if(!do_mob(user, L, 50))
-			user.Knockdown(50)
+		if(!do_mob(user, L, 5 SECONDS))
+			REMOVE_TRAIT(L, TRAIT_PARALYSIS, "bead-trait")
+			user.Knockdown(5 SECONDS)
 			to_chat(L, span_boldwarning("All right. You're all right."))
-			L.Knockdown(50)
+			L.Knockdown(5 SECONDS)
 			qdel(src, force = TRUE)
 			return
+	REMOVE_TRAIT(L, TRAIT_PARALYSIS, "bead-trait")
 	user.visible_message(span_warning("[user] gently lowers [L] to the ground..."), "<span class='velvet'><b>...aranupdejc</b><br>\
 	You devour [L]'s will. Your Psi has been [!full_restore ? "partially restored." : "fully restored.\n\
 	Additionally, you have gained one lucidity. Use it to purchase and upgrade abilities."]<br>\

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -144,12 +144,13 @@
 			if(!twinned)
 				target.visible_message(span_warning("[firer]'s [name] slam into [target], knocking them off their feet!"), \
 				span_userdanger("You're knocked off your feet!"))
-				L.Knockdown(60)
+				L.Knockdown(6 SECONDS)
 			else
+				L.Immobilize(0.15 SECONDS) // so they cant cancel the throw by moving
 				target.throw_at(get_step_towards(firer, target), 7, 2) //pull them towards us!
 				target.visible_message(span_warning("[firer]'s [name] slam into [target] and drag them across the ground!"), \
 				span_userdanger("You're suddenly dragged across the floor!"))
-				L.Knockdown(80) //these can't hit people who are already on the ground but they can be spammed to all shit
+				L.Knockdown(8 SECONDS) //these can't hit people who are already on the ground but they can be spammed to all shit
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, target, 'yogstation/sound/magic/pass_attack.ogg', 50, TRUE), 1)
 		else
 			var/mob/living/silicon/robot/R = target


### PR DESCRIPTION
# Document the changes in your pull request

Added a bunch of time defines

User-facing changes in changelog

Closes: #17507 

# Changelog

:cl:  
tweak: Darkspawn: Duality tendrils when thrown now immobilize for 0.1 seconds so people can no longer move-cancel the throw
tweak: Darkspawn: Devour will (dark bead) now hard-applies paralysis to prevent people from avoiding devours by using anti-stuns
tweak: Darkspawn: Devour will (dark bead) now immobilizes the user for 1 second so that they no longer accidentally cancel the do_after which is commonly done by newer players especially when chasing down crawling enemies
/:cl:
