### PR TITLE
The syndicate has ordered newer, more accurate sniper rifles from space australia

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -368,6 +368,8 @@
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
 	fire_delay = 40
 	burst_size = 1
+	spread = 0
+	default_spread = 0	//It's a sniper rifle, it doesn't miss.
 	w_class = WEIGHT_CLASS_NORMAL
 	zoomable = TRUE
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.


### PR DESCRIPTION
Now they have 0 innate spread because for a gun that fires once every FOUR SECONDS (that's 10x the base fire delay of guns), missing one shot because of RNG can really cause problems. Also it's a special nukie-only weapon (when seen on the station) so it being a sniper rifle that can miss is a bad thing.

# Changelog

:cl:  

tweak: Syndicate 50 cal sniper rifle base inaccuracy reduced from 5 to 0

/:cl:
