### PR TITLE
Shimmyjimmies ion bolts to be less "why are they like that" and more "hey that kinda makes sense"

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -126,8 +126,8 @@
 	name = "\improper MKIV ion heavy cannon"
 	desc = "A weapon for combat exosuits. Shoots technology-disabling ion beams. Don't catch yourself in the blast!"
 	icon_state = "mecha_ion"
-	energy_drain = 120
-	projectile = /obj/item/projectile/ion
+	energy_drain = 200
+	projectile = /obj/item/projectile/ion/heavy	//Big boy 2/2 EMP bolts
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -22,7 +22,7 @@
 			distance = 0
 		if(distance < heavy_range)
 			T.emp_act(EMP_HEAVY)
-		else if(distance == heavy_range)
+		else if(heavy_range && distance == heavy_range)	//0 radius heavy EMPs will have no effect
 			if(prob(50))
 				T.emp_act(EMP_HEAVY)
 			else

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,7 +4,8 @@
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/ion/hos
-	e_cost = 250
+	projectile_type = /obj/item/projectile/ion/light
+	e_cost = 200
 
 /obj/item/ammo_casing/energy/ion/weak
 	projectile_type = /obj/item/projectile/ion/weak

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -4,8 +4,10 @@
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/ion/hos
-	projectile_type = /obj/item/projectile/ion/weak
 	e_cost = 250
+
+/obj/item/ammo_casing/energy/ion/weak
+	projectile_type = /obj/item/projectile/ion/weak
 
 /obj/item/ammo_casing/energy/declone
 	projectile_type = /obj/item/projectile/energy/declone

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -59,4 +59,4 @@
 
 /obj/item/projectile/bullet/c10mm/emp/on_hit(atom/target, blocked = FALSE)
 	..()
-	empulse(target, 0, 1) //Heavy EMP on target, light EMP in tiles around
+	empulse(target, 0.5, 1) //Heavy EMP on target, light EMP in tiles around

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -6,12 +6,22 @@
 	nodamage = TRUE
 	flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
-	var/emp_radius = 1
+	var/light_emp_radius = 1
+	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles
 
 /obj/item/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()
-	empulse(target, emp_radius, emp_radius)
+	empulse(target, heavy_emp_radius, light_emp_radius)
 	return BULLET_ACT_HIT
 
 /obj/item/projectile/ion/weak
-	emp_radius = 0
+	light_emp_radius = 0
+	heavy_emp_radius = 0
+
+/obj/item/projectile/ion/light
+	light_emp_radius = 1
+	heavy_emp_radius = 0
+
+/obj/item/projectile/ion/heavy
+	light_emp_radius = 2
+	heavy_emp_radius = 2


### PR DESCRIPTION
OLD ION PROJECTILES:
hos gun/ion shotgun shells: 50/50 of heavy or light on target
literally everything else: heavy EMP on target, 50/50 heavy/light on surrounding tiles

ION PROJECTILES NOW:
Standard bulky ion gun: fires 0.5/1 bolts (heavy EMP in the epicenter, light surrounding)
ion carbines/hos gun: fires 0/1 bolts (light in a 1 tile radius, no heavy)
ion shotgun shell: no longer 50% chance of heavy EMP on hit
mech ion cannon: 2/2 EMP bolt (1 radius heavy, 50/50 of heavy or light in 2 tile radius)
stechkin EMP rounds: now guarantee a heavy EMP on the target

EMP blasts will now only apply a heavy EMP on the epicenter if the heavy radius is greater than 0. This won't affect large EMP effects like EMP grenades, mostly only makes an impact with small EMPs.


# Wiki Documentation

weak bolts: 0/0, used by ion shotgun
light bolts: 0/1, used by ion carbines
standard bolts: 0.5/1, standard EMP bolt used by hos gun and ion rifle
heavy bolts: 2/2, used by heavy ion cannon on mechs

# Changelog


:cl:  
rscadd: Added heavy and light EMP energy projectiles
tweak: Hos gun now shoots light bolts but can fire 5 of them instead of 3
tweak: Mech ion cannon shoots big boy ion bolts
tweak: Ion shotgun shells can no longer apply heavy EMP effects
tweak: Ion carbines fire weaker ion bolts that can't apply heavy EMP effects
tweak: Stechkin EMP rounds guarantee a heavy EMP on the target
/:cl:
