### PR TITLE
Purrbation no longer lops off a section of your spine to make space for a cat tail

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -130,7 +130,8 @@
 		var/obj/item/organ/cattification = new /obj/item/organ/tail/cat()
 		var/old_part = H.getorganslot(ORGAN_SLOT_TAIL)
 		cattification.Insert(H)
-		qdel(old_part)
+		if(istype(old_part, /obj/item/organ/tail/cat))	//Won't delete non-cat tails
+			qdel(old_part)								//No duplicate tails allowed, but different tails can share because it's funny
 		cattification = new /obj/item/organ/ears/cat()
 		old_part = H.getorganslot(ORGAN_SLOT_EARS)
 		cattification.Insert(H)


### PR DESCRIPTION
I'm gonna be real it's very annoying having my tail deleted as a lizard because it messes up the whole appearance of the character in a bad way. This pr causes purrbation to not delete lizard tails but still slaps in the cat tail because it's more acceptable having both tails when you already have one due to spine capacity something something. If you don't want a lizard tail remove the lizard tail.



# Changelog

:cl:  

tweak: Purrbation no longer deletes lizard tails because it's annoying to deal with and not fun

/:cl:
