### PR TITLE
Long Awaited Psychiatrist Rework

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -13052,9 +13052,6 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "dsb" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -2125,8 +2125,14 @@
 /area/security/brig)
 "arj" = (
 /obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/storage/briefcase,
+/obj/item/clipboard{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/storage/briefcase{
+	pixel_x = -8;
+	pixel_y = 1
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "arl" = (
@@ -2145,8 +2151,9 @@
 /area/medical/chemistry)
 "arn" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -9922,15 +9929,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "clb" = (
-/obj/machinery/button/door{
-	id = "psych";
-	name = "Psych Office Shutters Control";
-	pixel_x = 6;
-	pixel_y = -25
-	},
 /obj/effect/landmark/start/yogs/psychiatrist,
 /obj/structure/chair/office/light{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "psych";
+	name = "Psych Office Shutters Control";
+	pixel_x = -6;
+	pixel_y = -25;
+	req_access_txt = "5"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 9;
+	pixel_y = -24
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -10043,7 +10055,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "cmB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -11083,13 +11095,10 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "cHa" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cHc" = (
@@ -13053,8 +13062,13 @@
 /area/security/checkpoint/engineering)
 "dsb" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "dsf" = (
@@ -14113,10 +14127,6 @@
 /obj/machinery/computer/med_data/laptop{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 3;
-	pixel_y = -26
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "dOm" = (
@@ -14407,8 +14417,8 @@
 "dSi" = (
 /obj/structure/chair/comfy/brown,
 /obj/structure/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -14809,14 +14819,11 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos_distro)
 "eaJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -16060,7 +16067,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "evw" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -16790,18 +16796,15 @@
 /area/maintenance/starboard/aft)
 "eID" = (
 /obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "psych";
-	name = "privacy shutter"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/psych)
@@ -30864,10 +30867,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"jwP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "jwX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -31827,9 +31826,6 @@
 /area/hallway/primary/port)
 "jOO" = (
 /obj/machinery/chem_dispenser,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "jOQ" = (
@@ -33417,6 +33413,15 @@
 	name = "Psychiatrists office Maintenance";
 	req_access_txt = "5"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "krF" = (
@@ -33941,8 +33946,8 @@
 	pixel_y = -5
 	},
 /obj/item/laser_pointer{
-	pixel_y = -10;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = -10
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -34568,6 +34573,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kME" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "kMO" = (
@@ -36764,16 +36778,15 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "lJk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "lJv" = (
@@ -38143,9 +38156,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "meQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -38540,9 +38553,6 @@
 /area/maintenance/starboard/fore)
 "mmq" = (
 /obj/structure/bookcase/random/reference,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "mmr" = (
@@ -44621,6 +44631,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"olg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/medical/psych)
 "olJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -45150,9 +45167,6 @@
 /obj/machinery/door/airlock/wood{
 	name = "Psychiatrists office";
 	req_access_txt = "5"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -47027,9 +47041,7 @@
 	name = "Psychiatrists Office APC";
 	pixel_y = -23
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/medical/psych)
 "pcm" = (
@@ -47373,8 +47385,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "piI" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -50787,6 +50805,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qiS" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qjj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -50887,12 +50921,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southleft{
+	icon_state = "right";
 	name = "Filing Room";
-	req_access_txt = "5";
-	icon_state = "right"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	req_access_txt = "5"
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -51152,17 +51183,7 @@
 	},
 /area/science/xenobiology)
 "qpv" = (
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "qpw" = (
@@ -51924,9 +51945,6 @@
 	dir = 4
 	},
 /obj/structure/filingcabinet,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "qDJ" = (
@@ -57929,17 +57947,17 @@
 "sBc" = (
 /obj/structure/table/wood,
 /obj/item/folder/white{
-	pixel_x = -7;
-	pixel_y = -3
+	pixel_x = -9;
+	pixel_y = 6
 	},
 /obj/item/folder/white{
-	pixel_x = -2
+	pixel_y = -2
 	},
 /obj/item/folder/white{
-	pixel_x = 5;
-	pixel_y = 5
+	pixel_x = 7;
+	pixel_y = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "sBh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -60158,20 +60176,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"tiz" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "psych";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/psych)
 "tiH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
@@ -62920,6 +62924,9 @@
 "ukc" = (
 /obj/machinery/chem_master,
 /obj/item/book/manual/wiki/chemistry,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "ukq" = (
@@ -64061,9 +64068,6 @@
 "uCK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -69459,9 +69463,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -72864,8 +72865,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xIb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -74220,9 +74221,8 @@
 	},
 /area/crew_quarters/bar)
 "yew" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "yeO" = (
@@ -106820,7 +106820,7 @@ pUI
 aGK
 aQo
 lgU
-lve
+qiS
 lve
 opf
 opf
@@ -107593,7 +107593,7 @@ vAc
 aVN
 piI
 meQ
-jwP
+meQ
 pce
 aVN
 mNt
@@ -108108,7 +108108,7 @@ aVN
 qla
 xIb
 yew
-kME
+olg
 aVN
 rmQ
 aUg
@@ -109135,7 +109135,7 @@ aPX
 aVN
 eID
 ovp
-tiz
+eID
 aVN
 aVN
 vNv

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -2124,7 +2124,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "arj" = (
-/obj/effect/landmark/start/yogs/psychiatrist,
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/storage/briefcase,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "arl" = (
@@ -2142,7 +2144,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "arn" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "arz" = (
@@ -2299,7 +2304,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "asG" = (
-/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "asI" = (
@@ -9002,7 +9010,25 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/table,
+/obj/item/roller{
+	pixel_x = -3;
+	pixel_y = 14
+	},
+/obj/item/roller{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/pickaxe/mini,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "bYq" = (
@@ -9896,7 +9922,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "clb" = (
-/obj/machinery/light,
+/obj/machinery/button/door{
+	id = "psych";
+	name = "Psych Office Shutters Control";
+	pixel_x = 6;
+	pixel_y = -25
+	},
+/obj/effect/landmark/start/yogs/psychiatrist,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "clc" = (
@@ -10008,17 +10043,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "cmB" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/wood,
+/area/medical/psych)
 "cmL" = (
 /mob/living/simple_animal/crab/clown,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -11057,9 +11086,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cHc" = (
@@ -13022,13 +13052,13 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "dsb" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/machinery/light_switch{
+	pixel_x = -23
 	},
-/turf/open/floor/wood,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "dsf" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -13961,6 +13991,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dLh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dLn" = (
 /obj/structure/table,
 /obj/item/electronics/airlock,
@@ -14070,12 +14112,13 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
 "dNZ" = (
-/obj/structure/chair/sofa/left{
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light_switch{
+	pixel_x = 3;
+	pixel_y = -26
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -14365,16 +14408,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dSi" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/obj/machinery/button/door{
-	id = "psych";
-	name = "Psych Office Shutters Control";
-	pixel_x = -25;
-	pixel_y = -8
+/obj/structure/chair/comfy/brown,
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/medical/psych)
 "dSn" = (
 /obj/structure/rack,
@@ -14776,11 +14815,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -16752,6 +16791,23 @@
 /mob/living/simple_animal/cow/betsy,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"eID" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "psych";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/psych)
 "eIE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30811,6 +30867,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"jwP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "jwX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -31768,6 +31828,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jOO" = (
+/obj/machinery/chem_dispenser,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "jOQ" = (
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -33343,16 +33410,16 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "kru" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/closet/firecloset,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Psychiatrists office Maintenance";
+	req_access_txt = "5"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "krF" = (
@@ -33859,6 +33926,29 @@
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"kAU" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/lighter{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/item/laser_pointer{
+	pixel_y = -10;
+	pixel_x = -4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "kBi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/exoticpurple,
@@ -34480,6 +34570,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kME" = (
+/turf/open/floor/wood,
+/area/medical/psych)
 "kMO" = (
 /obj/structure/guncase/shotgun,
 /obj/item/gun/ballistic/shotgun/riot{
@@ -36021,14 +36114,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "lve" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -36680,15 +36770,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "lJv" = (
@@ -38057,6 +38145,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"meQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "mfG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -38447,18 +38542,9 @@
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
 "mmq" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/reagent_containers/pill/happy,
-/obj/item/reagent_containers/pill/happy,
-/obj/item/reagent_containers/pill/happy,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/bookcase/random/reference,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -40104,6 +40190,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction)
+"mNt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mNw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -44730,6 +44828,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"opf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "opo" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -46916,6 +47024,17 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pce" = (
+/obj/machinery/power/apc{
+	areastring = "/area/medical/psych";
+	name = "Psychiatrists Office APC";
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "pcm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -47256,6 +47375,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"piI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "piL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -50760,6 +50885,20 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
+"qla" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/machinery/door/window/southleft{
+	name = "Filing Room";
+	req_access_txt = "5";
+	icon_state = "right"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "qle" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -51016,20 +51155,16 @@
 	},
 /area/science/xenobiology)
 "qpv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psych";
-	dir = 1;
-	name = "Psychiatrist Office APC";
-	pixel_y = 23
-	},
 /obj/structure/cable{
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 25
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -51787,6 +51922,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"qDC" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "qDJ" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -56749,6 +56894,26 @@
 "ses" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"sey" = (
+/obj/structure/table/wood,
+/obj/item/assembly/flash{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/assembly/flash{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "seA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -57396,14 +57561,8 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "stI" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "stY" = (
@@ -57771,13 +57930,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sBc" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/item/folder/white{
+	pixel_x = -2
 	},
-/turf/open/floor/wood,
+/obj/item/folder/white{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet,
 /area/medical/psych)
 "sBh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -62755,6 +62920,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ukc" = (
+/obj/machinery/chem_master,
+/obj/item/book/manual/wiki/chemistry,
+/turf/open/floor/wood,
+/area/medical/psych)
 "ukq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -63358,27 +63528,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uut" = (
-/obj/structure/table,
-/obj/item/roller{
-	pixel_x = -3;
-	pixel_y = 14
-	},
-/obj/item/roller{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
-/obj/item/pickaxe/mini,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "uuB" = (
@@ -63912,6 +64064,9 @@
 "uCK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -66473,11 +66628,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "vAc" = (
-/obj/structure/closet/secure_closet/paramedic,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "vAs" = (
@@ -69160,6 +69314,28 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"wxa" = (
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "wxb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -70019,17 +70195,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wLc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Paramedic Staging Area Maintenance";
-	req_access_txt = "69"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "wLl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71698,6 +71863,22 @@
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/space/nearstation)
+"xnZ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Paramedic Staging Area Maintenance";
+	req_access_txt = "69"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "xol" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -72685,6 +72866,12 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"xIb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "xId" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -73501,7 +73688,10 @@
 	pixel_x = -4;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74032,6 +74222,12 @@
 	icon_state = "water"
 	},
 /area/crew_quarters/bar)
+"yew" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "yeO" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/warden,
@@ -106111,7 +106307,7 @@ ogx
 vXF
 rBH
 aGK
-aQo
+atx
 lMI
 aPk
 aKc
@@ -106368,7 +106564,7 @@ aqS
 gUX
 noR
 aGK
-aQo
+atx
 lMI
 aPk
 aPk
@@ -106628,11 +106824,11 @@ aGK
 aQo
 lgU
 lve
-aQo
-aPk
-aKc
-aKc
-avc
+lve
+opf
+opf
+lve
+dLh
 awB
 lrc
 msb
@@ -106882,14 +107078,14 @@ aGK
 aPX
 aPX
 aPX
-aPX
-aPX
+xnZ
+aVN
 kru
-aQo
-duI
-aKc
-aKc
-aKc
+aVN
+aVN
+aVN
+aVN
+mNt
 lCv
 lrc
 msb
@@ -107140,13 +107336,13 @@ nlk
 bNQ
 xVJ
 uut
-aPX
-kru
-lBc
-aPk
-aKc
-aKc
-aKc
+aVN
+kME
+sey
+jOO
+ukc
+aVN
+mNt
 aPk
 lrc
 lrc
@@ -107397,13 +107593,13 @@ ouT
 mtt
 avU
 vAc
-aPX
-kru
-aQo
-aPk
-aPk
-aPk
-aPk
+aVN
+piI
+meQ
+jwP
+pce
+aVN
+mNt
 aPk
 aPk
 aPk
@@ -107654,13 +107850,13 @@ aOI
 eCd
 avU
 bYc
-wLc
+aVN
 cmB
-pey
-gJg
-pey
-pey
-lve
+qDC
+kAU
+wxa
+aVN
+mNt
 oQP
 aQo
 aQo
@@ -107912,10 +108108,10 @@ hts
 drH
 stI
 aVN
-aVN
-aVN
-aVN
-aVN
+qla
+xIb
+yew
+kME
 aVN
 rmQ
 aUg
@@ -108940,7 +109136,7 @@ aPX
 aPX
 aPX
 aVN
-tiz
+eID
 ovp
 tiz
 aVN

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2420,7 +2420,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -4823,7 +4823,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -13190,7 +13190,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -21806,7 +21806,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -25077,7 +25077,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -26609,6 +26609,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gvv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "gvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -31136,7 +31143,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -47452,7 +47459,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56092,7 +56099,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56611,7 +56618,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -93802,7 +93809,7 @@ aDR
 oHO
 aqB
 vXV
-ayH
+gvv
 igF
 mOQ
 gdF

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2420,7 +2420,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -3728,7 +3728,7 @@
 /turf/closed/wall,
 /area/clerk)
 "ayH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -4823,7 +4823,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -13190,7 +13190,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -16204,6 +16204,9 @@
 "csH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "csP" = (
@@ -18789,7 +18792,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dph" = (
-/obj/structure/window/reinforced/tinted,
 /obj/structure/closet/secure_closet{
 	name = "psychiatrist locker";
 	req_access_txt = "5"
@@ -18805,7 +18807,7 @@
 	name = "very happy pills bottle"
 	},
 /obj/item/storage/pill_bottle/psicodine,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "dpF" = (
@@ -19763,6 +19765,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "dJr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -21026,9 +21031,6 @@
 /area/medical/surgery)
 "ejm" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/assembly/flash{
 	pixel_x = 7
 	},
@@ -21804,7 +21806,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -22536,6 +22538,7 @@
 /area/hallway/primary/fore)
 "eKY" = (
 /obj/machinery/power/apc{
+	areastring = "/area/medical/psych";
 	dir = 8;
 	name = "Psychiatrist APC";
 	pixel_x = -25
@@ -22981,8 +22984,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "eVI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -25074,7 +25077,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -31133,7 +31136,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -33323,10 +33326,13 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "jcS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /obj/machinery/camera{
-	c_tag = "Prison Common Room South";
+	c_tag = "Psychiatrist Office";
 	dir = 4;
-	network = list("ss13","prison")
+	network = list("ss13")
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -37778,7 +37784,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -39739,13 +39745,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lTC" = (
-/obj/machinery/light,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -47450,7 +47452,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -49049,7 +49051,6 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "pId" = (
@@ -49086,6 +49087,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -51125,6 +51132,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "qFC" = (
@@ -52940,10 +52951,6 @@
 /area/quartermaster/storage)
 "rrU" = (
 /obj/structure/bookcase/random/reference,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "rss" = (
@@ -53397,8 +53404,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -56085,7 +56092,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56604,7 +56611,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -57352,6 +57359,12 @@
 "thy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -59505,6 +59518,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"ubU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "ucg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -60120,8 +60140,10 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "upM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /obj/structure/window/reinforced/tinted,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "uqa" = (
@@ -60632,6 +60654,9 @@
 /area/hallway/primary/aft)
 "uBk" = (
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "uBu" = (
@@ -60963,13 +60988,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"uIQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "uIU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -62085,8 +62103,6 @@
 /obj/machinery/meter{
 	target_layer = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62096,6 +62112,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -64325,9 +64347,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "vXV" = (
-/obj/structure/window/reinforced/tinted,
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/chemistry,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "vYi" = (
@@ -68367,6 +68389,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xML" = (
@@ -68631,10 +68659,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xSC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "xSQ" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_x = -32
@@ -69186,16 +69210,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ydS" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/window/reinforced/tinted,
 /obj/machinery/door/window/southleft{
 	dir = 8;
 	name = "Filing Room";
 	req_access_txt = "5"
 	},
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/wood,
 /area/medical/psych)
 "yeb" = (
@@ -94039,7 +94059,7 @@ aDR
 ong
 ldb
 dph
-uIQ
+ayH
 pHX
 pHX
 lTC
@@ -94297,8 +94317,8 @@ ejm
 thy
 upM
 eVI
-xSC
 rUO
+ubU
 rDb
 chD
 mkD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2420,7 +2420,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2631,6 +2631,15 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
+"aqB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "aqH" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
@@ -3719,6 +3728,9 @@
 /turf/closed/wall,
 /area/clerk)
 "ayH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "ayK" = (
@@ -4811,7 +4823,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -13178,7 +13190,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -16190,8 +16202,8 @@
 /turf/open/floor/plating,
 /area/clerk)
 "csH" = (
-/obj/structure/bookcase/random/reference,
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/filingcabinet,
 /turf/open/floor/wood,
 /area/medical/psych)
 "csP" = (
@@ -18778,6 +18790,22 @@
 /area/maintenance/aft)
 "dph" = (
 /obj/structure/window/reinforced/tinted,
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "dpF" = (
@@ -20996,6 +21024,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"ejm" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/assembly/flash{
+	pixel_x = 7
+	},
+/obj/item/laser_pointer{
+	pixel_y = 9
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/assembly/flash{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "ejp" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
@@ -21755,7 +21804,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -22931,6 +22980,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"eVI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "eVJ" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -25019,7 +25074,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -31078,7 +31133,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -37718,6 +37773,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"ldb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "ldo" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -39162,7 +39226,7 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "lHz" = (
-/obj/structure/chair/sofa/right,
+/obj/machinery/chem_master,
 /turf/open/floor/wood,
 /area/medical/psych)
 "lHO" = (
@@ -39679,6 +39743,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -45488,10 +45555,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ong" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair/sofa/left,
+/obj/machinery/chem_heater,
 /turf/open/floor/wood,
 /area/medical/psych)
 "onr" = (
@@ -46455,7 +46519,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "oHO" = (
-/obj/structure/chair/sofa,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/wood,
 /area/medical/psych)
 "oHU" = (
@@ -47386,7 +47450,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -48985,6 +49049,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "pId" = (
@@ -52873,6 +52938,14 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"rrU" = (
+/obj/structure/bookcase/random/reference,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "rss" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -53320,10 +53393,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "rDb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -55910,10 +55985,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
-"sHf" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/medical/psych)
 "sHn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -56014,7 +56085,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56533,7 +56604,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -60049,6 +60120,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "upM" = (
+/obj/structure/window/reinforced/tinted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -60891,6 +60963,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uIQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "uIU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -64246,10 +64325,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "vXV" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
 /obj/structure/window/reinforced/tinted,
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "vYi" = (
@@ -66048,24 +66126,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/research)
-"wKO" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/psicodine,
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/wood,
-/area/medical/psych)
 "wKP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -69126,13 +69186,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ydS" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Filing Room";
+	req_access_txt = "5"
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -93718,7 +93780,7 @@ vTj
 bfs
 aDR
 oHO
-thy
+aqB
 vXV
 ayH
 igF
@@ -93975,9 +94037,9 @@ kmw
 arP
 aDR
 ong
-thy
+ldb
 dph
-ayH
+uIQ
 pHX
 pHX
 lTC
@@ -94231,10 +94293,10 @@ bfs
 bld
 dgn
 aDR
-wjG
+ejm
 thy
 upM
-xSC
+eVI
 xSC
 rUO
 rDb
@@ -94492,9 +94554,9 @@ csH
 pIr
 qFz
 ydS
+rrU
+wjG
 uBk
-sHf
-wKO
 aDR
 yiu
 cSb

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2420,7 +2420,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2631,15 +2631,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
-"aqB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "aqH" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot,
@@ -3727,12 +3718,6 @@
 "ayG" = (
 /turf/closed/wall,
 /area/clerk)
-"ayH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "ayK" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -4823,7 +4808,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -5644,17 +5629,14 @@
 "aJk" = (
 /obj/machinery/light,
 /obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/ethanol{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/ethanol{
-	pixel_x = -6;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
+/obj/structure/bedsheetbin{
+	pixel_x = 2
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "aJq" = (
@@ -10363,6 +10345,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bmJ" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bnc" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -11157,9 +11144,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "btY" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bub" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -11437,12 +11424,17 @@
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "bwo" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "bwq" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/turf_decal/bot,
@@ -12522,31 +12514,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "bDB" = (
-/obj/structure/table,
-/obj/item/roller{
-	pixel_x = -1;
-	pixel_y = 7
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
-/obj/item/roller{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/roller{
-	pixel_x = 5;
-	pixel_y = 13
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bDE" = (
 /obj/machinery/electrolyzer,
 /obj/effect/turf_decal/bot,
@@ -13026,23 +12999,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bIJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "viropen";
-	name = "Monkey Pen Shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "bIT" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Tool Storage Maintenance";
@@ -13190,7 +13146,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -13733,15 +13689,20 @@
 	pixel_x = 3;
 	pixel_y = -12
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
 /obj/item/roller{
-	pixel_y = 9
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/roller{
+	pixel_x = 2;
+	pixel_y = 10
 	},
 /obj/item/roller{
 	pixel_x = 5;
 	pixel_y = 13
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
@@ -14105,15 +14066,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bSN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "bTc" = (
 /obj/structure/extinguisher_cabinet{
@@ -14202,24 +14167,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bUq" = (
-/obj/structure/table,
-/obj/item/roller{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/roller{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/roller{
-	pixel_x = 5;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bUs" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
@@ -14296,6 +14246,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bVF" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "bVI" = (
 /obj/machinery/light{
 	dir = 1
@@ -14364,14 +14325,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -15240,20 +15201,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"chD" = (
-/obj/machinery/door/airlock/wood{
-	name = "Psychiatrists office";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/medical/psych)
 "chH" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -16201,14 +16148,6 @@
 	},
 /turf/open/floor/plating,
 /area/clerk)
-"csH" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "csP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16257,6 +16196,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/closet/l3closet,
+/obj/item/geiger_counter,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "ctE" = (
@@ -18519,6 +18460,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"diB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "diJ" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table,
@@ -18656,17 +18608,17 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dms" = (
-/obj/structure/bed,
-/obj/structure/cloth_curtain{
-	color = "#99ccff"
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
 	},
-/obj/item/bedsheet/medical,
-/obj/machinery/vending/wallmed{
-	pixel_y = -28
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/medical/psych)
 "dmu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
@@ -18791,25 +18743,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dph" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "dpF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -19764,15 +19697,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"dJr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "dJF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -19873,24 +19797,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dLp" = (
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "psych";
-	name = "Psych Office Shutters Control";
-	pixel_x = -25;
-	pixel_y = -8;
-	req_access_txt = "5"
-	},
-/obj/effect/landmark/start/yogs/psychiatrist,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "dLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -20205,6 +20111,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dSq" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -16;
+	pixel_y = 5
+	},
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "dSz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -21029,24 +20955,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"ejm" = (
-/obj/structure/table/wood,
-/obj/item/assembly/flash{
-	pixel_x = 7
-	},
-/obj/item/laser_pointer{
-	pixel_y = 9
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/obj/item/assembly/flash{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "ejp" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
@@ -21347,6 +21255,21 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/starboard/aft)
+"eoJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "epj" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -21795,7 +21718,7 @@
 	pixel_x = 32;
 	pixel_y = -40
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21806,7 +21729,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -22195,6 +22118,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"eFq" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "eFC" = (
 /obj/machinery/light,
 /obj/machinery/modular_computer/telescreen/preset/medical{
@@ -22363,11 +22291,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eHY" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -22536,24 +22459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eKY" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psych";
-	dir = 8;
-	name = "Psychiatrist APC";
-	pixel_x = -25
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = 27
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "eLF" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -22983,12 +22888,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"eVI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "eVJ" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -23265,18 +23164,17 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "faj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "fav" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -23519,6 +23417,27 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"fgF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fgV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23621,16 +23540,17 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "fju" = (
-/obj/machinery/iv_drip,
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/structure/window/reinforced/tinted{
+	dir = 1
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "fjz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -24287,23 +24207,19 @@
 /obj/item/stack/rods/twentyfive,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"fxA" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "fxX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fyq" = (
+/obj/effect/landmark/start/yogs/psychiatrist,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "fyr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -24810,9 +24726,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/wardrobe/pjs,
+/obj/structure/cloth_curtain{
+	color = "#99ccff"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -25077,7 +24997,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -25263,6 +25183,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "fOz" = (
@@ -25882,12 +25803,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"gdF" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/medical/psych)
 "gdH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -26118,11 +26033,20 @@
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "gjv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/item/pen/fountain{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/clipboard{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "gjC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -26609,13 +26533,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gvv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "gvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -27802,9 +27719,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "gYj" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = -23;
 	pixel_y = -1
@@ -28041,6 +27955,9 @@
 "hcw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -28401,6 +28318,13 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"hjl" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/psych)
 "hjz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/fore";
@@ -28712,6 +28636,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"hpd" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
+"hpo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hpG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29100,6 +29051,21 @@
 /obj/item/reagent_containers/food/snacks/donkpocket,
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
+/area/maintenance/aft)
+"hvb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/aft)
 "hvG" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -29624,6 +29590,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"hHw" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hHJ" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 4
@@ -29659,7 +29631,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "hIx" = (
@@ -29882,16 +29854,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hMY" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft_starboard)
 "hNs" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
@@ -30957,21 +30919,6 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/cola,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"igF" = (
-/obj/structure/table/wood,
-/obj/item/folder/white{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = -2
-	},
-/obj/item/folder/white{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "igI" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -31122,6 +31069,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
+/obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "ijG" = (
@@ -31143,7 +31091,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -31920,18 +31868,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"izE" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/psych)
 "izI" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool{
@@ -32399,19 +32335,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"iJz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "iJL" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -32791,12 +32714,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iRr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/medical/psych";
+	dir = 4;
+	name = "Psychiatrist APC";
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/medical/psych)
 "iRt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -33333,16 +33263,9 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "jcS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Psychiatrist Office";
-	dir = 4;
-	network = list("ss13")
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
+/obj/effect/landmark/stationroom/maint/fivexfour,
+/turf/template_noop,
+/area/maintenance/fore)
 "jda" = (
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -33401,6 +33324,12 @@
 "jdO" = (
 /turf/closed/wall,
 /area/medical/storage)
+"jea" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/aft)
 "jec" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -34223,6 +34152,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"jxu" = (
+/turf/closed/wall/r_wall,
+/area/medical/psych)
+"jyi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "jyo" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -35412,12 +35348,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "kar" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 6
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Filing Room";
+	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "kav" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -36088,6 +36031,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"kpR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "kql" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -36810,11 +36760,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"kGc" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "kGn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -37419,6 +37364,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kTi" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/psych)
 "kTm" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
@@ -37786,15 +37745,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"ldb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "ldo" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -39238,10 +39188,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHz" = (
-/obj/machinery/chem_master,
-/turf/open/floor/wood,
-/area/medical/psych)
 "lHO" = (
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39448,6 +39394,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lMs" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Psychiatrist Office";
+	dir = 4;
+	network = list("ss13");
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "lMB" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
@@ -39712,6 +39676,11 @@
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos_distro)
+"lSB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "lSK" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -39751,13 +39720,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lTC" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "lUd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39821,6 +39783,18 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"lWq" = (
+/obj/structure/cloth_curtain{
+	color = "#99ccff"
+	},
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/machinery/vending/wallmed{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39866,18 +39840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"lXH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/psych)
 "lXT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -40629,17 +40591,17 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "mkD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -42144,17 +42106,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"mNS" = (
-/obj/structure/cloth_curtain{
-	color = "#99ccff"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
 "mNZ" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -42190,12 +42141,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"mOQ" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/storage/briefcase,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -42208,6 +42153,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -42643,18 +42591,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos_distro)
-"nab" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_x = 5
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/wood,
-/area/medical/psych)
 "nam" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -45306,6 +45242,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ohK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ohL" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -45563,10 +45512,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ong" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/wood,
-/area/medical/psych)
 "onr" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -45796,6 +45741,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"otB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "otI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46527,10 +46481,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"oHO" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/wood,
-/area/medical/psych)
 "oHU" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -47459,7 +47409,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -49055,11 +49005,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pHX" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/medical/psych)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "pId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -49088,21 +49041,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"pIr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "pIA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49521,15 +49459,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "pTN" = (
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/medical/psych)
 "pUH" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -50366,6 +50301,15 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"qlM" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood,
+/area/medical/psych)
 "qlP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -50408,12 +50352,18 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
 "qns" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/obj/machinery/button/door{
+	id = "psych";
+	name = "Psych Office Shutters Control";
+	pixel_x = -23;
+	pixel_y = 22;
+	req_access_txt = "5"
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "qny" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -50587,7 +50537,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qqd" = (
-/obj/structure/closet/secure_closet/medical3,
 /obj/machinery/light_switch{
 	pixel_x = 15;
 	pixel_y = 25
@@ -50595,6 +50544,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "qrj" = (
@@ -51135,16 +51085,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qFz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "qFC" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -51555,6 +51495,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"qLz" = (
+/obj/machinery/paystand/register{
+	dir = 1;
+	name = "dusty unregistered pay stand";
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle";
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "qLJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -52165,13 +52120,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "qYx" = (
-/obj/effect/landmark/blobstart,
+/obj/machinery/camera{
+	c_tag = "Virology Monkey Pen";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 9
+	},
 /obj/structure/sign/warning/biohazard{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 8
-	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qZu" = (
@@ -52956,10 +52915,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"rrU" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/medical/psych)
 "rss" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -53099,13 +53054,6 @@
 /obj/item/toy/figure/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"rvT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "rwb" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -53406,16 +53354,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"rDb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "rDf" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
@@ -54309,11 +54247,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"rUO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "rVr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54333,12 +54266,6 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/structure/bedsheetbin{
-	pixel_x = 2
-	},
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
@@ -54931,9 +54858,20 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "sia" = (
-/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg2"
+	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft)
 "siG" = (
@@ -55348,9 +55286,6 @@
 	dir = 4;
 	name = "Medbay Aft APC";
 	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -56099,7 +56034,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56597,6 +56532,14 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sUY" = (
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "sVu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56618,7 +56561,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -57363,18 +57306,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"thy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "thI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -57903,6 +57834,16 @@
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tvc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft_starboard)
 "tvq" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
@@ -58203,18 +58144,6 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
-"tAC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "tBb" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/engine,
@@ -58398,6 +58327,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"tEx" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/medical/psych)
 "tEC" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -58552,6 +58485,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -59148,14 +59084,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tTA" = (
-/obj/structure/closet/l3closet,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/item/geiger_counter,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/medical3,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "tTK" = (
@@ -59525,13 +59460,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"ubU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "ucg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -60146,13 +60074,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"upM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "uqa" = (
 /obj/effect/turf_decal/trimline/white/corner,
 /turf/open/floor/plasteel,
@@ -60264,6 +60185,14 @@
 /area/medical/medbay/aft)
 "urv" = (
 /obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/ethanol{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bottle/ethanol{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -60659,13 +60588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"uBk" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "uBu" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable{
@@ -61094,15 +61016,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"uKT" = (
-/obj/structure/cloth_curtain{
-	color = "#99ccff"
-	},
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
 "uLo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
@@ -61498,6 +61411,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uSA" = (
+/obj/structure/bed,
+/obj/structure/cloth_curtain{
+	color = "#99ccff"
+	},
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "uSG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/foyer";
@@ -61872,6 +61794,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"uYM" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "uZh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
@@ -62114,18 +62040,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vdL" = (
@@ -62477,12 +62393,24 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vmd" = (
-/obj/structure/closet/secure_closet/medical3,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
+	},
+/obj/structure/table,
+/obj/item/roller{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/roller{
+	pixel_x = 2;
+	pixel_y = 10
+	},
+/obj/item/roller{
+	pixel_x = 5;
+	pixel_y = 13
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -64035,6 +63963,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vRr" = (
+/obj/machinery/chem_master,
+/obj/item/book/manual/wiki/chemistry,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/psych)
 "vRA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -64241,6 +64177,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"vUZ" = (
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vVb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -64353,12 +64300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"vXV" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/chemistry,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "vYi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -64548,6 +64489,18 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"waq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/aft)
 "war" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -64763,24 +64716,20 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wfd" = (
-/obj/structure/table,
-/obj/item/roller{
-	pixel_x = -1;
+/obj/structure/table/wood,
+/obj/item/taperecorder{
+	pixel_x = 15;
+	pixel_y = 4
+	},
+/obj/machinery/computer/med_data/laptop{
+	pixel_x = -4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
 	pixel_y = 7
 	},
-/obj/item/roller{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/roller{
-	pixel_x = 5;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "wfs" = (
 /obj/structure/transit_tube/diagonal{
 	dir = 4
@@ -64903,10 +64852,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wjG" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood,
-/area/medical/psych)
 "wjH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -65516,8 +65461,8 @@
 /turf/open/floor/plasteel,
 /area/science/nanite)
 "wwp" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Scondary Storage";
+/obj/machinery/door/airlock/wood{
+	name = "Psychiatrists office";
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -65526,18 +65471,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/aft)
+/turf/open/floor/wood,
+/area/medical/psych)
 "wwt" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
@@ -65597,9 +65535,6 @@
 "wxs" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
-	},
-/obj/structure/chair{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -65824,27 +65759,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"wDm" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wDn" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Room Access";
@@ -65950,21 +65864,23 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wFq" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/item/assembly/flash{
+	pixel_x = 3;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/item/laser_pointer{
+	pixel_y = 9
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/item/assembly/flash{
+	pixel_x = 7
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/medical/psych)
 "wFr" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -68000,7 +67916,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xBS" = (
-/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xCk" = (
@@ -68120,8 +68046,26 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "xFh" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/aft)
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "xFp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/disposalpipe/segment,
@@ -68382,28 +68326,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xMH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Psychiatrist maintenance";
-	req_one_access = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "xML" = (
 /turf/closed/wall,
 /area/hallway/primary/aft_starboard)
@@ -69216,15 +69138,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ydS" = (
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Filing Room";
-	req_access_txt = "5"
-	},
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/wood,
-/area/medical/psych)
 "yeb" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 1
@@ -69788,16 +69701,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"ylN" = (
-/obj/machinery/camera{
-	c_tag = "Virology Monkey Pen";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ylY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -93291,15 +93194,15 @@ bdo
 arP
 bld
 aqR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
+arP
+arP
+arP
+diB
+arP
+arP
+arP
+aqR
+arP
 bZk
 aLE
 aOl
@@ -93548,15 +93451,15 @@ bdC
 arP
 bld
 iSd
-aDR
-lHz
-eKY
-nab
-dJr
+qLz
+arP
+omk
+omk
+omk
 jcS
-dLp
-fxA
-izE
+arP
+aqR
+arP
 keM
 ehE
 aOl
@@ -93804,16 +93707,16 @@ aqR
 qGp
 bfq
 vTj
-bfs
-aDR
-oHO
-aqB
-vXV
-gvv
-igF
-mOQ
-gdF
-lXH
+aqR
+hHw
+arP
+omk
+omk
+omk
+omk
+arP
+aqR
+arP
 eQR
 aLE
 aOl
@@ -94062,15 +93965,15 @@ arP
 arP
 kmw
 arP
-aDR
-ong
-ldb
-dph
-ayH
+arP
+arP
+omk
+omk
+omk
+omk
 pHX
-pHX
-lTC
-aDR
+aqR
+arP
 cHu
 aLE
 aOl
@@ -94318,18 +94221,18 @@ baI
 arP
 bfs
 bld
+aqR
 dgn
-aDR
-ejm
-thy
-upM
-eVI
-rUO
-ubU
-rDb
-chD
+arP
+omk
+omk
+omk
+omk
+arP
+aqR
+arP
 mkD
-dvH
+aLE
 exY
 aPM
 pOw
@@ -94575,16 +94478,16 @@ omk
 arP
 aXJ
 bld
+aqR
 kzh
-aDR
-csH
-pIr
-qFz
-ydS
-rrU
-wjG
-uBk
-aDR
+arP
+omk
+omk
+omk
+omk
+arP
+aqR
+arP
 yiu
 cSb
 kXW
@@ -94833,15 +94736,15 @@ arP
 eAN
 bld
 aqR
-aDR
-aDR
-xMH
-aDR
-aDR
-aDR
-aDR
-aDR
-aDR
+aqR
+arP
+arP
+vUZ
+arP
+arP
+arP
+aqR
+arP
 lkp
 wvx
 rRD
@@ -95091,9 +94994,9 @@ bfz
 blr
 jFC
 smE
-tAC
+jHS
 vdJ
-iJz
+jFC
 jHS
 jHS
 jHS
@@ -104389,8 +104292,8 @@ fLU
 rZt
 bvD
 bzs
-liS
-avy
+fgF
+xDQ
 avy
 soo
 soo
@@ -104646,8 +104549,8 @@ rUj
 rZt
 vAD
 bzs
-wDm
-avy
+liS
+uYM
 avy
 ftv
 ozZ
@@ -106189,7 +106092,7 @@ hPm
 mWy
 jdO
 liS
-avy
+eFq
 avy
 clA
 iNp
@@ -106446,7 +106349,7 @@ pjM
 lux
 jdO
 uMg
-avy
+xDQ
 avy
 avy
 avy
@@ -107730,10 +107633,10 @@ tdV
 mzH
 gBy
 jhe
-liS
-bHX
+hpo
+hvb
 xBS
-aSI
+ohK
 sia
 avy
 pZl
@@ -107987,11 +107890,11 @@ rTQ
 ngi
 jaF
 jhe
-liS
-xkZ
-xCv
-bAw
-xkZ
+jxu
+jxu
+jxu
+jxu
+eoJ
 avy
 avy
 avy
@@ -108245,9 +108148,9 @@ vbD
 vFJ
 jhe
 wFq
-pYm
-pYm
-pYm
+hpd
+hjl
+jxu
 bSN
 pYm
 pYm
@@ -108495,17 +108398,17 @@ shN
 ejf
 qGf
 adK
+jhe
+jhe
+jhe
+jhe
+jhe
+jhe
 xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xFh
-xDQ
-kGc
-bAw
+fyq
+vRr
+jxu
+bmJ
 hEv
 bHX
 bAw
@@ -108754,19 +108657,19 @@ qxl
 adK
 rVt
 fHF
-mNS
-bKQ
+aDR
+lMs
 bUq
 wfd
 qns
 bwo
-bNd
-bNd
+sUY
+jxu
 bNd
 bNd
 bNd
 bgu
-xkZ
+jea
 bAw
 bzs
 eEO
@@ -109010,15 +108913,15 @@ vYV
 wvD
 xjo
 uJd
-ulL
+uSA
 dms
-bKQ
+jyi
 bDB
 gjv
 btY
 fju
-bNd
-ylN
+dSq
+jxu
 qYx
 rnx
 bNd
@@ -109267,20 +109170,20 @@ gms
 fQn
 adK
 jrP
-ulL
 xTZ
-bKQ
+dms
+qlM
 faj
 iRr
 pTN
 kar
-bNd
+tEx
+jxu
 nTv
-rvT
 cpO
 qbG
 uOh
-xGG
+bNd
 bNd
 bNd
 bNd
@@ -109524,15 +109427,15 @@ ayu
 aJk
 adK
 kav
-ulL
-uKT
-bKQ
+lWq
+aDR
+aDR
 wwp
-bKQ
-bKQ
-bKQ
-bNd
-bIJ
+aDR
+kTi
+aDR
+aDR
+jxu
 bXt
 xWw
 bNd
@@ -110040,7 +109943,7 @@ oLf
 jMu
 uru
 eUA
-vbU
+waq
 tJq
 bWN
 vbU
@@ -110297,7 +110200,7 @@ hkO
 nwZ
 rfK
 xPQ
-xPQ
+otB
 xPQ
 stl
 gTb
@@ -110547,10 +110450,10 @@ fRD
 kKV
 haC
 fOb
-xPQ
-xPQ
+kpR
+kpR
 hIg
-kKV
+bVF
 ijC
 vGx
 vGx
@@ -110799,7 +110702,7 @@ kiy
 kiy
 kiy
 ebl
-hLI
+lSB
 mNn
 xAW
 acz
@@ -112849,8 +112752,8 @@ jIl
 fvu
 fIu
 iXv
+tvc
 iXv
-hMY
 mnR
 wHs
 udM

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -77705,7 +77705,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/cmo)

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -35934,8 +35934,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
@@ -35947,10 +35948,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/aft)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bSf" = (
 /obj/item/crowbar,
 /turf/open/floor/plating{
@@ -35973,7 +35972,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Psychiatrists office Maintenance";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bSn" = (
@@ -35986,6 +35997,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bSo" = (
@@ -36271,8 +36283,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bSY" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
@@ -36438,11 +36453,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/carpet,
+/area/medical/psych)
 "bTG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -36528,6 +36543,10 @@
 "bTO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -38036,11 +38055,14 @@
 	pixel_y = 26;
 	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -42424,13 +42446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"cub" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cud" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42459,10 +42474,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"cuk" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cul" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49072,6 +49083,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dfW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/chem_dispenser,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "dgi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
@@ -51374,8 +51392,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/closet/emcloset,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "efn" = (
@@ -52664,22 +52681,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eUQ" = (
+/obj/machinery/camera{
+	c_tag = "Departure Lounge - Security Post";
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "eWm" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/door/window/southleft{
+	name = "Filing Room";
 	req_access_txt = "5"
 	},
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/psicodine,
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "eWC" = (
@@ -53022,17 +53047,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fnS" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -53642,8 +53664,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "fKf" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = -2
+	},
+/obj/item/folder/white{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -54280,15 +54311,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -23
 	},
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psych";
-	name = "Psychiatrists Office APC";
-	pixel_y = -23
-	},
-/obj/structure/cable/yellow,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "gdD" = (
@@ -54785,11 +54810,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/space/nearstation)
-"gvo" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/aft)
 "gvA" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -55094,6 +55114,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gIO" = (
+/obj/effect/landmark/start/yogs/psychiatrist,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "gIP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -55190,6 +55217,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"gLq" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "gLv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55804,9 +55846,6 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/medical/psych)
@@ -56903,6 +56942,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"hYx" = (
+/obj/machinery/chem_master,
+/obj/item/book/manual/wiki/chemistry,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "hYG" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -61418,6 +61462,17 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"kTK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Psychiatrists office Maintenance";
+	req_access_txt = "5"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kTL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -62416,29 +62471,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"lwJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit/departure_lounge)
 "lwP" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -63067,14 +63099,8 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "lTW" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
-	dir = 1;
-	name = "Departure Lounge APC";
-	pixel_y = 23
-	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -64543,6 +64569,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"mTn" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "mTr" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -65483,6 +65513,29 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nzQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
+	dir = 1;
+	name = "Departure Lounge APC";
+	pixel_y = 23
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "nzX" = (
 /obj/machinery/computer/ai_overclocking{
 	dir = 4
@@ -65950,13 +66003,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "nOu" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/chair/sofa{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/item/storage/briefcase,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "nOA" = (
@@ -66587,18 +66636,37 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "okv" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Psychiatrists office Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 5
+	},
+/obj/item/lighter{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/laser_pointer{
+	pixel_y = -10;
+	pixel_x = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "okH" = (
 /obj/machinery/camera{
 	c_tag = "Interrogation room";
@@ -68371,12 +68439,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"pxE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "pxO" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -72210,6 +72272,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rYL" = (
@@ -73139,9 +73204,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -73784,6 +73846,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/psych)
@@ -75154,9 +75219,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tVx" = (
-/obj/effect/landmark/start/yogs/psychiatrist,
-/obj/structure/chair/wood{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -75206,6 +75270,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"tXA" = (
+/obj/item/twohanded/required/kirbyplants/random{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "tXU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -76569,9 +76640,6 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -76888,23 +76956,21 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "uWO" = (
-/obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_x = -15
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
 	},
-/obj/item/folder{
-	pixel_x = -14;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Psychiatrist Office"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/computer/med_data/laptop{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = 6
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -77257,6 +77323,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"vlt" = (
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "vmx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -77442,16 +77515,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vrP" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "vsa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -77597,6 +77660,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"vyf" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet,
+/area/medical/psych)
 "vyA" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -77632,7 +77705,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/cmo)
@@ -78051,15 +78124,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vPZ" = (
-/obj/machinery/light/small,
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "vQi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -78135,6 +78199,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tcom)
+"vRk" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "vRn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -78357,6 +78425,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"vYl" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop{
+	pixel_x = 3;
+	pixel_y = 2;
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "vYq" = (
 /obj/machinery/light{
 	dir = 8
@@ -78512,6 +78589,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"wdP" = (
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/psych";
+	name = "Psychiatrists Office APC";
+	pixel_y = -23
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "wel" = (
 /obj/item/cigbutt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -79489,9 +79595,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"wOE" = (
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wOY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -79666,9 +79769,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wVI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -80941,6 +81041,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"xOx" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "xOC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -81351,9 +81458,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
 "yaA" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "yaP" = (
@@ -81429,17 +81537,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -81483,6 +81588,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ydF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "ydZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -105055,7 +105169,7 @@ sZP
 hiu
 auQ
 auQ
-cub
+auQ
 bUs
 cLa
 cML
@@ -105311,8 +105425,8 @@ auQ
 caS
 yaA
 gdq
+vYl
 auQ
-gvo
 lMW
 cMb
 cMM
@@ -105566,10 +105680,10 @@ csH
 jhM
 auQ
 fnS
-fQD
+vlt
 nOu
+gIO
 auQ
-wOE
 bUr
 cLa
 cMN
@@ -105825,8 +105939,8 @@ auQ
 uWO
 tVx
 fKf
+eUQ
 auQ
-cuk
 bUs
 cLa
 cMO
@@ -106080,10 +106194,10 @@ qHu
 cCe
 auQ
 eWm
-pxE
+fQD
 cdG
+tXA
 auQ
-wOE
 bUt
 cLa
 cMP
@@ -106336,11 +106450,11 @@ uOF
 ecc
 bPc
 auQ
-auQ
-auQ
+gLq
+vyf
 okv
+wdP
 auQ
-wOE
 bUs
 cLa
 cMI
@@ -106592,12 +106706,12 @@ uDC
 bIs
 csM
 cCj
-cCj
-cCe
+auQ
+ydF
 bSb
 bTF
 bSV
-bSV
+kTK
 wfl
 cPb
 uWh
@@ -106848,13 +106962,13 @@ ctA
 cCj
 cCj
 bKg
-cCj
-cCj
-cCe
+vRk
+auQ
+mTn
 bSe
-cPb
-cPb
-cPb
+dfW
+hYx
+auQ
 cLk
 cZr
 qbF
@@ -107106,12 +107220,12 @@ kVV
 tFJ
 bOL
 tFJ
-vPZ
-cCe
+auQ
+auQ
 bSm
-cPb
-lwJ
-vrP
+auQ
+auQ
+auQ
 vrg
 hTx
 lsu
@@ -107368,7 +107482,7 @@ cCe
 bSn
 cPb
 efl
-cLm
+xOx
 dzP
 cLm
 cLm
@@ -107624,7 +107738,7 @@ gzL
 cCe
 bSo
 cPb
-cPb
+nzQ
 lTW
 cvW
 cLm

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -35931,10 +35931,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "bSd" = (
@@ -35942,13 +35944,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bSe" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "bSf" = (
 /obj/item/crowbar,
@@ -35966,9 +35965,6 @@
 /turf/open/floor/wood,
 /area/library)
 "bSm" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35988,9 +35984,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bSn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35998,12 +35991,12 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bSo" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -36014,43 +36007,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bSq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/aft)
 "bSr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"bSs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;5;39;6"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -36280,13 +36244,16 @@
 /area/hallway/secondary/service)
 "bSV" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "bSY" = (
 /obj/machinery/camera{
@@ -36450,11 +36417,12 @@
 /area/crew_quarters/bar)
 "bTF" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -38049,22 +38017,16 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "caS" = (
-/obj/machinery/button/door{
-	id = "Psychiatristshutters";
-	name = "psychiatrist shutters control";
-	pixel_y = 26;
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "caV" = (
 /obj/machinery/power/apc{
@@ -38488,6 +38450,8 @@
 	},
 /area/crew_quarters/kitchen)
 "cdG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/medical/psych)
 "cdI" = (
@@ -42497,17 +42461,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cuA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cuD" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -42903,6 +42856,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -49084,11 +49040,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dfW" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/chem_dispenser,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "dgi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -50122,6 +50075,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -51393,6 +51349,9 @@
 	dir = 1
 	},
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "efn" = (
@@ -52683,10 +52642,14 @@
 /area/hallway/primary/central)
 "eUQ" = (
 /obj/machinery/camera{
-	c_tag = "Departure Lounge - Security Post";
-	dir = 1
+	c_tag = "Psychiatrist Office";
+	dir = 1;
+	network = list("ss13")
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "eWm" = (
 /obj/structure/window/reinforced/tinted{
@@ -52696,16 +52659,10 @@
 	name = "Filing Room";
 	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "eWC" = (
 /obj/structure/disposalpipe/segment,
@@ -53047,16 +53004,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fnS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "fnY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53880,8 +53834,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "fQD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -54308,13 +54265,16 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/ai_monitored/turret_protected/ai)
 "gdq" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/carpet,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/pen/fountain{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "gdD" = (
 /obj/structure/lattice/catwalk,
@@ -55119,7 +55079,18 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/carpet,
+/obj/machinery/button/door{
+	id = "psych";
+	name = "Psych Office Shutters Control";
+	pixel_x = -5;
+	pixel_y = -25;
+	req_access_txt = "5"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = -25
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "gIP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -55221,16 +55192,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "gLv" = (
 /obj/structure/cable/yellow{
@@ -55837,15 +55805,15 @@
 /area/security/brig)
 "hiu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Psychiatristshutters";
-	name = "psychiatrist shutters"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
 	},
 /turf/open/floor/plating,
 /area/medical/psych)
@@ -56630,9 +56598,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hMq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -56945,7 +56910,7 @@
 "hYx" = (
 /obj/machinery/chem_master,
 /obj/item/book/manual/wiki/chemistry,
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "hYG" = (
 /obj/structure/chair,
@@ -58599,9 +58564,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jhM" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = -30
-	},
 /obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_x = -4;
@@ -61393,7 +61355,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -61448,7 +61410,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/computer/atmos_control/tank/air_tank{
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -61470,6 +61432,16 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychiatrists office Maintenance";
 	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -62440,7 +62412,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 1;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -64571,7 +64543,10 @@
 /area/engine/foyer)
 "mTn" = (
 /obj/structure/filingcabinet,
-/turf/open/floor/carpet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "mTr" = (
 /obj/machinery/airalarm{
@@ -65514,25 +65489,31 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nzQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/closet/emcloset,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
 	pixel_y = 23
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -65677,7 +65658,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 1;
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
@@ -66004,8 +65985,13 @@
 /area/medical/paramedic)
 "nOu" = (
 /obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/storage/briefcase,
+/obj/item/clipboard{
+	pixel_x = 7
+	},
+/obj/item/storage/briefcase{
+	pixel_x = -7;
+	pixel_y = 1
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "nOA" = (
@@ -66662,8 +66648,8 @@
 	pixel_y = 8
 	},
 /obj/item/laser_pointer{
-	pixel_y = -10;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -10
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -69518,6 +69504,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qkN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qkV" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -75220,7 +75227,13 @@
 /area/maintenance/port/aft)
 "tVx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
@@ -75275,7 +75288,10 @@
 	pixel_x = 6;
 	pixel_y = -2
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "tXU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -76960,19 +76976,13 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_x = 6
 	},
-/turf/open/floor/carpet,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "uXQ" = (
 /obj/structure/disposalpipe/segment{
@@ -77328,6 +77338,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/medical/psych)
 "vmx" = (
@@ -77479,17 +77492,20 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "vrg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -78428,11 +78444,14 @@
 "vYl" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
+	dir = 4;
 	pixel_x = 3;
-	pixel_y = 2;
-	dir = 4
+	pixel_y = 2
 	},
-/turf/open/floor/carpet,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "vYq" = (
 /obj/machinery/light{
@@ -78518,7 +78537,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -78608,15 +78627,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psych";
-	name = "Psychiatrists Office APC";
-	pixel_y = -23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "wel" = (
 /obj/item/cigbutt,
@@ -78663,6 +78674,15 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -79482,7 +79502,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -79642,6 +79662,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -80204,7 +80227,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -81462,7 +81485,10 @@
 	dir = 5
 	},
 /obj/structure/chair/comfy/brown,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood,
 /area/medical/psych)
 "yaP" = (
 /obj/machinery/computer/operating,
@@ -81589,13 +81615,19 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ydF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/power/apc{
+	areastring = "/area/medical/psych";
+	dir = 1;
+	name = "Psychiatrists Office APC";
+	pixel_y = 23
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/medical/psych)
 "ydZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -106969,7 +107001,7 @@ bSe
 dfW
 hYx
 auQ
-cLk
+qkN
 cZr
 qbF
 cxe
@@ -108250,7 +108282,7 @@ gJv
 wiX
 sbo
 cCe
-bSq
+bTL
 cPb
 sPb
 cLm
@@ -108764,7 +108796,7 @@ bOT
 cEZ
 cFY
 bOT
-bSs
+cLk
 ctH
 cPb
 wtH
@@ -109278,7 +109310,7 @@ cpy
 cpy
 cpy
 cul
-cuA
+cpy
 cvq
 cvD
 icg

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -198,6 +198,7 @@
 #define	TRAIT_MAGIC_CHOKE		"magic_choke"
 #define TRAIT_SOOTHED_THROAT    "soothed-throat"
 #define TRAIT_LAW_ENFORCEMENT_METABOLISM "law-enforcement-metabolism"
+#define TRAIT_PSYCH				"psych-diagnosis"
 #define TRAIT_ALWAYS_CLEAN      "always-clean"
 #define TRAIT_BOOZE_SLIDER      "booze-slider"
 #define TRAIT_QUICK_CARRY		"quick-carry"

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -78,14 +78,10 @@
 		return
 	COOLDOWN_START(src, hug_therapy_cd, hug_therapy_cd_time)
 	var/cure_chance = random_cure_chance / 6
-	if(HAS_TRAIT(hugger.mind, TRAIT_PSYCH))
-		cure_chance *= 3.5
 	if(HAS_TRAIT(hugger, TRAIT_FRIENDLY))
 		cure_chance *= 1.25
-	if(iscarbon(hugged))
-		var/mob/living/carbon/C = hugged
-		if(C.hypnosis_vulnerable())
-			cure_chance *= 1.5
+	cure_chance *= psych_bonus(flasher) * 0.35 // hugging is not that good at curing trauma but it helps
+	cure_chance *= check_hypno_vulnerable(hugged)
 	if(prob(cure_chance))
 		qdel(src) // Sometimes, all you need is a good hug..
 
@@ -96,12 +92,8 @@
 		return
 	COOLDOWN_START(src, flash_therapy_cd, flash_therapy_cd_time)
 	var/cure_chance = random_cure_chance / 10
-	if(HAS_TRAIT(flasher.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
-		cure_chance *= 10
-	if(iscarbon(flashed))
-		var/mob/living/carbon/C = flashed
-		if(C.hypnosis_vulnerable())
-			cure_chance *= 1.5
+	cure_chance *= psych_bonus(flasher)
+	cure_chance *= check_hypno_vulnerable(flashed)
 	if(prob(cure_chance))
 		qdel(src)
 
@@ -112,12 +104,8 @@
 		return
 	COOLDOWN_START(src, laser_therapy_cd, laser_therapy_cd_time)
 	var/cure_chance = random_cure_chance / 11
-	if(HAS_TRAIT(laserer.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
-		cure_chance *= 10
-	if(iscarbon(lasered))
-		var/mob/living/carbon/C = lasered
-		if(C.hypnosis_vulnerable())
-			cure_chance *= 1.5
+	cure_chance *= psych_bonus(laserer)
+	cure_chance *= check_hypno_vulnerable(lasered)
 	if(prob(cure_chance))
 		qdel(src)
 
@@ -130,11 +118,16 @@
 	var/cure_chance = random_cure_chance / 15
 	if(istype(the_light, /obj/item/flashlight/pen)) // Use a proper penlight!
 		cure_chance *= 1.25
-	if(HAS_TRAIT(shiner.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
-		cure_chance *= 10
-	if(iscarbon(shined))
-		var/mob/living/carbon/C = shined
-		if(C.hypnosis_vulnerable())
-			cure_chance *= 1.5
+	cure_chance *= psych_bonus(shiner)
+	cure_chance *= check_hypno_vulnerable(shined)
 	if(prob(cure_chance))
 		qdel(src)
+
+/datum/brain_trauma/proc/psych_bonus(mob/living/psych)
+	return HAS_TRAIT(laserer.mind, TRAIT_PSYCH) ? 10 : 1
+
+/datum/brain_trauma/proc/check_hypno_vulnerable(mob/living/carbon/victim)
+	if(istype(victim))
+		return victim.hypnosis_vulnerable() ? 1.5 : 1
+	else
+		return 1

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -124,7 +124,7 @@
 		qdel(src)
 
 /datum/brain_trauma/proc/psych_bonus(mob/living/psych)
-	return HAS_TRAIT(laserer.mind, TRAIT_PSYCH) ? 10 : 1
+	return HAS_TRAIT(psych.mind, TRAIT_PSYCH) ? 10 : 1
 
 /datum/brain_trauma/proc/check_hypno_vulnerable(mob/living/carbon/victim)
 	if(istype(victim))

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -115,7 +115,7 @@
 	if(prob(cure_chance))
 		qdel(src)
 
-/datum/brain_trauma/proc/on_shine_light(mob/living/shiner, mob/living/shined, /obj/item/flashlight/the_light)
+/datum/brain_trauma/proc/on_shine_light(mob/living/shiner, mob/living/shined, obj/item/flashlight/the_light)
 	if(!COOLDOWN_FINISHED(src, pen_therapy_cd))
 		return
 	COOLDOWN_START(src, pen_therapy_cd, pen_therapy_cd_time)

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -80,7 +80,7 @@
 	var/cure_chance = random_cure_chance / 6
 	if(HAS_TRAIT(hugger, TRAIT_FRIENDLY))
 		cure_chance *= 1.25
-	cure_chance *= psych_bonus(flasher) * 0.35 // hugging is not that good at curing trauma but it helps
+	cure_chance *= psych_bonus(hugger) * 0.35 // hugging is not that good at curing trauma but it helps
 	cure_chance *= check_hypno_vulnerable(hugged)
 	if(prob(cure_chance))
 		qdel(src) // Sometimes, all you need is a good hug..

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -72,6 +72,8 @@
 
 //Called when hugging. expand into generally interacting, where future coders could switch the intent?
 /datum/brain_trauma/proc/on_hug(mob/living/hugger, mob/living/hugged)
+	if(resilience >= TRAUMA_RESILIENCE_WOUND)
+		return
 	if(!COOLDOWN_FINISHED(src, hug_therapy_cd))
 		return
 	COOLDOWN_START(src, hug_therapy_cd, hug_therapy_cd_time)
@@ -88,6 +90,8 @@
 		qdel(src) // Sometimes, all you need is a good hug..
 
 /datum/brain_trauma/proc/on_flash(mob/living/flasher, mob/living/flashed)
+	if(resilience >= TRAUMA_RESILIENCE_WOUND)
+		return
 	if(!COOLDOWN_FINISHED(src, flash_therapy_cd))
 		return
 	COOLDOWN_START(src, flash_therapy_cd, flash_therapy_cd_time)
@@ -102,6 +106,8 @@
 		qdel(src)
 
 /datum/brain_trauma/proc/on_shine_laser(mob/living/laserer, mob/living/lasered)
+	if(resilience >= TRAUMA_RESILIENCE_WOUND)
+		return
 	if(!COOLDOWN_FINISHED(src, laser_therapy_cd))
 		return
 	COOLDOWN_START(src, laser_therapy_cd, laser_therapy_cd_time)
@@ -116,6 +122,8 @@
 		qdel(src)
 
 /datum/brain_trauma/proc/on_shine_light(mob/living/shiner, mob/living/shined, obj/item/flashlight/the_light)
+	if(resilience >= TRAUMA_RESILIENCE_WOUND)
+		return
 	if(!COOLDOWN_FINISHED(src, pen_therapy_cd))
 		return
 	COOLDOWN_START(src, pen_therapy_cd, pen_therapy_cd_time)

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -80,6 +80,10 @@
 		cure_chance *= 3.5
 	if(HAS_TRAIT(hugger, TRAIT_FRIENDLY))
 		cure_chance *= 1.25
+	if(iscarbon(hugged))
+		var/mob/living/carbon/C = hugged
+		if(C.hypnosis_vulnerable())
+			cure_chance *= 1.5
 	if(prob(cure_chance))
 		qdel(src) // Sometimes, all you need is a good hug..
 
@@ -90,6 +94,10 @@
 	var/cure_chance = random_cure_chance / 10
 	if(HAS_TRAIT(flasher.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
 		cure_chance *= 10
+	if(iscarbon(flashed))
+		var/mob/living/carbon/C = flashed
+		if(C.hypnosis_vulnerable())
+			cure_chance *= 1.5
 	if(prob(cure_chance))
 		qdel(src)
 
@@ -100,6 +108,10 @@
 	var/cure_chance = random_cure_chance / 11
 	if(HAS_TRAIT(laserer.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
 		cure_chance *= 10
+	if(iscarbon(lasered))
+		var/mob/living/carbon/C = lasered
+		if(C.hypnosis_vulnerable())
+			cure_chance *= 1.5
 	if(prob(cure_chance))
 		qdel(src)
 
@@ -112,5 +124,9 @@
 		cure_chance *= 1.5
 	if(HAS_TRAIT(shiner.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
 		cure_chance *= 10
+	if(iscarbon(shined))
+		var/mob/living/carbon/C = shined
+		if(C.hypnosis_vulnerable())
+			cure_chance *= 1.5
 	if(prob(cure_chance))
 		qdel(src)

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -15,6 +15,16 @@
 	var/random_gain = TRUE //can this be gained through random traumas?
 	var/resilience = TRAUMA_RESILIENCE_BASIC //how hard is this to cure?
 	var/clonable = TRUE // will this transfer if the brain is cloned?
+	// Therapy
+	var/random_cure_chance = 0 // This will be multiplied by a random amount; more resilient traumas should have less chance
+	var/flash_therapy_cd_time = 5 MINUTES // Flashing the patient, most effective method
+	COOLDOWN_DECLARE(flash_therapy_cd)
+	var/laser_therapy_cd_time = 8 MINUTES // Shining a laser into the patient's eyes, second most effective
+	COOLDOWN_DECLARE(laser_therapy_cd)
+	var/pen_therapy_cd_time = 3 MINUTES // Shining a light (usually penlight) into the patient's eyes, third most effective
+	COOLDOWN_DECLARE(pen_therapy_cd)
+	var/hug_therapy_cd_time = 1 MINUTES // Hugging the patient, lowest chance method but easiest. Hugs!
+	COOLDOWN_DECLARE(hug_therapy_cd)
 
 /datum/brain_trauma/Destroy()
 	if(brain && brain.traumas)
@@ -42,6 +52,7 @@
 	to_chat(owner, gain_text)
 	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/handle_speech)
 	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
+	random_cure_chance *= rand(6, 15) / 10 // 0.6-1.5x
 
 //Called when removed from a mob
 /datum/brain_trauma/proc/on_lose(silent)
@@ -61,4 +72,45 @@
 
 //Called when hugging. expand into generally interacting, where future coders could switch the intent?
 /datum/brain_trauma/proc/on_hug(mob/living/hugger, mob/living/hugged)
-	return
+	if(!COOLDOWN_FINISHED(src, hug_therapy_cd))
+		return
+	COOLDOWN_START(src, hug_therapy_cd, hug_therapy_cd_time)
+	var/cure_chance = random_cure_chance / 6
+	if(HAS_TRAIT(hugger.mind, TRAIT_PSYCH))
+		cure_chance *= 3.5
+	if(HAS_TRAIT(hugger, TRAIT_FRIENDLY))
+		cure_chance *= 1.25
+	if(prob(cure_chance))
+		qdel(src) // Sometimes, all you need is a good hug..
+
+/datum/brain_trauma/proc/on_flash(mob/living/flasher, mob/living/flashed)
+	if(!COOLDOWN_FINISHED(src, flash_therapy_cd))
+		return
+	COOLDOWN_START(src, flash_therapy_cd, flash_therapy_cd_time)
+	var/cure_chance = random_cure_chance / 10
+	if(HAS_TRAIT(flasher.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
+		cure_chance *= 10
+	if(prob(cure_chance))
+		qdel(src)
+
+/datum/brain_trauma/proc/on_shine_laser(mob/living/laserer, mob/living/lasered)
+	if(!COOLDOWN_FINISHED(src, laser_therapy_cd))
+		return
+	COOLDOWN_START(src, laser_therapy_cd, laser_therapy_cd_time)
+	var/cure_chance = random_cure_chance / 11
+	if(HAS_TRAIT(laserer.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
+		cure_chance *= 10
+	if(prob(cure_chance))
+		qdel(src)
+
+/datum/brain_trauma/proc/on_shine_light(mob/living/shiner, mob/living/shined, /obj/item/flashlight/the_light)
+	if(!COOLDOWN_FINISHED(src, pen_therapy_cd))
+		return
+	COOLDOWN_START(src, pen_therapy_cd, pen_therapy_cd_time)
+	var/cure_chance = random_cure_chance / 15
+	if(istype(the_light, /obj/item/flashlight/pen)) // Use a proper penlight!
+		cure_chance *= 1.5
+	if(HAS_TRAIT(shiner.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
+		cure_chance *= 10
+	if(prob(cure_chance))
+		qdel(src)

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -121,7 +121,7 @@
 	COOLDOWN_START(src, pen_therapy_cd, pen_therapy_cd_time)
 	var/cure_chance = random_cure_chance / 15
 	if(istype(the_light, /obj/item/flashlight/pen)) // Use a proper penlight!
-		cure_chance *= 1.5
+		cure_chance *= 1.25
 	if(HAS_TRAIT(shiner.mind, TRAIT_PSYCH)) // Non-practitioners are bad at this
 		cure_chance *= 10
 	if(iscarbon(shined))

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -3,6 +3,7 @@
 //Most of the old brain damage effects have been transferred to the dumbness trauma.
 
 /datum/brain_trauma/mild
+	random_cure_chance = 12
 
 /datum/brain_trauma/mild/hallucinations
 	name = "Hallucinations"

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -3,7 +3,7 @@
 //Most of the old brain damage effects have been transferred to the dumbness trauma.
 
 /datum/brain_trauma/mild
-	random_cure_chance = 12
+	random_cure_chance = 10
 
 /datum/brain_trauma/mild/hallucinations
 	name = "Hallucinations"

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -4,6 +4,7 @@
 
 /datum/brain_trauma/severe
 	resilience = TRAUMA_RESILIENCE_SURGERY
+	random_cure_chance = 4
 
 /datum/brain_trauma/severe/mute
 	name = "Mutism"

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -2,6 +2,7 @@
 //they are the easiest to cure, which means that if you want
 //to keep them, you can't cure your other traumas
 /datum/brain_trauma/special
+	random_cure_chance = 15
 
 /datum/brain_trauma/special/godwoken
 	name = "Godwoken Syndrome"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -92,10 +92,13 @@
 										 span_danger("You direct [src] to [M]'s eyes."))
 					if(M.stat == DEAD || (HAS_TRAIT(M, TRAIT_BLIND)) || !M.flash_act(visual = 1)) //mob is dead or fully blind
 						to_chat(user, span_warning("[M]'s pupils don't react to the light!"))
-					else if(M.dna && M.dna.check_mutation(XRAY))	//mob has X-ray vision
-						to_chat(user, span_danger("[M]'s pupils give an eerie glow!"))
-					else //they're okay!
-						to_chat(user, span_notice("[M]'s pupils narrow."))
+					else
+						for(var/datum/brain_trauma/trauma in M.get_traumas())
+							trauma.on_shine_light(user, M, src)
+						if(M.dna && M.dna.check_mutation(XRAY))	//mob has X-ray vision
+							to_chat(user, span_danger("[M]'s pupils give an eerie glow!"))
+						else //they're okay!
+							to_chat(user, span_notice("[M]'s pupils narrow."))
 
 			if(BODY_ZONE_PRECISE_MOUTH)
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -111,6 +111,8 @@
 			//chance to actually hit the eyes depends on internal component
 			if(prob(effectchance * diode.rating) && C.flash_act(severity))
 				outmsg = span_notice("You blind [C] by shining [src] in [C.p_their()] eyes.")
+				for(var/datum/brain_trauma/trauma in C.get_traumas())
+					trauma.on_shine_laser(user, C)
 			else
 				outmsg = span_warning("You fail to blind [C] by shining [src] at [C.p_their()] eyes!")
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -144,6 +144,8 @@
 				visible_message(span_disarm("[user] blinds [M] with the flash!"))
 				to_chat(user, span_danger("You blind [M] with the flash!"))
 				to_chat(M, span_userdanger("[user] blinds you with the flash!"))
+				for(var/datum/brain_trauma/trauma in M.get_traumas())
+					trauma.on_flash(user, M)
 			else
 				to_chat(M, span_userdanger("You are blinded by [src]!"))
 			if(M.IsParalyzed())

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -416,6 +416,8 @@
 				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/lamphug, src)
 		for(var/datum/brain_trauma/trauma in M.get_traumas())
 			trauma.on_hug(M, src)
+		for(var/datum/brain_trauma/trauma in get_traumas())
+			trauma.on_hug(M, src)
 
 		var/averagestacks = (fire_stacks + M.fire_stacks)/2 //transfer firestacks between players
 		fire_stacks = averagestacks

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -122,9 +122,11 @@
 	if(HAS_TRAIT(user.mind, TRAIT_PSYCH) && LAZYLEN(get_traumas()))
 		var/highest_trauma = 0
 		for(var/datum/brain_trauma/B in get_traumas())
-			if(istype(B, /datum/brain_trauma/special))
-				highest_trauma = 3
+			if(istype(B, /datum/brain_trauma/magic))
+				highest_trauma = 4
 				break
+			else if(istype(B, /datum/brain_trauma/special) && highest_trauma < 3)
+				highest_trauma = 3
 			else if(istype(B, /datum/brain_trauma/severe) && highest_trauma < 2)
 				highest_trauma = 2
 			else if(istype(B, /datum/brain_trauma/mild) && highest_trauma < 1)
@@ -136,6 +138,8 @@
 			if(2)
 				. += span_warning("[t_His] behavior is very clearly abnormal.")
 			if(3)
+				. += span_warning("[t_His] behavior is strange but intriguing.")
+			if(4)
 				. += span_warning("[t_His] behavior seems otherworldly.")
 
 	var/appears_dead = 0

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -119,6 +119,25 @@
 			badwings = "Weaponized "
 		. += "[t_He] [t_has] also have a pair of [span_warning(badwings)][(dna.features["wings"])] wings on their back"
 
+	if(HAS_TRAIT(user.mind, TRAIT_PSYCH) && LAZYLEN(get_traumas()))
+		var/highest_trauma = 0
+		for(var/datum/brain_trauma/B in get_traumas())
+			if(istype(B, /datum/brain_trauma/special))
+				highest_trauma = 3
+				break
+			else if(istype(B, /datum/brain_trauma/severe) && highest_trauma < 2)
+				highest_trauma = 2
+			else if(istype(B, /datum/brain_trauma/mild) && highest_trauma < 1)
+				highest_trauma = 1
+		
+		switch(highest_trauma)
+			if(1)
+				. += span_warning("[t_His] behavior seems a bit off.")
+			if(2)
+				. += span_warning("[t_His] behavior is very clearly abnormal.")
+			if(3)
+				. += span_warning("[t_His] behavior seems otherworldly.")
+
 	var/appears_dead = 0
 	if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
 		appears_dead = 1

--- a/yogstation/code/modules/jobs/job_types/psychiatrist.dm
+++ b/yogstation/code/modules/jobs/job_types/psychiatrist.dm
@@ -19,6 +19,7 @@
 	base_access = list(ACCESS_MEDICAL)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED
+	mind_traits = list(TRAIT_PSYCH)
 	display_order = JOB_DISPLAY_ORDER_PSYCHIATRIST
 	minimal_character_age = 24 //Psychology, therapy, and the like; all branches that would probably need to be certified as properly educated
 


### PR DESCRIPTION
# Document the changes in your pull request

The psychiatrist is now a serious role with serious, dangerous equipment. Unfortunately, this is going to be a controversial one.

## Therapy

Psychiatrist can now detect (via examine) and apply therapy to cure traumas by flashing, shining laser pointers or flashlights into peoples' eyes, or just hugging them, because sometimes all you need is a hug. More effective if the patient is susceptible to hypnosis!

## Drugs

Psychiatrists now have a **chemistry lab in their office**. The intent is to place them squarely in the "drug gimmick" role that chemistry sometimes took part in. This also enables them to create their own hallucinogens or otherwise useful chemicals for therapy as mentioned in the wiki documentation. Psychiatrists should not be making medicines very often like a chemist would and should focus instead on their own job. I would consider a psychiatrist making things like libital and distributing them freely without it being related to a patient case or keeping them for personal use to be powergaming.

## Office improvements

Psychiatrists have been equipped with some extra things for therapy, including a couple flashes. Now it makes sense for a psych to be carrying around a (secretly hypno) flash.

All offices have been regulated to carry about the same equipment as box does for consistency.

Their offices have also been **expanded** (good luck everyone else!) (boxstation size unchanged) and divided from the public eye so they can organize themselves in private without patients seeing and having any illusions shattered. Their "Filing Room" (the filing cabinet is the only thing visible from the outside) is fitted with their tools they can prepare gather for effective therapy or drug distribution. Also hidden from the security cameras, sneaky!

I could not fit a chem heater in meta or asteroid so they got a lighter instead.

# Wiki Documentation

Traumas on-gain have their therapy cure chance adjusted 60%-150% to make it sometimes harder or easier to cure traumas.

Magic traumas cannot be cured via therapy

Special traumas have a 15% baseline chance, being meant to be cured before other traumas

Mild traumas have a 10% baseline chance

Severe traumas have a 5% baseline chance

All therapies will have a 1.5x modifier if the patient is "hypnosis vulnerable" (not mindshielded) (hallucinating or sleeping or stupid trauma or unstable mood)

---

Flash therapy can be attempted every 5 minutes

Uses the random cure chance directly, but non-psychiatrists will have a 0.1x modifier

---

Laser (pointer) therapy can be attempted every 8 minutes

About 0.91x effective as flashing, non-psychiatrists will have a 0.1x modifier

---

Shining light into someones eyes (or light therapy) can be attempted every 3 minutes

About 0.83x effective as flashing, non-psychiatrists will have a 0.1x modifier and using a non-penlight flashlight will suffer a 0.8x modifier

---

Hugging therapy can be attempted every 1 minute

About 0.58x as effective as flashing, non-psychiatrists will have a 0.29x modifier and "friendly" huggers will have a 1.25x modifier

# Changelog

:cl:  ynot01, Wejengin2
experimental: Psychiatrist has been reworked. They can now examine to detect traumas and have a wide variety of tools to cure them.
/:cl:
