### PR TITLE
Medibot will now accurately insult medbay for having dead patients

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -390,7 +390,15 @@
 				var/list/i_need_scissors = list('sound/voice/medbot/fuck_you.ogg', 'sound/voice/medbot/turn_off.ogg', 'sound/voice/medbot/im_different.ogg', 'sound/voice/medbot/close.ogg', 'sound/voice/medbot/shindemashou.ogg')
 				playsound(src, pick(i_need_scissors), 70)
 			else
-				var/list/messagevoice = list("Radar, put a mask on!" = 'sound/voice/medbot/radar.ogg',"There's always a catch, and I'm the best there is." = 'sound/voice/medbot/catch.ogg',"I knew it, I should've been a plastic surgeon." = 'sound/voice/medbot/surgeon.ogg',"What kind of medbay is this? Everyone's dropping like flies." = 'sound/voice/medbot/flies.ogg',"Delicious!" = 'sound/voice/medbot/delicious.ogg', "Why are we still here? Just to suffer?" = 'sound/voice/medbot/why.ogg')
+				var/list/messagevoice = list("Radar, put a mask on!" = 'sound/voice/medbot/radar.ogg',"There's always a catch, and I'm the best there is." = 'sound/voice/medbot/catch.ogg',"I knew it, I should've been a plastic surgeon." = 'sound/voice/medbot/surgeon.ogg',"Delicious!" = 'sound/voice/medbot/delicious.ogg', "Why are we still here? Just to suffer?" = 'sound/voice/medbot/why.ogg')
+				if(prob( 100 / (LAZYLEN(messagevoice) + 1) )) // Simulate the odds of it still being in the list
+					var/any_dead = FALSE
+					for(var/mob/living/carbon/C in view(6))
+						if(C.stat == DEAD)
+							any_dead = TRUE
+							break
+					if(any_dead) // But only actually choose to insult medbay if they actually have dead patients
+						messagevoice = list("What kind of medbay is this? Everyone's dropping like flies." = 'sound/voice/medbot/flies.ogg')
 				var/message = pick(messagevoice)
 				speak(message)
 				playsound(src, messagevoice[message], 50)


### PR DESCRIPTION
# Document the changes in your pull request

What kind of medbay is this? Everyone's dropping like flies.

will only trigger if medibot sees anyone that is dead

# Changelog

:cl:  
tweak: Medibot will only say that everyone is dropping like flies if they are dropping like flies
/:cl:
