### PR TITLE
A couple hardlight changes

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -9,7 +9,7 @@
 	// Default research tech, prevents bricking
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "desttagger", "handlabel", "packagewrap",
 	"destructive_analyzer", "circuit_imprinter", "rack_creator", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand", "ticket_machine", "ticket_remote", "light_tube", "light_bulb",
-	"space_heater", "beaker", "large_beaker", "vial", "large_vial", "bucket", "fork", "tray","plate", "bowl", "mixing_bowl", "drinking_glass", "shot_glass", "shaker", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_38", "ntusp_conversion", "apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "blastdoorcontroller", "aac_electronics", "mousetrap",
+	"space_heater", "beaker", "large_beaker", "vial", "large_vial", "bucket", "fork", "tray","plate", "bowl", "mixing_bowl", "drinking_glass", "shot_glass", "shaker", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_38", "apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "blastdoorcontroller", "aac_electronics", "mousetrap",
 	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","wallframe/flasher", "rsf", "oven_tray", "bounced_radio", "signaler", "intercom_frame", "infrared_emitter", "health_sensor", "timer", "voice_analyser", "camera_assembly", "newscaster_frame", "prox_sensor", "flashlight", "extinguisher", "pocketfireextinguisher")
 
 /datum/techweb_node/mmi
@@ -669,8 +669,16 @@
 	id = "electronic_weapons"
 	display_name = "Electric Weapons"
 	description = "Weapons using electric technology"
-	prereq_ids = list("weaponry", "adv_power"  , "emp_basic")
+	prereq_ids = list("weaponry", "adv_power", "emp_basic")
 	design_ids = list("stunrevolver", "ioncarbine")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
+/datum/techweb_node/hardlight_weapons
+	id = "hardlight weapons"
+	display_name = "Hardlight Weaponry"
+	description = "Weaponized forcefields!"
+	prereq_ids = list("weaponry", "emp_super")
+	design_ids = list("hardlightbow", "ntusp_conversion")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/radioactive_weapons
@@ -1059,7 +1067,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "hardlightbow", "donksofttoyvendor", "donksoft_refill")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "donksofttoyvendor", "donksoft_refill")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	hidden = TRUE
 

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -411,6 +411,10 @@
 	ui_x = -736
 	ui_y = -416
 
+/datum/techweb_node/hardlight_weapons
+	ui_x = -672
+	ui_y = -352
+
 /datum/techweb_node/gygax
 	ui_x = -672
 	ui_y = -160

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -599,7 +599,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Hardlight Bow"
 	desc = "A modern bow that can fabricate hardlight arrows, designed for silent takedowns of targets."
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
-	cost = 8
+	cost = 6
 	surplus = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
# Document the changes in your pull request
rn the hardlight bow are very underwhelming because you spend a lot of ressources for them (illegal tech for sec one, 8 TC for syndie one) and it's just a kinda mid weapon even if pretty cool.

I could powercreep them but I prefer adjusting the prices instead, less chances to break the balance.

For the sec hardlight bow I'm taking it out of illegal tech and instead put it in a new node called hardlight weaponry that need basic weapon tech and T4 microlaser tech. I put the nt usp conversion kit along in it so it doesn't feel lonely and also because it doesn't feel right for sec to be able to make laser sidegrades with their disablers at roundstart (realistically it'll get researched fairly fast since it only need basic weapon tech instead of advanced one).

For the syndicate hardlight bow the cost in the uplink go from 8 TC to 6 like the other small guns that traitors get.

# Wiki Documentation

syndicate hardlight bow is now 6 TC

Hardlight weaponry tech node:
cost 2500 points
unlock security hardlight bow and nt usp conversion kit
require basic weapon tech and quantum electromagnetic technology

# Changelog

:cl:  
rscadd: Added hardlight weaponry tech node unlocking the sec hardlight bow and nt usp conversion kit
tweak: syndicate hardlight bow cost 6 TC from 8 previously
/:cl:
