### PR TITLE
Returns the ebow to its former glory but without stuns

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -96,7 +96,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	weapon_weight = WEAPON_LIGHT
 	obj_flags = 0
-	overheat_time = 20 SECONDS
+	overheat_time = 2 SECONDS
 	holds_charge = TRUE
 	unique_frequency = TRUE
 	can_flashlight = FALSE

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,16 +1,11 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	irradiate = 200
-	pass_flags = PASSGLASS
-
-/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
-	..()
-	if(ishuman(target))
-		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 5)
-		target.reagents.add_reagent(/datum/reagent/toxin/relaxant, 8)
-		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 8)
-		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 4)
+	damage = 15
+	damage_type = TOX
+	eyeblur = 10
+	knockdown = 10
+	slur = 5
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -668,9 +668,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Miniature Energy Crossbow"
 	desc = "A short bow mounted across a tiller in miniature. \
 	Small enough to fit into a pocket or slip into a bag unnoticed. \
-	It will synthesize and fire bolts tipped with some debilitating \
-	toxins that will irradiate and tire, causing them to \
-	be silenced. It can produce an infinite number \
+	It will synthesize and fire bolts tipped with a debilitating \
+	toxin that will damage and disorient targets, causing them to \
+	slur as if inebriated. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
 	cost = 8


### PR DESCRIPTION
# Document the changes in your pull request

20 second cooldown omegalul

Gun that wins every 20 seconds unless you miss is bad design

Sorry Gus

List of restorations:
- Chemicals removed
- 2 second cooldown
- 15 toxin damage
- 10 eye blur stacks
- 5 slur stacks
- 1 second of knockdown
- No longer irradiates
- No longer passes glass

Important:
**No stamina damage, no stuns**
**Still 8TC**
**Large bow still gone**

# Changelog

:cl:  
tweak: Miniature energy crossbow now knocks down and does a small amount of toxin damage instead of injecting chemicals
/:cl:
