### PR TITLE
[ADMIN] admin logs to stuff that should have it

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1031,6 +1031,8 @@
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
 		// Check the new name against the chat filter. If it triggers the IC chat filter, give an option to confirm.
 		if(newname)
+			log_admin("[key_name(usr)] renamed [src] to [newname].")
+			message_admins("Admin [key_name_admin(usr)] renamed [ADMIN_FLW(src)] to [newname].")
 			vv_auto_rename(newname)
 
 /atom/proc/vv_auto_rename(newname)

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -80,6 +80,8 @@
 			names += V
 	sleep(0.1 SECONDS)//For some reason, without this sleep, VVing will cause client to disconnect on certain objects.
 
+	log_admin("[key_name(usr)] viewed the variables of [D].")
+
 	var/list/variable_html = list()
 	if (islist)
 		var/list/L = D


### PR DESCRIPTION
# Document the changes in your pull request

Added an admin log to viewing variables, which is weird that there wasn't one

Added a `message admins` & admin log to renaming something via view variables panel, which is weird that there wasn't one