### PR TITLE
You can no longer pre-maturely cancel desynchronization

### DIFF
--- a/code/game/objects/items/devices/desynchronizer.dm
+++ b/code/game/objects/items/devices/desynchronizer.dm
@@ -21,8 +21,6 @@
 		return
 	if(!sync_holder)
 		desync(user)
-	else
-		resync()
 
 /obj/item/desynchronizer/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Finally a use for the alt-click (besides setting it to max time and forgetting) and a downside for a fairly strong item

# Changelog

:cl:  
tweak: You can no longer pre-maturely cancel desynchronization
/:cl:
