### PR TITLE
You can now wag an implanted tail

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2156,7 +2156,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(H.IsParalyzed() || H.IsStun())
 		return FALSE
 	var/obj/item/organ/tail = H.getorganslot(ORGAN_SLOT_TAIL)
-	return tail?.get_availability(H.dna.species)
+	return "tail_human" in mutant_bodyparts || "waggingtail_human" in mutant_bodyparts || "tail_lizard" in mutant_bodyparts || "waggingtail_lizard" in mutant_bodyparts
 
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
 	return ("waggingtail_human" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2156,7 +2156,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(H.IsParalyzed() || H.IsStun())
 		return FALSE
 	var/obj/item/organ/tail = H.getorganslot(ORGAN_SLOT_TAIL)
-	return "tail_human" in mutant_bodyparts || "waggingtail_human" in mutant_bodyparts || "tail_lizard" in mutant_bodyparts || "waggingtail_lizard" in mutant_bodyparts
+	return ("tail_human" in mutant_bodyparts) || ("waggingtail_human" in mutant_bodyparts) || ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
 
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
 	return ("waggingtail_human" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2155,7 +2155,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
 	if(H.IsParalyzed() || H.IsStun())
 		return FALSE
-	var/obj/item/organ/tail = H.getorganslot(ORGAN_SLOT_TAIL)
 	return ("tail_human" in mutant_bodyparts) || ("waggingtail_human" in mutant_bodyparts) || ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
 
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2155,6 +2155,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
 	if(H.IsParalyzed() || H.IsStun())
 		return FALSE
+	// var/obj/item/organ/tail = H.getorganslot(ORGAN_SLOT_TAIL)
 	return ("tail_human" in mutant_bodyparts) || ("waggingtail_human" in mutant_bodyparts) || ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
 
 /datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)


### PR DESCRIPTION
# Document the changes in your pull request

Used to check if the species started with a tail and didn't actually care if you had a tail or not so it also would silently fail if you were missing your tail

<img width='300' height='200' src='https://user-images.githubusercontent.com/28408322/215669904-51a0fa44-8fe7-4dc9-8f09-128ed01e2758.png'>

# Changelog

:cl:  
bugfix: You can now wag an implanted tail
/:cl:
