### PR TITLE
Steal Objective Clarification

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -57,7 +57,7 @@
 	excludefromjob = list("Chief Engineer")
 
 /datum/objective_item/steal/capmedal
-	name = "the Medal of Captaincy."
+	name = "the medal of captaincy."
 	targetitem = /obj/item/clothing/accessory/medal/gold/captain
 	difficulty = 5
 	excludefromjob = list("Captain")
@@ -84,7 +84,7 @@
 	excludefromjob = list("Head of Security", "Warden")
 
 /datum/objective_item/steal/reactive
-	name = "the Research Director's Reactive Teleport Armor."
+	name = "the Research Director's reactive teleport armor."
 	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
 	difficulty = 5
 	excludefromjob = list("Research Director")
@@ -158,7 +158,7 @@
 	return 0
 
 /datum/objective_item/steal/blueprints
-	name = "the station blueprints."
+	name = "the Chief Engineer's station blueprints."
 	targetitem = /obj/item/areaeditor/blueprints
 	difficulty = 10
 	excludefromjob = list("Chief Engineer")
@@ -229,7 +229,7 @@
 	difficulty = 10
 
 /datum/objective_item/special/boh
-	name = "the Research Director's Bag of Holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Quiz 1/23
+	name = "the Research Director's bag of holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Quiz Jan '23
 	targetitem = /obj/item/storage/backpack/holding
 	difficulty = 10
 

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -229,7 +229,7 @@
 	difficulty = 10
 
 /datum/objective_item/special/boh
-	name = "the Research Director's bag of holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Quiz Jan '23
+	name = "the Research Director's bag of holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Aquizit Jan '23
 	targetitem = /obj/item/storage/backpack/holding
 	difficulty = 10
 

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -63,7 +63,7 @@
 	excludefromjob = list("Captain")
 
 /datum/objective_item/steal/hypo
-	name = "the hypospray."
+	name = "the Chief Medical Officer's deluxe hypospray."
 	targetitem = /obj/item/hypospray/deluxe/cmo
 	difficulty = 5
 	excludefromjob = list("Chief Medical Officer")

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -27,13 +27,13 @@
 	return ..()
 
 /datum/objective_item/steal/caplaser
-	name = "the captain's antique laser gun."
+	name = "the Captain's antique laser gun."
 	targetitem = /obj/item/gun/energy/laser/captain
 	difficulty = 5
 	excludefromjob = list("Captain")
 
 /datum/objective_item/steal/hoslaser
-	name = "the head of security's personal laser gun."
+	name = "the Head of Security's personal laser gun."
 	targetitem = /obj/item/gun/energy/e_gun/hos
 	difficulty = 10
 	excludefromjob = list("Head Of Security")
@@ -51,13 +51,13 @@
 	excludefromjob = list("Captain")
 
 /datum/objective_item/steal/magboots
-	name = "the chief engineer's advanced magnetic boots."
+	name = "the Chief Engineer's advanced magnetic boots."
 	targetitem =  /obj/item/clothing/shoes/magboots/advance
 	difficulty = 5
 	excludefromjob = list("Chief Engineer")
 
 /datum/objective_item/steal/capmedal
-	name = "the medal of captaincy."
+	name = "the Medal of Captaincy."
 	targetitem = /obj/item/clothing/accessory/medal/gold/captain
 	difficulty = 5
 	excludefromjob = list("Captain")
@@ -84,7 +84,7 @@
 	excludefromjob = list("Head of Security", "Warden")
 
 /datum/objective_item/steal/reactive
-	name = "the reactive teleport armor."
+	name = "the Research Director's Reactive Teleport Armor."
 	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
 	difficulty = 5
 	excludefromjob = list("Research Director")
@@ -214,7 +214,7 @@
 
 //Old ninja objectives.
 /datum/objective_item/special/pinpointer/nuke
-	name = "the captain's pinpointer."
+	name = "the Captain's pinpointer."
 	targetitem = /obj/item/pinpointer
 	difficulty = 10
 
@@ -229,7 +229,7 @@
 	difficulty = 10
 
 /datum/objective_item/special/boh
-	name = "a bag of holding."
+	name = "the Research Director's Bag of Holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Quiz 1/23
 	targetitem = /obj/item/storage/backpack/holding
 	difficulty = 10
 

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -63,7 +63,7 @@
 	excludefromjob = list("Captain")
 
 /datum/objective_item/steal/hypo
-	name = "the Chief Medical Officer's deluxe hypospray."
+	name = "the Chief Medical Officer's hypospray deluxe."
 	targetitem = /obj/item/hypospray/deluxe/cmo
 	difficulty = 5
 	excludefromjob = list("Chief Medical Officer")


### PR DESCRIPTION
# Document the changes in your pull request

Specifies which heads usually have steal objective, such as the CMO’s specific hypospray or the CE’s magnetic boots.

Also made capitalization more consistent.

I thought of this after realizing that just “the hypospray” as an objective is a bit unclear as now there are generic hyposprays available to Medbay. 

# Changelog

:cl: 
tweak: clarifies if certain steal objectives are usually held by heads of staff
spellcheck: made capitalization of proper nouns more consistent in steal objectives
/:cl:
