### PR TITLE
Removes chasms from lavaland ruins

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1216,15 +1216,15 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/lavaland/surface/outdoors/explored)
-"gX" = (
-/obj/effect/mapping_helpers/no_lava,
-/turf/open/chasm/lavaland,
-/area/lavaland/surface/outdoors/explored)
 "hY" = (
 /obj/machinery/light,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/powered/clownplanet)
+"nH" = (
+/obj/effect/mapping_helpers/no_lava,
+/turf/open/floor/ballpit,
+/area/lavaland/surface/outdoors/explored)
 "pv" = (
 /obj/machinery/light{
 	dir = 4
@@ -1378,10 +1378,10 @@ cc
 cc
 pv
 XO
-gX
+nH
 XO
 XO
-gX
+nH
 pv
 cc
 cc
@@ -1411,11 +1411,11 @@ ye
 ye
 cc
 cc
-gX
-gX
+nH
+nH
 KX
-gX
-gX
+nH
+nH
 cc
 cc
 ye
@@ -1446,9 +1446,9 @@ aJ
 ye
 cc
 cc
-gX
-gX
-gX
+nH
+nH
+nH
 cc
 cc
 ye
@@ -2262,9 +2262,9 @@ cc
 ye
 cc
 cc
-gX
-gX
-gX
+nH
+nH
+nH
 cc
 cc
 ye
@@ -2295,11 +2295,11 @@ ye
 ye
 cc
 cc
-gX
-gX
+nH
+nH
 KX
-gX
-gX
+nH
+nH
 cc
 cc
 ye
@@ -2330,10 +2330,10 @@ cc
 cc
 MR
 XO
+nH
 XO
 XO
-XO
-gX
+nH
 MR
 cc
 cc
@@ -2364,7 +2364,7 @@ aa
 aa
 aa
 XO
-gX
+XO
 XO
 XO
 XO

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_mimingdrill.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_mimingdrill.dmm
@@ -144,9 +144,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/asteroid/basalt/lava,
 /area/ruin/unpowered)
-"D" = (
-/turf/open/chasm,
-/area/ruin/unpowered)
 "E" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating/asteroid/basalt/lava,
@@ -168,6 +165,9 @@
 "I" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava,
+/area/ruin/unpowered)
+"T" = (
+/turf/open/lava/smooth,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -280,9 +280,9 @@ i
 c
 q
 y
-D
-D
-D
+T
+T
+T
 y
 q
 a
@@ -297,9 +297,9 @@ p
 d
 q
 y
-D
+T
 F
-D
+T
 y
 q
 a
@@ -314,9 +314,9 @@ d
 b
 q
 y
-D
-D
-D
+T
+T
+T
 y
 q
 u


### PR DESCRIPTION
# Document the changes in your pull request

This is for the players who get their keys stuck and accidentally fall in these.
We removed the tendril ones so its only logical to do this too.

It was just the mime and clown ruin, replaced the clown one with safe ballpits and mime with lava because there's windows and its very hard to accidentally walk in there.

![chrome_HBRuKHtNfi](https://user-images.githubusercontent.com/48154165/215288509-b3c282ae-5ddc-481d-aafe-da09a89efd6f.png)
![chrome_r7gA68k2Uc](https://user-images.githubusercontent.com/48154165/215288512-4957fe1a-063b-4724-b992-6fc8366a07e2.png)


# Wiki Documentation

idk if we have ruin pictures on the wiki

# Changelog

:cl:  
mapping:[Lavaland] makes clown and mime ruin more player friendly
/:cl:
