### PR TITLE
Removes Cringe Metashield from IPC Martial Arts - Wings are obvious as fuck

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -116,7 +116,7 @@
 	if("wings" in dna.species.mutant_bodyparts)
 		var/badwings = ""
 		if(mind?.martial_art && istype(mind.martial_art, /datum/martial_art/ultra_violence))
-			badwings = "Weaponised "
+			badwings = "Weaponized "
 		. += "[t_He] [t_has] also have a pair of [span_warning(badwings)][(dna.features["wings"])] wings on their back"
 
 	var/appears_dead = 0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -114,10 +114,10 @@
 			. += span_warning("[t_He] [t_is] twitching ever so slightly.")
 
 	if("wings" in dna.species.mutant_bodyparts)
-		var/hacked = ""
+		var/badwings = ""
 		if(mind?.martial_art && istype(mind.martial_art, /datum/martial_art/ultra_violence))
-			hacked = ionnum() + ionnum() + " "
-		. += "[t_He] [t_has] also have a pair of [span_warning(hacked)][(dna.features["wings"])] wings on their back"
+			badwings = "Blood Soaked"
+		. += "[t_He] [t_has] also have a pair of [span_warning(badwings)][(dna.features["wings"])] wings on their back"
 
 	var/appears_dead = 0
 	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -113,6 +113,12 @@
 		if(100 to 200)
 			. += span_warning("[t_He] [t_is] twitching ever so slightly.")
 
+	if("wings" in dna.species.mutant_bodyparts)
+		var/hacked = ""
+		if(mind?.martial_art && istype(mind.martial_art, /datum/martial_art/ultra_violence))
+			hacked = ionnum() + ionnum() + " "
+		. += "[t_He] [t_has] also have a pair of [span_warning(hacked)][(dna.features["wings"])] wings on their back"
+
 	var/appears_dead = 0
 	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
 		appears_dead = 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -116,7 +116,7 @@
 	if("wings" in dna.species.mutant_bodyparts)
 		var/badwings = ""
 		if(mind?.martial_art && istype(mind.martial_art, /datum/martial_art/ultra_violence))
-			badwings = "Blood Soaked"
+			badwings = "Weaponised "
 		. += "[t_He] [t_has] also have a pair of [span_warning(badwings)][(dna.features["wings"])] wings on their back"
 
 	var/appears_dead = 0


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/993128/213927951-e79300d0-ecc6-4c86-94ad-c78ae59843f7.png)

Wings are now on examine and if they are martial arts wings they are obvious via hacked message.

:cl:  
rscadd: Examine on Wings
tweak: IPC Martial Arts is now Obvious
/:cl:
