### PR TITLE
Patches an oversight that made venus traps a lot weaker than intended

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -142,10 +142,15 @@
 	
 	var/datum/beam/newVine = Beam(the_target, "vine", time=INFINITY, maxdistance = vine_grab_distance, beam_type=/obj/effect/ebeam/vine)
 	RegisterSignal(newVine, COMSIG_PARENT_QDELETING, .proc/remove_vine, newVine)
+	listclearnulls(vines)
 	vines += newVine
 	if(isliving(the_target))
 		var/mob/living/L = the_target
-		L.Paralyze(20)
+		if(iscarbon(the_target))
+			L.Immobilize(0.25 SECONDS)
+			L.Knockdown(2 SECONDS)
+		else
+			L.Paralyze(2 SECONDS)
 	ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/venus_human_trap/Login()


### PR DESCRIPTION
# Document the changes in your pull request

Venus human traps were intended to be able to fire ranged vines endlessly with a MAXIMUM of 4 being out at a given time

The list never cleared its nulls, so deleted vines lingered and counted against the maximum

Because having infinite ranged stuns is overpowered as shit, the paralyze (against carbons, fuck you simplemobs) was changed to a knockdown and given a 0.25 second immobilize so that the pull mechanic can take place at least minimally

# Changelog

:cl:  
bugfix: fixed venus human traps only being able to fire 4 ranged vines in a lifetime
tweak: venus human trap's ranged vines have been severely nerfed against carbons
/:cl:
