### PR TITLE
Nanomachine heart a new rnd exclusive traitor item for 6tc

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -164,7 +164,11 @@
 /obj/item/autosurgeon/nt_mantis
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/nt_mantis
-
+	
+/obj/item/autosurgeon/nanomachine
+	uses = 1
+	starting_organ = /obj/item/organ/heart/freedom/nanomachine
+	
 /obj/item/autosurgeon/nt_mantis/left
 	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/arm/nt_mantis/left

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -291,6 +291,5 @@
 	name = "Nanomachine heart"
 	desc = "An EMP proof heart that provides an additional boost to nanites and emergency healing"
 	organ_flags = ORGAN_SYNTHETIC //the power of freedom prevents heart attacks
-	var/min_next_adrenaline = 0
 	var/nanite_boost = 2
 	

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -279,17 +279,16 @@
 	var/min_next_adrenaline = 0
 
 /obj/item/organ/heart/freedom/on_life()
-		. = ..()
-		if(owner.health < 5 && world.time > min_next_adrenaline)
-			min_next_adrenaline = world.time + rand(250, 600) //anywhere from 4.5 to 10 minutes
-			to_chat(owner, span_userdanger("You feel yourself dying, but you refuse to give up!"))
-			owner.heal_overall_damage(15, 15, 0, BODYPART_ORGANIC)
-			if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/ephedrine) < 20)
-				owner.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 10)
+	. = ..()
+	if(owner.health < 5 && world.time > min_next_adrenaline)
+		min_next_adrenaline = world.time + rand(250, 600) //anywhere from 4.5 to 10 minutes
+		to_chat(owner, span_userdanger("You feel yourself dying, but you refuse to give up!"))
+		owner.heal_overall_damage(15, 15, 0, BODYPART_ORGANIC)
+		if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/ephedrine) < 20)
+			owner.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 10)
 
 /obj/item/organ/heart/freedom/nanomachine
 	name = "Nanomachine heart"
 	desc = "An EMP proof heart that provides an additional boost to nanites and emergency healing"
-	organ_flags = ORGAN_SYNTHETIC //the power of freedom prevents heart attacks
 	var/nanite_boost = 2
 	

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -279,10 +279,18 @@
 	var/min_next_adrenaline = 0
 
 /obj/item/organ/heart/freedom/on_life()
-	. = ..()
-	if(owner.health < 5 && world.time > min_next_adrenaline)
-		min_next_adrenaline = world.time + rand(250, 600) //anywhere from 4.5 to 10 minutes
-		to_chat(owner, span_userdanger("You feel yourself dying, but you refuse to give up!"))
-		owner.heal_overall_damage(15, 15, 0, BODYPART_ORGANIC)
-		if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/ephedrine) < 20)
-			owner.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 10)
+		. = ..()
+		if(owner.health < 5 && world.time > min_next_adrenaline)
+			min_next_adrenaline = world.time + rand(250, 600) //anywhere from 4.5 to 10 minutes
+			to_chat(owner, span_userdanger("You feel yourself dying, but you refuse to give up!"))
+			owner.heal_overall_damage(15, 15, 0, BODYPART_ORGANIC)
+			if(owner.reagents.get_reagent_amount(/datum/reagent/medicine/ephedrine) < 20)
+				owner.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 10)
+
+/obj/item/organ/heart/freedom/nanomachine
+	name = "Nanomachine heart"
+	desc = "An EMP proof heart that provides an additional boost to nanites and emergency healing"
+	organ_flags = ORGAN_SYNTHETIC //the power of freedom prevents heart attacks
+	var/min_next_adrenaline = 0
+	var/nanite_boost = 2
+	

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2310,6 +2310,17 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Research Director", "Scientist", "Roboticist")
 	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr) //yogs // >Increase price to reduce grief > limit it to hijack only :think:
 
+/datum/uplink_item/role_restricted/nanomachinesson
+	name = "Nanomachine Heart"
+	desc = "We saw that our rival nanotrasen had been making advances in nanites technlology so we one oneupped	them in the labs \
+			Our souped up heart does double the nanite regen of nanotrasens heart all while also being emp proof, and ontop of that\
+			comes with it having emergency healing routines to help you in the most dire of circumstances \
+			and in	the case you dont have any nanites in you to begin with you will be completely fine."
+	item = /obj/item/autosurgeon/nanomachine
+	cost = 8 
+	manufacturer = /datum/corporation/traitor/waffleco
+	restricted_roles = list("Research Director", "Scientist", "Roboticist")
+
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"
 	desc = "The Clown Car is the ultimate transportation method for any worthy clown! \


### PR DESCRIPTION
a new rnd(rd, roboticists, scientist) exclusive traitor item, that has the benefits of being a stronger nanite heart having double the nanite regen compared to the original, with none of the downsides its emp proof and the heart wont destroy itself if you have no nanites
alongside offering you emergency healing when close to death
:cl:  
rscadd: Added a nanomachine heart a stronger nanite heart with multiple other features
/:cl:
