### PR TITLE
adds description to wacky gene

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -14,7 +14,7 @@
 
 /datum/mutation/human/wacky
 	name = "Wacky"
-	desc = "Unknown."
+	desc = "Causes the user to talk in an odd manner."
 	quality = MINOR_NEGATIVE
 	text_gain_indication = span_sans("You feel an off sensation in your voicebox.")
 	text_lose_indication = span_notice("The off sensation passes.")


### PR DESCRIPTION
changes 	desc "Unknown." to "Causes the user to talk in an odd manner." I have got honestly no idea why it was just "unknown" because no other ones are? but this makes it easier to see what it does. no wiki changes.

:cl:  Ktlwjec
tweak: Updates the description for wacky gene.
/:cl: