### PR TITLE
makes hardlight bow recharge rates reasonable + makes their arrows even better

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -160,7 +160,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/energy
 	no_pin_required = FALSE
 	draw_slowdown = 0
-	var/recharge_time = 1.5 SECONDS
+	var/recharge_time = 1 SECONDS
 
 /obj/item/gun/ballistic/bow/energy/update_icon()
 	cut_overlay(arrow_overlay, TRUE)
@@ -265,7 +265,6 @@
 	icon_state = "bow_syndicate"
 	item_state = "bow_syndicate"
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/energy/syndicate
-	recharge_time = 2 SECONDS
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 5

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -183,4 +183,5 @@
 /obj/item/projectile/energy/arrow/clockbolt
 	name = "redlight bolt"
 	damage = 18
+	wound_bonus = 5
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/clockbolt

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -147,8 +147,7 @@
 /obj/item/projectile/energy/arrow //Hardlight projectile. Significantly more robust than a standard laser. Capable of hardening in target's flesh
 	name = "energy bolt"
 	icon_state = "arrow_energy"
-	damage = 32
-	damage_type = BURN
+	damage = 40
 	speed = 0.6
 	var/embed_chance = 0.4
 	var/obj/item/embed_type = /obj/item/ammo_casing/caseless/arrow/energy
@@ -165,7 +164,7 @@
 	name = "disabler bolt"
 	icon_state = "arrow_disable"
 	light_color = LIGHT_COLOR_BLUE
-	damage = 48
+	damage = 50
 	damage_type = STAMINA
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/disabler
 
@@ -173,8 +172,8 @@
 	name = "X-ray bolt"
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
-	damage = 21
-	irradiate = 400
+	damage = 30
+	irradiate = 500
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/xray

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -148,6 +148,7 @@
 	name = "energy bolt"
 	icon_state = "arrow_energy"
 	damage = 40
+	wound_bonus = -60
 	speed = 0.6
 	var/embed_chance = 0.4
 	var/obj/item/embed_type = /obj/item/ammo_casing/caseless/arrow/energy
@@ -173,6 +174,7 @@
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
 	damage = 30
+	wound_bonus = -30
 	irradiate = 500
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF


### PR DESCRIPTION
# Document the changes in your pull request

I came here expecting to reduce the recharge a little of the bows and buff up the projectiles and discovered the Syndicate bow has a recharge of TWO WHOLE SECONDS so I just kinda halved that and made the universal charge time one second, because it was obnoxious

this is technically a clockie buff too because they get to fire their arrows more often

Buffs up all the arrows too damage-wise (EXCEPT RATVAR) (it's probably a mistake) because I would rather overtweak them then run it back with how much of a meme of a weapon it is right now so we'll see? Burn and x-ray got negative wound_bonuses because NONE of the arrows have any wound stuff so uh yeah. HOWEVER, Ratvar arrows got a +5 wound bonus because it was pretty low and I have decided that I hate people today

# Wiki Documentation

Burn arrow now does 40 burn instead of 32
Stamina arrow now does 50 instead of 48
X-ray arrow now does 30/500 for burn/irradiate instead of 21/400

# Changelog

:cl:  
tweak: All energy bows have had their recharge_time reduced to 1 from 1.5. For the syndicate bow it is going from TWO to ONE (HALF the time) because it had a TWO SECOND RECHARGE
tweak: All arrows (except ratvar!!) do even MORE damage (x-ray has MORE irradiate)
tweak: Burn and x-ray arrows now have negative wound chance, ratvar arrow had a very slight wound chance increase
/:cl:
