### PR TITLE
Increase wizard playercount from 27 to 34 so its not syndicate station 2 (the second one)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -191,7 +191,7 @@
 	cost = 20
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
 	var/list/roundstart_wizards = list()
-	minimum_players = 27
+	minimum_players = 34
 
 /datum/dynamic_ruleset/roundstart/wizard/acceptable(population=0, threat=0)
 	if(GLOB.wizardstart.len == 0)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -8,7 +8,7 @@
 	report_type = "wizard"
 	antag_flag = ROLE_WIZARD
 	false_report_weight = 10
-	required_players = 27
+	required_players = 37
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -8,7 +8,7 @@
 	report_type = "wizard"
 	antag_flag = ROLE_WIZARD
 	false_report_weight = 10
-	required_players = 37
+	required_players = 34
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 14


### PR DESCRIPTION
# Document the changes in your pull request

Dont we have some "people who arent readied still count as half a person" thing to let fun antags roll on lower pop counts but wizard kind of needs that higher pop to not be boring 9more people to kill and etc)


:cl:  
tweak: wizard minimum playercount is now 34 from 27
/:cl:
