### PR TITLE
slugs have even more damage falloff and overall shotgun pellet reworks

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -11,7 +11,7 @@
 	desc = "A .357 Ironfeather shell that contains six pellets."
 	projectile_type = /obj/item/projectile/bullet/pellet/a357_ironfeather
 	pellets = 6
-	variance = 25 //Same spread and pellets as buckshot
+	variance = 20 //Same spread and pellets as buckshot
 
 /obj/item/ammo_casing/a357/nutcracker
 	name = ".357 Nutcracker bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -33,7 +33,7 @@
 	icon_state = "ishell2"
 	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	pellets = 5
-	variance = 35
+	variance = 30
 
 /obj/item/ammo_casing/shotgun/stunslug
 	name = "taser slug"
@@ -68,7 +68,7 @@
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
-	variance = 25
+	variance = 20
 
 /obj/item/ammo_casing/shotgun/buckshot/syndie
 	name = "syndicate buckshot shell"
@@ -82,7 +82,7 @@
 	icon_state = "flshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_flechette
 	pellets = 6
-	variance = 15
+	variance = 10
 
 /obj/item/ammo_casing/shotgun/clownshot
 	name = "buckshot shell..?"
@@ -90,7 +90,7 @@
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_clownshot
 	pellets = 20
-	variance = 40
+	variance = 35
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -98,7 +98,7 @@
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
-	variance = 25
+	variance = 20
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/improvised
@@ -108,7 +108,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_improvised
 	materials = list(/datum/material/iron=250)
 	pellets = 10
-	variance = 25
+	variance = 20
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
@@ -117,7 +117,7 @@
 	icon_state = "ionshell"
 	projectile_type = /obj/item/projectile/ion/weak
 	pellets = 4
-	variance = 35
+	variance = 30
 
 /obj/item/ammo_casing/shotgun/laserbuckshot
 	name = "laser buckshot"
@@ -125,7 +125,7 @@
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/laser/buckshot
 	pellets = 5
-	variance = 35
+	variance = 30
 
 /obj/item/ammo_casing/shotgun/uraniumpenetrator
 	name = "depleted uranium slug"
@@ -141,7 +141,7 @@
 	icon_state = "fshell" 
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_cryoshot
 	pellets = 4
-	variance = 35
+	variance = 30
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
@@ -206,5 +206,5 @@
 	desc = "An advanced shotgun shell that uses stored electrical energy to discharge a massive shock on impact, arcing to nearby targets."
 	icon_state = "Thshell"
 	pellets = 3
-	variance = 30
+	variance = 25
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_thundershot

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -163,6 +163,8 @@
 		damage -= tile_dropoff
 	if(stamina > 0)
 		stamina -= tile_dropoff_s
+	if(damage < 0 && stamina < 0)
+		qdel(src)
 
 // Mech Scattershot
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,9 +1,9 @@
 /obj/item/projectile/bullet/shotgun/slug
 	name = "12g shotgun slug"
 	speed = 0.5 //Shotgun = slower
-	var/tile_dropoff = 2
-	var/tile_dropoff_s = 1.5
-	damage = 46 //About 2/3's the damage of buckshot but doesn't suffer from damage falloff, negative AP, or spread
+	var/tile_dropoff = 3
+	var/tile_dropoff_s = 2.25
+	damage = 46 //About 2/3's the damage of buckshot but doesn't suffer from spread or negative AP
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
 
@@ -70,7 +70,7 @@
 /obj/item/projectile/bullet/shotgun/slug/uranium
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
-	damage = 26
+	damage = 35 //Most certainly to drop below 3-shot threshold because of damage falloff
 	armour_penetration = 60 // he he funny round go through armor
 	wound_bonus = -40
 	penetrating = TRUE //Goes through an infinite number of mobs
@@ -81,8 +81,6 @@
 		damage -= tile_dropoff
 	if(stamina > 0)
 		stamina -= tile_dropoff_s
-	if(damage < 0 && stamina < 0)
-		qdel(src)
 
 /obj/item/projectile/bullet/pellet
 	speed = 0.5 //Shotgun = slower
@@ -92,14 +90,14 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12 //Total of 72 (big)
+	damage = 11 //Total of 66
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 	
 /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
 	name = "syndicate buckshot pellet"
-	damage = 15.5 //3.5 more damage so it sucks less?
+	damage = 14.5 //3.5 more damage so it sucks less?
 	wound_bonus = 2
 	bare_wound_bonus = 2
 	wound_falloff_tile = -2.5
@@ -107,7 +105,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_flechette
 	name = "flechette pellet"
 	speed = 0.4 //You're special
-	damage = 13
+	damage = 12
 	wound_bonus = 4
 	bare_wound_bonus = 4
 	armour_penetration = 40 //You're the exception of pellets not sucking against armor because ??
@@ -122,7 +120,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 14.5 //Total of 87 (very big)
+	stamina = 13 //Total of 78 with less falloff (very big)
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/shotgun_cryoshot
@@ -142,11 +140,7 @@
 	damage = 6
 	wound_bonus = 0
 	bare_wound_bonus = 7.5
-	tile_dropoff = 0.35	//Will likely disappear anyway befoer this really matters
-
-/obj/item/projectile/bullet/pellet/shotgun_improvised/Initialize()
-	. = ..()
-	range = rand(1, 8)
+	tile_dropoff = 0.35
 
 /obj/item/projectile/bullet/pellet/shotgun_improvised/on_range()
 	do_sparks(1, TRUE, src)
@@ -169,8 +163,6 @@
 		damage -= tile_dropoff
 	if(stamina > 0)
 		stamina -= tile_dropoff_s
-	if(damage < 0 && stamina < 0)
-		qdel(src)
 
 // Mech Scattershot
 


### PR DESCRIPTION
# Document the changes in your pull request

hm i wonder why buckshot was where it was before

makes shotguns less obnoxious damage-wise considering they're the most lethal weapon in sec's arsenal yes i understand this "nerfs" cargo antags and the gimmick of stealing armory however have you also considered using antag gear or a mosin or a wt (you're next bucko) or a "good enough" laser gun or a bow (I'll be making them not shit soon™)

ADDENDUM: Pellets are now more accurate (not by a MASSIVE margin) because the idea is to make them not just a club of a melee weapon and they should still be effective in close quarters. So! If you're more accurate, you hit more! AKA they work a lil more like they do in real life (but not by much!)

also slugs have more falloff of both damage types now and now slugs won't qdel themselves if they go out of range bcuz uh that might unintentionally slap some slug types that go kaboom or zappy or whatever the hell

# Wiki Documentation

DU slug does 35 instead of 25 damage now
Buckshot does 11 per pellet instead of 12 for a total of 66 instead of 72
ILLEGAL buckshot does 14.5 instead of 15.5 for a total of 87 instead of 93
Flechette does 12 instead of 13 now for a total of 72 instead of 78
Rubbershot does 3/13 instead of 3/14.5 for a total of 18/78 instead of 18/87
Improv pellets no longer have random range

# Changelog

:cl:  
tweak: Pellet damage nerfed across the board, mostly
tweak: Pellets are more tightly clumped in every pellet-based shell
tweak: Improv pellets now don't have a random range because why printing buckshot is so easy
tweak: Slugs have more damage falloff but they don't delete themselves if they don't have damage
tweak: DU slug damage from 25 to 35
/:cl:
