### PR TITLE
Increase nuke op from 27 to 37 so its not syndicate station 3 (the third one)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -295,7 +295,7 @@
 	flags = HIGH_IMPACT_RULESET
 	antag_cap = list("denominator" = 18, "offset" = 1)
 	var/datum/team/nuclear/nuke_team
-	minimum_players = 30
+	minimum_players = 40
 
 /datum/dynamic_ruleset/roundstart/nuclear/ready(population, forced = FALSE)
 	required_candidates = get_antag_cap(population)
@@ -983,7 +983,7 @@
 	requirements = list(100,100,100,100,100,100,100,100,100,100)
 	antag_cap = list(999,999,999,999,999)
 	minimum_players = 40
-	
+
 /datum/dynamic_ruleset/roundstart/wizard/ragin/bullshit/pre_execute()
 	. = ..()
 	if(.)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,8 +5,8 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
-	required_enemies = 2
+	required_players = 37 // 40 players - 3 players to be the nuke ops = 27 players remaining
+	required_enemies = 3
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,7 +5,7 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 37 // 40 players - 3 players to be the nuke ops = 27 players remaining
+	required_players = 35 // 35 players - 3 players to be the nuke ops = 32 players remaining
 	required_enemies = 3
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE


### PR DESCRIPTION
# Document the changes in your pull request

Increase Nuke Op pop requirements from 30 to 37.
Increases the minimum amount of nuke ops from 2 to 3.

30 players is lowpop, even when you consider adjusted TC + operatives for playercounts. This change was done to compensate for a previous PR that made lobby idlers partially count as players.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  BurgerBB
tweak: Increase Nuke Op pop requirements from 30 to 35.
tweak: Increases the minimum amount of nuke ops from 2 to 3.
/:cl:
