### PR TITLE
Darkspawn Duality now double-hits structures & machinery

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1134,6 +1134,9 @@
 		if(!T.darkspawn)
 			return ..()
 		else if(user.a_intent == INTENT_DISARM && density)
+			// we dont want Duality double-hitting the airlock when we're trying to pry it open
+			if(user.get_active_held_item() != C)
+				return
 			if(!locked && !welded)
 				if(!T.darkspawn.has_psi(15))
 					to_chat(user, span_warning("You need at least 15 Psi to force open an airlock!"))

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -69,7 +69,7 @@
 			if(I.light_range && I.light_power)
 				disintegrate(I)
 		// Double hit structures if duality
-		else if(!QDELETED(target) && (isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != src)
+		else if(!QDELETED(target) && (isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() == src)
 			target.attackby(twin, user)
 	switch(user.a_intent) //Note that airlock interactions can be found in airlock.dm.
 		if(INTENT_HELP)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -69,7 +69,7 @@
 			if(I.light_range && I.light_power)
 				disintegrate(I)
 		// Double hit structures if duality
-		else if(!QDELETED(target) && (isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != twin)
+		else if(!QDELETED(target) && (isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != src)
 			target.attackby(twin, user)
 	switch(user.a_intent) //Note that airlock interactions can be found in airlock.dm.
 		if(INTENT_HELP)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -68,6 +68,9 @@
 			var/obj/item/I = target
 			if(I.light_range && I.light_power)
 				disintegrate(I)
+		// Double hit structures if duality
+		else if((isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != twin)
+			target.attackby(twin, user)
 	switch(user.a_intent) //Note that airlock interactions can be found in airlock.dm.
 		if(INTENT_HELP)
 			if(isopenturf(target))

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -69,7 +69,7 @@
 			if(I.light_range && I.light_power)
 				disintegrate(I)
 		// Double hit structures if duality
-		else if((isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != twin)
+		else if(!QDELETED(target) && (isstructure(target) || ismachinery(target)) && twin && user.get_active_held_item() != twin)
 			target.attackby(twin, user)
 	switch(user.a_intent) //Note that airlock interactions can be found in airlock.dm.
 		if(INTENT_HELP)


### PR DESCRIPTION
# Document the changes in your pull request

Useful for stuff like breaking windows or cameras or APCs

Double hits mobs, why not structures too?

# Changelog

:cl:  
tweak: Darkspawn Duality now double-hits structures and machinery aswell
/:cl:
