### PR TITLE
Security nerf: Mindshield firing pins no longer printable

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -670,6 +670,15 @@
 	for(var/i in 1 to 5)
 		new /obj/item/firing_pin(src)
 
+/obj/item/storage/box/secfiringpins
+	name = "box of mindshield firing pins"
+	desc = "A box full of mindshield firing pins, to allow newly-developed firearms to operate."
+	illustration = "id"
+
+/obj/item/storage/box/secfiringpins/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/firing_pin/implant/mindshield(src)
+
 /obj/item/storage/box/lasertagpins
 	name = "box of laser tag firing pins"
 	desc = "A box full of laser tag firing pins, to allow newly-developed firearms to require wearing brightly coloured plastic armor before being able to be used."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -419,9 +419,8 @@
 
 /datum/supply_pack/security/secfiringpins
 	name = "Mindshield Firing Pins Crate"
-	desc = "Upgrade your arsenal with 10 mindshield firing pins. Requires Armory access to open."
+	desc = "Upgrade your arsenal with 10 mindshield firing pins. Requires Security access to open."
 	cost = 2000
-	access_view = ACCESS_ARMORY // next to firing pins for ease of access
 	contains = list(/obj/item/storage/box/secfiringpins,
 					/obj/item/storage/box/secfiringpins)
 	crate_name = "firing pins crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -413,9 +413,17 @@
 	name = "Standard Firing Pins Crate"
 	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
 	cost = 2000
-	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/storage/box/firingpins,
 					/obj/item/storage/box/firingpins)
+	crate_name = "firing pins crate"
+
+/datum/supply_pack/security/secfiringpins
+	name = "Mindshield Firing Pins Crate"
+	desc = "Upgrade your arsenal with 10 mindshield firing pins. Requires Armory access to open."
+	cost = 2000
+	access_view = ACCESS_ARMORY // next to firing pins for ease of access
+	contains = list(/obj/item/storage/box/secfiringpins,
+					/obj/item/storage/box/secfiringpins)
 	crate_name = "firing pins crate"
 
 /datum/supply_pack/security/justiceinbound

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -420,7 +420,7 @@
 /datum/supply_pack/security/secfiringpins
 	name = "Mindshield Firing Pins Crate"
 	desc = "Upgrade your arsenal with 10 mindshield firing pins. Requires Security access to open."
-	cost = 2000
+	cost = 3000
 	contains = list(/obj/item/storage/box/secfiringpins,
 					/obj/item/storage/box/secfiringpins)
 	crate_name = "firing pins crate"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -99,16 +99,6 @@
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/pin_mindshield
-	name = "Mindshield Firing Pin"
-	desc = "This is a security firing pin which only authorizes users who are mindshield-implanted."
-	id = "pin_loyalty"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/silver = 600, /datum/material/diamond = 600, /datum/material/uranium = 200)
-	build_path = /obj/item/firing_pin/implant/mindshield
-	category = list("Firing Pins")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 /datum/design/stunmine/sec //mines ported from BeeStation
 	name = "Stun Mine"
 	desc = "A basic non-lethal stunning mine. Stuns anyone who walks over it."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -654,7 +654,7 @@
 	display_name = "Advanced Weapon Development Technology"
 	description = "Our weapons are breaking the rules of reality by now."
 	prereq_ids = list("adv_engi", "weaponry")
-	design_ids = list("pin_loyalty", "borg_transform_security", "platingmkii", "platingmkiv", "holo_sight")
+	design_ids = list("borg_transform_security", "platingmkii", "platingmkiv", "holo_sight")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 /datum/techweb_node/advmine


### PR DESCRIPTION
# Document the changes in your pull request

Being able to print firing pins contributes to the printable-gun-crisis

Security must now work with their limited (10) roundstart firing pins, which creates a sense of scarcity and importance, and have to order more from cargo

Promotes security-cargo interaction

# Changelog

:cl:  
tweak: Security can no longer print mindshield firing pins
tweak: Firing pins crate now require security access instead of armory access to open
tweak: Mindshield firing pins are now available at cargo for 3000 credits
/:cl:
