### PR TITLE
Gax Arrivals Redesign

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -77,14 +77,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"abL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "abO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -202,13 +194,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"adF" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/grass,
 /area/hallway/secondary/entry)
 "adH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -349,6 +334,15 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"agr" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "agx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
@@ -939,17 +933,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"avd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "avf" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -971,10 +954,6 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"avh" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "avy" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1493,6 +1472,12 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"aJP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aJR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -2167,6 +2152,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"baY" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2527,13 +2519,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"biO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bjo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2841,16 +2826,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bqV" = (
-/obj/machinery/light,
-/obj/structure/table/wood,
-/obj/item/storage/box/fancy/cigarettes,
-/obj/item/lighter/greyscale{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "brd" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -2960,10 +2935,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"btN" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "buE" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
@@ -3394,6 +3365,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"bGC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bGP" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -3571,12 +3554,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bLX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bMe" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/grille,
@@ -3873,6 +3850,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bSN" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 15;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/gax;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "bSU" = (
 /obj/machinery/light{
 	dir = 1
@@ -4161,10 +4150,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"ccy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "ccC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4566,15 +4551,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"cnv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cny" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -4642,13 +4618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"coW" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cpF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -5883,6 +5852,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"cTq" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cTL" = (
 /obj/machinery/suit_storage_unit/command,
 /obj/effect/turf_decal/bot,
@@ -6069,6 +6051,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cXv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cXz" = (
 /obj/structure/sign/departments/minsky/research/genetics{
 	pixel_x = -32;
@@ -6584,16 +6571,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"djB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "djO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -6854,11 +6831,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dqU" = (
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "drq" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
@@ -7074,6 +7046,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"dxL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "dxR" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -7207,18 +7186,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"dCn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dCF" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/morgue)
@@ -7240,6 +7207,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"dCY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dDm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7766,6 +7742,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"dUa" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "dUm" = (
 /obj/machinery/air_sensor{
 	id_tag = "tox_sensor"
@@ -7869,6 +7849,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"dVT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dVZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7908,15 +7892,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"dWm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dWp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -8512,21 +8487,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"elw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "elH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -8640,6 +8600,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ent" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eoa" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/engine/engineering";
@@ -8866,6 +8836,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"esj" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "esr" = (
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -9709,6 +9683,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"eJP" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eJX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -10159,14 +10137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"eUP" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "eUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -10418,6 +10388,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"fcq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fct" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -10756,13 +10733,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"fjG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fkk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -10773,6 +10743,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fkr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "fkJ" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -10957,6 +10937,13 @@
 "fpt" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"fpG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "fpM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -11223,13 +11210,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"fwz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fxk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -11530,6 +11510,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"fCh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "fCk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -11653,6 +11642,12 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fDY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fEg" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -11882,11 +11877,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"fIh" = (
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/secondary/entry)
 "fIC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12105,6 +12095,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fPh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "fQa" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -12131,18 +12129,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fQr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fQF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -12347,15 +12333,6 @@
 /obj/machinery/electrolyzer,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"fVI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12468,6 +12445,16 @@
 "fXQ" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
+"fXT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "fXY" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -12687,6 +12674,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"gcx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "gcE" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -12704,6 +12700,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gcR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gda" = (
 /obj/machinery/light{
 	dir = 8
@@ -12835,15 +12836,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"ggU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "ghk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -13005,6 +12997,17 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"glu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/palebush,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "glL" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot,
@@ -13066,6 +13069,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"gmI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gmX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13211,14 +13229,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"grk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/machinery/light,
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "grB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -13418,10 +13428,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"gvn" = (
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13943,6 +13949,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"gJu" = (
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "gJz" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
@@ -14323,9 +14334,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"gXv" = (
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "gXE" = (
 /obj/machinery/light{
 	dir = 1
@@ -14335,6 +14343,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gXJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gXW" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/button/door{
@@ -14562,6 +14577,13 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
+"hdm" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "hdt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -14771,6 +14793,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjr" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "hjs" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -15292,18 +15322,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"hsV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "htr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -15342,17 +15360,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"huE" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "huP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/library";
@@ -15883,15 +15890,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/processing)
-"hIL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hJq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -16479,15 +16477,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hXO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "hYs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -16911,6 +16900,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"inH" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ios" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -17314,15 +17310,6 @@
 /obj/machinery/sci_bombardment,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ixx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "ixB" = (
 /obj/machinery/button/flasher{
 	id = "brigentry";
@@ -17663,6 +17650,10 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"iJE" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "iJF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -18216,13 +18207,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"iZA" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
 	dir = 9
@@ -18234,10 +18218,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"iZL" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iZW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18444,6 +18424,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jeM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "jfa" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -18587,6 +18574,14 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
+"jkW" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18618,6 +18613,12 @@
 "jls" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"jlz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jlS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19018,16 +19019,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"jyt" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
+"jyF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jyJ" = (
@@ -19130,15 +19126,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"jAI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19469,6 +19456,12 @@
 	dir = 1
 	},
 /area/chapel/main)
+"jHp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jHK" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -19493,14 +19486,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jIa" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19597,6 +19582,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jKU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "jLo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19604,6 +19597,10 @@
 /obj/effect/spawner/lootdrop/tanks,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"jLK" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jMK" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air to distro";
@@ -19743,12 +19740,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jPD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jQr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -20056,6 +20047,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jWD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "jWH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -20149,17 +20149,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"jZq" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/palebush,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "jZt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -20696,15 +20685,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"kpG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kpN" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -20815,6 +20795,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ktu" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "kup" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -20992,16 +20979,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
-"kyk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "kym" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -21510,6 +21487,15 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"kLD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "kLK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -21701,6 +21687,15 @@
 "kOZ" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"kPj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "kPv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -21751,12 +21746,6 @@
 /obj/effect/spawner/lootdrop/techstorage/command,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"kQb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kQd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -21766,12 +21755,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kQj" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kRf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -21844,6 +21827,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kUo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kUA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21857,6 +21847,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kVq" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kVx" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -22236,6 +22230,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"lcF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lcN" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
@@ -22850,13 +22850,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lqW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lrP" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -22884,18 +22877,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ltc" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gax;
-	width = 7
+"lsV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ltm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23146,6 +23133,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"lyp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "lyq" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -23210,6 +23201,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"lzx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "lzE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23414,6 +23410,13 @@
 "lFe" = (
 /turf/closed/wall,
 /area/janitor)
+"lFf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/item/beacon,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lFh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -23536,6 +23539,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"lHc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -23625,15 +23636,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"lLn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lLw" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -24177,6 +24179,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"lVl" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -24559,6 +24570,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"mgv" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
+/obj/item/reagent_containers/food/snacks/cookie,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "mgL" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -24674,13 +24699,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mjl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mjp" = (
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -24818,11 +24836,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"mln" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "mlF" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -25410,14 +25423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"myt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "myv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -25700,16 +25705,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
-"mJz" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals South";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25831,6 +25826,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"mMq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mMR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Disposals Access";
@@ -25957,6 +25964,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mPT" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26275,6 +26286,14 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mXk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mXs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -26471,6 +26490,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"neg" = (
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26632,6 +26654,18 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"nhT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -26794,6 +26828,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"nmv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nmK" = (
 /obj/machinery/light{
 	dir = 1
@@ -26961,11 +27001,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"nsG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "nsK" = (
 /obj/machinery/air_sensor{
 	id_tag = "air_sensor"
@@ -27105,6 +27140,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"nuV" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -27121,6 +27160,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"nwt" = (
+/obj/machinery/light,
+/obj/structure/table/wood,
+/obj/item/storage/box/fancy/cigarettes,
+/obj/item/lighter/greyscale{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "nwQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27394,13 +27443,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"nAz" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "nAM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -27509,12 +27551,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"nDr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nDx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -27844,13 +27880,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"nKA" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "nKB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -28100,6 +28129,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"nRC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nSb" = (
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
@@ -29168,12 +29212,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ovZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "owe" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -29236,21 +29274,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"oyM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Corridor";
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
@@ -29418,15 +29441,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oCO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "oCY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -29683,14 +29697,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
-"oMy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -29849,15 +29855,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"oTS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "oTT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29919,22 +29916,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oWv" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 2";
-	dir = 4
-	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 8;
-	name = "Arrivals APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -30131,6 +30112,18 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"pbC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pbD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30481,6 +30474,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"pjr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Corridor";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "pjz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -30701,6 +30709,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pnC" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pnQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -30746,6 +30760,16 @@
 "pps" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
+"ppw" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals South";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ppI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30955,6 +30979,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"pww" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "pwH" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -31052,6 +31081,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pAK" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/entry)
 "pAX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window{
@@ -31225,33 +31258,22 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pDm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+"pDr" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/space/basic,
+/area/space)
 "pDZ" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"pEf" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/grassybush,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31338,10 +31360,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"pGE" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "pHb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/potato,
@@ -31402,6 +31420,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"pIc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pIe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31414,22 +31444,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pIJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"pIQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "pIR" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31654,6 +31668,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pPQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pQf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -31750,17 +31773,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"pRP" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
 "pSb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32047,12 +32059,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"pXs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "pXU" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -32147,16 +32153,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"pZp" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
-"pZx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qaG" = (
 /obj/structure/table,
 /obj/item/cultivator{
@@ -32368,6 +32364,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"qfz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qfO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -32454,18 +32461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qhd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qhj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -32925,6 +32920,10 @@
 "qsS" = (
 /turf/open/floor/grass,
 /area/medical/genetics)
+"qte" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/hallway/secondary/entry)
 "qth" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33143,6 +33142,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"qAJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qBd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -33563,16 +33568,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"qPy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qPM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -34251,6 +34246,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"rdU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rdV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -34263,13 +34270,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"rey" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/pointybush,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "rez" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -34674,10 +34674,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"rox" = (
-/obj/item/beacon,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "rph" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -34874,10 +34870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"rrU" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rrV" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -35532,6 +35524,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rIl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "rIp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -35891,17 +35888,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"rTG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rUk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -36329,6 +36315,15 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"sfL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "sfQ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -36432,10 +36427,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"six" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "siK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -37101,11 +37092,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"szb" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "szi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -37270,6 +37256,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"sCX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "sDq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -38257,6 +38252,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"tcv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -38406,12 +38410,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"tgw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38812,6 +38810,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"tsP" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ttR" = (
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -38865,6 +38871,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tvB" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tvD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -38988,13 +39005,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"tza" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tzj" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -39823,6 +39833,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"tUw" = (
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "tUy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Conference Room Maintenance";
@@ -40141,15 +40154,6 @@
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
-"ubV" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ucp" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/flasher/portable,
@@ -40797,6 +40801,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uvH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uvK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -41194,10 +41204,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"uGG" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "uGI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/landmark/event_spawn,
@@ -41432,12 +41438,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"uKE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "uKT" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -41579,14 +41579,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"uNK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/secondary/entry)
 "uNN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -41755,24 +41747,18 @@
 "uTb" = (
 /turf/closed/wall/r_wall,
 /area/library)
-"uTr" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
-/obj/item/reagent_containers/food/snacks/cookie,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
 "uTw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uTJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "uTM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -41988,6 +41974,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uZw" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "uZR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42145,6 +42139,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"veT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vfo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -42498,10 +42501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"vlP" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall,
-/area/hallway/secondary/entry)
 "vlQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -43164,6 +43163,13 @@
 "vBO" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"vCb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vCh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -43191,13 +43197,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"vDu" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "vDA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -43232,14 +43231,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"vEu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "vES" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -43365,18 +43356,6 @@
 "vIw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vIz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "vIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43617,15 +43596,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"vMS" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "vMZ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -43875,6 +43845,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vUt" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vUA" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -44048,6 +44027,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"vWW" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vWY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -44113,14 +44099,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"vYM" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
@@ -44436,6 +44414,14 @@
 	dir = 8
 	},
 /area/escapepodbay)
+"wio" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/light,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wiI" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -45063,10 +45049,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"wzg" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass,
-/area/hallway/secondary/entry)
 "wzn" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -45745,11 +45727,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
-"wQY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46167,14 +46144,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"xcx" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
-/area/hallway/secondary/entry)
 "xcG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -46205,18 +46174,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"xdJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xdK" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -46323,6 +46280,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xgr" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay 2";
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/hallway/secondary/entry";
+	dir = 8;
+	name = "Arrivals APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xgB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -46394,6 +46367,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"xia" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xib" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldgen,
@@ -46508,18 +46493,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xkk" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xkF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -46610,10 +46583,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"xmz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xmW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46860,15 +46829,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"xrV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "xsi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46881,6 +46841,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"xsp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xst" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -47036,6 +47003,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"xxu" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xxy" = (
 /obj/machinery/light{
 	dir = 8
@@ -47273,6 +47244,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"xDX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -47386,6 +47368,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"xGx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "xGG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -47455,8 +47445,14 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"xHU" = (
-/turf/open/floor/plasteel/white,
+"xHS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xId" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -47709,14 +47705,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xOP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -47925,11 +47913,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"xTo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xTt" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -48269,6 +48252,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"yat" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "yay" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -48319,6 +48309,11 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"ybC" = (
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "ybJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -48472,6 +48467,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"yeW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "yfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -48490,6 +48494,18 @@
 "yfF" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"yfU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "yfX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -48569,19 +48585,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"yhj" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "yhm" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -91012,27 +91015,27 @@ gUI
 lLz
 gAq
 asc
-huE
-oWv
-six
-avh
-iZL
-pIQ
-kQj
-xcx
-dqU
-xrV
-dqU
-dqU
-oyM
-jIa
-jIa
-abL
-vEu
+xDX
+xgr
+xxu
+eJP
+mPT
+gXJ
+pnC
+hjr
+ybC
+kPj
+ybC
+ybC
+pjr
+uZw
+uZw
+xGx
+uTJ
 vvd
 vvd
-gvn
-uTr
+iJE
+mgv
 tSW
 aCD
 aCD
@@ -91268,10 +91271,10 @@ bJT
 nPi
 lzE
 lzE
-qPy
+ent
 qSn
-xOP
-jAI
+lHc
+agr
 aAR
 aAR
 aAR
@@ -91281,15 +91284,15 @@ aAR
 xus
 aAR
 aAR
-fwz
-lqW
+xsp
+vCb
 aAR
 aAR
 aAR
 aAR
-xTo
-djB
-bqV
+cXv
+fXT
+nwt
 tSW
 aCD
 vRP
@@ -91525,28 +91528,28 @@ bND
 hTG
 vvd
 ofj
-bLX
+uvH
 jWH
 vvd
-fVI
-bND
+yeW
+lFf
 vvd
 vvd
 vvd
 vvd
 vvd
-kyk
-fIh
-fIh
-fIh
-uNK
-fIh
-fIh
+fkr
+gJu
+gJu
+gJu
+jKU
+gJu
+gJu
 vvd
 vvd
 vvd
-ggU
-gXv
+sfL
+tUw
 sqz
 aCD
 aCD
@@ -91785,13 +91788,13 @@ vvd
 vvd
 jWH
 vvd
-ixx
-rox
-xHU
+tcv
+neg
+neg
 vvd
-jZq
-rey
-iZA
+glu
+fpG
+yat
 tSW
 sqz
 sqz
@@ -91799,10 +91802,10 @@ sqz
 sqz
 sqz
 tSW
-jyt
+xia
 vvd
 vvd
-lLn
+dCY
 vvd
 sqz
 aCD
@@ -92042,25 +92045,25 @@ jrO
 jrO
 tDz
 vvd
-ixx
-xHU
-xHU
+tcv
+neg
+neg
 vvd
-adF
-btN
+hdm
+dUa
 tSW
 tSW
 vRP
 vRP
-ltc
+bSN
 vRP
 vRP
 tSW
 tSW
-xkk
-vMS
-pDm
-vMS
+pIc
+pPQ
+nRC
+pPQ
 tSW
 aCD
 vRP
@@ -92299,12 +92302,12 @@ wph
 faQ
 uhZ
 vvd
-ixx
-xHU
-xHU
+tcv
+neg
+neg
 vvd
-pEf
-szb
+dxL
+pww
 tSW
 vRP
 vRP
@@ -92314,9 +92317,9 @@ vRP
 vRP
 vRP
 sqz
-nDr
+lsV
 vvd
-lLn
+dCY
 vvd
 sqz
 aCD
@@ -92556,12 +92559,12 @@ bwD
 vDA
 uhZ
 vvd
-oTS
-xHU
-xHU
-kQb
-nKA
-wzg
+jWD
+neg
+neg
+lcF
+jeM
+esj
 tSW
 vRP
 vRP
@@ -92571,9 +92574,9 @@ vRP
 vRP
 vRP
 sqz
-biO
+jyF
 sfo
-fQr
+bGC
 vvd
 sqz
 aCD
@@ -92813,12 +92816,12 @@ mYp
 ein
 uhZ
 vvd
-ixx
-xHU
-xHU
-kQb
-ccy
-ccy
+tcv
+neg
+neg
+lcF
+lyp
+lyp
 sqz
 vRP
 vRP
@@ -92828,10 +92831,10 @@ vRP
 vRP
 vRP
 sqz
-ccy
-ccy
-xdJ
-rrU
+lyp
+lyp
+mMq
+kVq
 tSW
 aCD
 aCD
@@ -93070,13 +93073,13 @@ eUd
 iJg
 uhZ
 vvd
-oCO
-mln
-nsG
-ubV
-oMy
+fCh
+lzx
+rIl
+lVl
+fPh
 aNH
-nAz
+ktu
 vRP
 vRP
 vRP
@@ -93084,11 +93087,11 @@ vRP
 vRP
 vRP
 vRP
-coW
-cnv
-eUP
-avd
-mJz
+vWW
+kLD
+jkW
+qfz
+ppw
 tSW
 aCD
 aCD
@@ -93326,12 +93329,12 @@ wod
 dvp
 nXs
 uhZ
-ovZ
-hXO
-pXs
+aJP
+xHS
+nmv
 vvd
-wQY
-vlP
+gcR
+qte
 tSW
 sqz
 vRP
@@ -93343,8 +93346,8 @@ vRP
 vRP
 sqz
 tSW
-vlP
-elw
+qte
+gmI
 vvd
 sqz
 aCD
@@ -93583,14 +93586,14 @@ ybr
 rjN
 rrI
 uhZ
-tza
-dCn
-yhj
-myt
-hsV
-oMy
+inH
+rdU
+cTq
+mXk
+pbC
+fPh
 cUR
-nAz
+ktu
 vRP
 vRP
 vRP
@@ -93598,11 +93601,11 @@ vRP
 vRP
 vRP
 vRP
-coW
-hIL
-eUP
-rTG
-pXs
+vWW
+gcx
+jkW
+tvB
+nmv
 sqz
 aCD
 aCD
@@ -93841,9 +93844,9 @@ uhZ
 uhZ
 uhZ
 bPm
-ccy
-vIz
-ccy
+lyp
+yfU
+lyp
 kqq
 sqz
 sqz
@@ -93856,9 +93859,9 @@ vRP
 vRP
 vRP
 sqz
-ccy
-ccy
-xdJ
+lyp
+lyp
+mMq
 vaq
 sqz
 aCD
@@ -94113,10 +94116,10 @@ vRP
 vRP
 vRP
 sqz
-jPD
-pZx
-qhd
-kQb
+qAJ
+jlz
+nhT
+lcF
 sqz
 aCD
 vRP
@@ -94356,7 +94359,7 @@ ddu
 xut
 aCD
 cjI
-pIJ
+sCX
 sqz
 aCD
 sqz
@@ -94370,10 +94373,10 @@ vRP
 vRP
 vRP
 sqz
-nDr
+lsV
 vvd
-lLn
-kQb
+dCY
+lcF
 sqz
 sqz
 sqz
@@ -94627,14 +94630,14 @@ vRP
 vRP
 vRP
 sqz
-uGG
+nuV
 vvd
-dWm
-kpG
-vYM
+vUt
+veT
+tsP
 aNH
-vDu
-pRP
+baY
+pDr
 vRP
 vRP
 vRP
@@ -94884,10 +94887,10 @@ vRP
 vRP
 vRP
 sqz
-uGG
+nuV
 vvd
-tgw
-kQb
+jHp
+lcF
 sqz
 tSW
 sqz
@@ -95141,11 +95144,11 @@ vRP
 vRP
 vRP
 lMA
-mjl
-xmz
-uKE
-grk
-pZp
+fcq
+dVT
+fDY
+wio
+pAK
 vRP
 vRP
 vRP
@@ -95398,10 +95401,10 @@ vRP
 vRP
 vRP
 lMA
-pGE
+jLK
 vvd
 vvd
-fjG
+kUo
 lMA
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -102,6 +102,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"abZ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "acG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5778,6 +5786,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"cQn" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/uno,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "cQK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11779,6 +11792,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fFd" = (
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "fFq" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -13394,6 +13411,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"gus" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/mothplushie,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "guu" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -16083,6 +16105,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hPK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "hPZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -17650,6 +17682,12 @@
 /obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"iJl" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "iJE" = (
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet,
@@ -20047,15 +20085,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jWD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "jWH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -47244,6 +47273,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"xDK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "xDX" = (
 /obj/machinery/light{
 	dir = 8
@@ -92045,9 +92084,9 @@ jrO
 jrO
 tDz
 vvd
-tcv
-neg
-neg
+xDK
+cQn
+iJl
 vvd
 hdm
 dUa
@@ -92302,9 +92341,9 @@ wph
 faQ
 uhZ
 vvd
-tcv
-neg
-neg
+xDK
+fFd
+iJl
 vvd
 dxL
 pww
@@ -92559,9 +92598,9 @@ bwD
 vDA
 uhZ
 vvd
-jWD
-neg
-neg
+hPK
+abZ
+iJl
 lcF
 jeM
 esj
@@ -92816,9 +92855,9 @@ mYp
 ein
 uhZ
 vvd
-tcv
-neg
-neg
+xDK
+gus
+iJl
 lcF
 lyp
 lyp
@@ -94362,7 +94401,7 @@ cjI
 sCX
 sqz
 aCD
-sqz
+aCD
 aCD
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -21114,6 +21114,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"kBW" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "kCl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -32773,6 +32777,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qnz" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "qnE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94145,8 +94153,8 @@ bpR
 tSW
 sqz
 sqz
-aCD
-aCD
+qnz
+kBW
 vRP
 vRP
 vRP
@@ -94400,10 +94408,10 @@ aCD
 cjI
 sCX
 sqz
-aCD
-aCD
-aCD
-vRP
+qnz
+qnz
+qnz
+kBW
 vRP
 vRP
 vRP
@@ -94657,17 +94665,17 @@ vRP
 vRP
 nQs
 vRP
-aCD
-aCD
-aCD
+vRP
+qnz
+qnz
+kBW
+qnz
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
+qnz
 sqz
 nuV
 vvd
@@ -94914,17 +94922,17 @@ vRP
 vRP
 vRP
 vRP
-aCD
-aCD
-aCD
+vRP
+vRP
+qnz
+kBW
+qnz
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
+qnz
 sqz
 nuV
 vvd
@@ -95172,16 +95180,16 @@ vRP
 vRP
 vRP
 vRP
-aCD
-aCD
+vRP
+qnz
+kBW
+qnz
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
+qnz
 lMA
 fcq
 dVT
@@ -95430,15 +95438,15 @@ vRP
 vRP
 vRP
 vRP
-aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+kBW
+kBW
+kBW
+kBW
+kBW
+kBW
+kBW
+kBW
 lMA
 jLK
 vvd

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -21114,10 +21114,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
-"kBW" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "kCl" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -32777,10 +32773,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qnz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "qnE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -94153,8 +94145,8 @@ bpR
 tSW
 sqz
 sqz
-qnz
-kBW
+aCD
+tkl
 vRP
 vRP
 vRP
@@ -94408,10 +94400,10 @@ aCD
 cjI
 sCX
 sqz
-qnz
-qnz
-qnz
-kBW
+aCD
+aCD
+aCD
+tkl
 vRP
 vRP
 vRP
@@ -94666,16 +94658,16 @@ vRP
 nQs
 vRP
 vRP
-qnz
-qnz
-kBW
-qnz
+aCD
+aCD
+tkl
+aCD
 vRP
 vRP
 vRP
 vRP
 vRP
-qnz
+aCD
 sqz
 nuV
 vvd
@@ -94924,15 +94916,15 @@ vRP
 vRP
 vRP
 vRP
-qnz
-kBW
-qnz
+aCD
+tkl
+aCD
 vRP
 vRP
 vRP
 vRP
 vRP
-qnz
+aCD
 sqz
 nuV
 vvd
@@ -95181,15 +95173,15 @@ vRP
 vRP
 vRP
 vRP
-qnz
-kBW
-qnz
+aCD
+tkl
+aCD
 vRP
 vRP
 vRP
 vRP
 vRP
-qnz
+aCD
 lMA
 fcq
 dVT
@@ -95439,14 +95431,14 @@ vRP
 vRP
 vRP
 vRP
-kBW
-kBW
-kBW
-kBW
-kBW
-kBW
-kBW
-kBW
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
 lMA
 jLK
 vvd

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1048,18 +1048,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"axt" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gax;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "axz" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -6310,6 +6298,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"deT" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 15;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/gax;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dfj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -11131,7 +11131,7 @@
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -13238,7 +13238,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16189,7 +16189,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16435,7 +16435,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -16960,7 +16960,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17017,6 +17017,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ivI" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -18760,6 +18766,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"jvZ" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jwp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -20052,25 +20069,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/library)
-"kbG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 8;
-	name = "Arrivals APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kbY" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel/dark,
@@ -21337,14 +21335,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"kMb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kMj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -22814,7 +22804,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -25719,6 +25709,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mPN" = (
+/turf/closed/wall,
+/area/space)
 "mQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28191,6 +28184,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"obr" = (
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/hallway/secondary/entry";
+	dir = 8;
+	name = "Arrivals APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "obz" = (
 /obj/machinery/light{
 	dir = 1
@@ -30066,6 +30071,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
+"phl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay 3 & 4";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "php" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -40503,7 +40518,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -44949,7 +44964,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -89681,20 +89696,20 @@ gCc
 eMS
 aCD
 aCD
-tkl
-tkl
-tkl
-tkl
-tkl
-aCD
 vRP
 vRP
-axt
 vRP
 vRP
-aCD
-tkl
-ubS
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 jta
 aCD
 vRP
@@ -89938,11 +89953,6 @@ cka
 eMS
 vRP
 vRP
-aCD
-vRP
-aCD
-vRP
-tkl
 vRP
 vRP
 vRP
@@ -89950,8 +89960,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-ubS
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 aCD
 ubS
 vRP
@@ -90195,39 +90210,39 @@ tSW
 lMA
 sqz
 sqz
-sqz
-lMA
-sqz
-aCD
-tkl
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-tkl
-ubS
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
 vRP
 vRP
 vRP
@@ -90449,14 +90464,28 @@ lLz
 gAq
 asc
 wbP
-kbG
-iBB
-kPZ
-oaC
-atT
-sqz
-sqz
-sqz
+obr
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -90464,27 +90493,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-ubS
 vRP
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -90706,14 +90721,28 @@ lzE
 lzE
 eKr
 qSn
-kMb
-aAR
-gCL
-aAR
-eVX
-bYN
-aNH
-hDt
+ivI
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -90721,27 +90750,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-aCD
 vRP
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -90963,23 +90978,28 @@ vvd
 ofj
 qGF
 jWH
-kJv
-oAE
-ckA
 vvd
-vaq
-cjI
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
+vvd
 tSW
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-tkl
-aCD
+qOt
 vRP
 vRP
 vRP
@@ -90993,12 +91013,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -91220,14 +91235,28 @@ vvd
 vvd
 mDo
 xus
-rCa
-aAR
-blt
-aAR
-jJf
-bYN
-cUR
-hDt
+vvd
+vvd
+vvd
+vvd
+vvd
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -91235,27 +91264,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-ubS
 vRP
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -91477,14 +91492,28 @@ jrO
 jrO
 jrO
 tDz
-oRf
-sfo
-kqi
-sfo
-ohh
-sqz
-sqz
-sqz
+vvd
+vvd
+vvd
+vvd
+vvd
+tSW
+vRP
+vRP
+vRP
+qOt
+qOt
+deT
+qOt
+qOt
+mPN
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -91492,27 +91521,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-ubS
 vRP
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -91734,14 +91749,28 @@ faQ
 wph
 faQ
 uhZ
-bPm
-sqz
-tyo
-sqz
-kqq
-sqz
-aCD
-tkl
+vvd
+vvd
+vvd
+vvd
+vvd
+tSW
+vRP
+vRP
+qOt
+qOt
+vRP
+vRP
+vRP
+qOt
+qOt
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -91749,27 +91778,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-ubS
 vRP
 vRP
 vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-cFo
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -91991,14 +92006,14 @@ rBq
 bwD
 vDA
 uhZ
-sqz
-sqz
-bpR
+phl
+iBB
+kPZ
+oaC
+atT
 tSW
-sqz
-sqz
-aCD
-tkl
+qOt
+qOt
 vRP
 vRP
 vRP
@@ -92006,17 +92021,13 @@ vRP
 vRP
 vRP
 vRP
-tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -92027,6 +92038,10 @@ vRP
 vRP
 vRP
 vRP
+vRP
+vRP
+vRP
+qOt
 vRP
 vRP
 vRP
@@ -92248,28 +92263,28 @@ vgB
 mYp
 ein
 uhZ
-aCD
-cjI
-ryX
+aAR
+aAR
+gCL
+aAR
+eVX
 sqz
-aCD
-vRP
-aCD
-tkl
-aCD
+sqz
+sqz
 vRP
 vRP
 vRP
 vRP
 vRP
-aCD
-tkl
-aCD
 vRP
 vRP
-vRP
-vRP
-vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -92283,7 +92298,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -92505,23 +92520,14 @@ vrX
 eUd
 iJg
 uhZ
-vRP
-vRP
-nQs
-vRP
-aCD
-aCD
-aCD
-tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-ubS
+kJv
+oAE
+ckA
+vvd
+vaq
+bYN
+aNH
+hDt
 vRP
 vRP
 vRP
@@ -92529,7 +92535,13 @@ vRP
 vRP
 vRP
 vRP
-vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -92541,6 +92553,9 @@ vRP
 vRP
 vRP
 vRP
+vRP
+vRP
+qOt
 vRP
 vRP
 vRP
@@ -92762,23 +92777,14 @@ wod
 dvp
 nXs
 uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-aCD
-tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-ubS
+rCa
+aAR
+blt
+aAR
+jJf
+cjI
+tSW
+sqz
 vRP
 vRP
 vRP
@@ -92786,10 +92792,13 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -92798,6 +92807,12 @@ vRP
 vRP
 vRP
 vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+qOt
 vRP
 vRP
 vRP
@@ -93019,23 +93034,14 @@ ybr
 rjN
 rrI
 uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-ubS
+oRf
+sfo
+kqi
+sfo
+ohh
+bYN
+cUR
+hDt
 vRP
 vRP
 vRP
@@ -93043,6 +93049,13 @@ vRP
 vRP
 vRP
 vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -93055,6 +93068,8 @@ vRP
 vRP
 vRP
 vRP
+vRP
+qOt
 vRP
 vRP
 vRP
@@ -93276,23 +93291,14 @@ gBR
 uhZ
 uhZ
 uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-ubS
-ubS
-aCD
-aCD
-ubS
-ubS
-ubS
-aCD
-aCD
-ubS
-ubS
+bPm
+sqz
+tyo
+sqz
+kqq
+sqz
+sqz
+sqz
 vRP
 vRP
 vRP
@@ -93300,6 +93306,13 @@ vRP
 vRP
 vRP
 vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -93312,6 +93325,8 @@ vRP
 vRP
 vRP
 vRP
+vRP
+qOt
 vRP
 vRP
 vRP
@@ -93533,6 +93548,28 @@ wja
 noP
 sDq
 xut
+sqz
+sqz
+bpR
+tSW
+sqz
+sqz
+qOt
+qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -93546,29 +93583,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -93790,6 +93805,28 @@ hNn
 aMP
 ddu
 xut
+aCD
+cjI
+ryX
+sqz
+qOt
+sqz
+qOt
+qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+tSW
+vvd
+vvd
+tSW
+tSW
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -93803,29 +93840,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -94049,6 +94064,26 @@ aLl
 aLl
 vRP
 vRP
+nQs
+vRP
+qOt
+vRP
+qOt
+qOt
+qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+qOt
+tSW
+vvd
+vvd
+tSW
+vvd
+tSW
+jvZ
 vRP
 vRP
 vRP
@@ -94062,27 +94097,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -94309,6 +94324,23 @@ vRP
 vRP
 vRP
 vRP
+qOt
+qOt
+qOt
+qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+qOt
+tSW
+vvd
+vvd
+tSW
+tSW
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -94322,24 +94354,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -94566,6 +94581,23 @@ vRP
 vRP
 vRP
 vRP
+qOt
+qOt
+qOt
+qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+qOt
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -94579,24 +94611,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -94824,6 +94839,22 @@ vRP
 vRP
 vRP
 vRP
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+tSW
+vvd
+vvd
+vvd
+vvd
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -94837,23 +94868,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -95081,6 +95096,22 @@ vRP
 vRP
 vRP
 vRP
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+tSW
+tSW
+tSW
+tSW
+tSW
+tSW
+qOt
 vRP
 vRP
 vRP
@@ -95094,23 +95125,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -95353,6 +95368,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -95366,8 +95382,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -95610,6 +95625,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -95623,8 +95639,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -95867,6 +95882,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -95880,8 +95896,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -96124,6 +96139,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -96137,8 +96153,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -96381,6 +96396,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -96394,8 +96410,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -96638,6 +96653,7 @@ vRP
 vRP
 vRP
 vRP
+qOt
 vRP
 vRP
 vRP
@@ -96651,8 +96667,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+qOt
 vRP
 vRP
 vRP
@@ -96895,21 +96910,21 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
+qOt
 vRP
 vRP
 vRP
@@ -98959,7 +98974,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+cFo
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -77,6 +77,14 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"abL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "abO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -194,6 +202,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"adF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
 /area/hallway/secondary/entry)
 "adH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -886,16 +901,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"atT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aua" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -934,6 +939,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"avd" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "avf" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -955,6 +971,10 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"avh" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "avy" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2507,6 +2527,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"biO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bjo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2614,15 +2641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"blt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "blK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2823,6 +2841,16 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"bqV" = (
+/obj/machinery/light,
+/obj/structure/table/wood,
+/obj/item/storage/box/fancy/cigarettes,
+/obj/item/lighter/greyscale{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "brd" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -2932,6 +2960,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"btN" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "buE" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
@@ -3539,6 +3571,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bLX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bMe" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/grille,
@@ -4060,14 +4098,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bYN" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cac" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4131,6 +4161,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"ccy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ccC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4442,12 +4476,6 @@
 /obj/effect/landmark/start/depsec/service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"ckA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ckJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4538,6 +4566,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"cnv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cny" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -4605,6 +4642,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"coW" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "cpF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -6298,18 +6342,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"deT" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gax;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dfj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -6552,6 +6584,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"djB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "djO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -6812,6 +6854,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dqU" = (
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "drq" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
@@ -7160,6 +7207,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"dCn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dCF" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/morgue)
@@ -7849,6 +7908,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"dWm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dWp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -8444,6 +8512,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"elw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "elH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -9643,18 +9726,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eKr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eKx" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -10088,6 +10159,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"eUP" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "eUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -10142,15 +10221,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
-"eVX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eVZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -10686,6 +10756,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"fjG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fkk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -11146,6 +11223,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"fwz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fxk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -11798,6 +11882,11 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"fIh" = (
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "fIC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12042,6 +12131,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fQr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fQF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -12246,6 +12347,15 @@
 /obj/machinery/electrolyzer,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"fVI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12725,6 +12835,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"ggU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "ghk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -13092,6 +13211,14 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"grk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/light,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "grB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -13291,6 +13418,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"gvn" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13525,13 +13656,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"gCL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gCR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/camera{
@@ -14199,6 +14323,9 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"gXv" = (
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "gXE" = (
 /obj/machinery/light{
 	dir = 1
@@ -15165,6 +15292,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"hsV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "htr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -15203,6 +15342,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"huE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "huP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/library";
@@ -15601,13 +15751,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hDt" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hDE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -15740,6 +15883,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/processing)
+"hIL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hJq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -16327,6 +16479,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hXO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hYs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -17017,12 +17178,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ivI" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -17159,6 +17314,15 @@
 /obj/machinery/sci_bombardment,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ixx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "ixB" = (
 /obj/machinery/button/flasher{
 	id = "brigentry";
@@ -17287,13 +17451,6 @@
 "iBt" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
-"iBB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iBC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -18059,6 +18216,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"iZA" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "iZD" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
 	dir = 9
@@ -18070,6 +18234,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"iZL" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iZW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18766,17 +18934,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"jvZ" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "jwp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -18861,6 +19018,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"jyt" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jyJ" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -18961,6 +19130,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"jAI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19315,6 +19493,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jIa" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19338,15 +19524,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jJf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -19566,6 +19743,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jPD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jQr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19966,6 +20149,17 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"jZq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/palebush,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "jZt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -20502,6 +20696,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"kpG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kpN" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -20521,19 +20724,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"kqi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kqo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/anesthetic_machine/roundstart,
@@ -20802,6 +20992,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
+"kyk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "kym" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -21259,12 +21459,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"kJv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kJw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -21557,11 +21751,10 @@
 /obj/effect/spawner/lootdrop/techstorage/command,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"kPZ" = (
+"kQb" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 2
 	},
-/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kQd" = (
@@ -21573,6 +21766,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"kQj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kRf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -22651,6 +22850,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lqW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lrP" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -22678,6 +22884,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ltc" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 15;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/gax;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "ltm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23407,6 +23625,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"lLn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lLw" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -24447,6 +24674,13 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mjl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mjp" = (
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -24584,6 +24818,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"mln" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "mlF" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -25171,6 +25410,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"myt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "myv" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -25338,15 +25585,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"mDo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mDz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25462,6 +25700,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
+"mJz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals South";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25709,9 +25957,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mPN" = (
-/turf/closed/wall,
-/area/space)
 "mQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26716,6 +26961,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"nsG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "nsK" = (
 /obj/machinery/air_sensor{
 	id_tag = "air_sensor"
@@ -27144,6 +27394,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nAz" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "nAM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -27252,6 +27509,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"nDr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nDx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -27581,6 +27844,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nKA" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "nKB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -28127,13 +28397,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"oaC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oaJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -28184,18 +28447,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"obr" = (
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 8;
-	name = "Arrivals APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "obz" = (
 /obj/machinery/light{
 	dir = 1
@@ -28341,13 +28592,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"ohh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ohv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -28924,6 +29168,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ovZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "owe" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -28986,6 +29236,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"oyM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Corridor";
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
@@ -29066,10 +29331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oAE" = (
-/obj/item/beacon,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oAK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29157,6 +29418,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"oCO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "oCY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -29413,6 +29683,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
+"oMy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -29534,13 +29812,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"oRf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oRt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -29578,6 +29849,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oTS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "oTT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29639,6 +29919,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"oWv" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay 2";
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/hallway/secondary/entry";
+	dir = 8;
+	name = "Arrivals APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -30071,16 +30367,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
-"phl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "php" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -30939,11 +31225,33 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pDm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pDZ" = (
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pEf" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31030,6 +31338,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"pGE" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pHb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/potato,
@@ -31102,6 +31414,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pIJ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"pIQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pIR" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31422,6 +31750,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"pRP" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space)
 "pSb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -31708,6 +32047,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pXs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pXU" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -31802,6 +32147,16 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"pZp" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/entry)
+"pZx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qaG" = (
 /obj/structure/table,
 /obj/item/cultivator{
@@ -32099,6 +32454,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qhd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qhj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -32889,13 +33256,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qGF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qGI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33203,6 +33563,16 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"qPy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qPM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -33893,6 +34263,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rey" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "rez" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -34297,6 +34674,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"rox" = (
+/obj/item/beacon,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "rph" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -34493,6 +34874,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"rrU" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rrV" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -34710,15 +35095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ryX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "rza" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -34865,13 +35241,6 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"rCa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rCn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35522,6 +35891,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"rTG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rUk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
@@ -36052,6 +36432,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"six" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "siK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -36717,6 +37101,11 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"szb" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "szi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38017,6 +38406,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"tgw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38575,18 +38970,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tyo" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "tyI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -38605,6 +38988,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"tza" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tzj" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -39751,6 +40141,15 @@
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
+"ubV" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ucp" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/flasher/portable,
@@ -40795,6 +41194,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uGG" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uGI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/landmark/event_spawn,
@@ -41029,6 +41432,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"uKE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uKT" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -41170,6 +41579,14 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"uNK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "uNN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -41338,6 +41755,20 @@
 "uTb" = (
 /turf/closed/wall/r_wall,
 /area/library)
+"uTr" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
+/obj/item/reagent_containers/food/snacks/cookie,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "uTw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -42067,6 +42498,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"vlP" = (
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
+/area/hallway/secondary/entry)
 "vlQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -42756,6 +43191,13 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"vDu" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vDA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -42790,6 +43232,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"vEu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "vES" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -42915,6 +43365,18 @@
 "vIw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vIz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43155,6 +43617,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"vMS" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vMZ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -43642,6 +44113,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"vYM" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
@@ -43719,19 +44198,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"wbP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wbW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -44597,6 +45063,10 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"wzg" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/entry)
 "wzn" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -45275,6 +45745,11 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
+"wQY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45692,6 +46167,14 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"xcx" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "xcG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -45722,6 +46205,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"xdJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xdK" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -46013,6 +46508,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xkk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xkF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -46103,6 +46610,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"xmz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xmW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46349,6 +46860,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"xrV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "xsi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46935,6 +47455,9 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"xHU" = (
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "xId" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -47186,6 +47709,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"xOP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -47394,6 +47925,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xTo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xTt" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -48033,6 +48569,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
+"yhj" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "yhm" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -87437,7 +87986,7 @@ vRP
 vRP
 vRP
 vRP
-cFo
+vRP
 vRP
 vRP
 vRP
@@ -89696,26 +90245,26 @@ gCc
 eMS
 aCD
 aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
 jta
 aCD
-vRP
-vRP
-vRP
-vRP
+aCD
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -89951,27 +90500,27 @@ fhN
 xzo
 cka
 eMS
+aCD
+aCD
 vRP
 vRP
+aCD
 vRP
 vRP
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
 aCD
-ubS
+aCD
 vRP
-vRP
-vRP
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -90208,41 +90757,41 @@ tSW
 tSW
 tSW
 lMA
+tSW
+tSW
+tSW
+tSW
+sqz
+sqz
+sqz
+tSW
+sqz
+sqz
+tSW
 sqz
 sqz
 tSW
 tSW
+sqz
+sqz
+sqz
 tSW
 tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
+aCD
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -90463,29 +91012,30 @@ gUI
 lLz
 gAq
 asc
-wbP
-obr
+huE
+oWv
+six
+avh
+iZL
+pIQ
+kQj
+xcx
+dqU
+xrV
+dqU
+dqU
+oyM
+jIa
+jIa
+abL
+vEu
 vvd
 vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
+gvn
+uTr
 tSW
-qOt
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -90499,7 +91049,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -90719,30 +91268,30 @@ bJT
 nPi
 lzE
 lzE
-eKr
+qPy
 qSn
-ivI
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
+xOP
+jAI
+aAR
+aAR
+aAR
+aAR
+aAR
+aAR
+xus
+aAR
+aAR
+fwz
+lqW
+aAR
+aAR
+aAR
+aAR
+xTo
+djB
+bqV
 tSW
-qOt
+aCD
 vRP
 vRP
 vRP
@@ -90756,7 +91305,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -90976,30 +91525,31 @@ bND
 hTG
 vvd
 ofj
-qGF
+bLX
 jWH
 vvd
+fVI
+bND
 vvd
 vvd
 vvd
 vvd
 vvd
+kyk
+fIh
+fIh
+fIh
+uNK
+fIh
+fIh
 vvd
 vvd
 vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+ggU
+gXv
+sqz
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -91013,7 +91563,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -91233,30 +91782,31 @@ waL
 adu
 vvd
 vvd
-mDo
-xus
+vvd
+jWH
+vvd
+ixx
+rox
+xHU
+vvd
+jZq
+rey
+iZA
+tSW
+sqz
+sqz
+sqz
+sqz
+sqz
+tSW
+jyt
 vvd
 vvd
+lLn
 vvd
-vvd
-vvd
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -91270,7 +91820,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -91493,27 +92042,27 @@ jrO
 jrO
 tDz
 vvd
+ixx
+xHU
+xHU
 vvd
-vvd
-vvd
-vvd
+adF
+btN
+tSW
 tSW
 vRP
 vRP
+ltc
 vRP
-qOt
-qOt
-deT
-qOt
-qOt
-mPN
+vRP
 tSW
-vvd
-vvd
-vvd
-vvd
 tSW
-qOt
+xkk
+vMS
+pDm
+vMS
+tSW
+aCD
 vRP
 vRP
 vRP
@@ -91527,7 +92076,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -91750,27 +92299,28 @@ wph
 faQ
 uhZ
 vvd
+ixx
+xHU
+xHU
 vvd
-vvd
-vvd
-vvd
+pEf
+szb
 tSW
 vRP
 vRP
-qOt
-qOt
 vRP
 vRP
 vRP
-qOt
-qOt
-tSW
+vRP
+vRP
+sqz
+nDr
 vvd
+lLn
 vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -91784,7 +92334,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -92006,14 +92555,14 @@ rBq
 bwD
 vDA
 uhZ
-phl
-iBB
-kPZ
-oaC
-atT
+vvd
+oTS
+xHU
+xHU
+kQb
+nKA
+wzg
 tSW
-qOt
-qOt
 vRP
 vRP
 vRP
@@ -92021,13 +92570,13 @@ vRP
 vRP
 vRP
 vRP
-tSW
+sqz
+biO
+sfo
+fQr
 vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+aCD
 vRP
 vRP
 vRP
@@ -92041,7 +92590,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -92263,28 +92812,29 @@ vgB
 mYp
 ein
 uhZ
-aAR
-aAR
-gCL
-aAR
-eVX
+vvd
+ixx
+xHU
+xHU
+kQb
+ccy
+ccy
 sqz
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 sqz
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+ccy
+ccy
+xdJ
+rrU
 tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -92298,7 +92848,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -92520,14 +93069,14 @@ vrX
 eUd
 iJg
 uhZ
-kJv
-oAE
-ckA
 vvd
-vaq
-bYN
+oCO
+mln
+nsG
+ubV
+oMy
 aNH
-hDt
+nAz
 vRP
 vRP
 vRP
@@ -92535,13 +93084,14 @@ vRP
 vRP
 vRP
 vRP
+coW
+cnv
+eUP
+avd
+mJz
 tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -92555,7 +93105,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -92777,12 +93326,12 @@ wod
 dvp
 nXs
 uhZ
-rCa
-aAR
-blt
-aAR
-jJf
-cjI
+ovZ
+hXO
+pXs
+vvd
+wQY
+vlP
 tSW
 sqz
 vRP
@@ -92792,13 +93341,13 @@ vRP
 vRP
 vRP
 vRP
+sqz
 tSW
+vlP
+elw
 vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+aCD
 vRP
 vRP
 vRP
@@ -92812,7 +93361,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -93034,14 +93583,14 @@ ybr
 rjN
 rrI
 uhZ
-oRf
-sfo
-kqi
-sfo
-ohh
-bYN
+tza
+dCn
+yhj
+myt
+hsV
+oMy
 cUR
-hDt
+nAz
 vRP
 vRP
 vRP
@@ -93049,13 +93598,14 @@ vRP
 vRP
 vRP
 vRP
-tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+coW
+hIL
+eUP
+rTG
+pXs
+sqz
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -93069,7 +93619,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -93292,9 +93841,9 @@ uhZ
 uhZ
 uhZ
 bPm
-sqz
-tyo
-sqz
+ccy
+vIz
+ccy
 kqq
 sqz
 sqz
@@ -93306,13 +93855,13 @@ vRP
 vRP
 vRP
 vRP
-tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+ccy
+ccy
+xdJ
+vaq
+sqz
+aCD
 vRP
 vRP
 vRP
@@ -93326,7 +93875,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -93554,8 +94103,8 @@ bpR
 tSW
 sqz
 sqz
-qOt
-qOt
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -93563,13 +94112,13 @@ vRP
 vRP
 vRP
 vRP
-tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+sqz
+jPD
+pZx
+qhd
+kQb
+sqz
+aCD
 vRP
 vRP
 vRP
@@ -93583,7 +94132,7 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
 vRP
 vRP
 vRP
@@ -93807,12 +94356,11 @@ ddu
 xut
 aCD
 cjI
-ryX
+pIJ
 sqz
-qOt
+aCD
 sqz
-qOt
-qOt
+aCD
 vRP
 vRP
 vRP
@@ -93820,13 +94368,15 @@ vRP
 vRP
 vRP
 vRP
-tSW
+vRP
+sqz
+nDr
 vvd
-vvd
-tSW
-tSW
-tSW
-qOt
+lLn
+kQb
+sqz
+sqz
+sqz
 vRP
 vRP
 vRP
@@ -93840,7 +94390,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -94066,24 +94615,26 @@ vRP
 vRP
 nQs
 vRP
-qOt
-vRP
-qOt
-qOt
-qOt
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
 vRP
 vRP
-qOt
-tSW
+vRP
+vRP
+vRP
+sqz
+uGG
 vvd
-vvd
-tSW
-vvd
-tSW
-jvZ
+dWm
+kpG
+vYM
+aNH
+vDu
+pRP
 vRP
 vRP
 vRP
@@ -94097,7 +94648,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -94109,8 +94659,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
+cFo
 vRP
 vRP
 vRP
@@ -94323,24 +94872,25 @@ vRP
 vRP
 vRP
 vRP
-vRP
-qOt
-qOt
-qOt
-qOt
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
 vRP
 vRP
-qOt
-tSW
+vRP
+vRP
+vRP
+sqz
+uGG
 vvd
-vvd
+tgw
+kQb
+sqz
 tSW
-tSW
-tSW
-qOt
+sqz
 vRP
 vRP
 vRP
@@ -94354,7 +94904,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -94581,23 +95130,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
-qOt
-qOt
-qOt
-vRP
-vRP
-vRP
-vRP
-vRP
-qOt
-tSW
-vvd
-vvd
-vvd
-vvd
-tSW
-qOt
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -94606,12 +95140,27 @@ vRP
 vRP
 vRP
 vRP
+lMA
+mjl
+xmz
+uKE
+grk
+pZp
 vRP
 vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -94839,22 +95388,21 @@ vRP
 vRP
 vRP
 vRP
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-tSW
+aCD
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+lMA
+pGE
 vvd
 vvd
-vvd
-vvd
-tSW
-qOt
+fjG
+lMA
 vRP
 vRP
 vRP
@@ -94868,7 +95416,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -95096,22 +95645,21 @@ vRP
 vRP
 vRP
 vRP
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-tSW
-tSW
-tSW
-tSW
-tSW
-tSW
-qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+lMA
+lMA
+sqz
+sqz
+lMA
+lMA
 vRP
 vRP
 vRP
@@ -95125,7 +95673,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -95368,7 +95917,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -95382,7 +95930,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -95625,7 +96174,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -95639,7 +96187,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -95882,7 +96431,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -95896,7 +96444,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -96139,7 +96688,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -96153,7 +96701,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -96396,7 +96945,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -96410,7 +96958,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -96653,7 +97202,6 @@ vRP
 vRP
 vRP
 vRP
-qOt
 vRP
 vRP
 vRP
@@ -96667,7 +97215,8 @@ vRP
 vRP
 vRP
 vRP
-qOt
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -96910,21 +97459,21 @@ vRP
 vRP
 vRP
 vRP
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
-qOt
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP

--- a/_maps/shuttles/arrival_gax.dmm
+++ b/_maps/shuttles/arrival_gax.dmm
@@ -130,6 +130,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
+"N" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "O" = (
 /obj/machinery/light{
 	dir = 4
@@ -226,8 +236,8 @@ K
 K
 K
 K
-w
-s
+K
+N
 "}
 (6,1,1) = {"
 o
@@ -244,8 +254,8 @@ K
 K
 K
 K
-w
-s
+K
+N
 "}
 (8,1,1) = {"
 o

--- a/_maps/shuttles/arrival_gax.dmm
+++ b/_maps/shuttles/arrival_gax.dmm
@@ -87,6 +87,16 @@
 "w" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
+"x" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "y" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -129,16 +139,6 @@
 "M" = (
 /obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"N" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
 /area/shuttle/arrival)
 "O" = (
 /obj/machinery/light{
@@ -237,7 +237,7 @@ K
 K
 K
 K
-N
+x
 "}
 (6,1,1) = {"
 o
@@ -255,7 +255,7 @@ K
 K
 K
 K
-N
+x
 "}
 (8,1,1) = {"
 o


### PR DESCRIPTION
# Document the changes in your pull request

Arranged Gax Arrivals to allow Freeminer Ship to have a docking port. Needed to basically do a full redesign to do so.

Oops I forgot this part: Gave two more doors to Gax arrival shuttle as it now has a lower dock to depart on.

![image](https://user-images.githubusercontent.com/70451213/216156645-e3abc628-cfee-4477-b405-c479fcff33ff.png)


# Wiki Documentation

New map image will need to be put on wiki.

# Changelog

:cl:  
mapping: Adds freeminer docking port to Gax
mapping: Redesign of Gax Arrivals so freeminer ship can fit
mapping: Added 2 doors on the south of Gax shuttle for departures.
/:cl:
