### PR TITLE
The ReWallening: Remaps most of the reinforced walls on Yogstation.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1404,8 +1404,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aic" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
+/turf/closed/wall,
+/area/maintenance/solars/port/fore)
 "aih" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -2157,9 +2157,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/main)
-"ant" = (
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
 "anv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9176,6 +9173,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"bea" = (
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "beg" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -9227,9 +9227,6 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"beq" = (
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -9469,10 +9466,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bgc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/turf/closed/wall,
+/area/crew_quarters/heads/hos)
 "bgh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -11331,10 +11326,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"bvK" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "bvL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -12832,9 +12823,8 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bHi" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/closed/wall,
+/area/crew_quarters/heads/chief)
 "bHn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -13179,9 +13169,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"bLe" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/chief)
 "bLf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/landmark/xeno_spawn,
@@ -15000,6 +14987,9 @@
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"cfw" = (
+/turf/closed/wall,
+/area/security/warden)
 "cfD" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -15112,9 +15102,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cgO" = (
-/turf/closed/wall,
-/area/security/warden)
 "cgR" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -28320,9 +28307,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"htI" = (
-/turf/closed/wall,
-/area/ai_monitored/secondarydatacore)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -32662,6 +32646,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jhe" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jhp" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -39831,9 +39819,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mof" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41104,10 +41089,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"mNn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -52914,11 +52895,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"rPO" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "rPT" = (
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -63772,10 +63748,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"wmY" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "wnz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -83800,8 +83772,8 @@ alR
 alR
 alR
 alR
-ant
-ant
+aic
+aic
 alU
 alU
 alU
@@ -84825,11 +84797,11 @@ aaa
 gXs
 aaa
 aaa
-ant
-ant
-ant
-ant
-ant
+aic
+aic
+aic
+aic
+aic
 alU
 alU
 alU
@@ -97153,9 +97125,9 @@ aaZ
 aaZ
 upk
 hSO
-cgO
+cfw
 ewO
-cgO
+cfw
 lIb
 lLO
 wYv
@@ -98531,7 +98503,7 @@ rkO
 biP
 cfb
 cdi
-bLe
+bHi
 ugK
 qMu
 oTG
@@ -99211,7 +99183,7 @@ agr
 agt
 ayd
 quK
-cgO
+cfw
 mpL
 lLO
 xIP
@@ -99468,7 +99440,7 @@ upk
 ewO
 sdW
 ewO
-cgO
+cfw
 mLd
 lLO
 nSq
@@ -100996,7 +100968,7 @@ aaa
 aaa
 aaa
 aaf
-mof
+bgc
 abq
 abq
 abq
@@ -117805,7 +117777,7 @@ atN
 atN
 atN
 atN
-bHi
+jhe
 fXS
 cOe
 gpq
@@ -118062,7 +118034,7 @@ sLZ
 ief
 tXb
 oGM
-rPO
+cOx
 fXS
 cOe
 gpq
@@ -118319,7 +118291,7 @@ kJz
 mSg
 wnI
 oGM
-rPO
+cOx
 fXS
 chH
 cNW
@@ -118576,7 +118548,7 @@ oxg
 dBH
 pDa
 oGM
-mNn
+bMB
 fXS
 cNW
 cNW
@@ -118833,7 +118805,7 @@ oxg
 twt
 wnI
 oGM
-bvK
+bNA
 fXS
 bNA
 cOe
@@ -119030,7 +119002,7 @@ osI
 hld
 nDj
 yaD
-aic
+bea
 aOb
 aPq
 aPq
@@ -119090,7 +119062,7 @@ oxg
 tQv
 iiJ
 oGM
-wmY
+axl
 fXS
 cOe
 cOe
@@ -119287,7 +119259,7 @@ nYC
 iEt
 udt
 mUs
-aic
+bea
 aMZ
 aMZ
 aMZ
@@ -119347,7 +119319,7 @@ oGM
 oGM
 oGM
 oGM
-beq
+cOe
 fXS
 cjE
 bMB
@@ -119544,7 +119516,7 @@ fxr
 uVA
 afW
 aFR
-aic
+bea
 eVK
 kAe
 rHv
@@ -119601,9 +119573,9 @@ cOe
 cOe
 cOe
 cOe
-beq
-bgc
-htI
+cOe
+cmo
+cNW
 cOe
 fXS
 lLH
@@ -119801,7 +119773,7 @@ xBH
 sHo
 sHo
 lsn
-aic
+bea
 odE
 tHk
 mZa
@@ -120058,7 +120030,7 @@ aNZ
 sHo
 sHo
 sHo
-aic
+bea
 odE
 aPq
 hrX
@@ -120315,7 +120287,7 @@ pMy
 sHo
 sHo
 sHo
-aic
+bea
 odE
 thb
 sQs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1404,8 +1404,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aic" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "aih" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -2157,6 +2157,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/main)
+"ant" = (
+/turf/closed/wall,
+/area/maintenance/solars/port/fore)
 "anv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9173,11 +9176,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"bea" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "beg" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -9230,8 +9228,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "beq" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -9470,6 +9468,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"bgc" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bgh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -10325,10 +10328,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"bmA" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "bmD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -11332,6 +11331,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"bvK" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bvL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -12829,8 +12832,9 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bHi" = (
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bHn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -13175,6 +13179,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"bLe" = (
+/turf/closed/wall,
+/area/crew_quarters/heads/chief)
 "bLf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/landmark/xeno_spawn,
@@ -15105,6 +15112,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cgO" = (
+/turf/closed/wall,
+/area/security/warden)
 "cgR" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -15175,11 +15185,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cig" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "ciq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -19246,9 +19251,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dEb" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/chief)
 "dEd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28319,8 +28321,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "htI" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/ai_monitored/secondarydatacore)
 "htO" = (
 /obj/machinery/power/apc{
@@ -33346,9 +33347,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"jwK" = (
-/turf/closed/wall,
-/area/security/warden)
 "jxf" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -39833,6 +39831,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mof" = (
+/turf/closed/wall,
+/area/crew_quarters/heads/hos)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41103,6 +41104,10 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"mNn" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -52247,10 +52252,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"rCG" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "rCQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -52913,6 +52914,11 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"rPO" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "rPT" = (
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -60273,9 +60279,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"uTh" = (
-/turf/closed/wall,
-/area/ai_monitored/secondarydatacore)
 "uTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -63770,6 +63773,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "wmY" = (
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
 "wnz" = (
@@ -66762,10 +66766,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"xGG" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -83800,8 +83800,8 @@ alR
 alR
 alR
 alR
-bHi
-bHi
+ant
+ant
 alU
 alU
 alU
@@ -84825,11 +84825,11 @@ aaa
 gXs
 aaa
 aaa
-bHi
-bHi
-bHi
-bHi
-bHi
+ant
+ant
+ant
+ant
+ant
 alU
 alU
 alU
@@ -97153,9 +97153,9 @@ aaZ
 aaZ
 upk
 hSO
-jwK
+cgO
 ewO
-jwK
+cgO
 lIb
 lLO
 wYv
@@ -98531,7 +98531,7 @@ rkO
 biP
 cfb
 cdi
-dEb
+bLe
 ugK
 qMu
 oTG
@@ -99211,7 +99211,7 @@ agr
 agt
 ayd
 quK
-jwK
+cgO
 mpL
 lLO
 xIP
@@ -99468,7 +99468,7 @@ upk
 ewO
 sdW
 ewO
-jwK
+cgO
 mLd
 lLO
 nSq
@@ -100996,7 +100996,7 @@ aaa
 aaa
 aaa
 aaf
-aic
+mof
 abq
 abq
 abq
@@ -117017,11 +117017,11 @@ bTC
 aaf
 aaf
 bQZ
-bPN
+bQZ
 ahO
 ahO
 akC
-bPN
+bQZ
 qny
 fwn
 mdj
@@ -117278,7 +117278,7 @@ ylH
 bTl
 bTl
 akD
-bPN
+bQZ
 bZZ
 lSM
 gFN
@@ -117792,7 +117792,7 @@ ahz
 bTl
 bTl
 cum
-bPN
+bQZ
 bZZ
 lSM
 gFN
@@ -117805,7 +117805,7 @@ atN
 atN
 atN
 atN
-xGG
+bHi
 fXS
 cOe
 gpq
@@ -118049,7 +118049,7 @@ bTl
 bTl
 caY
 aRd
-bPN
+bQZ
 alN
 qot
 gFN
@@ -118062,7 +118062,7 @@ sLZ
 ief
 tXb
 oGM
-cig
+rPO
 fXS
 cOe
 gpq
@@ -118306,7 +118306,7 @@ bTl
 aiH
 bTl
 bTl
-bPN
+bQZ
 alX
 xtJ
 gFN
@@ -118319,7 +118319,7 @@ kJz
 mSg
 wnI
 oGM
-cig
+rPO
 fXS
 chH
 cNW
@@ -118559,11 +118559,11 @@ aex
 vdN
 aex
 ado
-bPN
-bPN
-bPN
-bPN
-bPN
+bQZ
+bQZ
+bQZ
+bQZ
+bQZ
 alY
 dqh
 qoK
@@ -118576,7 +118576,7 @@ oxg
 dBH
 pDa
 oGM
-htI
+mNn
 fXS
 cNW
 cNW
@@ -118833,7 +118833,7 @@ oxg
 twt
 wnI
 oGM
-rCG
+bvK
 fXS
 bNA
 cOe
@@ -119030,7 +119030,7 @@ osI
 hld
 nDj
 yaD
-beq
+aic
 aOb
 aPq
 aPq
@@ -119090,7 +119090,7 @@ oxg
 tQv
 iiJ
 oGM
-bmA
+wmY
 fXS
 cOe
 cOe
@@ -119287,7 +119287,7 @@ nYC
 iEt
 udt
 mUs
-beq
+aic
 aMZ
 aMZ
 aMZ
@@ -119347,7 +119347,7 @@ oGM
 oGM
 oGM
 oGM
-wmY
+beq
 fXS
 cjE
 bMB
@@ -119544,7 +119544,7 @@ fxr
 uVA
 afW
 aFR
-beq
+aic
 eVK
 kAe
 rHv
@@ -119601,9 +119601,9 @@ cOe
 cOe
 cOe
 cOe
-wmY
-bea
-uTh
+beq
+bgc
+htI
 cOe
 fXS
 lLH
@@ -119801,7 +119801,7 @@ xBH
 sHo
 sHo
 lsn
-beq
+aic
 odE
 tHk
 mZa
@@ -120058,7 +120058,7 @@ aNZ
 sHo
 sHo
 sHo
-beq
+aic
 odE
 aPq
 hrX
@@ -120315,7 +120315,7 @@ pMy
 sHo
 sHo
 sHo
-beq
+aic
 odE
 thb
 sQs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -590,7 +590,7 @@
 /area/security/prison)
 "ads" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/security/prison)
 "adt" = (
 /obj/structure/lattice/catwalk,
@@ -669,9 +669,6 @@
 /obj/item/reagent_containers/food/snacks/cakeslice/donk,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"adR" = (
-/turf/closed/wall/r_wall,
-/area/security/main)
 "adS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -1406,9 +1403,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"aic" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/fore/secondary)
 "aih" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -2160,9 +2154,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/main)
-"ant" = (
-/turf/closed/wall/r_wall,
-/area/security/processing)
 "anv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2289,9 +2280,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"aof" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/fore)
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -2434,7 +2422,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2643,7 +2631,7 @@
 /area/quartermaster/storage)
 "aqx" = (
 /obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
 "aqH" = (
 /obj/effect/landmark/secequipment,
@@ -3715,9 +3703,6 @@
 /obj/item/radio/off,
 /obj/item/assembly/timer,
 /turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"ayL" = (
-/turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "ayM" = (
 /obj/item/storage/secure/safe{
@@ -4796,7 +4781,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -6012,7 +5997,7 @@
 /area/maintenance/port/fore)
 "aLl" = (
 /obj/structure/lattice,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/solars/port/fore)
 "aLr" = (
 /obj/structure/closet/secure_closet/personal,
@@ -9182,9 +9167,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"bea" = (
-/turf/closed/wall/r_wall,
-/area/quartermaster/warehouse)
 "beg" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -9236,9 +9218,6 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"beq" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -9424,7 +9403,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfF" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "bfI" = (
 /obj/structure/cable{
@@ -9463,8 +9442,9 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "bfV" = (
-/turf/closed/wall/r_wall,
-/area/science/robotics/lab)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -9480,9 +9460,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"bgc" = (
-/turf/closed/wall/r_wall,
-/area/science/lab)
 "bgh" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -10104,11 +10081,13 @@
 /area/engine/engineering)
 "bkE" = (
 /obj/structure/sign/warning/docking,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/port)
 "bkF" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/port)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bkT" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
@@ -10343,7 +10322,7 @@
 /area/crew_quarters/dorms)
 "bmA" = (
 /turf/closed/wall,
-/area/crew_quarters/heads/captain)
+/area/crew_quarters/heads/hos)
 "bmD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -10351,7 +10330,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnc" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/robotics/mechbay)
 "bne" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11321,9 +11300,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"bvx" = (
-/turf/closed/wall/r_wall,
-/area/science/research)
 "bvA" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -11349,9 +11325,6 @@
 "bvJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
-"bvK" = (
-/turf/closed/wall,
 /area/crew_quarters/heads/hor)
 "bvL" = (
 /obj/item/radio/intercom{
@@ -12377,7 +12350,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bCs" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/storage/tech)
 "bCu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -12448,7 +12421,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "bDc" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/storage)
 "bDe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -12849,12 +12822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bHi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/engine/atmos_distro)
 "bHn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -13147,7 +13114,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -13199,10 +13166,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"bLe" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/science/xenobiology)
 "bLf" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/landmark/xeno_spawn,
@@ -13211,7 +13174,7 @@
 /area/maintenance/disposal/incinerator)
 "bLh" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/research)
 "bLj" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -14099,7 +14062,7 @@
 /area/ai_monitored/storage/eva)
 "bTH" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/ai_monitored/storage/eva)
 "bTJ" = (
 /obj/machinery/light/small{
@@ -14663,7 +14626,7 @@
 /area/ai_monitored/turret_protected/ai)
 "cbp" = (
 /obj/structure/sign/warning/radiation/rad_area,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cbx" = (
 /obj/machinery/computer/rdconsole/robotics,
@@ -15021,9 +14984,6 @@
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"cfw" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/aft)
 "cfD" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -15136,10 +15096,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cgO" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/engine/engineering)
 "cgR" = (
 /obj/structure/table,
 /obj/item/stack/rods/fifty,
@@ -15210,9 +15166,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cig" = (
-/turf/closed/wall,
-/area/engine/engineering)
 "ciq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15301,8 +15254,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjD" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/aft)
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "cjE" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -15366,7 +15319,7 @@
 /area/engine/engineering)
 "ckG" = (
 /obj/machinery/bounty_board,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ckO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -19282,9 +19235,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dEb" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hop)
 "dEd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -21399,7 +21349,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -24567,7 +24517,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -28355,11 +28305,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "htI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/security/warden)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -28418,7 +28365,7 @@
 /area/quartermaster/qm)
 "huX" = (
 /obj/machinery/smartfridge/chemistry,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "hva" = (
 /obj/structure/rack,
@@ -30412,7 +30359,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -32699,9 +32646,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jhe" = (
-/turf/closed/wall/r_wall,
-/area/medical/storage)
 "jhp" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -33326,7 +33270,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
 "juN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -35147,7 +35091,7 @@
 /area/science/storage)
 "klD" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/medical/chemistry)
 "klZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -36490,7 +36434,7 @@
 	layer = 2.35;
 	level = 1
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/mixing)
 "kSb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -37424,9 +37368,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"lmN" = (
-/turf/closed/wall,
-/area/ai_monitored/storage/satellite)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -37682,9 +37623,6 @@
 /obj/machinery/light,
 /turf/open/floor/engine,
 /area/escapepodbay)
-"lsK" = (
-/turf/closed/wall/r_wall,
-/area/construction)
 "lsS" = (
 /obj/structure/closet/radiation,
 /obj/structure/cable{
@@ -39880,9 +39818,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mof" = (
-/turf/closed/wall/r_wall,
-/area/quartermaster/sorting)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41154,8 +41089,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "mNn" = (
-/turf/closed/wall,
-/area/medical/genetics/cloning)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -43348,7 +43284,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
 "nKh" = (
 /obj/structure/sink/puddle,
@@ -44318,7 +44254,7 @@
 /area/solar/port/fore)
 "ohc" = (
 /obj/structure/sign/warning/pods,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ohd" = (
 /obj/structure/table,
@@ -45874,7 +45810,7 @@
 "oOf" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/maintenance/solars/port/fore)
 "oOn" = (
 /obj/machinery/door/window/westleft{
@@ -46482,7 +46418,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -48230,8 +48166,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pOw" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/port)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "pOx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -48836,9 +48773,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"qaO" = (
-/turf/closed/wall/r_wall,
-/area/security/interrogation)
 "qaQ" = (
 /obj/machinery/vending/cola/random,
 /obj/item/radio/intercom{
@@ -51875,7 +51809,7 @@
 	layer = 2.35;
 	level = 1
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/mixing)
 "rrL" = (
 /obj/structure/plasticflaps,
@@ -52127,7 +52061,7 @@
 /area/maintenance/aft)
 "ryf" = (
 /obj/structure/sign/departments/minsky/research/research,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/lab)
 "rym" = (
 /obj/effect/turf_decal/siding/wood{
@@ -52307,8 +52241,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "rCG" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "rCQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -52971,9 +52906,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"rPO" = (
-/turf/closed/wall/r_wall,
-/area/security/prison/hallway)
 "rPT" = (
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -53066,7 +52998,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
 "rSl" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
@@ -53280,7 +53212,7 @@
 /area/bridge)
 "rWb" = (
 /obj/structure/sign/warning/vacuum,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "rWj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54963,7 +54895,7 @@
 /area/science/robotics/lab)
 "sHQ" = (
 /obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/ai_monitored/storage/eva)
 "sHY" = (
 /obj/effect/turf_decal/pool/corner{
@@ -55020,7 +54952,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -55551,7 +55483,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -57146,7 +57078,7 @@
 /area/quartermaster/storage)
 "tAz" = (
 /obj/structure/sign/warning/docking,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/hallway/secondary/entry)
 "tBb" = (
 /obj/structure/window/reinforced,
@@ -58121,7 +58053,7 @@
 /area/science/xenobiology)
 "tVc" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/research)
 "tVL" = (
 /obj/structure/lattice,
@@ -60336,7 +60268,7 @@
 /area/engine/foyer)
 "uTh" = (
 /turf/closed/wall,
-/area/security/execution/transfer)
+/area/crew_quarters/heads/chief)
 "uTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -61261,9 +61193,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"vmm" = (
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
 "vmY" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
@@ -62182,7 +62111,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "vGx" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/medical/genetics)
 "vGB" = (
 /obj/structure/table/wood,
@@ -63833,9 +63762,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"wmY" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/aft_starboard)
 "wnz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -66527,7 +66453,7 @@
 /area/medical/medbay/lobby)
 "xyU" = (
 /turf/closed/wall,
-/area/engine/atmos)
+/area/maintenance/solars/port/fore)
 "xzh" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -66794,8 +66720,8 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "xFh" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/aft)
+/turf/closed/wall,
+/area/ai_monitored/secondarydatacore)
 "xFp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/disposalpipe/segment,
@@ -66833,8 +66759,10 @@
 /turf/open/floor/carpet,
 /area/library)
 "xGG" = (
-/turf/closed/wall,
-/area/medical/virology)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -77710,11 +77638,11 @@ aaf
 aaf
 aaa
 aaf
-beq
+asE
 asE
 boU
 asE
-beq
+asE
 aaa
 aaa
 aaa
@@ -77724,11 +77652,11 @@ aaa
 aaa
 aaa
 aaa
-beq
+asE
 asE
 fib
 asE
-beq
+asE
 aaa
 aaa
 aaa
@@ -77957,17 +77885,17 @@ gXs
 gXs
 aaa
 aaa
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
-apJ
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
+pRl
 bjJ
 bpi
 buX
@@ -77985,7 +77913,7 @@ tAz
 bjJ
 bpi
 fuj
-beq
+asE
 aaa
 aaa
 aaa
@@ -78214,7 +78142,7 @@ aaa
 gXs
 gXs
 aaa
-apJ
+pRl
 apN
 apN
 apN
@@ -78224,11 +78152,11 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 bkh
 bpX
 asE
-beq
+asE
 aaa
 aaa
 aaa
@@ -78238,21 +78166,21 @@ aaa
 aaa
 aaa
 aaa
-beq
+asE
 asE
 fip
 bkh
-beq
+asE
 aaa
 aaa
 aaa
 aaa
 aaa
-beq
+asE
 aSm
 aSm
 asE
-beq
+asE
 aaf
 aaa
 aaa
@@ -78471,7 +78399,7 @@ aaa
 apJ
 apJ
 apJ
-apJ
+pRl
 apN
 apN
 apN
@@ -78481,7 +78409,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 jrS
 ieh
 mnb
@@ -78499,13 +78427,13 @@ aSm
 mnb
 hlb
 bsq
-beq
+asE
 aaa
 aaa
 aaa
 aaa
 aaa
-beq
+asE
 jrS
 qwF
 mnb
@@ -78738,7 +78666,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 jda
 gEt
 bAX
@@ -78995,7 +78923,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 nJw
 rRe
 mnb
@@ -79252,7 +79180,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 jda
 sjg
 buZ
@@ -79509,7 +79437,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 jda
 qOw
 ayl
@@ -79766,7 +79694,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 jda
 qOw
 ayl
@@ -80013,7 +79941,7 @@ apJ
 apJ
 fRK
 vcD
-apJ
+pRl
 apN
 apN
 apN
@@ -80023,7 +79951,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 puZ
 bqi
 bvB
@@ -80270,7 +80198,7 @@ aBj
 wjO
 kxl
 wJA
-apJ
+pRl
 apN
 apN
 apN
@@ -80280,7 +80208,7 @@ apN
 apN
 apN
 apN
-apJ
+pRl
 knS
 gce
 mnb
@@ -80527,9 +80455,9 @@ arp
 xLR
 tWf
 xgF
-apJ
-apJ
-apJ
+pRl
+pRl
+pRl
 aNo
 asF
 aSi
@@ -80537,7 +80465,7 @@ asF
 asF
 asF
 asF
-apJ
+pRl
 jrS
 gEt
 bAX
@@ -80812,13 +80740,13 @@ aSm
 mnb
 hlb
 bsq
-beq
+asE
 aaa
 gIj
 hgK
 aSm
 aaa
-beq
+asE
 jrS
 ieh
 mnb
@@ -81069,13 +80997,13 @@ aSm
 tqk
 rWA
 tNQ
-beq
+asE
 aSm
 aSm
 hhC
 asE
 aSm
-beq
+asE
 jda
 iBD
 azA
@@ -81312,17 +81240,17 @@ beP
 aEi
 yjF
 bvL
-beq
-beq
-beq
+asE
+asE
+asE
 aSm
 aSm
 aSm
 aSm
 aSm
-beq
-beq
-beq
+asE
+asE
+asE
 eHU
 hmO
 pWW
@@ -81336,7 +81264,7 @@ asE
 aEi
 yjF
 kBL
-beq
+asE
 aaf
 gXs
 gXs
@@ -83869,8 +83797,8 @@ alR
 alR
 alR
 alR
-alR
-alR
+xyU
+xyU
 alU
 alU
 alU
@@ -84894,11 +84822,11 @@ aaa
 gXs
 aaa
 aaa
-alR
-alR
-alR
-alR
-alR
+xyU
+xyU
+xyU
+xyU
+xyU
 alU
 alU
 alU
@@ -84937,7 +84865,7 @@ ioi
 gRH
 beU
 fDz
-bkF
+nxy
 aaa
 aaa
 aaa
@@ -85451,7 +85379,7 @@ aXQ
 aXQ
 aXQ
 mAI
-bkF
+nxy
 aaa
 aaa
 aaa
@@ -85708,7 +85636,7 @@ aXQ
 llg
 aXQ
 jGC
-bkF
+nxy
 aaa
 aaa
 aaa
@@ -85965,7 +85893,7 @@ aXQ
 hVt
 aXQ
 mkz
-bkF
+nxy
 aaa
 aaa
 aaa
@@ -86479,7 +86407,7 @@ kGQ
 llT
 aXQ
 jGC
-bkF
+nxy
 aaa
 aaa
 aaa
@@ -88062,7 +87990,7 @@ bCq
 bCq
 bCq
 bCq
-cfw
+ffb
 ffb
 iHQ
 rFS
@@ -88319,11 +88247,11 @@ gZD
 gZD
 gZD
 faN
-cfw
+ffb
 uwf
 qko
 iMh
-cfw
+ffb
 aaa
 aaa
 aaa
@@ -88576,11 +88504,11 @@ gZD
 gZD
 gZD
 gZD
-cfw
+ffb
 jIf
 cPm
 knD
-cfw
+ffb
 aaa
 aaa
 aaa
@@ -88833,11 +88761,11 @@ gZD
 gZD
 gZD
 gZD
-cfw
+ffb
 ord
 dCD
 wob
-cfw
+ffb
 aag
 aag
 aag
@@ -89090,11 +89018,11 @@ bCq
 jcq
 bCq
 bCq
-cfw
-cfw
+ffb
+ffb
 xUj
-cfw
-cfw
+ffb
+ffb
 bCq
 sWJ
 bCq
@@ -91090,17 +91018,17 @@ aLD
 aLE
 aOl
 aPH
-pOw
+aPH
 cAF
 cAF
 cAF
 cAF
-bea
+gjl
 bQz
 bQz
 bQz
 bQz
-bea
+gjl
 gjl
 bgA
 bhW
@@ -91347,7 +91275,7 @@ kyx
 aLE
 aOl
 aPI
-pOw
+aPH
 aaa
 gXs
 aaa
@@ -91357,7 +91285,7 @@ gXs
 aaa
 gXs
 aaa
-mof
+fUQ
 fUQ
 fUQ
 fUQ
@@ -91557,7 +91485,7 @@ aeL
 mnm
 aat
 aat
-uTh
+afA
 rnS
 rnS
 rnS
@@ -91604,7 +91532,7 @@ pdR
 aLE
 aOl
 qLZ
-pOw
+aPH
 gXs
 aBa
 aBa
@@ -91614,7 +91542,7 @@ aBa
 aBa
 aBa
 gXs
-mof
+fUQ
 kNE
 fUQ
 kNE
@@ -91814,7 +91742,7 @@ aat
 acK
 aat
 aat
-uTh
+afA
 rnS
 rnS
 rnS
@@ -91861,7 +91789,7 @@ bZk
 aLE
 aOl
 eWE
-pOw
+aPH
 aaa
 aBa
 ykR
@@ -91871,7 +91799,7 @@ upE
 vQx
 aBa
 aaa
-mof
+fUQ
 kNQ
 fUQ
 bgv
@@ -92071,7 +91999,7 @@ abh
 lDc
 abh
 acd
-uTh
+afA
 rnS
 rnS
 rnS
@@ -92118,7 +92046,7 @@ keM
 ehE
 aOl
 aLE
-pOw
+aPH
 gXs
 aBa
 nKv
@@ -92128,7 +92056,7 @@ bPc
 xQR
 aBa
 gXs
-mof
+fUQ
 kOO
 cGg
 nmL
@@ -92328,7 +92256,7 @@ aat
 acK
 aat
 npo
-uTh
+afA
 rnS
 rnS
 rnS
@@ -92375,7 +92303,7 @@ eQR
 aLE
 aOl
 aLE
-pOw
+aPH
 aaa
 aBa
 hKB
@@ -92385,7 +92313,7 @@ hQm
 dBl
 aBa
 aaa
-mof
+fUQ
 aZK
 uEH
 mmY
@@ -92585,7 +92513,7 @@ aat
 acK
 aat
 aat
-uTh
+afA
 rnS
 rnS
 rnS
@@ -92632,7 +92560,7 @@ cHu
 aLE
 aOl
 aLE
-pOw
+aPH
 gXs
 aBa
 eMT
@@ -92642,7 +92570,7 @@ vwz
 aEG
 aBa
 gXs
-mof
+fUQ
 bfj
 xjz
 mqp
@@ -92842,7 +92770,7 @@ aat
 acK
 aat
 adL
-uTh
+afA
 rnS
 rnS
 rnS
@@ -92889,7 +92817,7 @@ mkD
 dvH
 exY
 aPM
-pOw
+aPH
 aaa
 aBa
 aBa
@@ -92899,7 +92827,7 @@ xZb
 aBa
 aBa
 aaa
-mof
+fUQ
 hGf
 nES
 bhZ
@@ -93099,13 +93027,13 @@ acj
 voo
 aat
 aai
-uTh
-uTh
-uTh
-uTh
-uTh
-uTh
-uTh
+afA
+afA
+afA
+afA
+afA
+afA
+afA
 uzO
 afA
 afA
@@ -93146,7 +93074,7 @@ yiu
 cSb
 kXW
 aPH
-pOw
+aPH
 aaa
 gXs
 aaa
@@ -93156,7 +93084,7 @@ bOS
 aaa
 gXs
 aaa
-mof
+fUQ
 weD
 kjt
 omc
@@ -93358,13 +93286,13 @@ xGQ
 aat
 sQI
 afO
-acd
+aiT
 aje
 akh
-acd
+aiT
 czC
 tQn
-rPO
+tYk
 aJt
 aJt
 aaf
@@ -93403,7 +93331,7 @@ tcS
 wvx
 rRD
 aJw
-mlj
+aJw
 bOS
 bOS
 bOS
@@ -93413,7 +93341,7 @@ bOS
 bOS
 bOS
 bOS
-mof
+fUQ
 fUQ
 fUQ
 bjl
@@ -93621,13 +93549,13 @@ abD
 eFR
 sDg
 hKu
-qaO
-qaO
-qaO
-qaO
+jAS
+jAS
+jAS
+jAS
 hlB
-qaO
-ant
+jAS
+afl
 haD
 hKn
 aBz
@@ -93872,10 +93800,10 @@ aat
 aat
 aat
 aat
-acd
+aiT
 ajk
 gkk
-acd
+aiT
 pwb
 myr
 jAS
@@ -93884,7 +93812,7 @@ eIu
 eIu
 jNQ
 bQS
-ant
+afl
 fJZ
 oMX
 ihO
@@ -93945,20 +93873,20 @@ aJq
 aJq
 bpz
 ovg
-mlj
-bNq
-bNq
+aJw
+bCq
+bCq
 iWF
 wwL
 bLw
-bNq
+bCq
 iWF
 vrm
 vrm
 vrm
 vrm
 bLw
-bNq
+bCq
 bCq
 wZb
 bCq
@@ -94129,10 +94057,10 @@ aat
 bab
 aat
 mBE
-acd
-acd
-acd
-acd
+aiT
+aiT
+aiT
+aiT
 jZd
 myr
 jAS
@@ -94141,14 +94069,14 @@ sTW
 wEg
 swc
 bQS
-aiX
-aiX
+agj
+agj
 mbK
-aiX
-aiX
-aiX
-aiX
-ant
+agj
+agj
+agj
+agj
+afl
 tPc
 afl
 aph
@@ -94159,13 +94087,13 @@ aph
 aqR
 aqR
 avt
-ayL
-ayL
+ayW
+ayW
 byI
-ayL
-ayL
-ayL
-ayL
+ayW
+ayW
+ayW
+ayW
 ayW
 ayW
 ayW
@@ -94202,7 +94130,7 @@ wER
 nzj
 aJq
 bBf
-mlj
+aJw
 gXs
 aaa
 aaf
@@ -94215,7 +94143,7 @@ aaf
 aaa
 aaa
 aaa
-bNq
+bCq
 eki
 qsH
 bCq
@@ -94386,10 +94314,10 @@ uNu
 adN
 uNu
 aat
-acd
+aiT
 iyN
 wjk
-acd
+aiT
 pLj
 lCM
 jvl
@@ -94405,7 +94333,7 @@ agj
 whz
 sDG
 dDy
-aiX
+agj
 rnT
 iNE
 aph
@@ -94416,13 +94344,13 @@ aYK
 baL
 baL
 bfA
-ayL
+ayW
 bts
 aAb
 ttQ
 bKG
 bOU
-ayL
+ayW
 cdN
 chK
 cqP
@@ -94437,18 +94365,18 @@ bOS
 diK
 jAv
 obw
-aZM
-aZM
+jwK
+jwK
 unk
 guI
 hez
-aZM
-aZM
-aZM
-mlj
+jwK
+jwK
+jwK
+aJw
 cNI
-mlj
-mlj
+aJw
+aJw
 kIe
 bqu
 pQS
@@ -94662,7 +94590,7 @@ ltp
 qNj
 lLO
 noK
-aiX
+agj
 mgc
 lFP
 aOi
@@ -94673,7 +94601,7 @@ aph
 aph
 aph
 avt
-ayL
+ayW
 oIU
 aAb
 aqZ
@@ -94694,7 +94622,7 @@ bOS
 pOa
 lKE
 eIv
-aZM
+jwK
 irC
 iUT
 jjW
@@ -94704,7 +94632,7 @@ bfo
 aBN
 bhq
 sxt
-mlj
+aJw
 oiE
 rIo
 gBO
@@ -94716,7 +94644,7 @@ aJw
 diK
 aJq
 bBh
-mlj
+aJw
 gXs
 gXs
 gXs
@@ -94900,10 +94828,10 @@ uNu
 aep
 uNu
 aat
-acd
+aiT
 rRB
 gkk
-acd
+aiT
 atJ
 myr
 jAS
@@ -94919,7 +94847,7 @@ agj
 nWP
 sgF
 qtW
-aiX
+agj
 hde
 kUv
 aph
@@ -94930,7 +94858,7 @@ apS
 ape
 aph
 avt
-ayL
+ayW
 qPt
 oPr
 qZu
@@ -94951,7 +94879,7 @@ tnB
 rtY
 ukk
 rVS
-aZM
+jwK
 oQp
 xul
 xul
@@ -95157,10 +95085,10 @@ uNu
 aam
 uNu
 aau
-acd
-acd
-acd
-acd
+aiT
+aiT
+aiT
+aiT
 xxg
 sCo
 via
@@ -95172,11 +95100,11 @@ agj
 agj
 kTp
 iBC
-agj
-agj
-agj
 aiX
 aiX
+aiX
+aiX
+agj
 wlI
 kUv
 aOn
@@ -95187,7 +95115,7 @@ aYU
 aqf
 aph
 avt
-ayL
+ayW
 bty
 azS
 bET
@@ -95208,7 +95136,7 @@ tnB
 qCo
 wTr
 aAL
-aZM
+jwK
 irQ
 kRv
 jzw
@@ -95218,7 +95146,7 @@ dBV
 jwK
 mJX
 nlC
-dEb
+bmr
 rDJ
 pYV
 mKb
@@ -95241,7 +95169,7 @@ aDq
 wPB
 bfv
 gXs
-lsK
+bNI
 bNI
 wAp
 bNI
@@ -95414,10 +95342,10 @@ aat
 aat
 aat
 aat
-acd
+aiT
 cnd
 xvo
-acd
+aiT
 pLj
 fsi
 lnA
@@ -95444,7 +95372,7 @@ gOe
 mMn
 aph
 wIv
-ayL
+ayW
 ayK
 wXY
 jzo
@@ -95461,11 +95389,11 @@ urO
 bOS
 aaa
 aaa
-aPR
+tnB
 goG
 jHe
 afu
-aZM
+jwK
 ivM
 bbW
 pfA
@@ -95475,7 +95403,7 @@ lvY
 jwK
 bhs
 bkT
-dEb
+bmr
 ehi
 nfX
 nfX
@@ -95498,7 +95426,7 @@ ies
 rGb
 hdX
 aaa
-lsK
+bNI
 vWM
 pSG
 vDt
@@ -95701,7 +95629,7 @@ aph
 aph
 aph
 avt
-ayL
+ayW
 abt
 pIj
 aAW
@@ -95717,12 +95645,12 @@ aJq
 urO
 bOS
 aaa
-aPR
-aPR
-aPR
+tnB
+tnB
+tnB
 dzl
-aPR
-aZM
+tnB
+jwK
 aZu
 bbY
 yfL
@@ -95732,7 +95660,7 @@ xul
 jwK
 jwK
 jwK
-dEb
+bmr
 jui
 nfX
 bqy
@@ -95755,7 +95683,7 @@ ucA
 wRg
 bfv
 aaa
-lsK
+bNI
 cCd
 wiW
 mMH
@@ -95928,10 +95856,10 @@ adr
 aat
 aat
 aat
-acd
+aiT
 lIi
 gkk
-acd
+aiT
 xdR
 fsi
 cVB
@@ -95958,13 +95886,13 @@ rBV
 out
 uGm
 vNR
-ayL
+ayW
 aug
 pIj
 aAR
 aCA
 bPe
-ayL
+ayW
 aKf
 aKt
 cqQ
@@ -95974,7 +95902,7 @@ aJq
 urO
 bOS
 aaa
-aPR
+tnB
 aTQ
 xjX
 wTr
@@ -95989,7 +95917,7 @@ xul
 mqz
 bjA
 xul
-dEb
+bmr
 poG
 boZ
 nfX
@@ -96012,7 +95940,7 @@ tOr
 fen
 hdX
 gXs
-lsK
+bNI
 bNJ
 rWs
 dww
@@ -96185,10 +96113,10 @@ ads
 kZX
 aeU
 abF
-acd
-acd
-acd
-acd
+aiT
+aiT
+aiT
+aiT
 pLj
 dGT
 qQY
@@ -96200,9 +96128,9 @@ faV
 agj
 mKD
 qhW
-agj
-agj
-agj
+aiX
+aiX
+aiX
 aiX
 tRq
 aKE
@@ -96215,13 +96143,13 @@ tkG
 jdk
 apd
 avt
-ayL
+ayW
 ars
 axw
 aDE
 aDE
 sHQ
-ayL
+ayW
 ayW
 ayW
 ayW
@@ -96231,7 +96159,7 @@ aJq
 urO
 bOS
 aaa
-aPR
+tnB
 cLS
 exk
 ucJ
@@ -96269,7 +96197,7 @@ aDq
 sFG
 bfv
 gXs
-lsK
+bNI
 lSK
 dAU
 bNJ
@@ -96445,7 +96373,7 @@ aga
 agJ
 qZY
 bAL
-acd
+aiT
 pLj
 jKq
 tYk
@@ -96486,9 +96414,9 @@ bOS
 tnj
 aNz
 lVL
-aPR
-aPR
-aPR
+tnB
+tnB
+tnB
 gmQ
 hRj
 bBi
@@ -96526,7 +96454,7 @@ lYK
 bfv
 bfv
 aaa
-lsK
+bNI
 bNJ
 fbZ
 cCd
@@ -96772,7 +96700,7 @@ cFC
 pAt
 bne
 ize
-mlj
+aJw
 gXs
 aaa
 gXs
@@ -96783,7 +96711,7 @@ bfv
 bfv
 aaa
 aaa
-lsK
+bNI
 bNJ
 dAU
 cCd
@@ -96952,7 +96880,7 @@ aaa
 aaa
 gXs
 aaZ
-aaZ
+aIi
 hnI
 xJP
 tev
@@ -97040,7 +96968,7 @@ aaa
 gXs
 aaa
 gXs
-lsK
+bNI
 rgM
 caK
 rjh
@@ -97222,15 +97150,15 @@ aaZ
 aaZ
 upk
 hSO
-upk
+htI
 ewO
-upk
+htI
 lIb
 lLO
 wYv
-agj
-agj
-agj
+aiX
+aiX
+aiX
 aiX
 nUc
 anz
@@ -97286,7 +97214,7 @@ aJw
 hvG
 aJq
 sfF
-mlj
+aJw
 aaa
 gXs
 aaa
@@ -97297,7 +97225,7 @@ aaa
 gXs
 gXs
 gXs
-lsK
+bNI
 bNL
 hqa
 dBU
@@ -97316,11 +97244,11 @@ bCs
 bCs
 uzc
 ccw
-cig
+ccw
 iLA
 dTz
 ckG
-cig
+ccw
 jTW
 tWQ
 qQV
@@ -97543,18 +97471,18 @@ aJw
 hvG
 aJq
 jFt
-mlj
-rCG
+aJw
+qtP
 nQC
-rCG
+qtP
 nQC
-rCG
+qtP
 nQC
-rCG
-rCG
+qtP
+qtP
 nQC
-rCG
-lsK
+qtP
+bNI
 bNI
 urs
 bNI
@@ -98256,9 +98184,9 @@ ewO
 mKD
 lLO
 sFX
-agj
-agj
-agj
+aiX
+aiX
+aiX
 aiX
 eGN
 anv
@@ -98578,7 +98506,7 @@ bCv
 bCv
 bCv
 siG
-bzs
+xDQ
 ujI
 saX
 bVE
@@ -98600,7 +98528,7 @@ rkO
 biP
 cfb
 cdi
-cfb
+uTh
 ugK
 qMu
 oTG
@@ -98835,7 +98763,7 @@ lHv
 nDu
 bCv
 eEO
-bzs
+xDQ
 bLK
 bLK
 taW
@@ -99275,12 +99203,12 @@ akw
 jUA
 aeM
 nSl
-aIi
+aaZ
 agr
 agt
 ayd
 quK
-upk
+htI
 mpL
 lLO
 xIP
@@ -99537,7 +99465,7 @@ upk
 ewO
 sdW
 ewO
-upk
+htI
 mLd
 lLO
 nSq
@@ -99570,9 +99498,9 @@ bOS
 fzE
 aNz
 iKC
-aPR
-aPR
-aPR
+tnB
+tnB
+tnB
 urt
 hRj
 xjd
@@ -99794,13 +99722,13 @@ wBD
 lqw
 skM
 oNV
-adR
+abp
 sfG
 ajH
 uUk
-agj
-agj
-agj
+aiX
+aiX
+aiX
 aiX
 viK
 hEG
@@ -99829,7 +99757,7 @@ aJq
 urO
 bOS
 aaa
-aPR
+tnB
 itZ
 exk
 qkB
@@ -100086,7 +100014,7 @@ dDZ
 urO
 bOS
 aaa
-aPR
+tnB
 pex
 yec
 uQf
@@ -100141,7 +100069,7 @@ bxJ
 qyN
 wTF
 qRi
-cgO
+cSZ
 fEW
 kcG
 uiV
@@ -100292,9 +100220,9 @@ aKN
 aaa
 gXs
 wfc
-adR
-adR
-adR
+abp
+abp
+abp
 vZk
 suo
 aqH
@@ -100308,7 +100236,7 @@ rpM
 agX
 agY
 hTY
-adR
+abp
 mKD
 lLO
 qFU
@@ -100343,11 +100271,11 @@ aJq
 urO
 bOS
 aaa
-aPR
-aPR
-aPR
+tnB
+tnB
+tnB
 omM
-aPR
+tnB
 aZV
 ixh
 jaj
@@ -100565,7 +100493,7 @@ thk
 eut
 ahH
 tmO
-adR
+abp
 xpf
 qLJ
 cun
@@ -100601,7 +100529,7 @@ urO
 bOS
 aaa
 aaa
-aPR
+tnB
 fyh
 tdh
 rlC
@@ -100806,9 +100734,9 @@ aKN
 aaa
 aaa
 pEf
-adR
-adR
-adR
+abp
+abp
+abp
 bJe
 abP
 cME
@@ -100822,10 +100750,10 @@ wOC
 agX
 agY
 ssh
-adR
-aiX
+abp
+agj
 auW
-aiX
+agj
 aiX
 aiX
 aiX
@@ -100905,10 +100833,10 @@ bWQ
 bWQ
 bWQ
 bWQ
-bWQ
-bWQ
-dNY
-dNY
+mva
+mva
+vKp
+vKp
 hjC
 hjC
 dNY
@@ -101065,7 +100993,7 @@ aaa
 aaa
 aaa
 aaf
-abq
+bmA
 abq
 abq
 abq
@@ -101079,7 +101007,7 @@ hrH
 aHL
 agY
 ljc
-adR
+abp
 hZw
 eTm
 eVf
@@ -101193,7 +101121,7 @@ wil
 eFL
 rWb
 urG
-cig
+ccw
 aaa
 hfr
 hfr
@@ -101336,7 +101264,7 @@ agy
 aha
 agY
 lwy
-adR
+abp
 awY
 cnM
 tmM
@@ -101450,7 +101378,7 @@ pMs
 pMs
 qzt
 czr
-cig
+ccw
 aaa
 ayY
 ayY
@@ -101593,7 +101521,7 @@ agY
 agX
 agY
 rBY
-adR
+abp
 plz
 qyV
 hCQ
@@ -101643,9 +101571,9 @@ aZV
 aZV
 aZV
 aZV
-bmA
-bmA
-bmA
+aZV
+aZV
+aZV
 bqH
 bqH
 bmc
@@ -101701,13 +101629,13 @@ ccw
 ccw
 uDp
 clJ
-cig
+ccw
 wil
 tSu
 brz
 rWb
 wub
-cig
+ccw
 aaa
 aaa
 aaa
@@ -101850,7 +101778,7 @@ agA
 nqF
 ata
 hCn
-adR
+abp
 vTT
 daY
 pcF
@@ -101920,12 +101848,12 @@ iAN
 wag
 eMZ
 bLK
-xyU
+bLK
 qve
 yhk
 hAJ
 fjz
-xyU
+bLK
 bLK
 bvA
 lKf
@@ -101958,13 +101886,13 @@ kra
 ccw
 vwZ
 mvb
-cig
-cig
+ccw
+ccw
 tKP
-cig
-cig
+ccw
+ccw
 dKN
-cgO
+cSZ
 aaa
 aaa
 aaa
@@ -102107,7 +102035,7 @@ agY
 agX
 agY
 fyS
-adR
+abp
 plz
 wnZ
 guJ
@@ -102221,7 +102149,7 @@ mXz
 aaa
 jmH
 ucZ
-cig
+ccw
 aaa
 aaa
 aaa
@@ -102364,7 +102292,7 @@ pjD
 nbH
 atg
 ckZ
-adR
+abp
 ame
 cnM
 qlP
@@ -102621,7 +102549,7 @@ aoD
 ahc
 agY
 oif
-adR
+abp
 aji
 pYn
 ame
@@ -102878,7 +102806,7 @@ cDK
 laB
 hkT
 oWm
-adR
+abp
 anb
 ajR
 ame
@@ -102949,12 +102877,12 @@ bzs
 liS
 avy
 avy
-soo
-soo
+avy
+avy
 cXW
 nJX
-soo
-soo
+avy
+avy
 tJN
 tzt
 bBC
@@ -102976,7 +102904,7 @@ bJv
 iKp
 avy
 avy
-avy
+soo
 aaa
 aaa
 aaa
@@ -103133,9 +103061,9 @@ sME
 meN
 abp
 ahe
-adR
+abp
 rRw
-adR
+abp
 ajo
 ajo
 ajo
@@ -103218,7 +103146,7 @@ wOj
 tCY
 xtP
 cRU
-htI
+lOu
 gBB
 bKw
 pAj
@@ -103388,9 +103316,9 @@ abp
 abp
 mkx
 abp
-adR
+abp
 kCI
-aic
+trb
 aGt
 aGt
 aGt
@@ -103645,7 +103573,7 @@ iCk
 anr
 aoZ
 afY
-adR
+abp
 ahg
 ahL
 aiu
@@ -103902,7 +103830,7 @@ abp
 abp
 xUO
 abp
-adR
+abp
 eEt
 wCs
 trb
@@ -104746,7 +104674,7 @@ hPm
 mWy
 jdO
 liS
-avy
+soo
 avy
 clA
 iNp
@@ -104760,7 +104688,7 @@ hRo
 jzD
 aNK
 cJu
-bHi
+kvn
 wcl
 wjH
 bKZ
@@ -105003,7 +104931,7 @@ pjM
 lux
 jdO
 liS
-avy
+soo
 avy
 avy
 avy
@@ -106029,7 +105957,7 @@ uoF
 dxC
 fQm
 aPS
-jhe
+jdO
 liS
 bzs
 bzs
@@ -106286,7 +106214,7 @@ riv
 tdV
 mzH
 gBy
-jhe
+jdO
 liS
 bHX
 xBS
@@ -106543,7 +106471,7 @@ rsV
 rTQ
 ngi
 jaF
-jhe
+jdO
 liS
 xkZ
 xCv
@@ -106800,7 +106728,7 @@ oIh
 jaT
 vbD
 vFJ
-jhe
+jdO
 wFq
 pYm
 pYm
@@ -106814,8 +106742,8 @@ pYm
 ijr
 vOo
 hEv
-avy
-avy
+soo
+soo
 aaf
 aaf
 aaf
@@ -107052,15 +106980,15 @@ shN
 ejf
 qGf
 adK
-xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xDQ
+bKQ
+bKQ
+bKQ
+bKQ
+bKQ
+bKQ
+bKQ
+bKQ
+bzs
 kGc
 bAw
 hEv
@@ -107072,17 +107000,17 @@ bzs
 hhd
 bAw
 bHX
-xDQ
-xDQ
-xDQ
+bzs
+bzs
+bzs
 wAc
 wAc
 wAc
-xDQ
+bzs
 wAc
 wAc
 wAc
-xDQ
+bzs
 wAc
 wAc
 wAc
@@ -107298,7 +107226,7 @@ mhS
 mhS
 mhS
 eXN
-gtC
+eXN
 tIV
 kub
 tTO
@@ -107343,7 +107271,7 @@ bzs
 gac
 cgm
 kaA
-sAV
+cmd
 gft
 fwi
 dAA
@@ -107366,11 +107294,11 @@ tgv
 nIj
 oQJ
 ntH
-vmm
+gtB
 rCd
 iKg
 mVN
-vmm
+gtB
 ody
 kfG
 xnR
@@ -107623,7 +107551,7 @@ tgv
 nIj
 ycf
 iJL
-vmm
+gtB
 tZD
 ohh
 rUm
@@ -107837,7 +107765,7 @@ rvT
 cpO
 qbG
 uOh
-xGG
+bNd
 bNd
 bNd
 bNd
@@ -107880,11 +107808,11 @@ tgv
 oBt
 dgV
 pyG
-vmm
-vmm
+gtB
+gtB
 dVb
-vmm
-vmm
+gtB
+gtB
 gBP
 vxS
 qlI
@@ -108136,15 +108064,15 @@ tgv
 tgv
 eva
 oNw
-lmN
-vmm
+tgv
+gtB
 jEd
 qQs
 fnK
-vmm
-vmm
-vmm
-vmm
+gtB
+gtB
+gtB
+gtB
 gtB
 gtB
 gtB
@@ -108345,7 +108273,7 @@ mOU
 hxw
 hxw
 kua
-xGG
+bNd
 eHY
 tpA
 nUI
@@ -108393,13 +108321,13 @@ tFW
 stR
 dgZ
 rur
-lmN
+tgv
 nSR
 otV
 nnx
 lxF
 lbE
-vmm
+gtB
 vMR
 wEX
 lZD
@@ -108631,7 +108559,7 @@ ldW
 ldW
 ldW
 cmd
-cmd
+sAV
 vvV
 ozm
 kAj
@@ -108859,7 +108787,7 @@ xPQ
 stl
 gTb
 qbw
-xGG
+bNd
 jDu
 rfy
 taj
@@ -108907,13 +108835,13 @@ hZg
 cBP
 uIU
 xgS
-lmN
+tgv
 pRt
 kyA
 kik
 eEZ
 jWq
-vmm
+gtB
 qzd
 qLi
 mtW
@@ -109357,12 +109285,12 @@ kiy
 kiy
 ebl
 hLI
-mNn
+kYK
 xAW
 acz
-mNn
+kYK
 xAW
-mNn
+kYK
 kYK
 siU
 siU
@@ -109614,10 +109542,10 @@ bBN
 bfL
 ebl
 isI
-mNn
+kYK
 twb
 sqM
-mNn
+kYK
 vYY
 gPb
 kYK
@@ -109871,7 +109799,7 @@ wec
 uII
 rJa
 dwP
-mNn
+kYK
 xDf
 fNs
 gcy
@@ -111162,7 +111090,7 @@ bOA
 xML
 uWP
 qUc
-wmY
+xML
 lXW
 jQU
 vGx
@@ -111430,11 +111358,11 @@ aeI
 dJq
 hQd
 iNT
-bDb
-bDb
-bDb
-bDb
-bDb
+bJN
+bJN
+bJN
+bJN
+bJN
 bAw
 dGx
 bzs
@@ -111948,7 +111876,7 @@ uYC
 qZJ
 bOL
 iPe
-bDb
+bJN
 xBS
 uxA
 bzs
@@ -112182,13 +112110,13 @@ bnc
 bnc
 bnc
 nsx
-bfV
+box
 wKy
 wKy
-bfV
+box
 tVc
 dSz
-bvx
+bhA
 soM
 xXT
 vRX
@@ -112197,15 +112125,15 @@ bDb
 bDb
 bDb
 bDb
-bDb
-bDb
-bDb
+bJN
+bJN
+bJN
 qgG
 qgG
 oRb
 gIc
 lKH
-bDb
+bJN
 bDb
 bDb
 bDb
@@ -112442,7 +112370,7 @@ nwv
 yhy
 bpS
 wRN
-bfV
+box
 kyO
 vJw
 byf
@@ -112699,7 +112627,7 @@ sHM
 cHX
 bsQ
 cAR
-bfV
+box
 ssK
 vaq
 byf
@@ -112956,8 +112884,8 @@ xwW
 cHX
 buj
 mZk
-bfV
-bvx
+box
+bhA
 bnE
 byf
 bzt
@@ -114253,8 +114181,8 @@ bDb
 bDb
 bDb
 bDb
-bJN
-bJN
+bDb
+bDb
 lip
 sBI
 wJm
@@ -114511,7 +114439,7 @@ jtJ
 bHe
 bIz
 bIz
-bJN
+bDb
 xHn
 tqt
 jaq
@@ -114745,11 +114673,11 @@ aFu
 aYV
 aYV
 rmU
-bfV
-bfV
+box
+box
 nct
 vDW
-bfV
+box
 veK
 qgQ
 xCw
@@ -114768,7 +114696,7 @@ kkv
 bEc
 bIB
 bIB
-bJN
+bDb
 mvV
 jSi
 jaq
@@ -115003,7 +114931,7 @@ aYV
 aYV
 sSF
 sYJ
-bfV
+box
 era
 ruh
 eVz
@@ -115025,7 +114953,7 @@ nUQ
 bsf
 bEo
 bEo
-bJN
+bDb
 eDW
 xwn
 pMu
@@ -115220,10 +115148,10 @@ gXs
 tgE
 gXs
 aqQ
-aof
-aof
-aof
-aof
+ewG
+ewG
+ewG
+ewG
 alP
 alP
 syq
@@ -115260,7 +115188,7 @@ aYV
 aYV
 vLR
 wnB
-bfV
+box
 sew
 bou
 bou
@@ -115282,7 +115210,7 @@ dDp
 bsg
 bEo
 bEo
-bJN
+bDb
 kCh
 tqt
 jaq
@@ -115480,7 +115408,7 @@ aqQ
 aoh
 aoN
 apA
-aof
+ewG
 aoP
 alP
 alP
@@ -115517,7 +115445,7 @@ bcx
 aYV
 vLR
 vhG
-bfV
+box
 sne
 vbP
 uXk
@@ -115539,7 +115467,7 @@ bDf
 bsm
 bGY
 bGY
-bJN
+bDb
 smk
 tqt
 jaq
@@ -115774,11 +115702,11 @@ bal
 aYV
 vLR
 qhl
-bfV
-bfV
-bfV
-bfV
-bfV
+box
+box
+box
+box
+box
 box
 lEQ
 edL
@@ -115796,11 +115724,11 @@ bDc
 bsn
 bDc
 bDc
-bLe
+hIx
 piv
 yiM
 piv
-bDb
+bJN
 bDb
 bDb
 bDb
@@ -116035,7 +115963,7 @@ bhA
 xqe
 inu
 anp
-bvx
+bhA
 wIe
 hNN
 yhF
@@ -116074,7 +116002,7 @@ fEq
 mLJ
 bQL
 exS
-atN
+wkN
 bMB
 cOe
 vIg
@@ -116248,10 +116176,10 @@ aaa
 aaa
 aaa
 aqQ
-aof
-aof
-aof
-aof
+ewG
+ewG
+ewG
+ewG
 alP
 alP
 qIs
@@ -116331,7 +116259,7 @@ pyE
 aSa
 cbY
 gWK
-atN
+wkN
 cOe
 fFK
 giq
@@ -116549,7 +116477,7 @@ bhA
 gSd
 nTF
 dfD
-bvx
+bhA
 wIe
 vDs
 tfF
@@ -116588,7 +116516,7 @@ itG
 bBb
 wvX
 kBr
-atN
+wkN
 cNW
 gri
 cNW
@@ -116802,11 +116730,11 @@ aYV
 jKG
 mYV
 hVF
-bgc
-bgc
-bgc
-bgc
-bgc
+boB
+boB
+boB
+boB
+boB
 boB
 boB
 boB
@@ -116817,8 +116745,8 @@ bvJ
 bvJ
 bvJ
 bpY
-bvK
-bvK
+byt
+byt
 jJG
 xQd
 oWf
@@ -116828,7 +116756,7 @@ bLh
 bMs
 bMs
 bMs
-bPN
+bQZ
 lxz
 bgH
 lkd
@@ -116845,7 +116773,7 @@ auT
 bBe
 wvX
 mNo
-atN
+wkN
 mpt
 sLr
 cOe
@@ -117075,8 +117003,8 @@ vGL
 hTo
 bqb
 bHY
-bvK
-bEs
+byt
+bEC
 bGc
 rAr
 cIT
@@ -117086,11 +117014,11 @@ bTC
 aaf
 aaf
 bQZ
-bQZ
+bPN
 ahO
 ahO
 akC
-bQZ
+bPN
 qny
 fwn
 mdj
@@ -117102,7 +117030,7 @@ bxC
 bym
 avH
 kBr
-atN
+wkN
 iMn
 qoX
 cOe
@@ -117332,7 +117260,7 @@ emB
 bwR
 jKn
 rss
-bvK
+byt
 bEv
 vRL
 isH
@@ -117347,7 +117275,7 @@ ylH
 bTl
 bTl
 akD
-bQZ
+bPN
 bZZ
 lSM
 gFN
@@ -117359,7 +117287,7 @@ qeQ
 aGe
 avK
 yiW
-atN
+wkN
 cNW
 fXS
 cNW
@@ -117583,13 +117511,13 @@ wPV
 vAF
 pwe
 qMc
-bvK
+byt
 bxi
 byp
 bzJ
 aDa
 rvu
-bvK
+byt
 bEu
 tbz
 cEu
@@ -117616,7 +117544,7 @@ mRV
 oXH
 qXd
 exS
-atN
+wkN
 ngy
 sLr
 cOe
@@ -117830,7 +117758,7 @@ aYV
 aYV
 rmU
 ryf
-bgc
+boB
 jWu
 bhV
 bka
@@ -117840,13 +117768,13 @@ uvc
 xrJ
 gTh
 oaO
-bvK
+byt
 fdU
 bys
 bzM
 aDa
 bCj
-bvK
+byt
 flm
 dKR
 gbn
@@ -117861,12 +117789,11 @@ ahz
 bTl
 bTl
 cum
-bQZ
+bPN
 bZZ
 lSM
 gFN
 woT
-wkN
 atN
 atN
 atN
@@ -117874,7 +117801,8 @@ atN
 atN
 atN
 atN
-cOe
+atN
+rCG
 fXS
 cOe
 gpq
@@ -118086,7 +118014,7 @@ aCR
 fJJ
 bdx
 jHi
-bgc
+boB
 cnI
 nUH
 bkv
@@ -118097,13 +118025,13 @@ ggC
 xcV
 teq
 nyu
-bvK
+byt
 cBu
 byr
 bzL
 bxZ
 bCi
-bvK
+byt
 acP
 lpj
 bFU
@@ -118118,7 +118046,7 @@ bTl
 bTl
 caY
 aRd
-bQZ
+bPN
 alN
 qot
 gFN
@@ -118131,7 +118059,7 @@ sLZ
 ief
 tXb
 oGM
-oGM
+xGG
 fXS
 cOe
 gpq
@@ -118343,7 +118271,7 @@ aMZ
 wmI
 wmI
 wXX
-bgc
+boB
 joq
 qTl
 kSy
@@ -118354,13 +118282,13 @@ edl
 boB
 qfK
 ekZ
-bvK
+byt
 bxm
 byu
 dbJ
 bCf
 aGs
-bvK
+byt
 abe
 lpj
 bFU
@@ -118375,7 +118303,7 @@ bTl
 aiH
 bTl
 bTl
-bQZ
+bPN
 alX
 xtJ
 gFN
@@ -118388,7 +118316,7 @@ kJz
 mSg
 wnI
 oGM
-oGM
+xGG
 fXS
 chH
 cNW
@@ -118600,19 +118528,19 @@ auf
 aPq
 aPq
 lrQ
-bgc
-bgc
-bgc
-bgc
-bgc
-bgc
-bgc
+boB
+boB
+boB
+boB
+boB
+boB
+boB
 giP
-bgc
+boB
 wMP
 lOq
-bvK
-bvK
+byt
+byt
 byt
 byt
 byt
@@ -118628,11 +118556,11 @@ aex
 vdN
 aex
 ado
-bQZ
-bQZ
-bQZ
-bQZ
-bQZ
+bPN
+bPN
+bPN
+bPN
+bPN
 alY
 dqh
 qoK
@@ -118645,7 +118573,7 @@ oxg
 dBH
 pDa
 oGM
-oGM
+mNn
 fXS
 cNW
 cNW
@@ -118865,7 +118793,7 @@ biY
 bjS
 bnr
 bpr
-bgc
+boB
 paA
 ggD
 iMX
@@ -118888,7 +118816,7 @@ ado
 ahB
 oos
 ajF
-bQZ
+bPN
 alj
 alj
 aXb
@@ -118902,7 +118830,7 @@ oxg
 twt
 wnI
 oGM
-oGM
+bfV
 fXS
 bNA
 cOe
@@ -119121,12 +119049,12 @@ hoc
 hoc
 bjT
 boB
-bgc
-bgc
+boB
+boB
 txG
 bsF
 nHU
-bxn
+bqe
 bqe
 bzO
 ayt
@@ -119145,7 +119073,7 @@ bEC
 ahF
 aiR
 bHp
-bQZ
+bPN
 alk
 alk
 pWH
@@ -119159,7 +119087,7 @@ oxg
 tQv
 iiJ
 oGM
-oGM
+pOw
 fXS
 cOe
 cOe
@@ -119378,7 +119306,7 @@ nYj
 hoc
 ncq
 bjS
-bqe
+bxn
 lPo
 xWd
 buw
@@ -119402,12 +119330,12 @@ bEC
 cNW
 cNW
 rTR
-bQZ
-bQZ
-bQZ
+bPN
+bPN
+bPN
 aRv
-bQZ
-bQZ
+bPN
+bPN
 oGM
 oGM
 oGM
@@ -119416,7 +119344,7 @@ oGM
 oGM
 oGM
 oGM
-oGM
+cjD
 fXS
 cjE
 bMB
@@ -119635,7 +119563,7 @@ rBz
 hoc
 hoc
 bjT
-bqe
+bxn
 gaq
 blD
 cBt
@@ -119670,15 +119598,15 @@ cOe
 cOe
 cOe
 cOe
-oGM
-oGM
-oGM
+cjD
+bkF
+xFh
 cOe
 fXS
-cjD
-cjD
-cjD
-cjD
+lLH
+lLH
+lLH
+lLH
 bPT
 aaa
 aaa
@@ -119892,7 +119820,7 @@ hTT
 hMG
 hoc
 bjT
-bqe
+bxn
 xWN
 blD
 lmI
@@ -119932,7 +119860,7 @@ ceR
 fIH
 cOe
 mfN
-cjD
+lLH
 bQq
 cly
 cmw
@@ -120149,12 +120077,12 @@ olb
 mpq
 hoc
 bjT
-bqe
+bxn
 mSl
 blD
 bsG
 hrk
-bxn
+bqe
 bqe
 bzO
 bzO
@@ -120406,7 +120334,7 @@ dVX
 qSc
 hoc
 bjT
-bqe
+bxn
 rMr
 gAh
 pth
@@ -120446,7 +120374,7 @@ piV
 xTe
 bCw
 bKB
-cjD
+lLH
 shT
 clz
 cmx
@@ -120663,12 +120591,12 @@ uIX
 bUV
 hoc
 bjT
-bqe
-bqe
+bxn
+bxn
 bQs
-bqe
-bqe
-bqe
+bxn
+bxn
+bxn
 bqe
 bqe
 bqe
@@ -120703,10 +120631,10 @@ cNW
 cNW
 arG
 cNW
-cjD
-cjD
-cjD
-cjD
+lLH
+lLH
+lLH
+lLH
 bPT
 aaa
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1403,6 +1403,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"aic" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "aih" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -2282,7 +2286,7 @@
 /area/crew_quarters/fitness)
 "aof" = (
 /turf/closed/wall,
-/area/maintenance/solars/port/fore)
+/area/security/warden)
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -3706,6 +3710,9 @@
 /obj/item/radio/off,
 /obj/item/assembly/timer,
 /turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
+"ayL" = (
+/turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "ayM" = (
 /obj/item/storage/secure/safe{
@@ -9221,6 +9228,11 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"beq" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -9445,8 +9457,9 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "bfV" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10086,8 +10099,8 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "bkF" = (
-/turf/closed/wall,
-/area/ai_monitored/secondarydatacore)
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "bkT" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
@@ -11297,9 +11310,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"bvx" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
 "bvA" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -11326,9 +11336,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"bvK" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/chief)
 "bvL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -14065,7 +14072,7 @@
 /area/ai_monitored/storage/eva)
 "bTH" = (
 /obj/structure/sign/warning/securearea,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "bTJ" = (
 /obj/machinery/light/small{
@@ -15170,10 +15177,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cig" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/area/maintenance/starboard/aft)
 "ciq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15261,6 +15267,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjD" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "cjE" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -19240,11 +19250,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dEb" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "dEd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -37375,6 +37380,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lmN" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39827,7 +39837,7 @@
 /area/hallway/primary/central)
 "mof" = (
 /turf/closed/wall,
-/area/security/warden)
+/area/crew_quarters/heads/chief)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41098,6 +41108,9 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"mNn" = (
+/turf/closed/wall,
+/area/maintenance/solars/port/fore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -48775,10 +48788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"qaO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "qaQ" = (
 /obj/machinery/vending/cola/random,
 /obj/item/radio/intercom{
@@ -52247,7 +52256,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "rCG" = (
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/ai_monitored/secondarydatacore)
 "rCQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -52911,6 +52920,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"rPO" = (
+/turf/closed/wall,
+/area/crew_quarters/heads/hos)
 "rPT" = (
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -54900,7 +54912,7 @@
 /area/science/robotics/lab)
 "sHQ" = (
 /obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "sHY" = (
 /obj/effect/turf_decal/pool/corner{
@@ -60271,10 +60283,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"uTh" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "uTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -61199,10 +61207,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"vmm" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "vmY" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
@@ -63772,6 +63776,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"wmY" = (
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "wnz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -66762,10 +66769,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"xGG" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -83800,8 +83803,8 @@ alR
 alR
 alR
 alR
-aof
-aof
+mNn
+mNn
 alU
 alU
 alU
@@ -84825,11 +84828,11 @@ aaa
 gXs
 aaa
 aaa
-aof
-aof
-aof
-aof
-aof
+mNn
+mNn
+mNn
+mNn
+mNn
 alU
 alU
 alU
@@ -94090,13 +94093,13 @@ aph
 aqR
 aqR
 avt
-ayW
-ayW
+ayL
+ayL
 byI
-ayW
-ayW
-ayW
-ayW
+ayL
+ayL
+ayL
+ayL
 ayW
 ayW
 ayW
@@ -94347,13 +94350,13 @@ aYK
 baL
 baL
 bfA
-ayW
+ayL
 bts
 aAb
 ttQ
 bKG
 bOU
-ayW
+ayL
 cdN
 chK
 cqP
@@ -94604,7 +94607,7 @@ aph
 aph
 aph
 avt
-ayW
+ayL
 oIU
 aAb
 aqZ
@@ -94861,7 +94864,7 @@ apS
 ape
 aph
 avt
-ayW
+ayL
 qPt
 oPr
 qZu
@@ -95118,7 +95121,7 @@ aYU
 aqf
 aph
 avt
-ayW
+ayL
 bty
 azS
 bET
@@ -95375,7 +95378,7 @@ gOe
 mMn
 aph
 wIv
-ayW
+ayL
 ayK
 wXY
 jzo
@@ -95632,7 +95635,7 @@ aph
 aph
 aph
 avt
-ayW
+ayL
 abt
 pIj
 aAW
@@ -95648,12 +95651,12 @@ aJq
 urO
 bOS
 aaa
-tnB
-tnB
+aPR
+aPR
 tnB
 dzl
-tnB
-jwK
+aPR
+aZM
 aZu
 bbY
 yfL
@@ -95889,13 +95892,13 @@ rBV
 out
 uGm
 vNR
-ayW
+ayL
 aug
 pIj
 aAR
 aCA
 bPe
-ayW
+ayL
 aKf
 aKt
 cqQ
@@ -95905,12 +95908,12 @@ aJq
 urO
 bOS
 aaa
-tnB
+aPR
 aTQ
 xjX
 wTr
 kUB
-jwK
+aZM
 aZq
 iVI
 jCA
@@ -96146,13 +96149,13 @@ tkG
 jdk
 apd
 avt
-ayW
+ayL
 ars
 axw
 aDE
 aDE
 sHQ
-ayW
+ayL
 ayW
 ayW
 ayW
@@ -96162,7 +96165,7 @@ aJq
 urO
 bOS
 aaa
-tnB
+aPR
 cLS
 exk
 ucJ
@@ -96417,14 +96420,14 @@ bOS
 tnj
 aNz
 lVL
-tnB
-tnB
-tnB
+aPR
+aPR
+aPR
 gmQ
 hRj
 bBi
 cSJ
-jwK
+aZM
 aZC
 dzR
 bcZ
@@ -97153,9 +97156,9 @@ aaZ
 aaZ
 upk
 hSO
-mof
+aof
 ewO
-mof
+aof
 lIb
 lLO
 wYv
@@ -98531,7 +98534,7 @@ rkO
 biP
 cfb
 cdi
-bvK
+mof
 ugK
 qMu
 oTG
@@ -99211,7 +99214,7 @@ agr
 agt
 ayd
 quK
-mof
+aof
 mpL
 lLO
 xIP
@@ -99468,7 +99471,7 @@ upk
 ewO
 sdW
 ewO
-mof
+aof
 mLd
 lLO
 nSq
@@ -99501,9 +99504,9 @@ bOS
 fzE
 aNz
 iKC
-tnB
-tnB
-tnB
+aPR
+aPR
+aPR
 urt
 hRj
 xjd
@@ -99760,7 +99763,7 @@ aJq
 urO
 bOS
 aaa
-tnB
+aPR
 itZ
 exk
 qkB
@@ -100017,7 +100020,7 @@ dDZ
 urO
 bOS
 aaa
-tnB
+aPR
 pex
 yec
 uQf
@@ -100274,11 +100277,11 @@ aJq
 urO
 bOS
 aaa
-tnB
-tnB
-tnB
+aPR
+aPR
+aPR
 omM
-tnB
+aPR
 aZV
 ixh
 jaj
@@ -100996,7 +100999,7 @@ aaa
 aaa
 aaa
 aaf
-bfV
+rPO
 abq
 abq
 abq
@@ -117805,7 +117808,7 @@ atN
 atN
 atN
 atN
-xGG
+cig
 fXS
 cOe
 gpq
@@ -118062,7 +118065,7 @@ sLZ
 ief
 tXb
 oGM
-dEb
+beq
 fXS
 cOe
 gpq
@@ -118319,7 +118322,7 @@ kJz
 mSg
 wnI
 oGM
-dEb
+beq
 fXS
 chH
 cNW
@@ -118576,7 +118579,7 @@ oxg
 dBH
 pDa
 oGM
-vmm
+bfV
 fXS
 cNW
 cNW
@@ -118833,7 +118836,7 @@ oxg
 twt
 wnI
 oGM
-qaO
+cjD
 fXS
 bNA
 cOe
@@ -119030,7 +119033,7 @@ osI
 hld
 nDj
 yaD
-bvx
+bkF
 aOb
 aPq
 aPq
@@ -119090,7 +119093,7 @@ oxg
 tQv
 iiJ
 oGM
-uTh
+aic
 fXS
 cOe
 cOe
@@ -119287,7 +119290,7 @@ nYC
 iEt
 udt
 mUs
-bvx
+bkF
 aMZ
 aMZ
 aMZ
@@ -119347,7 +119350,7 @@ oGM
 oGM
 oGM
 oGM
-rCG
+wmY
 fXS
 cjE
 bMB
@@ -119544,7 +119547,7 @@ fxr
 uVA
 afW
 aFR
-bvx
+bkF
 eVK
 kAe
 rHv
@@ -119601,9 +119604,9 @@ cOe
 cOe
 cOe
 cOe
+wmY
+lmN
 rCG
-cig
-bkF
 cOe
 fXS
 lLH
@@ -119801,7 +119804,7 @@ xBH
 sHo
 sHo
 lsn
-bvx
+bkF
 odE
 tHk
 mZa
@@ -120058,7 +120061,7 @@ aNZ
 sHo
 sHo
 sHo
-bvx
+bkF
 odE
 aPq
 hrX
@@ -120315,7 +120318,7 @@ pMy
 sHo
 sHo
 sHo
-bvx
+bkF
 odE
 thb
 sQs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1404,9 +1404,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aic" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/turf/closed/wall,
+/area/crew_quarters/heads/hos)
 "aih" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
@@ -2284,9 +2283,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"aof" = (
-/turf/closed/wall,
-/area/security/warden)
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -9177,6 +9173,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"bea" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "beg" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
@@ -9229,10 +9230,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "beq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -9456,10 +9455,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
-"bfV" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10098,9 +10093,6 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/maintenance/port)
-"bkF" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
 "bkT" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
@@ -10333,6 +10325,10 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"bmA" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "bmD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -12832,6 +12828,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"bHi" = (
+/turf/closed/wall,
+/area/maintenance/solars/port/fore)
 "bHn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -15177,9 +15176,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cig" = (
-/obj/structure/table,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/ai_monitored/secondarydatacore)
 "ciq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15267,10 +15267,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cjD" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "cjE" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -19250,6 +19246,9 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dEb" = (
+/turf/closed/wall,
+/area/crew_quarters/heads/chief)
 "dEd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -27523,7 +27522,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/bridge/meeting_room)
 "heO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -28319,6 +28318,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"htI" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -33345,7 +33348,7 @@
 /area/maintenance/solars/starboard/aft)
 "jwK" = (
 /turf/closed/wall,
-/area/bridge/meeting_room)
+/area/security/warden)
 "jxf" = (
 /obj/structure/sink{
 	pixel_y = 30
@@ -37380,11 +37383,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"lmN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "lmY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39835,9 +39833,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mof" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/chief)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41108,9 +41103,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"mNn" = (
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -52256,7 +52248,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "rCG" = (
-/turf/closed/wall,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
 "rCQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -52920,9 +52913,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"rPO" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
 "rPT" = (
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -60283,6 +60273,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"uTh" = (
+/turf/closed/wall,
+/area/ai_monitored/secondarydatacore)
 "uTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -66769,6 +66762,10 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"xGG" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -83803,8 +83800,8 @@ alR
 alR
 alR
 alR
-mNn
-mNn
+bHi
+bHi
 alU
 alU
 alU
@@ -84828,11 +84825,11 @@ aaa
 gXs
 aaa
 aaa
-mNn
-mNn
-mNn
-mNn
-mNn
+bHi
+bHi
+bHi
+bHi
+bHi
 alU
 alU
 alU
@@ -94371,14 +94368,14 @@ bOS
 diK
 jAv
 obw
-jwK
-jwK
+aZM
+aZM
 unk
 guI
 hez
-jwK
-jwK
-jwK
+aZM
+aZM
+aZM
 aJw
 cNI
 aJw
@@ -94628,7 +94625,7 @@ bOS
 pOa
 lKE
 eIv
-jwK
+aZM
 irC
 iUT
 jjW
@@ -94885,14 +94882,14 @@ tnB
 rtY
 ukk
 rVS
-jwK
+aZM
 oQp
 xul
 xul
 xul
 kPb
-jwK
-jwK
+aZM
+aZM
 bhs
 nkd
 bmr
@@ -95142,14 +95139,14 @@ tnB
 qCo
 wTr
 aAL
-jwK
+aZM
 irQ
 kRv
 jzw
 kji
 kRv
 dBV
-jwK
+aZM
 mJX
 nlC
 bmr
@@ -95399,14 +95396,14 @@ tnB
 goG
 jHe
 afu
-jwK
+aZM
 ivM
 bbW
 pfA
 kjm
 kRv
 lvY
-jwK
+aZM
 bhs
 bkT
 bmr
@@ -95663,9 +95660,9 @@ yfL
 bdX
 kUQ
 xul
-jwK
-jwK
-jwK
+aZM
+aZM
+aZM
 bmr
 jui
 nfX
@@ -97156,9 +97153,9 @@ aaZ
 aaZ
 upk
 hSO
-aof
+jwK
 ewO
-aof
+jwK
 lIb
 lLO
 wYv
@@ -98534,7 +98531,7 @@ rkO
 biP
 cfb
 cdi
-mof
+dEb
 ugK
 qMu
 oTG
@@ -99214,7 +99211,7 @@ agr
 agt
 ayd
 quK
-aof
+jwK
 mpL
 lLO
 xIP
@@ -99471,7 +99468,7 @@ upk
 ewO
 sdW
 ewO
-aof
+jwK
 mLd
 lLO
 nSq
@@ -100999,7 +100996,7 @@ aaa
 aaa
 aaa
 aaf
-rPO
+aic
 abq
 abq
 abq
@@ -117808,7 +117805,7 @@ atN
 atN
 atN
 atN
-cig
+xGG
 fXS
 cOe
 gpq
@@ -118065,7 +118062,7 @@ sLZ
 ief
 tXb
 oGM
-beq
+cig
 fXS
 cOe
 gpq
@@ -118322,7 +118319,7 @@ kJz
 mSg
 wnI
 oGM
-beq
+cig
 fXS
 chH
 cNW
@@ -118579,7 +118576,7 @@ oxg
 dBH
 pDa
 oGM
-bfV
+htI
 fXS
 cNW
 cNW
@@ -118836,7 +118833,7 @@ oxg
 twt
 wnI
 oGM
-cjD
+rCG
 fXS
 bNA
 cOe
@@ -119033,7 +119030,7 @@ osI
 hld
 nDj
 yaD
-bkF
+beq
 aOb
 aPq
 aPq
@@ -119093,7 +119090,7 @@ oxg
 tQv
 iiJ
 oGM
-aic
+bmA
 fXS
 cOe
 cOe
@@ -119290,7 +119287,7 @@ nYC
 iEt
 udt
 mUs
-bkF
+beq
 aMZ
 aMZ
 aMZ
@@ -119547,7 +119544,7 @@ fxr
 uVA
 afW
 aFR
-bkF
+beq
 eVK
 kAe
 rHv
@@ -119605,8 +119602,8 @@ cOe
 cOe
 cOe
 wmY
-lmN
-rCG
+bea
+uTh
 cOe
 fXS
 lLH
@@ -119804,7 +119801,7 @@ xBH
 sHo
 sHo
 lsn
-bkF
+beq
 odE
 tHk
 mZa
@@ -120061,7 +120058,7 @@ aNZ
 sHo
 sHo
 sHo
-bkF
+beq
 odE
 aPq
 hrX
@@ -120318,7 +120315,7 @@ pMy
 sHo
 sHo
 sHo
-bkF
+beq
 odE
 thb
 sQs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2280,6 +2280,9 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"aof" = (
+/turf/closed/wall,
+/area/maintenance/solars/port/fore)
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -9442,9 +9445,8 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "bfV" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/turf/closed/wall,
+/area/crew_quarters/heads/hos)
 "bfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10084,9 +10086,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "bkF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/ai_monitored/secondarydatacore)
 "bkT" = (
 /obj/structure/closet/wardrobe/black,
@@ -10320,9 +10320,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"bmA" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hos)
 "bmD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -11300,6 +11297,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"bvx" = (
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "bvA" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -11326,6 +11326,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"bvK" = (
+/turf/closed/wall,
+/area/crew_quarters/heads/chief)
 "bvL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -15166,6 +15169,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cig" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "ciq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15253,9 +15261,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cjD" = (
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "cjE" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -19235,6 +19240,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dEb" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "dEd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28304,9 +28314,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"htI" = (
-/turf/closed/wall,
-/area/security/warden)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -39818,6 +39825,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mof" = (
+/turf/closed/wall,
+/area/security/warden)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41088,10 +41098,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"mNn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "mNo" = (
 /obj/machinery/vending/assist,
 /obj/machinery/airalarm{
@@ -47352,7 +47358,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ptH" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/escapepodbay)
 "ptV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
@@ -48165,10 +48171,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pOw" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "pOx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -48773,6 +48775,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"qaO" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "qaQ" = (
 /obj/machinery/vending/cola/random,
 /obj/item/radio/intercom{
@@ -52241,9 +52247,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "rCG" = (
-/obj/structure/table,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/ai_monitored/secondarydatacore)
 "rCQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -60267,8 +60272,9 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uTh" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/chief)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "uTk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
@@ -61193,6 +61199,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"vmm" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "vmY" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
@@ -66451,9 +66461,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"xyU" = (
-/turf/closed/wall,
-/area/maintenance/solars/port/fore)
 "xzh" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -66719,9 +66726,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"xFh" = (
-/turf/closed/wall,
-/area/ai_monitored/secondarydatacore)
 "xFp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/disposalpipe/segment,
@@ -66759,10 +66763,9 @@
 /turf/open/floor/carpet,
 /area/library)
 "xGG" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
+/area/maintenance/starboard/aft)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -83797,8 +83800,8 @@ alR
 alR
 alR
 alR
-xyU
-xyU
+aof
+aof
 alU
 alU
 alU
@@ -84822,11 +84825,11 @@ aaa
 gXs
 aaa
 aaa
-xyU
-xyU
-xyU
-xyU
-xyU
+aof
+aof
+aof
+aof
+aof
 alU
 alU
 alU
@@ -97150,9 +97153,9 @@ aaZ
 aaZ
 upk
 hSO
-htI
+mof
 ewO
-htI
+mof
 lIb
 lLO
 wYv
@@ -98528,7 +98531,7 @@ rkO
 biP
 cfb
 cdi
-uTh
+bvK
 ugK
 qMu
 oTG
@@ -99208,7 +99211,7 @@ agr
 agt
 ayd
 quK
-htI
+mof
 mpL
 lLO
 xIP
@@ -99465,7 +99468,7 @@ upk
 ewO
 sdW
 ewO
-htI
+mof
 mLd
 lLO
 nSq
@@ -100993,7 +100996,7 @@ aaa
 aaa
 aaa
 aaf
-bmA
+bfV
 abq
 abq
 abq
@@ -117802,7 +117805,7 @@ atN
 atN
 atN
 atN
-rCG
+xGG
 fXS
 cOe
 gpq
@@ -118059,7 +118062,7 @@ sLZ
 ief
 tXb
 oGM
-xGG
+dEb
 fXS
 cOe
 gpq
@@ -118316,7 +118319,7 @@ kJz
 mSg
 wnI
 oGM
-xGG
+dEb
 fXS
 chH
 cNW
@@ -118573,7 +118576,7 @@ oxg
 dBH
 pDa
 oGM
-mNn
+vmm
 fXS
 cNW
 cNW
@@ -118830,7 +118833,7 @@ oxg
 twt
 wnI
 oGM
-bfV
+qaO
 fXS
 bNA
 cOe
@@ -119027,7 +119030,7 @@ osI
 hld
 nDj
 yaD
-aMZ
+bvx
 aOb
 aPq
 aPq
@@ -119087,7 +119090,7 @@ oxg
 tQv
 iiJ
 oGM
-pOw
+uTh
 fXS
 cOe
 cOe
@@ -119284,7 +119287,7 @@ nYC
 iEt
 udt
 mUs
-aMZ
+bvx
 aMZ
 aMZ
 aMZ
@@ -119344,7 +119347,7 @@ oGM
 oGM
 oGM
 oGM
-cjD
+rCG
 fXS
 cjE
 bMB
@@ -119541,7 +119544,7 @@ fxr
 uVA
 afW
 aFR
-aMZ
+bvx
 eVK
 kAe
 rHv
@@ -119598,9 +119601,9 @@ cOe
 cOe
 cOe
 cOe
-cjD
+rCG
+cig
 bkF
-xFh
 cOe
 fXS
 lLH
@@ -119798,7 +119801,7 @@ xBH
 sHo
 sHo
 lsn
-aMZ
+bvx
 odE
 tHk
 mZa
@@ -120055,7 +120058,7 @@ aNZ
 sHo
 sHo
 sHo
-aMZ
+bvx
 odE
 aPq
 hrX
@@ -120312,7 +120315,7 @@ pMy
 sHo
 sHo
 sHo
-aMZ
+bvx
 odE
 thb
 sQs


### PR DESCRIPTION
# Document the changes in your pull request

Here is basically what I did. I mass replaced every rwall with a regular war, and then manually placed reinforced walls based on an arbitrary checklist (below).

> Reinforced walls must encase:
> - Anything that contains expensive objects, such as Head equipment and the AI core.
> - Anything that contains dangerous objects or people, such as gas, chemicals, prisoners, the command console, or science experiments.
> - Anything that will be used for general EVA construction

Areas that are reinforced:
- All Head offices.
- All of engineering and atmos (Except the lobby).
- All of command.
- Anything that involves the AI.
- Secure Tech Storage
- Anything that contains prisoners.
- The Armory (except the warden's office).
- Toxins.
- All Xenobiology containment cells.
- The experimentor room.
- Cloning (but not genetics).
- Chemistry.
- Aux Base construction area.
- Space Pod construction area.
- Execution Area/Transfer Center.

I also removed the near-redundant reinforced walls outside the secondary AI core because they made no sense.

(Also it is better to use the mapdiffbot to see what was changed given that I basically took a hammer to the station and did everything without really thinking too much.)

# Wiki Documentation

Wiki slaves will need to take screenshots of all the areas affect lol lmao.


# Changelog

:cl:  BurgerBB
mapping: Removes and adds reinforced walls to some areas on Yogstation.
mapping: Removes the near-redundant reinforced walls outside the secondary AI core.
/:cl:
