### PR TITLE
(port) adds disfiguration

### DIFF
--- a/code/datums/diseases/advance/symptoms/disfiguration.dm
+++ b/code/datums/diseases/advance/symptoms/disfiguration.dm
@@ -1,0 +1,46 @@
+/*
+//////////////////////////////////////
+Disfiguration
+	Hidden.
+	No change to resistance.
+	Increases stage speed.
+	Slightly increases transmittability.
+	Critical Level.
+BONUS
+	Adds disfiguration trait making the mob appear as "Unknown" to others.
+//////////////////////////////////////
+*/
+
+/datum/symptom/disfiguration
+
+	name = "Disfiguration"
+	desc = "The virus liquefies facial muscles, disfiguring the host."
+	stealth = 2
+	resistance = 0
+	stage_speed = 3
+	transmittable = 1
+	level = 5
+	severity = 1
+	symptom_delay_min = 25
+	symptom_delay_max = 75
+
+/datum/symptom/disfiguration/Activate(datum/disease/advance/A)
+	. = ..()
+	if(!.)
+		return
+	var/mob/living/M = A.affected_mob
+	if (HAS_TRAIT(M, TRAIT_DISFIGURED))
+		return
+	switch(A.stage)
+		if(5)
+			ADD_TRAIT(M, TRAIT_DISFIGURED, DISEASE_TRAIT)
+			M.visible_message("<span class='warning'>[M]'s face appears to cave in!</span>", "<span class='notice'>You feel your face crumple and cave in!</span>")
+		else
+			M.visible_message("<span class='warning'>[M]'s face begins to contort...</span>", "<span class='notice'>Your face feels wet and malleable...</span>")
+
+
+/datum/symptom/disfiguration/End(datum/disease/advance/A)
+	. = ..()
+	if(!.)
+		return
+	if(A.affected_mob)

--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -30,6 +30,7 @@ new /datum/disease_ability/symptom/medium/nano_destroy,
 new /datum/disease_ability/symptom/medium/viraladaptation,
 new /datum/disease_ability/symptom/medium/viralevolution,
 new /datum/disease_ability/symptom/medium/vitiligo,
+new /datum/disease_ability/symptom/medium/disfiguration,
 new /datum/disease_ability/symptom/medium/revitiligo,
 new /datum/disease_ability/symptom/medium/itching,
 new /datum/disease_ability/symptom/medium/heal/weight_loss,
@@ -379,6 +380,8 @@ new /datum/disease_ability/symptom/powerful/heal/youth
 	short_desc = "Change the voice of victims."
 	long_desc = "Change the voice of victims, causing confusion in communications."
 
+/datum/disease_ability/symptom/medium/disfiguration
+	symptoms = list(/datum/symptom/disfiguration)
 
 /datum/disease_ability/symptom/medium/visionloss
 	symptoms = list(/datum/symptom/visionloss)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -571,6 +571,7 @@
 #include "code\datums\diseases\advance\symptoms\confusion.dm"
 #include "code\datums\diseases\advance\symptoms\cough.dm"
 #include "code\datums\diseases\advance\symptoms\deafness.dm"
+#include "code\datums\diseases\advance\symptoms\disfiguration.dm"
 #include "code\datums\diseases\advance\symptoms\dizzy.dm"
 #include "code\datums\diseases\advance\symptoms\fever.dm"
 #include "code\datums\diseases\advance\symptoms\fire.dm"


### PR DESCRIPTION
original pr:https://github.com/tgstation/tgstation/pull/45297
"Disfiguration: Makes the host disfigured, causing them to appear as Unknown. (I originally said prosopagnosia but it turns out that trait doesn't affect what you see while mousing over mobs, so it is kind of pointless as a symptom.)" IT IS A LEVEL 5 SYMPTOM
:cl:  
rscadd: Added new viro symptom Disfiguration: Makes the host disfigured, causing them to appear as Unknown. (I originally said prosopagnosia but it turns out that trait doesn't affect what you see while mousing over mobs, so it is kind of pointless as a symptom.)
/:cl:
