### PR TITLE
Adds cloaker belt to uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1380,14 +1380,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_tools/shadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness."
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use.
 	item = /obj/item/shadowcloak
 	cost = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/nuclearshadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness."
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use.
 	item = /obj/item/shadowcloak
 	cost = 60
 	include_modes = list(datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1390,7 +1390,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use."
 	item = /obj/item/shadowcloak
 	cost = 60
-	include_modes = list(datum/game_mode/nuclear)
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndireverse
 	name = "Bluespace Projectile Weapon Disrupter"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1385,6 +1385,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_tools/nuclearshadowcloak
+	name = "Cloaker Belt"
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness.
+	item = /obj/item/shadowcloak
+	cost = 60
+	include_modes = list(datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndireverse
 	name = "Bluespace Projectile Weapon Disrupter"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1380,14 +1380,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_tools/shadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness.
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness."
 	item = /obj/item/shadowcloak
 	cost = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/nuclearshadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness.
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness."
 	item = /obj/item/shadowcloak
 	cost = 60
 	include_modes = list(datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1389,7 +1389,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Cloaker Belt"
 	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use."
 	item = /obj/item/shadowcloak
-	cost = 60
+	cost = 20
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/syndireverse

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1383,6 +1383,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness.
 	item = /obj/item/shadowcloak
 	cost = 10
+	exclude_modes = list(/datum/game_mode/nuclear)
+
 
 /datum/uplink_item/stealthy_tools/syndireverse
 	name = "Bluespace Projectile Weapon Disrupter"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1380,14 +1380,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_tools/shadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use.
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use."
 	item = /obj/item/shadowcloak
 	cost = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/nuclearshadowcloak
 	name = "Cloaker Belt"
-	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use.
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use."
 	item = /obj/item/shadowcloak
 	cost = 60
 	include_modes = list(datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1378,6 +1378,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	manufacturer = /datum/corporation/traitor/cybersun
 
+/datum/uplink_item/stealthy_tools/shadowcloak
+	name = "Cloaker Belt"
+	desc = "Renders the wearer invisible while active. Has a short charge that is refilled in darkness.
+	item = /obj/item/shadowcloak
+	cost = 10
+
 /datum/uplink_item/stealthy_tools/syndireverse
 	name = "Bluespace Projectile Weapon Disrupter"
 	desc = "Hidden in an ordinary-looking playing card, this device will teleport an opponent's gun to your hand when they fire at you. Just make sure to hold this in your hand!"


### PR DESCRIPTION
# Document the changes in your pull request

Puts the cloaker belt in the uplink. Cloaker belt exists in the code already, I found it under yogstation/code/game/objects/items/devices/traitordevices.dm. Searched through PRs and discord and never saw it mentioned so I guess its fine to implement.

The belt charges, and drains charge, faster the darker or brighter it is. Only charges and drains while the belt is active. At full charge, you stay invisible in a well-lit area for about 5-6 seconds, then begin slowly fading into full visibility. The invisibility is not affected by moving or interacting with things.

I decided to make it 10 TC, 2 more than the stealth implant. Though the belt is more conspicuous and has limited charge, you aren't restricted to being in a box. Uses the toolbelt sprite, but is still called "cloaker belt," because metashielding it would be too strong and giving it a unique sprite would be giving your stealth item a "valid me" sign. Edit: Nukies can purchase it for 20 tc and i might change the price again

Hopefully, this should provide a way for traitors to be stealthy, but still make an impact on the round; It encourages you to sabatoge lights and power to sneakily move around the station.

Edit: Ok I double checked and it has to be activated to charge in the dark. I don't think it really matters and maybe that can get changed later but yeah
Nukies get it for 20 tc this is open to debate sorry I keep changing things

# Wiki Documentation

Add cloaker belt to the uplink items page.

# Changelog

:cl:  
rscadd: Added Cloaker Belt to the uplink
/:cl:
