### PR TITLE
Reduces emag hit & run spam by introducing a do_after

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -129,6 +129,8 @@
 	var/atom/A = target
 	if(!proximity && prox_check)
 		return
+	if(!do_after(user, 1 SECONDS, target))
+		return
 	log_combat(user, A, "attempted to emag")
 	A.emag_act(user)
 


### PR DESCRIPTION
# Document the changes in your pull request

Jamie says emag spam is very bad so this will make emag spam not spam

1 second do_after is fair I feel, won't feel sluggish but will definitely make you dedicated to emagging that one thing and you won't be spamming anything unless it's directly adjacent to you

People will probably still spam but they will be far worse at it

# Changelog

:cl:  
tweak: Emag now takes 1 second to use
/:cl:
