### PR TITLE
Reduces touch of death cooldown and makes it deal up to 200 brute damage

### DIFF
--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -226,5 +226,6 @@
 		qdel(suit)
 		new /obj/effect/decal/cleanable/molten_object(M.loc)
 		return ..()
+	M.adjustBruteLoss(max(200-(M.getOxyLoss() + M.getToxLoss() + M.getBruteLoss() + M.getFireLoss()),0))		
 	M.death(FALSE)
 	return ..()	//yogs end

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -117,8 +117,8 @@
 	hand_path = /obj/item/melee/touch_attack/touchofdeath
 
 	school = "evocation"
-	charge_max = 600
+	charge_max = 400
 	clothes_req = TRUE
-	cooldown_min = 200 //100 deciseconds reduction per rank
+	cooldown_min = 200 //50 deciseconds reduction per rank
 
 	action_icon_state = "touchofdeath"	//yogs end


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the cooldown of touch of death and causes it to deal up to 200 brute damage to prevent easy defibs.

# Wiki Documentation

Touch of death cooldown is now 40/35/30/25/20

# Changelog

:cl:  
tweak: Touch of death cooldowns are now 40/35/30/25/20 (20 second reduction from before) and now deals up to 200 brute damage (on top of killing it's victim).
/:cl:
