### PR TITLE
Actually adds passive vent to RPD

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 		new /datum/pipe_info/pipe("Injector",			/obj/machinery/atmospherics/components/unary/outlet_injector, TRUE),
 		new /datum/pipe_info/pipe("Scrubber",			/obj/machinery/atmospherics/components/unary/vent_scrubber, TRUE),
 		new /datum/pipe_info/pipe("Unary Vent",			/obj/machinery/atmospherics/components/unary/vent_pump, TRUE),
+		new /datum/pipe_info/pipe("Passive Vent",		/obj/machinery/atmospherics/components/unary/passive_vent, TRUE),
 		new /datum/pipe_info/pipe("Manual Valve",		/obj/machinery/atmospherics/components/binary/valve, TRUE),
 		new /datum/pipe_info/pipe("Digital Valve",		/obj/machinery/atmospherics/components/binary/valve/digital, TRUE),
 		new /datum/pipe_info/pipe("Pressure Valve",		/obj/machinery/atmospherics/components/binary/pressure_valve, TRUE),

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -1,6 +1,5 @@
 /obj/machinery/atmospherics/components/unary/passive_vent
 	icon_state = "passive_vent_map-3"
-
 	name = "passive vent"
 	desc = "It is an open vent."
 
@@ -18,43 +17,17 @@
 	icon_state = "passive_vent"
 
 /obj/machinery/atmospherics/components/unary/passive_vent/process_atmos()
-	return
-	/*  MONSTER EXTOOLS PROC NEEDED (EQUALIZE)
-////////////////////////////////////////////////////////////////////////
-	/datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
-	. = FALSE
-	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
-		. = TRUE
-		var/self_heat_cap = heat_capacity()
-		var/other_heat_cap = other.heat_capacity()
-		var/new_temp = (temperature * self_heat_cap + other.temperature * other_heat_cap) / (self_heat_cap + other_heat_cap)
-		temperature = new_temp
-		other.temperature = new_temp
+	var/turf/location = get_turf(loc)
+	if(isclosedturf(location))
+		return
 
-	var/min_p_delta = 0.1
-	var/total_volume = volume + other.volume
-	var/list/gas_list = gases | other.gases
-	for(var/gas_id in gas_list)
-		assert_gas(gas_id)
-		other.assert_gas(gas_id)
-		//math is under the assumption temperatures are equal
-		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
-			. = TRUE
-			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
-			gases[gas_id][MOLES] = total_moles * (volume/total_volume)
-			other.gases[gas_id][MOLES] = total_moles * (other.volume/total_volume)
-	////////////////////////////////////////////////////////////////////////////////
-
-
-	..()
-
-	var/datum/gas_mixture/external = loc.return_air()
+	var/datum/gas_mixture/external = location.return_air()
 	var/datum/gas_mixture/internal = airs[1]
 
 	if(internal.equalize(external))
 		air_update_turf()
 		update_parents()
-*/
+
 /obj/machinery/atmospherics/components/unary/passive_vent/can_crawl_through()
 	return TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request
The code for passive vents has been in the game for 2 years and nobody bothered to add it to the RPD. Long-term, we should replace all space injectors with these on all maps.

# Changelog

:cl:  
rscadd: Passive vents can now be constructed using the RPD
/:cl:
