### PR TITLE
Fixes a bug where some emotes could be used while dead via keybinds

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -175,7 +175,7 @@
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check = TRUE , intentional)
 	var/mob/living/carbon/human/H = user
-	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user) && ..()
+	return H?.dna?.species?.can_wag_tail(user) && ..()
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -73,8 +73,10 @@
 		return pick('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
 
 /datum/emote/living/carbon/hiss/can_run_emote(mob/living/user, status_check = TRUE, intentional)
+	if(!..())
+		return FALSE
 	if(!ishuman(user))
-		return
+		return FALSE
 	var/mob/living/carbon/human/H = user
 	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
 	return is_type_in_list(T, viable_tongues)
@@ -118,6 +120,8 @@
 	cooldown = 10 SECONDS
 
 /datum/emote/living/carbon/meow/can_run_emote(mob/living/user, status_check = TRUE, intentional)
+	if(!..())
+		return FALSE
 	return iscatperson(user)
 
 /datum/emote/living/carbon/meow/get_sound(mob/living/user)
@@ -132,6 +136,8 @@
 	sound = 'sound/voice/rattled.ogg'
 
 /datum/emote/living/carbon/rattle/can_run_emote(mob/living/user, status_check = TRUE, intentional)
+	if(!..())
+		return FALSE
 	return isskeleton(user)
 
 /datum/emote/living/carbon/human/pale

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -73,13 +73,11 @@
 		return pick('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')
 
 /datum/emote/living/carbon/hiss/can_run_emote(mob/living/user, status_check = TRUE, intentional)
-	if(!..())
-		return FALSE
 	if(!ishuman(user))
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/tongue/T = H.getorganslot(ORGAN_SLOT_TONGUE)
-	return is_type_in_list(T, viable_tongues)
+	var/obj/item/organ/tongue/T = H?.getorganslot(ORGAN_SLOT_TONGUE)
+	return is_type_in_list(T, viable_tongues) && ..()
 
 /datum/emote/living/carbon/human/hug
 	key = "hug"
@@ -120,9 +118,7 @@
 	cooldown = 10 SECONDS
 
 /datum/emote/living/carbon/meow/can_run_emote(mob/living/user, status_check = TRUE, intentional)
-	if(!..())
-		return FALSE
-	return iscatperson(user)
+	return iscatperson(user) && ..()
 
 /datum/emote/living/carbon/meow/get_sound(mob/living/user)
 	return pick('sound/voice/feline/meow1.ogg', 'sound/voice/feline/meow2.ogg', 'sound/voice/feline/meow3.ogg', 'sound/voice/feline/meow4.ogg', 'sound/effects/meow1.ogg')
@@ -136,9 +132,7 @@
 	sound = 'sound/voice/rattled.ogg'
 
 /datum/emote/living/carbon/rattle/can_run_emote(mob/living/user, status_check = TRUE, intentional)
-	if(!..())
-		return FALSE
-	return isskeleton(user)
+	return isskeleton(user) && ..()
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"
@@ -180,10 +174,8 @@
 		H.dna.species.stop_wagging_tail(H)
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check = TRUE , intentional)
-	if(!..())
-		return FALSE
 	var/mob/living/carbon/human/H = user
-	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user)
+	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user) && ..()
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
@@ -216,11 +208,8 @@
 		. = "closes " + message
 
 /datum/emote/living/carbon/human/wing/can_run_emote(mob/user, status_check = TRUE, intentional)
-	if(!..())
-		return FALSE
 	var/mob/living/carbon/human/H = user
-	if(H.dna && H.dna.species && (H.dna.features["wings"] != "None"))
-		return TRUE
+	return H?.dna?.species && H?.dna?.features["wings"] != "None" && ..()
 
 /mob/living/carbon/human/proc/OpenWings()
 	if(!dna || !dna.species)
@@ -249,11 +238,8 @@
 		T.Entered(src)
 
 /datum/emote/living/carbon/human/robot_tongue/can_run_emote(mob/user, status_check = TRUE , intentional)
-	if(!..())
-		return FALSE
 	var/obj/item/organ/tongue/T = user.getorganslot("tongue")
-	if(T.status == ORGAN_ROBOTIC)
-		return TRUE
+	return T?.status == ORGAN_ROBOTIC && ..()
 
 /datum/emote/living/carbon/human/robot_tongue/beep
 	key = "beep"
@@ -300,10 +286,7 @@
  // Clown Robotic Tongue ONLY. Henk.
 
 /datum/emote/living/carbon/human/robot_tongue/clown/can_run_emote(mob/user, status_check = TRUE , intentional)
-	if(!..())
-		return FALSE
-	if(user.mind.assigned_role == "Clown")
-		return TRUE
+	return user?.mind?.assigned_role == "Clown" && ..()
 
 /datum/emote/living/carbon/human/robot_tongue/clown/honk
 	key = "honk"


### PR DESCRIPTION
They were overriding the can_run_emote proc rather than extending it

closes: #17691 

:cl:  @ynot01, @ThatLing, Tawaporah Koko @monster860 
bugfix: Dead Lizards now stay quiet like they should
/:cl:
