### PR TITLE
Umbral tendril and light eater now actually eat all lights on a person

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -198,7 +198,7 @@
 			if(borg.lamp_enabled)
 				borg.smash_headlamp()
 		else if(ishuman(AM))
-			for(var/obj/item/O in AM)
+			for(var/obj/item/O in AM.GetAllContents())
 				if(O.light_range && O.light_power)
 					disintegrate(O)
 		if(L.pulling && L.pulling.light_range && isitem(L.pulling))

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -59,7 +59,7 @@
 			var/mob/living/L = target
 			if(isethereal(target))
 				target.emp_act(EMP_LIGHT)
-			for(var/obj/item/O in target)
+			for(var/obj/item/O in target.GetAllContents())
 				if(O.light_range && O.light_power)
 					disintegrate(O)
 				if(L.pulling && L.pulling.light_range && isitem(L.pulling))


### PR DESCRIPTION
# Document the changes in your pull request

Contents of contents were not checked so stuff like seclite in helmet would not be deleted

![](https://thumbs.gfycat.com/DimNastyEnglishpointer-max-1mb.gif)

Such lights get properly deleted now

![](https://thumbs.gfycat.com/DeadShimmeringDeinonychus-max-1mb.gif)

# Changelog

:cl:  
bugfix: fixed umbral tendril and light eater not deleting all lights
/:cl:
