### PR TITLE
Syndicate bombs now always detonate when exploded and active as opposed to sometimes

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -38,6 +38,10 @@
 	if(.)
 		payload.detonate()
 
+/obj/machinery/syndicatebomb/ex_act(severity, target) // Little boom can chain a big boom.
+	if(!try_detonate())
+		..()
+
 /obj/machinery/syndicatebomb/obj_break()
 	if(!try_detonate())
 		..()


### PR DESCRIPTION
# Document the changes in your pull request

Follow-up to #17168

When blowing up lightly directly on top of it I could get it to detonate but when trying explosions next to it it wouldn't detonate and when I dev exploded it it just deleted itself

Now it will always try to detonate and will succeed if the bomb is counting down

# Changelog

:cl:  
tweak: Syndicate Bombs will now detonate always if counting down and exploded
/:cl:
