### PR TITLE
Fix crystallizer input

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -122,12 +122,6 @@
 /obj/machinery/atmospherics/components/binary/crystallizer/proc/inject_gases()
 	var/datum/gas_mixture/contents = airs[2]
 	for(var/gas_type in selected_recipe.requirements)
-		if (!contents.get_moles(gas_type))
-			continue
-
-		if (internal.get_moles(gas_type) >= selected_recipe.requirements[gas_type] * 2)
-			continue
-
 		var/datum/gas_mixture/filtered = new
 		filtered.set_temperature(contents.return_temperature())
 		var/filtered_amount = min(gas_input, contents.get_moles(gas_type))


### PR DESCRIPTION
# Document the changes in your pull request
These changes cause the crystallizer input to choke when 1 gas isn't present


# Changelog

:cl:  
bugfix: Crystallizer gas input is fixed
/:cl:
