### PR TITLE
riot shotguns need 2 hands to shoot

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -40,6 +40,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off  = TRUE
+	weapon_weight = WEAPON_HEAVY
 
 // Breaching Shotgun //
 


### PR DESCRIPTION
riot shotguns need two hands to shoot. 

does not affect combat shotguns so they're actually competitive versus riot shotguns. this is to kill the shield + shotgun shit on everything meta, makes several gamemodes less unenjoyable (primarily darkspawn)

# Changelog

:cl:  
tweak: riot shotguns are two-handed
/:cl:
