### PR TITLE
Various crystallizer tweaks and fixes

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -1,8 +1,5 @@
 ///Global list of recipes for atmospheric machines to use
 GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
-///Defines for the recipes var
-#define ENDOTHERMIC_REACTION "endothermic"
-#define EXOTHERMIC_REACTION "exothermic"
 
 /*
  * Global proc to build the gas recipe global list
@@ -26,8 +23,10 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	///Maximum temperature for the recipe
 	var/max_temp = INFINITY
 	///Type of reaction (either endothermic or exothermic)
-	var/reaction_type = ""
-	///Amount of energy released/consumed by the reaction (always positive)
+	/**
+	 * Amount of thermal energy released/consumed by the reaction.
+	 * Positive numbers make the reaction release energy (exothermic) while negative numbers make the reaction consume energy (endothermic).
+	 */
 	var/energy_release = 0
 	var/dangerous = FALSE
 	///Gas required for the recipe to work
@@ -43,8 +42,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Metallic hydrogen"
 	min_temp = 50000
 	max_temp = 150000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 2500000
+	energy_release = -2500000
 	requirements = list(/datum/gas/hydrogen = 300, /datum/gas/bz = 50)
 	products = list(/obj/item/stack/sheet/mineral/metal_hydrogen = 1)
 
@@ -53,8 +51,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "supermatter extraction tongs"
 	min_temp = 50000
 	max_temp = 150000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 150000
+	energy_release = -150000
 	requirements = list(/datum/gas/hydrogen = 100, /datum/gas/hypernoblium = 5, /datum/gas/bz = 5)
 	products = list(/obj/item/hemostat/supermatter = 1)
 
@@ -63,8 +60,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "supermatter base structure"
 	min_temp = 50000
 	max_temp = 150000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 200000
+	energy_release = -200000
 	requirements = list(/datum/gas/hydrogen = 1000, /datum/gas/bz = 100, /datum/gas/hypernoblium = 10)
 	products = list(/obj/structure/supermatter_base_structure = 1)
 
@@ -73,8 +69,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Healium crystal"
 	min_temp = 200
 	max_temp = 400
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 2000000
+	energy_release = -2000000
 	requirements = list(/datum/gas/healium = 100, /datum/gas/freon = 120, /datum/gas/plasma = 50)
 	products = list(/obj/item/grenade/gas_crystal/healium_crystal = 1)
 
@@ -83,7 +78,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Pluonium crystal"
 	min_temp = 200
 	max_temp = 400
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 1500000
 	requirements = list(/datum/gas/pluonium = 100, /datum/gas/nitrogen = 80, /datum/gas/oxygen = 80)
 	products = list(/obj/item/grenade/gas_crystal/pluonium_crystal = 1)
@@ -93,8 +87,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Hot ice"
 	min_temp = 15
 	max_temp = 35
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 3000000
+	energy_release = -3000000
 	requirements = list(/datum/gas/freon = 60, /datum/gas/plasma = 160, /datum/gas/oxygen = 80)
 	products = list(/obj/item/stack/sheet/hot_ice = 1)
 
@@ -103,7 +96,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Ammonia crystal"
 	min_temp = 200
 	max_temp = 240
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 950000
 	requirements = list(/datum/gas/hydrogen = 50, /datum/gas/nitrogen = 40)
 	products = list(/obj/item/stack/ammonia_crystals = 2)
@@ -113,8 +105,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Tesla generator"
 	min_temp = 8000
 	max_temp = 12000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 350000
+	energy_release = -350000
 	dangerous = TRUE
 	requirements = list(/datum/gas/stimulum = 500, /datum/gas/freon = 500, /datum/gas/nitryl = 800)
 	products = list(/obj/machinery/the_singularitygen/tesla = 1)
@@ -124,8 +115,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Supermatter silver"
 	min_temp = 100000
 	max_temp = 200000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 250000
+	energy_release = -250000
 	dangerous = TRUE
 	requirements = list(/datum/gas/bz = 100, /datum/gas/hypernoblium = 125, /datum/gas/tritium = 250, /datum/gas/plasma = 750)
 	products = list(/obj/item/nuke_core/supermatter_sliver = 1)
@@ -135,7 +125,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Nitrous oxide crystal"
 	min_temp = 50
 	max_temp = 350
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 3500000
 	requirements = list(/datum/gas/nitrous_oxide = 100, /datum/gas/bz = 5)
 	products = list(/obj/item/grenade/gas_crystal/nitrous_oxide_crystal = 1)
@@ -145,8 +134,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Diamond"
 	min_temp = 10000
 	max_temp = 30000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 9500000
+	energy_release = -9500000
 	requirements = list(/datum/gas/carbon_dioxide = 10000)
 	products = list(/obj/item/stack/sheet/mineral/diamond = 1)
 
@@ -155,8 +143,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Uranium"
 	min_temp = 1000
 	max_temp = 5000
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 2500000
+	energy_release = -2500000
 	requirements = list(/datum/gas/tritium = 200, /datum/gas/hypernoblium = 50)
 	products = list(/obj/item/stack/sheet/mineral/uranium = 1)
 
@@ -165,7 +152,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Plasma sheet"
 	min_temp = 10
 	max_temp = 20
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 3500000
 	requirements = list(/datum/gas/plasma = 450)
 	products = list(/obj/item/stack/sheet/mineral/plasma = 1)
@@ -175,8 +161,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Crystal Cell"
 	min_temp = 50
 	max_temp = 90
-	reaction_type = ENDOTHERMIC_REACTION
-	energy_release = 800000
+	energy_release = -800000
 	requirements = list(/datum/gas/plasma = 800, /datum/gas/healium = 100, /datum/gas/bz = 50)
 	products = list(/obj/item/stock_parts/cell/crystal_cell = 1)
 
@@ -185,7 +170,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Zaukerite sheet"
 	min_temp = 5
 	max_temp = 20
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 2900000
 	requirements = list(/datum/gas/hypernoblium = 5, /datum/gas/zauker = 10, /datum/gas/bz = 7.5)
 	products = list(/obj/item/stack/sheet/mineral/zaukerite = 2)
@@ -195,7 +179,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	name = "Hypernoblium Crystal"
 	min_temp = 100000
 	max_temp = 200000
-	reaction_type = EXOTHERMIC_REACTION
 	energy_release = 2800000
 	requirements = list(/datum/gas/bz = 100, /datum/gas/hypernoblium = 100, /datum/gas/oxygen = 1000)
 	products = list(/obj/item/stack/hypernoblium_crystal = 1)

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	var/min_temp = TCMB
 	///Maximum temperature for the recipe
 	var/max_temp = INFINITY
-	///Type of reaction (either endothermic or exothermic)
 	/**
 	 * Amount of thermal energy released/consumed by the reaction.
 	 * Positive numbers make the reaction release energy (exothermic) while negative numbers make the reaction consume energy (endothermic).

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -18,7 +18,7 @@
 	///Base icon state for the machine to be used in update_icon()
 	var/base_icon = "crystallizer"
 	///Internal Gas mix used for processing the gases that have been put in
-	var/datum/gas_mixture/internal = new
+	var/datum/gas_mixture/internal
 	///Var that controls how much gas gets injected in moles/S
 	var/gas_input = 0
 	///Maximum allowed gas input
@@ -31,6 +31,10 @@
 	var/datum/gas_recipe/selected_recipe = null
 	///Stores the total amount of moles needed for the current recipe
 	var/total_recipe_moles = 0
+
+/obj/machinery/atmospherics/components/binary/crystallizer/Initialize()
+	. = ..()
+	internal = new
 
 /obj/machinery/atmospherics/components/binary/crystallizer/attackby(obj/item/I, mob/user, params)
 	if(!on)
@@ -118,18 +122,25 @@
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/inject_gases()
 	var/datum/gas_mixture/contents = airs[2]
 	for(var/gas_type in selected_recipe.requirements)
-		if(contents.get_moles(gas_type))
-			var/datum/gas_mixture/filtered = new
-			filtered.set_temperature(contents.return_temperature())
-			var/filtered_amount = clamp(contents.get_moles(gas_type), gas_input, selected_recipe.requirements - internal.get_moles(gas_type))
-			filtered.set_moles(gas_type, filtered_amount)
-			contents.adjust_moles(gas_type, -filtered_amount)
-			internal.merge(filtered)
+		if (!contents.get_moles(gas_type))
+			continue
+
+		if (internal.get_moles(gas_type) >= selected_recipe.requirements[gas_type] * 2)
+			continue
+
+		var/datum/gas_mixture/filtered = new
+		filtered.set_temperature(contents.return_temperature())
+		var/filtered_amount = min(gas_input, contents.get_moles(gas_type))
+		filtered.set_moles(gas_type, filtered_amount)
+		contents.adjust_moles(gas_type, -filtered_amount)
+		internal.merge(filtered)
 
 ///Checks if the gases required are all inside
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/internal_check()
 	var/gas_check = 0
 	for(var/gas_type in selected_recipe.requirements)
+		if(!internal.get_moles(gas_type))
+			return FALSE
 		if(internal.get_moles(gas_type) >= selected_recipe.requirements[gas_type])
 			gas_check++
 	if(gas_check == selected_recipe.requirements.len)
@@ -138,31 +149,21 @@
 
 ///Calculation for the heat of the various gas mixes and controls the quality of the item
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/heat_calculations()
-	if(selected_recipe.reaction_type == "endothermic")
-		internal.set_temperature(max(internal.return_temperature() - (selected_recipe.energy_release / internal.heat_capacity()), TCMB))
-	else if(selected_recipe.reaction_type == "exothermic")
-		internal.set_temperature(max(internal.return_temperature() + (selected_recipe.energy_release / internal.heat_capacity()), TCMB))
+	var/progress_amount_to_quality = MIN_PROGRESS_AMOUNT * 4.5 / (round(log(10, total_recipe_moles * 0.1), 0.01))
 
-	var/datum/gas_mixture/cooling_port = airs[1]
-	if(cooling_port.total_moles() > MINIMUM_MOLE_COUNT)
-		if(internal.total_moles() > 0)
-			var/coolant_temperature_delta = cooling_port.return_temperature() - internal.return_temperature()
-			var/cooling_heat_capacity = cooling_port.heat_capacity()
-			var/internal_heat_capacity = internal.heat_capacity()
-			var/cooling_heat_amount = HIGH_CONDUCTIVITY_RATIO * coolant_temperature_delta * (cooling_heat_capacity * internal_heat_capacity / (cooling_heat_capacity + internal_heat_capacity))
-			cooling_port.set_temperature(max(cooling_port.return_temperature() - cooling_heat_amount / cooling_heat_capacity, TCMB))
-			internal.set_temperature(max(internal.return_temperature() + cooling_heat_amount / internal_heat_capacity, TCMB))
-		update_parents()
-
-	if(	(internal.return_temperature() >= (selected_recipe.min_temp * MIN_DEVIATION_RATE) && internal.return_temperature() <= selected_recipe.min_temp) || \
+	if((internal.return_temperature() >= (selected_recipe.min_temp * MIN_DEVIATION_RATE) && internal.return_temperature() <= selected_recipe.min_temp) || \
 		(internal.return_temperature() >= selected_recipe.max_temp && internal.return_temperature() <= (selected_recipe.max_temp * MAX_DEVIATION_RATE)))
-		quality_loss = min(quality_loss + 1.5, 100)
+		quality_loss = min(quality_loss + progress_amount_to_quality, 100)
 
-	var/median_temperature = (selected_recipe.max_temp + selected_recipe.min_temp) * 0.5
+	var/median_temperature = (selected_recipe.max_temp + selected_recipe.min_temp) / 2
 	if(internal.return_temperature() >= (median_temperature * MIN_DEVIATION_RATE) && internal.return_temperature() <= (median_temperature * MAX_DEVIATION_RATE))
-		quality_loss = max(quality_loss - 5.5, -100)
+		quality_loss = max(quality_loss - progress_amount_to_quality, -85)
+	
+	internal.set_temperature(max(internal.return_temperature() + (selected_recipe.energy_release / internal.heat_capacity()), TCMB))
+	update_parents()
 
-/obj/machinery/atmospherics/components/binary/crystallizer/proc/apply_cooling()
+///Conduction between the internal gasmix and the moderating (cooling/heating) gasmix.
+/obj/machinery/atmospherics/components/binary/crystallizer/proc/heat_conduction()
 	var/datum/gas_mixture/cooling_port = airs[1]
 	if(cooling_port.total_moles() > MINIMUM_MOLE_COUNT)
 		if(internal.total_moles() > 0)
@@ -187,10 +188,7 @@
 	airs[2].merge(remove)
 
 /obj/machinery/atmospherics/components/binary/crystallizer/process_atmos()
-	if(!on || selected_recipe == null)
-		return
-
-	if(!check_gas_requirements())
+	if(!on || !is_operational() || selected_recipe == null)
 		return
 
 	inject_gases()
@@ -199,8 +197,9 @@
 		update_parents()
 		return
 
+	heat_conduction()
+
 	if(internal_check())
-		apply_cooling()
 		if(check_temp_requirements())
 			heat_calculations()
 			progress_bar = min(progress_bar + (MIN_PROGRESS_AMOUNT * 5 / (round(log(10, total_recipe_moles * 0.1), 0.01))), 100)
@@ -213,7 +212,8 @@
 	progress_bar = 0
 
 	for(var/gas_type in selected_recipe.requirements)
-		var/amount_consumed = selected_recipe.requirements[gas_type] + quality_loss * 5
+		var/required_gas_moles = selected_recipe.requirements[gas_type]
+		var/amount_consumed = required_gas_moles + (required_gas_moles * (quality_loss * 0.01))
 		if(internal.get_moles(gas_type) < amount_consumed)
 			quality_loss = min(quality_loss + 10, 100)
 		internal.adjust_moles(gas_type, -amount_consumed)
@@ -278,7 +278,7 @@
 	if(selected_recipe)
 		data["selected"] = selected_recipe.id
 	else
-		data["selected"] = null
+		data["selected"] = ""
 
 	var/list/internal_gas_data = list()
 	if(internal.total_moles())
@@ -305,7 +305,7 @@
 			var/amount_consumed = selected_recipe.requirements[gas_type]
 			requirements += "-[amount_consumed] moles of [initial(gas_required.name)]"
 		requirements += "In a temperature range between [selected_recipe.min_temp] K and [selected_recipe.max_temp] K"
-		requirements += "The crystallization reaction will be [selected_recipe.reaction_type]"
+		requirements += "The crystallization reaction will be [selected_recipe.energy_release ? (selected_recipe.energy_release > 0 ? "exothermic" : "endothermic") : "thermally neutral"]"
 	data["requirements"] = requirements.Join("\n")
 
 	var/temperature


### PR DESCRIPTION
# Document the changes in your pull request
Cleans up the code and should make the crystallizer work more consistently. It's very likely there was some faulty logic which duplicated gas before.

``process_atmos`` is currently called every 0.5s (SSair wait), which means it injects gasses at twice the listed rate. I, however, cannot be arsed to fix this.

Ports the following PRs, credits to the original authors.
- https://github.com/tgstation/tgstation/pull/57568
- https://github.com/tgstation/tgstation/pull/58614
- https://github.com/tgstation/tgstation/pull/60839
- https://github.com/tgstation/tgstation/pull/63656
- https://github.com/tgstation/tgstation/pull/65529
- https://github.com/tgstation/tgstation/pull/65781

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: The crystallizer should work more consistently.
/:cl:
