### PR TITLE
Ling fakedeath will no longer take closing the confirmation window as consent

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -76,7 +76,7 @@
 		to_chat(user, span_warning("We are already reviving."))
 		return
 	if(!user.stat && !revive_ready) //Confirmation for living changelings if they want to fake their death
-		switch(tgui_alert(usr,"Are we sure we wish to fake our own death?",,list("Yes", "No")))
-			if("No")
-				return
+		var/result = tgui_alert(usr,"Are we sure we wish to fake our own death?",,list("Yes", "No"))
+		if(result != "Yes")
+			return
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

![](https://thumbs.gfycat.com/TestyFocusedHawaiianmonkseal-max-1mb.gif)

# Changelog

:cl:  
bugfix: Ling fakedeath will no longer take closing the confirmation window as consent
/:cl:
