### PR TITLE
Objectives in stat panel + show completion

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -822,7 +822,7 @@
 /mob/proc/get_status_tab_items()
 	. = list()
 	var/list/objectives = mind?.get_all_objectives()
-	if(LAZYLEN(objectives) > 0)
+	if(LAZYLEN(objectives))
 		var/obj_count = 1
 		. += "<B>Objectives:</B>"
 		for(var/datum/objective/objective in mind?.get_all_objectives())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -821,7 +821,12 @@
 /// Adds this list to the output to the stat browser
 /mob/proc/get_status_tab_items()
 	. = list()
-
+	var/list/objectives = mind?.get_all_objectives()
+	if(LAZYLEN(objectives) > 0)
+		var/obj_count = 1
+		for(var/datum/objective/objective in mind?.get_all_objectives())
+			. += "<B>[obj_count]</B>: <font color=[objective.check_completion() ? "green" : "red"]>[objective.explanation_text][objective.check_completion() ? " (COMPLETED)" : ""]</font>"
+			obj_count++
 
 /mob/proc/get_proc_holders()
 	. = list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -824,6 +824,7 @@
 	var/list/objectives = mind?.get_all_objectives()
 	if(LAZYLEN(objectives) > 0)
 		var/obj_count = 1
+		. += "<B>Objectives:</B>"
 		for(var/datum/objective/objective in mind?.get_all_objectives())
 			. += "<B>[obj_count]</B>: <font color=[objective.check_completion() ? "green" : "red"]>[objective.explanation_text][objective.check_completion() ? " (COMPLETED)" : ""]</font>"
 			obj_count++


### PR DESCRIPTION
# Document the changes in your pull request

Relying on note memory bad

Auto updating objectives panel good

Gets marked with green and (COMPLETED) when complete

![](https://i.imgur.com/V7hJYCU.png)

# Changelog

:cl: 
rscadd: Added objective view in status panel
experimental: The syndicate now notifies its agents whether their objectives have been completed to satisfaction
/:cl:
