### PR TITLE
Makes Preternis also considered mob_robotic

### DIFF
--- a/code/modules/pool/pool.dm
+++ b/code/modules/pool/pool.dm
@@ -126,7 +126,7 @@ Place a pool filter somewhere in the pool if you want people to be able to modif
 	if(ishuman(user))
 		var/mob/living/carbon/human/F = user
 		var/datum/species/SS = F.dna.species
-		if(MOB_ROBOTIC in SS.inherent_biotypes || ispreternis(F))  //ZAP goes preternis
+		if(MOB_ROBOTIC in SS.inherent_biotypes)  //ZAP goes preternis and IPC
 			zap = 2 //You can protect yourself from water damage with thick clothing.
 		if(F.head && istype(F.head, /obj/item/clothing))
 			var/obj/item/clothing/CH = F.head

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -11,6 +11,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_MEDICALIGNORE) //Medical Ignore doesn't prevent basic treatment,only things that cannot help preternis,such as cryo and medbots
 	species_traits = list(DYNCOLORS, EYECOLOR, HAIR, LIPS, AGENDER, NOHUSK, ROBOTIC_LIMBS, DIGITIGRADE)//they're fleshy metal machines, they are efficient, and the outside is metal, no getting husked
+	inherent_biotypes = list(MOB_ORGANIC, MOB_ROBOTIC, MOB_HUMANOID)
 	no_equip = list(SLOT_SHOES)//this is just easier than using the digitigrade trait for now, making them digitigrade is part of the sprite rework pr
 	say_mod = "intones"
 	attack_verb = "assault"


### PR DESCRIPTION
This does nothing to change gameplay currently, but should increase consistency in the future as preternis are both organic AND robotic.

:cl:  
tweak: Nothing you need to worry about as a player
/:cl:
