### PR TITLE
[boring] Github labeler changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,21 +15,24 @@ DME Edit:
   - './*.dme'
   - '**/*.dme'
 
-# Any .dmi changes
+# Changes to a .dmi or anything in the icons folder
 Sprites: 
   - '**/*.dmi'
+  - 'icons/*.dmi'
 
 # Javascript changes
 Javascript: 
   - '**/*.js'
 
-# Changes to a .dmm
-Map Change: 
+# Changes to a .dmm or anything in the _maps folder
+Mapping: 
   - '**/*.dmm'
+  - '_maps/**'
 
-# Any changes to .ogg files are marked as sound
+# Changes to a .ogg or anything in the sound folder
 Sound: 
   - '**/*.ogg'
+  - 'sound/**'
 
 # Changes to the SQL subfolder
 SQL: 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,10 +24,12 @@ Sprites:
 Javascript: 
   - '**/*.js'
 
-# Changes to a .dmm or anything in the _maps folder
+# Changes to a .dmm or anything in the _maps folder or any of the map definitions
 Mapping: 
   - '**/*.dmm'
   - '_maps/**'
+  - 'code/datums/ruins/**'
+  - 'code/datums/shuttles.dm'
 
 # Changes to a .ogg or anything in the sound folder
 Sound: 


### PR DESCRIPTION
# Document the changes in your pull request
Players can ignore this.

Makes the labeler workflow more broad when tagging pr's.

All changes in the icon folder will now apply the sprites label, it used to be just .dmi files.
All changes in the sound folder will now apply the sound label, it used to be just .ogg files.
All changes in the _maps folder will now apply the mapping label, it was just .dmm files.

Also changes the name of the 'Map Change' label to 'Mapping' as i feel it now encompasses more than just simple mapping edits yet it still falls under the map department. **This will have to be adjusted on github after the pr is merged.**

# Changelog
:cl:  
tweak: github labeler changes
/:cl:
