### PR TITLE
Positronic brains are now assigned pacifism until they become a cyborg

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -348,6 +348,7 @@
 #define HOLDER_TRAIT "holder_trait"
 #define SINFULDEMON_TRAIT "sinfuldemon"
 #define CHANGESTING_TRAIT "changesting"
+#define POSIBRAIN_TRAIT "positrait"
 
 ///Traits given by station traits
 #define STATION_TRAIT_BANANIUM_SHIPMENTS "station_trait_bananium_shipments"

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -333,6 +333,8 @@
 				qdel(O.mmi)
 			O.mmi = W //and give the real mmi to the borg.
 
+			REMOVE_TRAIT(O, TRAIT_PACIFISM, POSIBRAIN_TRAIT) // remove the posibrain's pacifism
+
 			O.updatename(BM.client)
 
 			BM.mind.transfer_to(O)

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -140,6 +140,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	brainmob.stat = CONSCIOUS
 	brainmob.remove_from_dead_mob_list()
 	brainmob.add_to_alive_mob_list()
+	ADD_TRAIT(brainmob, TRAIT_PACIFISM, POSIBRAIN_TRAIT)
 
 	visible_message(new_mob_message)
 	check_success()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -197,6 +197,8 @@
 				mmi.brainmob.add_to_alive_mob_list()
 			mind.transfer_to(mmi.brainmob)
 			mmi.update_icon()
+			if(istype(mmi, /obj/item/mmi/posibrain))
+				ADD_TRAIT(mmi.brainmob, TRAIT_PACIFISM, POSIBRAIN_TRAIT)
 		else
 			to_chat(src, span_boldannounce("Oops! Something went very wrong, your MMI was unable to receive your mind. You have been ghosted. Please make a bug report so we can fix this bug."))
 			ghostize()


### PR DESCRIPTION
# Document the changes in your pull request

Tested locally

Posibrains are meant to `Above all else, do no harm.` but I see a lot of newer players completely miss or knowingly ignore this

This makes it so posibrains can no longer harm. When placed in a cyborg, they can harm. When they are ejected from the cyborg, they are once again not permitted to harm.

This makes it so in a mech (or spiderbot, I guess?) they cannot swing swords, punch people, or fire lethal weaponry.

# Changelog

:cl:  
tweak: Posibrains have been pacified to reinforce their non-harming nature
/:cl:
