### PR TITLE
DMRs now have rifled barrels

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -43,7 +43,7 @@
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
 	var/spread = 5						//Spread induced by the gun itself. SEE LINE BELOW.
-	var/default_spread = 5				//MUST be equal to the value above; used to calculate adjustments for if semi-auto is used on a burst weapon.
+	var/semi_auto_spread = 5			//Equal to the value above by default. The spread that a weapon will have if it is switched to semi-auto from a burst-fire mode.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -42,7 +42,7 @@
 
 /obj/item/gun/ballistic/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr
-	var/spread_difference = initial(spread) - default_spread //Set this way so laser sights work properly. Default value of 0
+	var/spread_difference = initial(spread) - semi_auto_spread //Set this way so laser sights work properly. Default value of 0
 	select = !select
 	if(!select)
 		burst_size = 1
@@ -170,7 +170,7 @@
 
 /obj/item/gun/ballistic/automatic/m90/burst_select()
 	var/mob/living/carbon/human/user = usr
-	var/spread_difference = initial(spread) - default_spread //It shouldn't need this but just in case someone decides to nerf the M90-gl's accuracy for whatever reason
+	var/spread_difference = initial(spread) - semi_auto_spread //It shouldn't need this but just in case someone decides to nerf the M90-gl's accuracy for whatever reason
 	switch(select)
 		if(0)
 			select = 1
@@ -313,8 +313,7 @@
 	mag_type = /obj/item/ammo_box/magazine/m308
 	fire_delay = 6
 	burst_size = 1
-	spread = 2 //Marksman rifle == accurate??
-	default_spread = 2
+	spread = 2 //Marksman rifle == accurate?
 	can_suppress = FALSE
 	can_bayonet = TRUE
 	knife_x_offset = 27
@@ -343,7 +342,6 @@
 	fire_delay = 5 //Can fire slightly faster than the LWT-650
 	burst_size = 1
 	spread = 2 //DMR gets to be special
-	default_spread = 2
 	can_suppress = FALSE
 	zoomable = TRUE
 	zoom_amt = 5 //Not as significant a scope as the sniper
@@ -375,7 +373,6 @@
 	fire_delay = 40
 	burst_size = 1
 	spread = 0
-	default_spread = 0	//It's a sniper rifle, it doesn't miss.
 	w_class = WEIGHT_CLASS_NORMAL
 	zoomable = TRUE
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -313,6 +313,8 @@
 	mag_type = /obj/item/ammo_box/magazine/m308
 	fire_delay = 6
 	burst_size = 1
+	spread = 2 //Marksman rifle == accurate??
+	default_spread = 2
 	can_suppress = FALSE
 	can_bayonet = TRUE
 	knife_x_offset = 27
@@ -340,6 +342,8 @@
 	mag_type = /obj/item/ammo_box/magazine/ks762
 	fire_delay = 5 //Can fire slightly faster than the LWT-650
 	burst_size = 1
+	spread = 2 //DMR gets to be special
+	default_spread = 2
 	can_suppress = FALSE
 	zoomable = TRUE
 	zoom_amt = 5 //Not as significant a scope as the sniper


### PR DESCRIPTION
# Document the changes in your pull request

no they're not perfectly accurate however they're better now considering they are MEANT to be accurate sir

also better describes semi_auto_spread (renamed from default_spread) in code and comments

# Wiki Documentation

Note in Guide to Combat under additional notes for each how they have less spread than most weaponry

# Changelog

:cl:  
tweak: spread for LWT-650 and K-41s DMRs has been set to 2, from 5
/:cl:
