### PR TITLE
Adds chem machine to all bar templates, not just Citadel template

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_arcade.dmm
@@ -24,12 +24,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"af" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -97,12 +91,6 @@
 "ay" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aA" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aB" = (
@@ -731,6 +719,12 @@
 /obj/item/toy/figure/chef,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Ai" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ak" = (
 /obj/machinery/light,
 /obj/machinery/firealarm{
@@ -909,6 +903,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"PG" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "PU" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -1317,7 +1320,7 @@ PU
 ag
 "}
 (15,1,1) = {"
-af
+Ai
 aB
 aJ
 bf
@@ -1334,7 +1337,7 @@ ag
 "}
 (16,1,1) = {"
 ag
-aA
+PG
 aK
 ag
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_box.dmm
@@ -24,12 +24,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"af" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ag" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -186,12 +180,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"aA" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aB" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1254,6 +1242,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"mQ" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pe" = (
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria,
@@ -1295,6 +1289,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vb" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "vA" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/that{
@@ -1686,7 +1689,7 @@ dd
 ag
 "}
 (15,1,1) = {"
-af
+mQ
 aB
 aJ
 bf
@@ -1703,7 +1706,7 @@ ag
 "}
 (16,1,1) = {"
 ag
-aA
+vb
 aK
 ag
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -45,12 +45,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
-"aj" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/crew_quarters/bar)
 "ak" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -157,12 +151,6 @@
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
 "ay" = (
-/turf/open/floor/plasteel/rockvault,
-/area/crew_quarters/bar)
-"az" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
 "aB" = (
@@ -730,6 +718,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/kitchen)
+"cC" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/crew_quarters/bar)
 "cI" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -961,6 +955,15 @@
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"PF" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/rockvault,
 /area/crew_quarters/bar)
 "Qz" = (
 /obj/structure/disposalpipe/segment,
@@ -1314,7 +1317,7 @@ da
 ac
 "}
 (15,1,1) = {"
-aj
+cC
 ay
 aM
 cc
@@ -1331,7 +1334,7 @@ ac
 "}
 (16,1,1) = {"
 ag
-az
+PF
 ba
 ag
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_cheese.dmm
@@ -179,17 +179,6 @@
 "aB" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aC" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/structure/chair/stool/bar,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -238,10 +227,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aJ" = (
-/obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aK" = (
@@ -952,6 +937,13 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1;
+	icon_state = "scrub_map_on-3"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "zN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -964,6 +956,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Af" = (
+/obj/machinery/computer/slot_machine,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "BJ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -990,22 +989,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"Ew" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
-	},
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "EV" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -1027,6 +1010,12 @@
 	name = "Bar Shutters Control";
 	pixel_y = 24;
 	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"HA" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1052,6 +1041,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"KP" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "PB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1089,6 +1090,12 @@
 	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Xe" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1281,9 +1288,9 @@ ag
 (11,1,1) = {"
 ag
 as
-aJ
-aY
-IK
+Af
+HA
+vy
 nY
 iI
 PB
@@ -1298,8 +1305,8 @@ ag
 ag
 ag
 ag
-aC
-vy
+ag
+ag
 aB
 au
 aE
@@ -1313,8 +1320,8 @@ cC
 (13,1,1) = {"
 ae
 aK
-ag
-ag
+KP
+ba
 ag
 ul
 cD
@@ -1329,10 +1336,10 @@ cC
 (14,1,1) = {"
 ah
 at
-Ew
-ba
-ag
-Hm
+xZ
+aB
+bl
+aB
 au
 aB
 jf
@@ -1346,9 +1353,9 @@ ag
 oC
 au
 hk
-aB
-bl
-aB
+Xe
+ag
+Hm
 cE
 br
 bY

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_clock.dmm
@@ -495,6 +495,12 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
+"rg" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "rj" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/bronze/reebe,
@@ -876,12 +882,6 @@
 	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/theatre)
-"Ke" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
 "KX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -1132,6 +1132,15 @@
 	},
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
+"Vv" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/bronze/reebe,
+/area/crew_quarters/bar)
 "Wq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1203,12 +1212,6 @@
 /area/crew_quarters/bar)
 "YH" = (
 /obj/item/clockwork/alloy_shards/small,
-/turf/open/floor/bronze/reebe,
-/area/crew_quarters/bar)
-"YX" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/bronze/reebe,
 /area/crew_quarters/bar)
 
@@ -1437,7 +1440,7 @@ rR
 Ws
 "}
 (15,1,1) = {"
-Ke
+rg
 AD
 Rz
 uu
@@ -1454,7 +1457,7 @@ Ws
 "}
 (16,1,1) = {"
 Ej
-YX
+Vv
 rj
 Ws
 Ws

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_conveyor.dmm
@@ -34,12 +34,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aj" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ak" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -124,12 +118,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ax" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ay" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aA" = (
@@ -1219,6 +1207,15 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/kitchen)
+"KJ" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "KY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4;
@@ -1295,6 +1292,12 @@
 /obj/effect/landmark/blobstart,
 /obj/item/clothing/mask/cigarette/rollie/cannabis,
 /turf/open/floor/plating,
+/area/crew_quarters/bar)
+"Uo" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "Yu" = (
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -1535,7 +1538,7 @@ cE
 ab
 "}
 (15,1,1) = {"
-aj
+Uo
 ax
 aL
 cD
@@ -1552,7 +1555,7 @@ ab
 "}
 (16,1,1) = {"
 ab
-ay
+KJ
 aD
 ab
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_diner.dmm
@@ -23,12 +23,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -127,12 +121,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "au" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"av" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ax" = (
@@ -1054,6 +1042,15 @@
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"yn" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "yv" = (
 /obj/effect/landmark/blobstart,
 /obj/item/reagent_containers/food/snacks/burger/plain,
@@ -1250,6 +1247,12 @@
 /obj/effect/turf_decal/ameritard,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"UE" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "WE" = (
 /obj/structure/disposalpipe/segment,
@@ -1529,7 +1532,7 @@ dc
 ab
 "}
 (15,1,1) = {"
-ah
+UE
 au
 aI
 aW
@@ -1546,7 +1549,7 @@ ab
 "}
 (16,1,1) = {"
 ab
-av
+yn
 aJ
 ab
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_disco.dmm
@@ -24,12 +24,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/bar)
 "ai" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -125,12 +119,6 @@
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
 "av" = (
-/turf/open/floor/plasteel/ameridiner,
-/area/crew_quarters/bar)
-"aw" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
 "ay" = (
@@ -875,6 +863,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"xP" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/crew_quarters/bar)
 "AW" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -1016,6 +1013,12 @@
 	name = "bar shutters"
 	},
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"Nr" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/plasteel/ameridiner,
 /area/crew_quarters/bar)
 "OT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1308,7 +1311,7 @@ bw
 ai
 "}
 (15,1,1) = {"
-ah
+Nr
 av
 aK
 aT
@@ -1325,7 +1328,7 @@ ai
 "}
 (16,1,1) = {"
 ai
-aw
+xP
 as
 ai
 ai

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_grassy.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_grassy.dmm
@@ -250,12 +250,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bT" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -415,6 +409,15 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ko" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "kW" = (
 /obj/structure/disposalpipe/segment,
@@ -826,12 +829,6 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
-"Cb" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "Cn" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -964,6 +961,12 @@
 "JJ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/grass,
+/area/crew_quarters/bar)
+"JV" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "JW" = (
 /obj/structure/flora/grass/jungle,
@@ -1495,7 +1498,7 @@ pg
 ac
 "}
 (15,1,1) = {"
-Cb
+JV
 bD
 uD
 ru
@@ -1512,7 +1515,7 @@ ac
 "}
 (16,1,1) = {"
 ag
-bT
+ko
 hc
 ag
 ag

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_irish.dmm
@@ -27,12 +27,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -177,12 +171,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "av" = (
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aw" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ax" = (
@@ -1652,6 +1640,12 @@
 /obj/machinery/oven,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"wR" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "yt" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -1837,6 +1831,15 @@
 	name = "bar shutters"
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"WE" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "XT" = (
 /obj/structure/table,
@@ -2074,7 +2077,7 @@ cY
 ad
 "}
 (15,1,1) = {"
-ah
+wR
 av
 aN
 bd
@@ -2091,7 +2094,7 @@ ad
 "}
 (16,1,1) = {"
 ad
-aw
+WE
 aO
 ad
 ad

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_purple.dmm
@@ -39,17 +39,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ai" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "aj" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -155,20 +144,6 @@
 /area/crew_quarters/bar)
 "aw" = (
 /turf/open/floor/mineral/titanium/purple,
-/area/crew_quarters/bar)
-"ax" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1;
-	icon_state = "tile_corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8;
-	icon_state = "tile_corner"
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "az" = (
 /obj/structure/disposalpipe/segment,
@@ -1241,6 +1216,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
+"sx" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "vD" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1485,6 +1471,23 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"Sm" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1;
+	icon_state = "tile_corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8;
+	icon_state = "tile_corner"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -1821,7 +1824,7 @@ bI
 ab
 "}
 (15,1,1) = {"
-ai
+sx
 aw
 aM
 cg
@@ -1838,7 +1841,7 @@ ab
 "}
 (16,1,1) = {"
 ab
-ax
+Sm
 ap
 ab
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_spacious.dmm
@@ -21,12 +21,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ah" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ai" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -107,12 +101,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"ar" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "as" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -994,6 +982,15 @@
 /obj/item/toy/figure/bartender,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"DJ" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Eu" = (
 /obj/structure/sign/plaques/deempisi,
 /turf/closed/wall,
@@ -1074,6 +1071,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"Nu" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "NK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -1368,7 +1371,7 @@ cq
 ab
 "}
 (15,1,1) = {"
-ah
+Nu
 cH
 Wu
 aG
@@ -1385,7 +1388,7 @@ ab
 "}
 (16,1,1) = {"
 ab
-ar
+DJ
 av
 ab
 ab

--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_trek.dmm
@@ -21,19 +21,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/crew_quarters/bar)
-"af" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 28
-	},
-/turf/open/floor/mineral/titanium,
-/area/crew_quarters/bar)
 "ag" = (
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"ah" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = -4
-	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "ai" = (
@@ -249,12 +237,6 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"aB" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/turf/open/floor/mineral/titanium,
-/area/crew_quarters/bar)
 "aC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1419,6 +1401,15 @@
 /obj/item/toy/figure/chef,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"Kd" = (
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/mineral/titanium,
+/area/crew_quarters/bar)
 "MN" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin{
@@ -1520,6 +1511,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"Zo" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/mineral/titanium,
+/area/crew_quarters/bar)
 
 (1,1,1) = {"
 aa
@@ -1746,7 +1743,7 @@ cF
 ag
 "}
 (15,1,1) = {"
-af
+Zo
 az
 aT
 be
@@ -1762,8 +1759,8 @@ cI
 ag
 "}
 (16,1,1) = {"
-ah
-aB
+ag
+Kd
 aV
 ag
 ag

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -27230,6 +27230,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ims" = (
+/obj/structure/closet/secure_closet/bartender,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "imF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -57349,17 +57360,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"ssZ" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "stv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67457,10 +67457,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"vSb" = (
-/obj/structure/closet/secure_closet/bartender,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "vSj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -72337,6 +72333,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xAE" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xAM" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/hallway/secondary/entry";
@@ -95750,7 +95752,7 @@ aqy
 aao
 rPj
 aFi
-ssZ
+xAE
 cum
 qNW
 cWI
@@ -96266,7 +96268,7 @@ rPj
 aFi
 eMm
 tFL
-vSb
+ims
 tqO
 aFi
 cMn

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -4813,16 +4813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"cus" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "cuu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -9184,6 +9174,19 @@
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
+"eAn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "eAL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -39917,6 +39920,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"uhh" = (
+/obj/machinery/light/small,
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "uhi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -42905,12 +42915,6 @@
 "vIw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vIO" = (
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "vIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -89388,7 +89392,7 @@ kPR
 kfu
 auf
 moB
-vIO
+uhh
 kfu
 fyF
 dUs
@@ -89645,7 +89649,7 @@ bqN
 srl
 cAY
 eKQ
-cus
+eAn
 kfu
 oas
 lzl

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -34334,18 +34334,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bLJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bLK" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -50322,14 +50310,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/library)
-"dDe" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "dDf" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -51680,6 +51660,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"enT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "eoA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Research Division";
@@ -54010,6 +54002,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"fWs" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fWu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61059,6 +61062,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"kLP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "kLT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 1
@@ -64853,18 +64868,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"ngx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "ngz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -69121,6 +69124,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pXT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pXW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -73294,12 +73312,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"sMc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "sMj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -73824,6 +73836,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"tbp" = (
+/obj/machinery/chem_master/condimaster{
+	name = "HoochMaster 2000"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "tdd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76229,21 +76247,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"uEc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "uEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -115037,7 +115040,7 @@ xaI
 jOj
 bIu
 jWC
-bLJ
+kLP
 dQT
 xVl
 bQB
@@ -115294,8 +115297,8 @@ gPa
 qVi
 uWq
 bmP
-ngx
-sMc
+enT
+tbp
 xVl
 iKo
 olG
@@ -115551,8 +115554,8 @@ brk
 qVi
 oJa
 bmP
-uEc
-dDe
+pXT
+fWs
 xVl
 cli
 new


### PR DESCRIPTION
# Document the changes in your pull request

Citadel bar template has a machine: HoochMaster 2000 (ignore that my commit calls it the 9000 oops) that none of the other bars have. This adds the machine to all the other bar templates so there's consistency.

# Changelog

:cl:  
mapping: Spreads HoochMaster 2000 (chem machine) to all bar templates from just Citadel bar
mapping: Also gives a HoochMaster 2000 to Asteroid, Yogsmeta, and Gax stations
/:cl:
