### PR TITLE
Sprayed runes and graffiti are now more convincingly cult runes and gang graffiti

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -315,11 +315,9 @@
 			drawing = pick(all_drawables)
 
 
-	var/temp = "rune"
-	if(is_alpha(drawing))
-		temp = "letter"
-	else if(is_digit(drawing))
-		temp = "number"
+	var/temp = "scribble"
+	if (drawing in runes)
+		temp = "rune"
 	else if(drawing in punctuation)
 		temp = "punctuation mark"
 	else if(drawing in symbols)
@@ -328,11 +326,15 @@
 		temp = "drawing"
 	else if(drawing in graffiti|oriented)
 		temp = "graffiti"
+	else if(is_digit(drawing))
+		temp = "number"
+	else if(is_alpha(drawing))
+		temp = "letter"
 	var/gang_check = hippie_gang_check(user,target) // yogs start -- gang check and temp setting
 	if(!gang_check)
 		return
-	else if(gang_check == "gang graffiti")
-		temp = gang_check // yogs end
+	//else if(gang_check == "gang graffiti")
+	//	temp = gang_check // yogs end
 
 
 	var/graf_rot

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -16,7 +16,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 /obj/effect/rune
 	name = "rune"
 	var/cultist_name = "basic rune"
-	desc = "An odd collection of symbols drawn in what seems to be blood."
+	desc = "A rune vandalizing the station."
 	var/cultist_desc = "a basic rune with no function." //This is shown to cultists who examine the rune in order to determine its true purpose.
 	anchored = TRUE
 	icon = 'icons/obj/rune.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

`is_alpha()` returned true no matter what you were drawing (unless it was a number) because it only respects the first letter and because that was the first check it would always default to `letter`. Now it is the last check.

Also removed a snowflake check that would rename gang graffiti to make it obvious that it was gang graffiti.

Cult runes and gang sprays should now be identical to sprayed runes except for the fact that they are perfectly centered which can be achieved by other means.

# Changelog

:cl:  
bugfix: Fixed a bug where every drawn graffiti would show up as a letter instead of rune, graffiti, number, symbol, etc
tweak: Cult runes are no longer obvious about being made of blood
tweak: Gang sprays are no longer named gang graffiti
/:cl:
