### PR TITLE
Cryopods will no longer reroll assassinate subtypes which have already been completed

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -278,7 +278,7 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 				to_chat(M.current, "<BR>[span_userdanger("Your target is no longer within reach. Objective removed!")]")
 				M.announce_objectives()
 		else if(O.target == mob_occupant.mind)
-			if((O.type in typesof(/datum/objective/assassinate)) && O.check_completion()) //kill once/kill+clone objective that's already been completed, don't give a new objective
+			if((O.type in subtypesof(/datum/objective/assassinate)) && O.check_completion()) //kill once/kill+clone objective that's already been completed, don't give a new objective
 				continue
 			O.target = null
 			O.find_target()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -278,6 +278,8 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 				to_chat(M.current, "<BR>[span_userdanger("Your target is no longer within reach. Objective removed!")]")
 				M.announce_objectives()
 		else if(O.target == mob_occupant.mind)
+			if((O.type in typesof(/datum/objective/assassinate)) && O.check_completion()) //kill once/kill+clone objective that's already been completed, don't give a new objective
+				continue
 			O.target = null
 			O.find_target()
 			O.update_explanation_text()


### PR DESCRIPTION
# Document the changes in your pull request

Cryopods reroll objectives targetting people if that person cryos
if that objective is currently complete, congrats, you now have to do it again
this should fix that

# Changelog

:cl:
bugfix: cryopods will no longer reroll objectives on the person cryoing if that objective has already been completed
/:cl:
