### PR TITLE
Keybind flipping only punishes you if you spam it (LET ME FLIP!!!)

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -67,7 +67,7 @@
 					span_notice("[flippy_mcgee] attempts to do a flip and falls over, what a doofus!"),
 					span_notice("You attempt to do a flip while still off balance from the last flip and fall down!")
 				)
-				if(prob(50))
+				if(prob(75))
 					flippy_mcgee.adjustBruteLoss(1)
 			else
 				flippy_mcgee.visible_message(

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -54,27 +54,27 @@
 
 /datum/emote/flip/check_cooldown(mob/user, intentional, update=TRUE, is_keybind = FALSE)
 	. = ..()
-	if(!.)
-		return
 	if (!is_keybind)
 		return
 	if(!can_run_emote(user, intentional=intentional))
 		return
-	if(isliving(user))
-		var/mob/living/flippy_mcgee = user
-		if(prob(20))
-			flippy_mcgee.Knockdown(1 SECONDS)
-			flippy_mcgee.visible_message(
-				span_notice("[flippy_mcgee] attempts to do a flip and falls over, what a doofus!"),
-				span_notice("You attempt to do a flip while still off balance from the last flip and fall down!")
-			)
-			if(prob(50))
-				flippy_mcgee.adjustBruteLoss(1)
-		else
-			flippy_mcgee.visible_message(
-				span_notice("[flippy_mcgee] stumbles a bit after their flip."),
-				span_notice("You stumble a bit from still being off balance from your last flip.")
-			)
+	if(!.)
+		if(isliving(user)) // Spammers get punished!
+			var/mob/living/flippy_mcgee = user
+			if(prob(40))
+				flippy_mcgee.Knockdown(1 SECONDS)
+				flippy_mcgee.visible_message(
+					span_notice("[flippy_mcgee] attempts to do a flip and falls over, what a doofus!"),
+					span_notice("You attempt to do a flip while still off balance from the last flip and fall down!")
+				)
+				if(prob(50))
+					flippy_mcgee.adjustBruteLoss(1)
+			else
+				flippy_mcgee.visible_message(
+					span_notice("[flippy_mcgee] stumbles a bit after their flip."),
+					span_notice("You stumble a bit from still being off balance from your last flip.")
+				)
+		return
 
 /datum/emote/spin
 	key = "spin"


### PR DESCRIPTION
# Document the changes in your pull request

Punishment is only considered if you try to flip but it's on cooldown

As exchange you are more likely to fall over and get hurt if you do try to spam it

# Changelog

:cl:  
tweak: Keybind flipping is now only punished if you try to spam it
/:cl:
