### PR TITLE
Reduces slowdown of worn duffel bag, galoshes, and clown shoes

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -360,7 +360,7 @@
 	desc = "A large duffel bag for holding extra things."
 	icon_state = "duffel"
 	item_state = "duffel"
-	slowdown = 1
+	slowdown = 0.75
 
 /obj/item/storage/backpack/duffelbag/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -360,7 +360,7 @@
 	desc = "A large duffel bag for holding extra things."
 	icon_state = "duffel"
 	item_state = "duffel"
-	slowdown = 0.75
+	slowdown = 0.5
 
 /obj/item/storage/backpack/duffelbag/ComponentInitialize()
 	. = ..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -54,7 +54,7 @@
 	icon_state = "galoshes"
 	permeability_coefficient = 0.01
 	clothing_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.75
 	strip_delay = 50
 	equip_delay_other = 50
 	resistance_flags = NONE
@@ -528,7 +528,7 @@
 	desc = "Standard issue NanoTrasen cloth footwraps, specially made for the frequent glass treader."
 	icon_state = "footwraps_e"
 	item_state = "footwraps_e"
-	xenoshoe = YES_DIGIT 
+	xenoshoe = YES_DIGIT
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/shoes/xeno_wraps/science
@@ -536,7 +536,7 @@
 	desc = "Standard issue NanoTrasen cloth footwraps, to reduce fatigue when standing at a console all day."
 	icon_state = "footwraps_sc"
 	item_state = "footwraps_sc"
-	xenoshoe = YES_DIGIT 
+	xenoshoe = YES_DIGIT
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/shoes/xeno_wraps/medical
@@ -552,7 +552,7 @@
 	desc = "Standard issue NanoTrasen cloth footwraps, with reinforcment to protect against falling crates."
 	icon_state = "footwraps_ca"
 	item_state = "footwraps_ca"
-	xenoshoe = YES_DIGIT 
+	xenoshoe = YES_DIGIT
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/shoes/airshoes
@@ -564,16 +564,16 @@
 	var/airToggle = FALSE
 	var/obj/vehicle/ridden/scooter/airshoes/A
 	permeability_coefficient = 0.05
-	var/recharging_time = 0 
+	var/recharging_time = 0
 	var/jumpdistance = 7 //Increased distance so it might see some offensive use
 	var/jumpspeed = 5 //fast
-	var/recharging_rate = 60 
+	var/recharging_rate = 60
 	syndicate = TRUE
 
 /obj/item/clothing/shoes/airshoes/Initialize()
 	. = ..()
 	A = new/obj/vehicle/ridden/scooter/airshoes(null)
-	
+
 /obj/item/clothing/shoes/airshoes/ui_action_click(mob/user, action)
 	if(!isliving(user))
 		return
@@ -594,7 +594,7 @@
 		if(recharging_time > world.time)
 			to_chat(user, span_warning("The boot's internal propulsion needs to recharge still!"))
 			return
-		
+
 		var/atom/target = get_edge_target_turf(user, user.dir) //gets the user's direction
 		if (user.throw_at(target, jumpdistance, jumpspeed, spin = FALSE, diagonals_first = TRUE))
 			playsound(src, 'sound/effects/stealthoff.ogg', 50, 1, 1)
@@ -628,7 +628,7 @@
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
 	slowdown = -0.2
 
-/obj/item/clothing/shoes/drip/equipped(mob/user, slot,) 
+/obj/item/clothing/shoes/drip/equipped(mob/user, slot,)
 	. = ..()
 	if(slot == SLOT_SHOES)
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "dripjordan", /datum/mood_event/dripjordan)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -76,7 +76,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+0.75
+	slowdown = SHOES_SLOWDOWN+0.5
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes/clown
 	var/datum/component/waddle
 	var/enabled_waddle = TRUE

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -76,7 +76,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.75
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes/clown
 	var/datum/component/waddle
 	var/enabled_waddle = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the movement slowdown coefficient of a worn pair of galoshes from 1 to 0.75

Reduces the movement slowdown coefficient of a worn duffel bag and pair of clown shoes from 1 to 0.5

Apparently the basic hardsuit slowdown coefficient is also 1? I don't feel like it's appropriate to put these 3 things on the same level as an entire hardsuit.

TESTING:
I walked from the doors in engineering hallway to the southern wall. 

slowdown = 1 -- 7.42s
slowdown = 0.75 -- 6.95s
slowdown = 0.5 -- 6.18s
showdown = 0 -- 5.09s

(no this is not exact this is me just trying to push my stopwatch thing on my phone while moving)

I think that half-second feels a whole lot better.

# Changelog

:cl:  
tweak: Reduces slowdown coefficient of galoshes from 1 to 0.75
tweak: Reduces slowdown coefficient of duffel bag and clown shoes from 1 to 0.5
/:cl:
