### PR TITLE
Guardian ghostpoll now shows ranged or not

### DIFF
--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -63,6 +63,7 @@
 
 /datum/guardian_stats/proc/short_info()
 	var/list/stats_info = list()
+	stats_info += "Ranged: [ranged ? "Yes" : "No"]"
 	stats_info += "Damage [level_to_grade(damage)]"
 	stats_info += "Defense [level_to_grade(defense)]"
 	stats_info += "Speed [level_to_grade(speed)]"


### PR DESCRIPTION
# Document the changes in your pull request

Now that ranged is "good" people (me) will want to see this

# Changelog

:cl:  
tweak: Holoparasite ghost poll now shows whether the stats are ranged or not
/:cl:
