### PR TITLE
Laser scalpel no longer makes you look like a spessman-shaped nuclear fuel rod

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -414,7 +414,7 @@
 		tool_behaviour = TOOL_SCALPEL
 		to_chat(user, span_notice("You lower the power, it can now make precise incisions."))
 		set_light_range(1)
-		set_light_power(0.3)
+		set_light_power(0.2)
 		force -= 1
 		icon_state = "scalpel_a"
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -397,6 +397,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 1
 	light_color = LIGHT_COLOR_GREEN
+	light_power = = 0.2	//Barely glows on low power
 	sharpness = SHARP_EDGED
 
 
@@ -406,12 +407,14 @@
 		tool_behaviour = TOOL_SAW
 		to_chat(user, span_notice("You increase the power, now it can cut bones."))
 		set_light_range(2)
+		set_light_power(1)
 		force += 1 //we don't want to ruin sharpened stuff
 		icon_state = "saw_a"
 	else
 		tool_behaviour = TOOL_SCALPEL
 		to_chat(user, span_notice("You lower the power, it can now make precise incisions."))
 		set_light_range(1)
+		set_light_power(0.3)
 		force -= 1
 		icon_state = "scalpel_a"
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -397,7 +397,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 1
 	light_color = LIGHT_COLOR_GREEN
-	light_power = = 0.2	//Barely glows on low power
+	light_power = 0.2	//Barely glows on low power
 	sharpness = SHARP_EDGED
 
 


### PR DESCRIPTION
Changed the base power from 1 to 0.2 so now you don't glow weirdly

![image](https://user-images.githubusercontent.com/43766432/212776298-53e37433-729f-489f-b418-a590a79f8536.png)
![image](https://user-images.githubusercontent.com/43766432/212776329-c3497529-3cc8-40d1-8df5-ed365758cc97.png)


# Changelog

:cl:  

tweak: Scalpel mode for the laser scalpel now significantly less bright

/:cl:
