### PR TITLE
COMSIG_ITEM_PRESTRIP now sends to the item rather than the mob

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -264,7 +264,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 		ADD_TRAIT(user, TRAIT_NOCRITDAMAGE, "memento_mori")
 		icon_state = "memento_mori_active"
 		active_owner = user
-		RegisterSignal(user, COMSIG_ITEM_PRESTRIP, .proc/moriwarn)
+		RegisterSignal(src, COMSIG_ITEM_PRESTRIP, .proc/moriwarn)
 
 /obj/item/clothing/neck/necklace/memento_mori/proc/moriwarn()
 	active_owner.visible_message(span_userdanger("The [src] writhes and shudders as it starts to tear away [active_owner]'s lifeforce!"))
@@ -273,7 +273,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 	icon_state = "memento_mori"
 	if(!active_owner)
 		return
-	UnregisterSignal(active_owner, COMSIG_ITEM_PRESTRIP)
+	UnregisterSignal(src, COMSIG_ITEM_PRESTRIP)
 	var/mob/living/carbon/human/H = active_owner //to avoid infinite looping when dust unequips the pendant
 	active_owner = null
 	to_chat(H, span_userdanger("You feel your life rapidly slipping away from you!"))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -849,7 +849,7 @@
 	who.visible_message(span_danger("[src] tries to remove [who]'s [what.name]."), \
 					span_userdanger("[src] tries to remove [who]'s [what.name]."))
 	what.add_fingerprint(src)
-	SEND_SIGNAL(who, COMSIG_ITEM_PRESTRIP)
+	SEND_SIGNAL(what, COMSIG_ITEM_PRESTRIP)
 	if(do_mob(src, who, what.strip_delay))
 		if(what && Adjacent(who))
 			if(islist(where))


### PR DESCRIPTION
It would trigger every item that used the signal on that mob rather than the item being stripped.

closes: #17596

:cl:  
bugfix: memento mori warning no longer appears when stripping other items
/:cl:
