### PR TITLE
Gives Captain some spiffy new blue SecHUD shades

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -145,6 +145,13 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/darkred
 
+/obj/item/clothing/glasses/hud/security/sunglasses/captain
+	name = "captain HUDSunglasses"
+	desc = "Sunglasses with a security HUD, but with a special Captain-like flair."
+	icon_state = "sunhudmed"
+	darkness_view = 2 // Just to give the cap something a slight step up
+	glass_colour_type = /datum/client_colour/glass_colour/blue
+
 /obj/item/clothing/glasses/hud/security/sunglasses/hos
 	name = "security advanced HUDSunglasses"
 	desc = "Sunglasses with a security HUD. This one is augmented with a medical scanner."

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -60,7 +60,7 @@
 	id_type = /obj/item/card/id/gold
 	pda_type = /obj/item/modular_computer/tablet/phone/preset/advanced/command/cap
 
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/captain
 	ears = /obj/item/radio/headset/heads/captain/alt
 	gloves = /obj/item/clothing/gloves/color/captain
 	uniform =  /obj/item/clothing/under/rank/captain


### PR DESCRIPTION
# Document the changes in your pull request

Caps get boring plain old sunglasses where all their heads get fancy ones. Was thinking about certain ways to let cap have something but honestly not much to do that isn't extreme power creep.

But sechud makes sense for them, to see jobs and mindshield status in a pinch. Used the CMO shades sprite to match the blue, and also made the darkness just a bit less not that anyone uses the glasses color overlay anyway.

# Changelog

:cl:  
rscadd: Gives captain a pair of SecHUD Sunglasses, shaded blue
/:cl:
