### PR TITLE
adds description to chav gene

### DIFF
--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -168,7 +168,7 @@
 
 /datum/mutation/human/chav
 	name = "Chav"
-	desc = "Unknown"
+	desc = "Causes the user to construct sentences in a more rudimentary manner."
 	quality = MINOR_NEGATIVE
 	text_gain_indication = span_notice("Ye feel like a reet prat like, innit?")
 	text_lose_indication = span_notice("You no longer feel like being rude and sassy.")


### PR DESCRIPTION
changes desc "Unknown." to "Causes the user to construct sentences in a more rudimentary manner." no reason why it should be unknown. no wiki changes

:cl:  Ktlwjec
tweak: Updates the description for chav gene.
/:cl:
