### PR TITLE
Contractors  get a syndicate prisoner bag to transport someone to the extract point

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -365,6 +365,7 @@
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
 	new /obj/item/storage/box/syndicate/contractor_loadout(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor_baton(src)
+	new /obj/item/bodybag/environmental/prisoner/syndicate
 
 	// All about 4 TC or less - some nukeops only items, but fit nicely to the theme.
 	var/list/item_list = list(

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -365,7 +365,7 @@
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
 	new /obj/item/storage/box/syndicate/contractor_loadout(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor_baton(src)
-	new /obj/item/bodybag/environmental/prisoner/syndicate
+	new /obj/item/bodybag/environmental/prisoner/syndicate(src)
 
 	// All about 4 TC or less - some nukeops only items, but fit nicely to the theme.
 	var/list/item_list = list(


### PR DESCRIPTION
# Document the changes in your pull request
Contractor kit will now come with a syndicate prisoner transport bag
# Wiki Documentation
update the kit to include the bag in syndicate items
# Changelog
:cl:  
rscadd: Syndicate contractor will now get a prisoner bag to aid in kidnappings and keeping their targets alive
/:cl:
