### PR TITLE
"""Replaces""" the old PDA in nukie shuttle with the correct one

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -914,11 +914,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/armory)
-"bX" = (
-/obj/structure/closet/syndicate/nuclear,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/syndicate/armory)
 "bY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1384,6 +1379,13 @@
 /obj/item/twohanded/vxtvulhammer,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/airlock)
+"Rz" = (
+/obj/structure/closet/syndicate/nuclear,
+/obj/effect/turf_decal/bot_white,
+/obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman,
+/obj/item/modular_computer/tablet/pda/preset/basic,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/syndicate/armory)
 
 (1,1,1) = {"
 aa
@@ -1778,7 +1780,7 @@ bm
 bB
 bG
 bQ
-bX
+Rz
 ci
 cn
 sI


### PR DESCRIPTION

# Document the changes in your pull request

Adds a basic modular PDA and bomberman disk to nukie shuttle to replace the military PDA currently inside.

Note: The old PDA wasn't in FastDMM2, so I assume its spawned via the locker so both will probably spawn inside.

# Changelog


:cl:  
rscadd: Added modular PDA and PDA bomb disk to cutter
mapping: same as above
/:cl:
