### PR TITLE
Gives atmos tech jumpsuit fire protection

### DIFF
--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -25,6 +25,7 @@
 	name = "atmospheric technician's jumpsuit"
 	icon_state = "atmos"
 	item_state = "atmos_suit"
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 0)
 	resistance_flags = NONE
 	mutantrace_variation = MUTANTRACE_VARIATION
 

--- a/yogstation/code/modules/clothing/head.dm
+++ b/yogstation/code/modules/clothing/head.dm
@@ -173,7 +173,7 @@
 	icon = 'yogstation/icons/obj/clothing/hats.dmi'
 	mob_overlay_icon = 'yogstation/icons/mob/clothing/head/head.dmi'
 	icon_state = "beret_atmospherics"
-	armor = list(rad = 10, fire = 10)
+	armor = list(rad = 10, fire = 80)
 	strip_delay = 60
 
 /obj/item/clothing/head/beret/ce
@@ -182,7 +182,7 @@
 	icon = 'yogstation/icons/obj/clothing/hats.dmi'
 	mob_overlay_icon = 'yogstation/icons/mob/clothing/head/head.dmi'
 	icon_state = "beret_ce"
-	armor = list(rad = 20, fire = 30)
+	armor = list(rad = 20, fire = 80)
 	strip_delay = 60
 
 /obj/item/clothing/head/beret/sci


### PR DESCRIPTION
# Document the changes in your pull request

Gives atmos tech jumpsuit and beret a fire protection of 80 (same as the CE and miner jumpsuits) instead of 0.

# Changelog

:cl:  
tweak: atmos clothes have fire protection now
/:cl:
