### PR TITLE
makes wt less stupid

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -709,11 +709,11 @@
 	cost = 3500
 	contains = list(/obj/item/gun/ballistic/automatic/wt550,
 					/obj/item/gun/ballistic/automatic/wt550)
-	crate_name = "auto rifle crate"
+	crate_name = "autocarbine crate"
 
 /datum/supply_pack/security/armory/wt550ammo
 	name = "Surplus Security Autocarbine Ammo Crate"
-	desc = "Contains four 22-round magazines for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	desc = "Contains four 20-round magazines for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 3000
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
@@ -721,8 +721,8 @@
 					/obj/item/ammo_box/magazine/wt550m9)
 
 /datum/supply_pack/security/armory/wt550ammo_rubber
-	name = "Surplus Security Autocarbine Ammo Crate"
-	desc = "Contains four 22-round less-than-lethal magazines for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	name = "Surplus Security Autocarbine Less-Lethal Ammo Crate"
+	desc = "Contains four 20-round less-than-lethal magazines for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 2500
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtr,
 					/obj/item/ammo_box/magazine/wt550m9/wtr,
@@ -731,7 +731,7 @@
 
 /datum/supply_pack/security/armory/wt550ammo_single
 	name = "Surplus Security Autocarbine Ammo Crate Single-Pack"
-	desc = "Contains a 22-round magazine for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	desc = "Contains a 20-round magazine for the surplus security autocarbine. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = 750 //one of the few single-pack items that who's price per unit is the exact same as the bulk
 	contains = list(/obj/item/ammo_box/magazine/wt550m9)
 	small_item = TRUE

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -2,40 +2,39 @@
 
 /obj/item/ammo_box/magazine/wt550m9
 	name = "\improper WT-550 magazine (4.6x30mm)"
-	desc = "A 22-round 4.6x30mm magazine, designed for the WT-550 Carbine. \
-			4.6x30mm rounds have inherent armor-penetrating capabilities."
+	desc = "A 20-round 4.6x30mm magazine, designed for the WT-550 Carbine."
 	icon_state = "46x30mmt-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm
 	caliber = "4.6x30mm"
-	max_ammo = 22
+	max_ammo = 20
 
 /obj/item/ammo_box/magazine/wt550m9/update_icon()
 	..()
 	switch(ammo_count())
-		if(19 to 22)
+		if(17 to 21) //Considers the extra bullet in the chamber
 			icon_state = "46x30mmt[sprite_designation]-20"
-		if(15 to 18)
+		if(13 to 16)
 			icon_state = "46x30mmt[sprite_designation]-16"
-		if(11 to 14)
+		if(9 to 12)
 			icon_state = "46x30mmt[sprite_designation]-12"
-		if(7 to 10)
+		if(5 to 8)
 			icon_state = "46x30mmt[sprite_designation]-8"
-		if(3 to 6)
+		if(1 to 4)
 			icon_state = "46x30mmt[sprite_designation]-4"
 		else
 			icon_state = "46x30mmt[sprite_designation]-0"
 
 /obj/item/ammo_box/magazine/wt550m9/wtap
 	name = "\improper WT-550 magazine (Armor-Piercing 4.6x30mm)"
-	desc = "A 22-round AP 4.6x30mm magazine, designed for the WT-550 Carbine. \
-			These rounds trade damage for even more armor-piercing capability."
+	desc = "A 20-round AP 4.6x30mm magazine, designed for the WT-550 Carbine. \
+			These rounds trade damage for armor-piercing capability."
 	icon_state = "46x30mmtA-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/ap
 	sprite_designation = "A"
 
 /obj/item/ammo_box/magazine/wt550m9/wtic
 	name = "\improper WT-550 magazine (Incendiary 4.6x30mm)"
-	desc = "A 22-round Incendiary 4.6x30mm magazine, designed for the WT-550 Carbine. \
+	desc = "A 20-round Incendiary 4.6x30mm magazine, designed for the WT-550 Carbine. \
 			These rounds trade damage for ignition of targets."
 	icon_state = "46x30mmtI-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/inc
@@ -43,7 +42,7 @@
 
 /obj/item/ammo_box/magazine/wt550m9/wtr
 	name = "\improper WT-550 magazine (Rubber Rounds 4.6x30mm)"
-	desc = "A 22-round 4.6x30mm magazine, designed for the WT-550 Carbine. \
+	desc = "A 20-round 4.6x30mm magazine, designed for the WT-550 Carbine. \
 			These rounds possess minimal lethality but deal high stamina damage to targets."
 	icon_state = "46x30mmtR-20"
 	ammo_type = /obj/item/ammo_casing/c46x30mm/rubber

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -92,6 +92,7 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	burst_size = 2
+	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 	can_suppress = FALSE
 	can_bayonet = TRUE

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -35,20 +35,18 @@
 	damage = 15
 	wound_bonus = -5
 	bare_wound_bonus = 5
-	armour_penetration = 20
 
 /obj/item/projectile/bullet/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet"
 	damage = 12
-	armour_penetration = 50
+	armour_penetration = 40
 
 /obj/item/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
 	damage = 9
 	fire_stacks = 1
-	armour_penetration = 20 //Doesn't inherit it normally
 
 /obj/item/projectile/bullet/c46x30mm/rubber
 	name = "4.6x30mm rubber bullet"
 	damage = 5
-	stamina = 22 //slightly more effective than the detective's revolver when fired in bursts, plus AP
+	stamina = 22

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -325,7 +325,7 @@
 
 /datum/design/mag_oldsmg
 	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
-	desc = "A 22 round magazine for the out of date security WT-550 Auto Carbine."
+	desc = "A 20-round magazine for the out of date security WT-550 Auto Carbine."
 	id = "mag_oldsmg"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000)
@@ -335,7 +335,7 @@
 
 /datum/design/mag_oldsmg/ap_mag
 	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
-	desc = "A 22 round armour piercing magazine for the out of date security WT-550 Auto Carbine."
+	desc = "A 20-round armour piercing magazine for the out of date security WT-550 Auto Carbine."
 	id = "mag_oldsmg_ap"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
@@ -343,7 +343,7 @@
 
 /datum/design/mag_oldsmg/ic_mag
 	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
-	desc = "A 22 round armour piercing magazine for the out of date security WT-550 Auto Carbine."
+	desc = "A 20-round incendiary magazine for the out of date security WT-550 Auto Carbine."
 	id = "mag_oldsmg_ic"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
@@ -351,7 +351,7 @@
 
 /datum/design/mag_oldsmg/rubber_mag
 	name = "WT-550 Auto Gun Rubber Bullet Magazine (4.6x30mm Rubber)"
-	desc = "A 22 round rubber bullet magazine for the out of date security WT-550 Auto Carbine."
+	desc = "A 20-round rubber bullet magazine for the out of date security WT-550 Auto Carbine."
 	id = "mag_oldsmg_rubber"
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtr

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2786,26 +2786,26 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/nt/ammo/wt
 	name = "4.6x30mm Magazine"
-	desc = "An additional 22-round 4.6x30mm magazine; suitable for use with the WT-550."
+	desc = "An additional 20-round 4.6x30mm magazine; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9
 	cost = 2
 	required_ert_uplink = null
 
 /datum/uplink_item/nt/ammo/wt/ap
 	name = "4.6x30mm AP Magazine"
-	desc = "An additional 22-round 4.6x30mm magazine loaded with armor-piercing rounds; suitable for use with the WT-550."
+	desc = "An additional 20-round 4.6x30mm magazine loaded with armor-piercing rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtap
 	cost = 4
 
 /datum/uplink_item/nt/ammo/wt/ic
 	name = "4.6x30mm Incendiary Magazine"
-	desc = "An additional 22-round 4.6x30mm magazine loaded with incendiary rounds; suitable for use with the WT-550."
+	desc = "An additional 20-round 4.6x30mm magazine loaded with incendiary rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtic
 	cost = 4
 
 /datum/uplink_item/nt/ammo/wt/r
 	name = "4.6x30mm Rubber Shot Magazine"
-	desc = "An additional 22-round 4.6x30mm magazine loaded with less-lethal rounds; suitable for use with the WT-550."
+	desc = "An additional 20-round 4.6x30mm magazine loaded with less-lethal rounds; suitable for use with the WT-550."
 	item = /obj/item/ammo_box/magazine/wt550m9/wtr
 	cost = 1
 


### PR DESCRIPTION
# Document the changes in your pull request

It's very easy to carry the ammo for it and it's way too easy to stuff into your bag for something that's vastly competitive don't even try to go "b-b-but shotguns are so much better" yes shotguns will kill things faster at closer range but they also take much longer to load, they don't fire as many projectiles, they have damage falloff, and their ammo is a lot harder to store and print off (also they're more expensive)

Also kills AP from the base bullet because it was obnoxious, get AP magazines if you want AP, speaking of which the AP of that AP has been lowered from 50 to 40, so you need like one or two (probably more) bullets to kill a nukie with AP rounds, have fun

why use this when you can buy a mosin? the mosin fires slower, has less ammo (meaning ammo storage is less efficient!) and doesn't have the alternative ammunition available for crew (tbh BOTH are good it's just you don't get to have both now if you want to lug around an armory in your backpack [illegal])

# Wiki Documentation

All WT magazines are 20 rounds again instead of 22 rounds (techweb? Security Items, Guide to Combat, cargo crates)
WT now lacks innate AP and is bulky (Guide to Combat, maybe Security Items)
WT ammo crate with less lethals is now properly named as such (cargo crates)

# Changelog

:cl:  
tweak: WT autocarbine has 20-round magazines again and is bulky
tweak: WT bullets no longer have innate AP, AP of the AP bullet reduced slightly
/:cl:
