### PR TITLE
Gives miners 1 jaunter at round start (in locker)

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -63,6 +63,7 @@
 	new /obj/item/survivalcapsule(src)
 	new /obj/item/assault_pod/mining(src)
 	new /obj/item/clothing/neck/bodycam/miner(src)
+	new /obj/item/wormhole_jaunter(src)
 
 
 GLOBAL_LIST_EMPTY(dumb_rev_heads)


### PR DESCRIPTION
# Document the changes in your pull request

Should I have made this 2 weeks ago? Yes. But I was dumb and forgot I knew how to do locker things.

I feel like this is the compromise between people who want to keep their chasm and people who don't want to punish people for not knowing where chasms may appear (if new) or if you lag into one. To note I am in the second camp.

One free get out of jail card. If you lose the first one and don't get a second and fall in another chasm, well that's on you, buddy.

If people like this -- can revert #17340 and close #17685 

# Changelog

:cl:  
tweak: Miners get a jaunter in their locker
experimental: If people like this chasms can come back
/:cl:
