### PR TITLE
aggressive grabs are significantly worse for the game

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -965,7 +965,9 @@
 
 //src is the user that will be carrying, target is the mob to be carried
 /mob/living/carbon/human/proc/can_piggyback(mob/living/carbon/target)
-	return (istype(target) && target.stat == CONSCIOUS)
+	if (istype(target) && target.stat == CONSCIOUS && src.a_intent == INTENT_HELP)
+		return TRUE
+	return FALSE
 
 /mob/living/carbon/human/proc/can_be_firemanned(mob/living/carbon/target)
 	return (ishuman(target) && !(target.mobility_flags & MOBILITY_STAND))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1481,6 +1481,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 
 /datum/species/proc/grab(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	var/datum/martial_art/M = target.check_block()
+	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
+		return FALSE
 	if(M)
 		M.handle_counter(target, user)
 		return FALSE
@@ -1580,6 +1582,8 @@ GLOBAL_LIST_EMPTY(mentor_races)
 	if(user == target)
 		return FALSE
 	if(user.loc == target.loc)
+		return FALSE
+	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
 		return FALSE
 	else
 		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)


### PR DESCRIPTION
fun fact there is a good reason why you couldn't shove or grab while aggressive grabbed, and the change made it more or less impossible to upgrade grab levels since you could just be shove-spammed

this change doesn't make it impossible to use items while grabbed, however you must now actually put in effort to escape grabs.

:cl:  
bugfix: you can no longer spidermonkey people to escape grabs
tweak: you can't grab while aggro grabbed
tweak: you can't shove while aggro grabbed
/:cl:
