### PR TITLE
Fixes some mech punch weirdness

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -391,7 +391,7 @@
 			var/dmg = rand(M.force/2, M.force)
 			switch(M.damtype)
 				if(BRUTE)
-					if(M.force > 20)
+					if(M.force >= 20)
 						Knockdown(1.5 SECONDS)//the victim could get up before getting hit again
 						var/throwtarget = get_edge_target_turf(M, get_dir(M, get_step_away(src, M)))
 						src.throw_at(throwtarget, 5, 2, src)//one tile further than mushroom punch/psycho brawling

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -108,12 +108,12 @@
 	else if(M.occupant.a_intent == INTENT_HARM)
 		last_damage = "grand blunt trauma"
 		M.do_attack_animation(src)
-		if(M.damtype == "brute")
-			var/throwtarget = get_edge_target_turf(M, get_dir(M, get_step_away(src, M)))
-			src.throw_at(throwtarget, 5, 2, src)//one tile further than mushroom punch/psycho brawling
 		switch(M.damtype)
 			if(BRUTE)
-				Unconscious(20)
+				if(M.force >= 20)
+					Unconscious(20)
+					var/throwtarget = get_edge_target_turf(M, get_dir(M, get_step_away(src, M)))
+					src.throw_at(throwtarget, 5, 2, src)//one tile further than mushroom punch/psycho brawling
 				take_overall_damage(rand(M.force/2, M.force))
 				playsound(src, 'sound/weapons/punch4.ogg', 50, 1)
 			if(BURN)


### PR DESCRIPTION
This pr does two things:
1: technically buffs mech punches to throw + knockdown if the mech has 20 force rather than greater than 20 force (enabling rocket fist + non-combat mech shenanigans for tator robos)
2: makes standard mech punches respect the low damage no-throw/knockout limitation, so odysseuses an ripleys and stuff shouldn't hard stun borgs now


# Changelog

:cl:  

tweak: Reduces mech knockdown threshold on punches to 20 (from 21)
bugfix: Low damage mech punches no longer stun and throw silicons and other non-human mobs
/:cl:
