### PR TITLE
Darkspawn can now open depowered doors instantly and for fri

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1135,6 +1135,9 @@
 			return ..()
 		else if(user.a_intent == INTENT_DISARM && density)
 			if(!locked && !welded)
+				if(!hasPower()) // a crowbar can do this and you're telling me tentacles struggle?
+					open(2)
+					return
 				if(!T.darkspawn.has_psi(15))
 					to_chat(user, span_warning("You need at least 15 Psi to force open an airlock!"))
 					return


### PR DESCRIPTION
# Document the changes in your pull request

It can open powered doors given some time so why wouldn't it be able to open depowered doors with ease?

# Changelog

:cl:  
tweak: Darkspawn can now open depowered doors with umbral tendrils for free and instantly
/:cl:
