### PR TITLE
Slipping now bypasses knockdown immunity.

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -563,11 +563,11 @@
 		var/olddir = C.dir
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
-			C.Knockdown(knockdown_amount)
-			C.Stun(stun_amount)
+			C.Knockdown(knockdown_amount, ignore_canstun = TRUE))
+			C.Stun(stun_amount, ignore_canstun = TRUE))
 			C.stop_pulling()
 		else
-			C.Knockdown(20)
+			C.Knockdown(20, ignore_canstun = TRUE)
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)
 			lube |= SLIDE_ICE

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -563,8 +563,8 @@
 		var/olddir = C.dir
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
-			C.Knockdown(knockdown_amount, ignore_canstun = TRUE))
-			C.Stun(stun_amount, ignore_canstun = TRUE))
+			C.Knockdown(knockdown_amount, ignore_canstun = TRUE)
+			C.Stun(stun_amount, ignore_canstun = TRUE)
 			C.stop_pulling()
 		else
 			C.Knockdown(20, ignore_canstun = TRUE)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -564,7 +564,7 @@
 		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
 			C.Knockdown(knockdown_amount, ignore_canstun = TRUE)
-			C.Stun(stun_amount, ignore_canstun = TRUE)
+			C.Stun(stun_amount)
 			C.stop_pulling()
 		else
 			C.Knockdown(20, ignore_canstun = TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

Slipping now bypasses knockdown immunity. Mobs/whatever that were stun immune would have the slip sound play but wouldn't actually slip because they were stun and knockdown immune. I can't tell if this was a bug or a balance decision so I'm just going to label this change as a tweak.

Species/items with slip immunity still work.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  BurgerBB
tweak: Slipping now bypasses knockdown immunity.
/:cl:
