### PR TITLE
[Box] Fixes Brig Phys camera to not be a copy-paste of Interrogation camera

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -22857,6 +22857,22 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"fbo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Brig - Infirmary";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "fbF" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -53830,23 +53846,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft)
-"sig" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 4;
-	network = list("interrogation")
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "siG" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -95423,7 +95422,7 @@ fsi
 lnA
 agj
 soz
-sig
+fbo
 sax
 tvs
 agj


### PR DESCRIPTION
# Document the changes in your pull request

As the title says. Replaced the camera in brig phys area, which was a copy-paste of the one in Interrogation, which was causing it to show up incorrectly when trying to monitor Interrogation. (Used the version from yogsmeta, just with a different dir so it's on the wal properly.)

Fixes issue #17561 

# Changelog

:cl:  
bugfix: The monitor outside interrogation now shows the correct view again
bugfix: Brig - Infirmary camera now shows up correctly on the standard camera console
/:cl:
