### PR TITLE
Makes neural overclocker autosurgeon single use

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -174,6 +174,7 @@
 	starting_organ = /obj/item/organ/alien/plasmavessel //Yogs End
 
 /obj/item/autosurgeon/syndicate/spinalspeed
+	uses = 1
 	starting_organ = /obj/item/organ/cyberimp/chest/spinalspeed
 
 //Limb autosurgeons


### PR DESCRIPTION
# Document the changes in your pull request

Medical mains have already been abusing this lol

# Changelog

:cl:  
tweak: Neural overclocker autosurgeon is now single use
/:cl:
