### PR TITLE
Mecha melee update part 1.5

### DIFF
--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -6,6 +6,8 @@
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
 	destruction_sleep_duration = 40
 	exit_delay = 40
+	guns_allowed = TRUE
+	melee_allowed = TRUE
 
 /obj/mecha/combat/restore_equipment()
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'

--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -35,15 +35,15 @@
 	var/fauna_damage_bonus = 0
 	//Structure damage multiplier, for stuff like big ol' smashy hammers. Base structure damage multiplier for mech melee attacks is 3.
 	var/structure_damage_mult = 3
-
+	//Standard cleave visual effect. Change this if you've got a weird weapon with non-standard cleave attacks.
 	var/cleave_effect = /obj/effect/temp_visual/dir_setting/firing_effect/mecha_swipe
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/can_attach(obj/mecha/M)
 	if(!..())
 		return FALSE
-	if(istype(M, /obj/mecha/combat))
-		return TRUE
 	if((locate(/obj/item/mecha_parts/concealed_weapon_bay) in M.contents) && !((locate(/obj/item/mecha_parts/mecha_equipment/melee_weapon) in M.equipment) || (locate(/obj/item/mecha_parts/mecha_equipment/weapon) in M.equipment) ))
+		return TRUE
+	if(M.melee_allowed)
 		return TRUE
 	return FALSE
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -24,9 +24,9 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/mecha/M)
 	if(!..())
 		return FALSE
-	if(istype(M, /obj/mecha/combat))
-		return TRUE
 	if((locate(/obj/item/mecha_parts/concealed_weapon_bay) in M.contents) && !((locate(/obj/item/mecha_parts/mecha_equipment/melee_weapon) in M.equipment) || (locate(/obj/item/mecha_parts/mecha_equipment/weapon) in M.equipment) ))
+		return TRUE
+	if(M.guns_allowed)
 		return TRUE
 	return FALSE
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -96,6 +96,9 @@
 	var/silicon_icon_state = null //if the mech has a different icon when piloted by an AI or MMI
 	var/is_currently_ejecting = FALSE //Mech cannot use equiptment when true, set to true if pilot is trying to exit mech
 
+	var/guns_allowed = FALSE	//Whether or not the mech is allowed to mount guns (mecha_equipment/weapon)
+	var/melee_allowed = FALSE	//Whether or not the mech is allowed to mount melee weapons (mecha_equipment/melee_weapon)
+
 	//Action datums
 	var/datum/action/innate/mecha/mech_eject/eject_action = new
 	var/datum/action/innate/mecha/mech_toggle_internals/internals_action = new
@@ -1302,9 +1305,36 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		if(skill)
 			evaNum *= skill.piloting_speed
 
-		var/obj/item/clothing/under/clothes = H.get_item_by_slot(SLOT_W_UNIFORM) //if the suit directly assists the pilot
+		var/obj/item/clothing/under/clothes = H.get_item_by_slot(SLOT_W_UNIFORM) //if the jumpsuit directly assists the pilot
 		if(clothes)
 			var/datum/component/mech_pilot/MP = clothes.GetComponent(/datum/component/mech_pilot)
 			if(MP)
 				evaNum *= MP.piloting_speed
 	return evaNum
+
+/obj/mecha/proc/face_atom(atom/A)			//Pretty much identical to the mob proc that does the same thing
+	if( !A || !x || !y || !A.x || !A.y )	//Do we have a target with a location and do we have a location?
+		return								//Note: we don't check for states and stuff because this is just for forcing facing. That can come later.
+	var/dx = A.x - x	//Gets the difference in x and y coordinates
+	var/dy = A.y - y
+	if(!dx && !dy) 		// Wall items are graphically shifted but on the floor
+		if(A.pixel_y > 16)
+			setDir(NORTH)
+		else if(A.pixel_y < -16)
+			setDir(SOUTH)
+		else if(A.pixel_x > 16)
+			setDir(EAST)
+		else if(A.pixel_x < -16)
+			setDir(WEST)
+		return
+
+	if(abs(dx) < abs(dy))
+		if(dy > 0)
+			setDir(NORTH)
+		else
+			setDir(SOUTH)
+	else
+		if(dx > 0)
+			setDir(EAST)
+		else
+			setDir(WEST)


### PR DESCRIPTION
Just tweaks the back-end stuff for mechs to be a little more up-to-date and adds the face_atom proc for later use. This'll be relevant later once I finish getting sidewinder sprites n stuff, but for now this can be useful. Also means admin-edited non-combat mechs can mount weapons for funsies.

# Wiki Documentation

Nothing player-facing

# Changelog

:cl:  
rscadd: Adds the face_atom proc for mechs
tweak: Behind-the-scenes mech stuff 
/:cl:
