### PR TITLE
Fixes runtime when firing suppressed weapons without suppressors

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -198,9 +198,9 @@
 	if(recoil > 0)
 		shake_camera(user, recoil + 1, recoil)
 
-	if(istype(suppressed))
+	if(suppressed)
 		playsound(user, suppressed_sound, suppressed_volume, vary_fire_sound)
-		if(suppressed.break_chance && prob(suppressed.break_chance))
+		if(istype(suppressed) && suppressed.break_chance && prob(suppressed.break_chance))
 			to_chat(user, span_warning("\the [suppressed] falls apart!"))
 			w_class -= suppressed.w_class
 			qdel(suppressed)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -198,7 +198,7 @@
 	if(recoil > 0)
 		shake_camera(user, recoil + 1, recoil)
 
-	if(suppressed)
+	if(istype(suppressed))
 		playsound(user, suppressed_sound, suppressed_volume, vary_fire_sound)
 		if(suppressed.break_chance && prob(suppressed.break_chance))
 			to_chat(user, span_warning("\the [suppressed] falls apart!"))


### PR DESCRIPTION
# Document the changes in your pull request

I think this works

:cl:  
bugfix: fixes runtime when firing a gun that is suppressed, but doesn't have a suppressor attached. Probably no visible changes
/:cl:
