### PR TITLE
Heretic runes will no longer eat more items than is required to transmutate

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -77,6 +77,7 @@
 				if(is_type_in_list(local_atom_in_range,local_required_atom_list))
 					selected_atoms |= local_atom_in_range
 					local_required_atoms -= list(local_required_atom_list)
+					break // We found the atom we want, so we can move on to the next required item
 
 		if(length(local_required_atoms) > 0)
 			continue


### PR DESCRIPTION
# Document the changes in your pull request

Eats 3 knives, makes 1 blade

Now eats 1 knife, makes 1 blade and can be done 3 times if you have 3 knives

# Changelog

:cl:  
bugfix: Heretic runes will no longer eat more items than is required to transmutate
/:cl:
