### PR TITLE
Makes traitor stimulants cheap and makes lethal options viable vs sleeping carp

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -62,8 +62,9 @@
 			return spec_return
 
 	if(mind)
-		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && (mind.martial_art.deflection_chance || ((mind.martial_art.id == "sleeping carp") && in_throw_mode))) //Some martial arts users can deflect projectiles!
-			if(prob(mind.martial_art.deflection_chance) || ((mind.martial_art.id == "sleeping carp") && in_throw_mode)) // special check if sleeping carp is our martial art and throwmode is on, deflect
+		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && (mind.martial_art.deflection_chance || mind.martial_art.id == "sleeping carp")) //Some martial arts users can deflect projectiles!
+			// special check if sleeping carp is our martial art and throwmode is on and not point blank, deflect
+			if(prob(mind.martial_art.deflection_chance) || (mind.martial_art.id == "sleeping carp" && in_throw_mode && (!P.firer || get_dist(src, P.firer) > 1)))
 				if((mobility_flags & MOBILITY_USE) && dna && !(dna.check_mutation(HULK)|| dna.check_mutation(ACTIVE_HULK))) //But only if they're otherwise able to use items, and hulks can't do it
 					if(!isturf(loc)) //if we're inside something and still got hit
 						P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1764,7 +1764,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
 			5 minutes after injection."
 	item = /obj/item/reagent_containers/autoinjector/medipen/stimpack/large // Yogs -- Stimpack change
-	cost = 8
+	cost = 2
 	surplus = 90
 
 /datum/uplink_item/device_tools/medkit

--- a/yogstation/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/yogstation/code/modules/reagents/reagent_containers/hypospray.dm
@@ -16,15 +16,15 @@
 
 /obj/item/reagent_containers/autoinjector/medipen/stimpack/large
 	name = "stimpack injector"
-	desc = "Contains three heavy doses of stimulants."
+	desc = "Contains a heavy dose of stimulants."
 	icon = 'yogstation/icons/obj/syringe.dmi'
 	icon_state = "stimpakpen"
-	volume = 75
+	volume = 25
 	amount_per_transfer_from_this = 25
-	list_reagents = list(/datum/reagent/medicine/stimulants = 75)
+	list_reagents = list(/datum/reagent/medicine/stimulants = 25)
 
 /obj/item/reagent_containers/autoinjector/medipen/stimpack/large/update_icon()
-	if(reagents.total_volume > 25)
+	if(reagents.total_volume >= 25)
 		icon_state = initial(icon_state)
 	else if(reagents.total_volume)
 		icon_state = "[initial(icon_state)]25"


### PR DESCRIPTION
# Document the changes in your pull request

Stimulants being 6TC made them a tough purchase. Stimulants being made 8TC made them insanely unattractive and virtually unseen in present day builds due to how restrictive it is. It's time to give them some love.

Stimulants are no longer 8TC, but have been nestled nicely in 2TC heaven for one a pop. Stims were, originally, 6TC for 2. Then they were made 8TC for 3. I believe 2TC stimulants are a good spot for them, perhaps 3TC. No longer the forefront of a build, but a useful and flexible asset like other 2TC utility.

### But sleeping carp plus stims are OP!

Previously, a sleeping carp user that had flash/bang protection could only be countered by batong rushing. This is because security has no melee options besides the batong. With this change, point blank (melee range) shots will no longer be deflected by sleeping carp. 

This means stimulants are no longer OP on sleeping carp, as security now has access to lethal options. 

I am not opposed to reducing sleeping carp's 14TC price from this nerf, but I don't immediately think it's necessary. As a reminder, CQC is 13TC.

# Changelog

:cl:  
tweak: Stimpack is now one-use and 2TC
tweak: Sleeping carp can no longer deflect projectiles at melee range  
/:cl:
