### PR TITLE
Fix decal floors being transparent, misdirection and cleanable for some reason

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -269,7 +269,7 @@
 		to_chat(user, span_notice("[target] is not a tile!"))
 		return
 	if(use_paint(user))
-		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, FALSE, color, null, null, alpha)
+		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, FALSE, color, null, null, 255)
 
 /obj/item/airlock_painter/decal/attack_self(mob/user)
 	. = ..()

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -269,7 +269,7 @@
 		to_chat(user, span_notice("[target] is not a tile!"))
 		return
 	if(use_paint(user))
-		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, FALSE, stored_dir, color, null, null, alpha)
+		F.AddComponent(/datum/component/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, FALSE, color, null, null, alpha)
 
 /obj/item/airlock_painter/decal/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION
#17486 fixed the runtime but still the args was misplaced again which made the decals transparent, misdirection and cleanable, it's not supposed to be transparent and cleanable.

fix #17643
the decal component used the decal painter transparency (alpha 210) for some reason so it made the decal actually transparent, it supposed to use the decal component alpha which is 255 `/datum/component/decal/Initialize(_icon, _icon_state, _dir, _cleanable=FALSE, _color, _layer=TURF_LAYER, _description, _alpha=255)`

~~WAit why the fuck is item a bit transparent~~

# Document the changes in your pull request

 Fix decal floors cleanable, misdirection and being transparent for some reason


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix decal floors cleanable, misdirection and being transparent for some reason
/:cl:
