### PR TITLE
Non-harmful projectiles no longer cause bleeding and damage when embedding

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -167,7 +167,6 @@
 	light_color = LIGHT_COLOR_BLUE
 	damage = 50
 	damage_type = STAMINA
-	embed_chance = 0
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/disabler
 
 /obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -167,6 +167,7 @@
 	light_color = LIGHT_COLOR_BLUE
 	damage = 50
 	damage_type = STAMINA
+	embed_chance = 0
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/disabler
 
 /obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -932,7 +932,8 @@
 	//We want an accurate reading of .len
 	listclearnulls(embedded_objects)
 	for(var/obj/item/embeddies in embedded_objects)
-		if(!embeddies.taped)
+		var/obj/item/ammo_casing/AC = embeddies
+		if(!(embeddies.taped || (istype(AC) && !AC.harmful)))
 			bleed_rate += 0.5
 
 	for(var/thing in wounds)


### PR DESCRIPTION
# Document the changes in your pull request

Non-harmful things that can embed (hardlight disabler bolts, taped items, etc) will no longer cause brute damage and bleeding when embedding

# Changelog

:cl:  
tweak: fixes non-harmful stuff hurting you when embedding
/:cl:
