### PR TITLE
Bluespace Locker can now also be a crate

### DIFF
--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(bluespace_locker)
 	// basically any normal-looking locker that isn't a secure one
 	var/list/valid_lockers = typecacheof(typesof(/obj/structure/closet) - typesof(/obj/structure/closet/body_bag)\
 	- typesof(/obj/structure/closet/secure_closet) - typesof(/obj/structure/closet/cabinet)\
-	- typesof(/obj/structure/closet/cardboard) - typesof(/obj/structure/closet/crate)\
+	- typesof(/obj/structure/closet/cardboard)\
 	- typesof(/obj/structure/closet/supplypod) - typesof(/obj/structure/closet/stasis)\
 	- typesof(/obj/structure/closet/abductor) - typesof(/obj/structure/closet/bluespace), only_root_path = TRUE)
 


### PR DESCRIPTION
Bluespace Locker can now also be a crate,

Makes it harder/easier to find the locker, also people have to search crates now, haha.

:cl:  
rscadd: Bluespace Locker can now also be a crate
/:cl:
