### PR TITLE
Fixes a fulton softlock runtime

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -120,7 +120,10 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			var/list/flooring_near_beacon = list()
 			for(var/turf/open/floor in orange(1, beacon))
 				flooring_near_beacon += floor
-			holder_obj.forceMove(pick(flooring_near_beacon))
+			if(LAZYLEN(flooring_near_beacon) > 0)
+				holder_obj.forceMove(pick(flooring_near_beacon))
+			else
+				to_chat(user, span_userdanger("The beacon malfunctions! It couldn't find a place to land!"))
 			animate(holder_obj, pixel_z = 10, time = 5 SECONDS)
 			sleep(5 SECONDS)
 			animate(holder_obj, pixel_z = 15, time = 1 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

Can occur if the beacon is deleted between the do_after or if the beacon is covered in walls

User will be stuck in the air forever and never released on runtime

# Changelog

:cl:  
bugfix: fixed a fulton extraction pack softlock
/:cl:
