### PR TITLE
Gem buffs and Gem Modularization

### DIFF
--- a/code/datums/components/gems.dm
+++ b/code/datums/components/gems.dm
@@ -1,0 +1,63 @@
+/// Components to list other things as gems so it would have sweeping changes across all gems
+/datum/component/gems
+	///owning ID, used to give points when sold
+	var/obj/item/card/id/claimed_by = null
+	///How many points we grant to whoever discovers us
+	var/point_value = 100
+	///what's our real name that will show upon discovery? null to do nothing
+	var/true_name
+	///the thing that spawns in the item.
+	var/sheet_type = null
+	//shows this overlay when not claimed
+	var/image/shine_overlay
+
+/datum/component/gems/Initialize()
+	. = ..()
+	///the thing that makes it a parent 
+	var/atom/parent = src.parent
+
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
+	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/attackby)
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_act)
+
+	shine_overlay = image(icon = 'icons/obj/gems.dmi',icon_state = "shine")
+	parent.add_overlay(shine_overlay)
+	parent.pixel_x = rand(-8,8)
+	parent.pixel_y = rand(-8,8)
+
+/datum/component/gems/proc/examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	examine_list += span_notice("Its value of [point_value] mining points can be registered by hitting it with an ID, to be claimed when sold.")
+
+/datum/component/gems/proc/attackby(datum/source, obj/item/item, mob/living/user, params) //Stolen directly from geysers, removed the internal gps
+	///yes I do need to cast this again everytime I call a parent 
+	var/atom/parent = src.parent
+
+	if(!istype(item, /obj/item/card/id))
+		return
+	if(claimed_by)
+		to_chat(user, span_warning("This gem has already been claimed!"))
+		return
+
+	to_chat(user, span_notice("You register the precious gemstone to your ID card, and will gain [point_value] mining points when it is sold!"))
+	playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
+
+	claimed_by = item
+	if(true_name)
+		parent.name = true_name
+
+	if(shine_overlay)
+		parent.cut_overlay(shine_overlay)
+		qdel(shine_overlay)
+
+/datum/component/gems/proc/welder_act(datum/source, mob/living/user, obj/item/I) //Jank code that detects if the gem in question has a sheet_type and spawns the items specifed in it
+	SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), user, I)
+	
+	if(I.use_tool(src, user, 0, volume=50))
+		if(src.sheet_type)
+			new src.sheet_type(user.loc)
+			to_chat(user, span_notice("You carefully cut [src]."))
+			qdel(src)
+		else
+			to_chat(user, span_notice("You can't seem to cut [src]."))
+	return TRUE

--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -13,8 +13,6 @@
 	var/point_value = 100
 	///what's our real name that will show upon discovery? null to do nothing
 	var/true_name
-	///the message given when you discover this gem.
-	var/analysed_message = null
 	///the thing that spawns in the item.
 	var/sheet_type = null
 
@@ -41,8 +39,6 @@
 
 	to_chat(user, span_notice("You register the precious gemstone to your ID card, and will gain [point_value] mining points when it is sold!"))
 	playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
-	if(analysed_message)
-		to_chat(user, analysed_message)
 
 	claimed_by = item
 	if(true_name)
@@ -68,7 +64,7 @@
 	icon_state = "rupee"
 	materials = list(/datum/material/uranium=20000)
 	sheet_type = /obj/item/stack/sheet/mineral/uranium{amount = 10}
-	point_value = 300
+	point_value = 600
 
 /obj/item/gem/magma
 	name = "calcified auric"
@@ -76,7 +72,7 @@
 	icon_state = "magma"
 	materials = list(/datum/material/gold=50000)
 	sheet_type = /obj/item/stack/sheet/mineral/gold{amount = 25}
-	point_value = 450
+	point_value = 900
 	light_range = 2
 	light_power = 1
 	light_color = "#ff7b00"
@@ -87,14 +83,14 @@
 	icon_state = "diamond"
 	materials = list(/datum/material/diamond=30000)
 	sheet_type = /obj/item/stack/sheet/mineral/diamond{amount = 15}
-	point_value = 750
+	point_value = 1500
 
 /obj/item/gem/phoron
 	name = "stabilized baroxuldium"
 	desc = "A soft, glowing crystal only found in the deepest veins of plasma. Famed for its exceptional durability and uncommon beauty: widely considered to be a jackpot by mining crews. It looks like it could be destructively analyzed to extract the condensed materials within."
 	icon_state = "phoron"
 	materials = list(/datum/material/plasma=80000)
-	point_value = 1200
+	point_value = 2400
 	light_range = 2
 	light_power = 2
 	light_color = "#62326a"
@@ -104,7 +100,7 @@
 	desc = "A strange mass of dilithium which pulses to a steady rhythm. Its strange surface exudes a unique radio signal detectable by GPS. It looks like it could be destructively analyzed to extract the condensed materials within."
 	icon_state = "purple"
 	materials = list(/datum/material/dilithium=64000)
-	point_value = 1600
+	point_value = 3200
 	light_range = 2
 	light_power = 1
 	light_color = "#b714cc"
@@ -125,7 +121,7 @@
 	name = "draconic amber"
 	desc = "A brittle, strange mineral that forms when an ash drake's blood hardens after death. Cherished by gemcutters for its faint glow and unique, soft warmth. Poacher tales whisper of the dragon's strength being bestowed to one that wears a necklace of this amber, though such rumors are fictitious."
 	icon_state = "amber"
-	point_value = 1600
+	point_value = 3200
 	light_range = 2
 	light_power = 2
 	light_color = "#FFBF00"
@@ -134,7 +130,7 @@
 	name = "null crystal"
 	desc = "A shard of stellar, crystallized energy. These strange objects occasionally appear spontaneously in areas where the bluespace fabric is largely unstable. Its surface gives a light jolt to those who touch it. Despite its size, it's absurdly light."
 	icon_state ="void"
-	point_value = 1800
+	point_value = 3600
 	light_range = 2
 	light_power = 1
 	light_color = "#4785a4"
@@ -144,7 +140,7 @@
 	name = "ichorium"
 	desc = "A weird, sticky substance, known to coalesce in the presence of otherworldly phenomena. While shunned by most spiritual groups, this gemstone has unique ties to the occult which find it handsomely valued by mysterious patrons."
 	icon_state = "red"
-	point_value = 2000
+	point_value = 4000
 	light_range = 2
 	light_power = 3
 	light_color = "#800000"
@@ -153,7 +149,7 @@
 	name = "dark salt lick"
 	desc = "An ominous cylinder that glows with an unnerving aura, seeming to hungrily draw in the space around it. The round edges of the lick are uneven patches of rough texture. Its only known property is that of anti-magic."
 	icon_state = "dark"
-	point_value = 3000
+	point_value = 6000
 	light_range = 3
 	light_power = 3
 	light_color = "#380a41"
@@ -179,22 +175,22 @@
 /obj/item/gem/ruby
 	name = "ruby"
 	icon_state = "ruby"
-	point_value = 200
+	point_value = 500
 
 /obj/item/gem/sapphire
 	name = "sapphire"
 	icon_state = "sapphire"
-	point_value = 200
+	point_value = 500
 
 /obj/item/gem/emerald
 	name = "emerald"
 	icon_state = "emerald"
-	point_value = 200
+	point_value = 500
 
 /obj/item/gem/topaz
 	name = "topaz"
 	icon_state = "topaz"
-	point_value = 200
+	point_value = 500
 
 /obj/item/ai_cpu/stalwart //very jank code-theft because it's not directly a gem
 	name = "bluespace data crystal"
@@ -211,27 +207,37 @@
 	light_range = 2
 	light_power = 6
 	light_color = "#0004ff"
-	///Have we been analysed with a mining scanner?
-	var/analysed = FALSE
+	///owning ID, used to give points when sold
+	var/obj/item/card/id/claimed_by = null
+	///what's our real name that will show upon discovery? null to do nothing
+	var/true_name
 	///How many points we grant to whoever discovers us
-	var/point_value = 2000
+	var/point_value = 4000
+
+	var/image/shine_overlay //shows this overlay when not claimed
+
+/obj/item/ai_cpu/stalwart/Initialize()
+	. = ..()
+	shine_overlay = image(icon = 'icons/obj/gems.dmi',icon_state = "shine")
+	add_overlay(shine_overlay)
+	pixel_x = rand(-8,8)
+	pixel_y = rand(-8,8)
 
 /obj/item/ai_cpu/stalwart/attackby(obj/item/item, mob/living/user, params) //Stolen directly from geysers, removed the internal gps
-	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
+	if(!istype(item, /obj/item/card/id))
 		return ..()
 
-	if(analysed)
-		to_chat(user, span_warning("This gem has already been analysed!"))
+	if(claimed_by)
+		to_chat(user, span_warning("This gem has already been claimed!"))
 		return
-	else
-		to_chat(user, span_notice("You analyse the precious gemstone!"))
-		analysed = TRUE
 
-	if(isliving(user))
-		var/mob/living/living = user
+	to_chat(user, span_notice("You register the precious gemstone to your ID card, and will gain [point_value] mining points when it is sold!"))
+	playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
 
-		var/obj/item/card/id/card = living.get_idcard()
-		if(card)
-			to_chat(user, span_notice("[point_value] mining points have been paid out!"))
-			card.mining_points += point_value
-			playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
+	claimed_by = item
+	if(true_name)
+		name = true_name
+
+	if(shine_overlay)
+		cut_overlay(shine_overlay)
+		qdel(shine_overlay)

--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -6,57 +6,14 @@
 	icon = 'icons/obj/gems.dmi'
 	icon_state = "rupee"
 	w_class = WEIGHT_CLASS_SMALL
-
-	///owning ID, used to give points when sold
-	var/obj/item/card/id/claimed_by = null
 	///How many points we grant to whoever discovers us
 	var/point_value = 100
-	///what's our real name that will show upon discovery? null to do nothing
-	var/true_name
 	///the thing that spawns in the item.
 	var/sheet_type = null
 
-	var/image/shine_overlay //shows this overlay when not claimed
-
 /obj/item/gem/Initialize()
 	. = ..()
-	shine_overlay = image(icon = 'icons/obj/gems.dmi',icon_state = "shine")
-	add_overlay(shine_overlay)
-	pixel_x = rand(-8,8)
-	pixel_y = rand(-8,8)
-
-/obj/item/gem/examine(mob/user)
-	. = ..()
-	. += span_notice("Its value of [point_value] mining points can be registered by hitting it with an ID, to be claimed when sold.")
-
-/obj/item/gem/attackby(obj/item/item, mob/living/user, params) //Stolen directly from geysers, removed the internal gps
-	if(!istype(item, /obj/item/card/id))
-		return ..()
-
-	if(claimed_by)
-		to_chat(user, span_warning("This gem has already been claimed!"))
-		return
-
-	to_chat(user, span_notice("You register the precious gemstone to your ID card, and will gain [point_value] mining points when it is sold!"))
-	playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
-
-	claimed_by = item
-	if(true_name)
-		name = true_name
-
-	if(shine_overlay)
-		cut_overlay(shine_overlay)
-		qdel(shine_overlay)
-
-/obj/item/gem/welder_act(mob/living/user, obj/item/I) //Jank code that detects if the gem in question has a sheet_type and spawns the items specifed in it
-	if(I.use_tool(src, user, 0, volume=50))
-		if(src.sheet_type)
-			new src.sheet_type(user.loc)
-			to_chat(user, span_notice("You carefully cut [src]."))
-			qdel(src)
-		else
-			to_chat(user, span_notice("You can't seem to cut [src]."))
-	return TRUE
+	AddComponent(/datum/component/gems)
 
 /obj/item/gem/rupee
 	name = "ruperium crystal"
@@ -207,37 +164,8 @@
 	light_range = 2
 	light_power = 6
 	light_color = "#0004ff"
-	///owning ID, used to give points when sold
-	var/obj/item/card/id/claimed_by = null
-	///what's our real name that will show upon discovery? null to do nothing
-	var/true_name
-	///How many points we grant to whoever discovers us
-	var/point_value = 4000
-
-	var/image/shine_overlay //shows this overlay when not claimed
+	var/point_value = 2000
 
 /obj/item/ai_cpu/stalwart/Initialize()
 	. = ..()
-	shine_overlay = image(icon = 'icons/obj/gems.dmi',icon_state = "shine")
-	add_overlay(shine_overlay)
-	pixel_x = rand(-8,8)
-	pixel_y = rand(-8,8)
-
-/obj/item/ai_cpu/stalwart/attackby(obj/item/item, mob/living/user, params) //Stolen directly from geysers, removed the internal gps
-	if(!istype(item, /obj/item/card/id))
-		return ..()
-
-	if(claimed_by)
-		to_chat(user, span_warning("This gem has already been claimed!"))
-		return
-
-	to_chat(user, span_notice("You register the precious gemstone to your ID card, and will gain [point_value] mining points when it is sold!"))
-	playsound(src, 'sound/machines/ping.ogg', 15, TRUE)
-
-	claimed_by = item
-	if(true_name)
-		name = true_name
-
-	if(shine_overlay)
-		cut_overlay(shine_overlay)
-		qdel(shine_overlay)
+	AddComponent(/datum/component/gems)

--- a/code/modules/cargo/bounties/gems.dm
+++ b/code/modules/cargo/bounties/gems.dm
@@ -16,14 +16,14 @@
 /datum/bounty/item/gems/magma
 	name = "Calcified Auric"
 	description = "Nanotransen needs three of these for a secret project. Meet their demands and get paid for your endeavors."
-	reward = 10000
-	required_count = 3
+	reward = 12000
+	required_count = 2
 	wanted_types = list(/obj/item/gem/magma)
 
 /datum/bounty/item/gems/diamonds
 	name = "Frost Diamonds"
 	description = "A CentCom official is being married in the coming months. Get them those wedding rings!"
-	reward = 10000
+	reward = 12000
 	required_count = 2
 	wanted_types = list(/obj/item/gem/fdiamond)
 

--- a/code/modules/cargo/bounties/gems.dm
+++ b/code/modules/cargo/bounties/gems.dm
@@ -1,6 +1,6 @@
 /datum/bounty/item/gems/ship(obj/O)
 	..()
-	var/obj/item/gem/sold = O
+	var/datum/component/gems/sold = O
 	var/obj/item/card/id/claim = sold?.claimed_by
 	if(claim)
 		var/area/shuttle/shuttle = get_area(O)

--- a/code/modules/cargo/exports/lavaland.dm
+++ b/code/modules/cargo/exports/lavaland.dm
@@ -75,7 +75,7 @@
 	. = ..()
 	if(dry_run)
 		return .
-	var/obj/item/gem/sold = O
+	var/datum/component/gems/sold = O
 	var/obj/item/card/id/claim = sold?.claimed_by
 	if(claim)
 		var/area/shuttle/shuttle = get_area(O)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -159,14 +159,14 @@
 	fromtendril = TRUE
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing/death(gibbed)
-	if(prob(10))
+	if(prob(75))
 		new /obj/item/gem/fdiamond(loc)
 		deathmessage = "spits out a diamond as it dies!"
 	. = ..()
 	deathmessage = initial(deathmessage)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing/death(gibbed)
-	if(prob(10))
+	if(prob(75))
 		new /obj/item/gem/magma(loc)
 		deathmessage = "spits out a golden gem as it dies!"
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -86,6 +86,6 @@
 	. = ..()
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/death(gibbed)
-	if(prob(10))
+	if(prob(75))
 		new /obj/item/gem/rupee(loc)
 	. = ..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -473,6 +473,7 @@
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\forced_gravity.dm"
 #include "code\datums\components\forensics.dm"
+#include "code\datums\components\gems.dm"
 #include "code\datums\components\grillable.dm"
 #include "code\datums\components\gunpoint.dm"
 #include "code\datums\components\heirloom.dm"


### PR DESCRIPTION
Worth more now drop more gem clean up gem

# Document the changes in your pull request

- All gems point values are doubled, and minor gems increased to 500
- Increased value of Diamond and Auric gem bounty by 2000 credits, reduced amount of gems necessary to complete bounty by 1 gem from 3
- Aligns Bluespace Data Crystal with the rest of the gems as it is technically not a gem
- Increases the likelihood of Gold Grubs, Ice, and Magmawing watchers dropping their respective gems from 10% to 75%
- Removes redundant analyzed code

After all this time I noticed that it isn't really worth it to haul all the gems back to cargo from Lavaland and that you never really get to see rupees, frost diamonds, or calcified auric even if they do drop because of the rarity of the mobs. 

This has been lightly tested and no glaring bugs have been detected.

# Modularization WIP

- Modularizing point value system so that new gems don't need a point_value var dumped at the end of it every time maybe
- Get welding feature to function
- Fix selling bounties and receiving points from ID

# Wiki Documentation

Stat changes above

# Changelog

:cl:  
bugfix: Aligns Bluespace Data Crystal with the rest of the gems as it is technically not a gem 
bugfix: Removes redundant analyzed code
tweak: All gems point values are doubled, and minor gems increased to 500
tweak: Increased value of Diamond and Auric gem bounty by 2000 credits, reduced amount of gems necessary to complete bounty by 1 gem from 3
tweak: Increases the likelihood of Gold Grubs, Ice, and Magmawing watchers dropping their respective gems from 10% to 75%
experimental: Modularization
/:cl:
