### PR TITLE
Bluespace locker no longer has infinite power

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18929,7 +18929,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -19943,7 +19943,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -20580,7 +20580,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -22794,7 +22794,7 @@
 /area/holodeck/rec_center/chapelcourt)
 "aTW" = (
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -25862,6 +25862,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"eiz" = (
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/plasteel/dark,
+/area/bluespace_locker)
 "eDa" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title1"
@@ -26444,7 +26448,7 @@
 /area/centcom/testchamber)
 "xuU" = (
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
+	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
 	name = "Test Chamber Blast Doors"
 	},
 /turf/open/floor/plasteel,
@@ -46001,7 +46005,7 @@ aVa
 aVa
 aOw
 aVa
-aVa
+eiz
 aGa
 aOQ
 aOQ

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25863,7 +25863,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ctf)
 "eiz" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc{
+	areastring = "/area/bluespace_locker";
+	name = "Bluespace Locker APC";
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
 "eDa" = (

--- a/yogstation/code/game/area/Space_Station_13_areas.dm
+++ b/yogstation/code/game/area/Space_Station_13_areas.dm
@@ -42,9 +42,7 @@
 /area/bluespace_locker
 	name = "Bluespace Locker"
 	icon_state = "away"
-	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	noteleport = TRUE
 
 /area/vacant_room/office/office_b


### PR DESCRIPTION
# Document the changes in your pull request
It's stupid that the bluespace locker gives you an area with infinite power for free. You will now have to provide an external power source (e.g. P.A.C.M.A.N generator) if you want to use machines inside.

I added an APC inside the locker and removed the ``requires_power = FALSE`` flag so stuff actually requires power. The APC spawns with 90% charge like default, however the 2 lights inside will use some of it over time.

![image](https://user-images.githubusercontent.com/24573384/212669362-de5e9064-470d-49de-825a-908a0af40546.png)


# Changelog

:cl:  
tweak: Bluespace locker no longer has infinite power, it's powered by an APC now and requires an external power source.
/:cl:
