### PR TITLE
Nanite Heart no longer helps itself be deleted

### DIFF
--- a/yogstation/code/modules/surgery/organs/heart.dm
+++ b/yogstation/code/modules/surgery/organs/heart.dm
@@ -9,7 +9,6 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return .
-	SEND_SIGNAL(owner, COMSIG_NANITE_ADJUST_VOLUME, -100) // nanites are more susceptible to EMP
 	Stop()
 
 /obj/item/organ/heart/nanite/on_life()


### PR DESCRIPTION
A person already loses nanites when emp'd
Nanite hearts made you lose extra nanites when emp'd
This often resulted in all nanites being removed instantly deleting your heart

Literally the only time anyone used it is in conjunction with vein muscle membrane which removed the downside of your heart getting deleted

Your heart will still be stopped (it already did this but no one knew because their heart was instead deleted)

this probably won't make it good enough to be worth using, but it's something

:cl:  
tweak: Nanite heart no longer makes it's owner lose additional nanites from an emp
/:cl:
