### PR TITLE
qol living heart now tells you how many people are around your target

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -34,7 +34,7 @@
 		if(1 to 2)
 			crowd_text = " They are not alone..."
 		if(3 to INFINITY)
-			crowd_text = "</span> <span class='boldwarning'>They are surrounded by many."
+			crowd_text = "</span> <span class='boldwarning'>They are surrounded by people."
 
 	if(userturf.z != targetturf.z)
 		to_chat(user,span_warning("[target.real_name] is ... vertical to you?"))

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -18,17 +18,34 @@
 	var/turf/targetturf = get_turf(target)
 	var/dist = get_dist(userturf,targetturf)
 	var/dir = get_dir(userturf,targetturf)
+	var/crowd = 0
+	var/crowd_text = ""
+	for(var/mob/living/L in view(7, target))
+		if(L == user)
+			continue
+		if(L == target)
+			continue
+		if(!L.client)
+			continue
+		crowd++
+	switch(crowd)
+		if(0)
+			crowd_text = "</span> <span class='boldnotice'>They are alone!"
+		if(1 to 2)
+			crowd_text = " They are not alone..."
+		if(3 to INFINITY)
+			crowd_text = "</span> <span class='boldwarning'>They are surrounded by many."
 
 	if(userturf.z != targetturf.z)
 		to_chat(user,span_warning("[target.real_name] is ... vertical to you?"))
 	else
 		switch(dist)
 			if(0 to 15)
-				to_chat(user,span_warning("[target.real_name] is near you. They are to the [dir2text(dir)] of you!"))
+				to_chat(user,span_warning("[target.real_name] is near you. They are to the [dir2text(dir)] of you![crowd_text]"))
 			if(16 to 31)
-				to_chat(user,span_warning("[target.real_name] is somewhere in your vicinty. They are to the [dir2text(dir)] of you!"))
+				to_chat(user,span_warning("[target.real_name] is somewhere in your vicinty. They are to the [dir2text(dir)] of you![crowd_text]"))
 			if(32 to 127)
-				to_chat(user,span_warning("[target.real_name] is far away from you. They are to the [dir2text(dir)] of you!"))
+				to_chat(user,span_warning("[target.real_name] is far away from you. They are to the [dir2text(dir)] of you![crowd_text]"))
 			else
 				to_chat(user,span_warning("[target.real_name] is beyond our reach."))
 


### PR DESCRIPTION
# Document the changes in your pull request

Living heart now tells you how many people are around your target

0 = They are alone
1-2 = They are not alone
3+ = They are surrounded by many

![](https://i.imgur.com/mgNROZP.png)

This is not going in my revamp PR because i ded and sneaking it in there at this stage would be disingenuous

# Changelog

:cl:  
rscadd: Heretic's Living Heart now tells you how many people are around your target
/:cl:
