### PR TITLE
More cult fake rune tomfoolery

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -10,6 +10,15 @@
 	var/rotation = 0
 	var/paint_colour = "#FFFFFF"
 
+/obj/effect/decal/cleanable/crayon/attack_hand(mob/living/user)
+	. = ..()
+	if(.)
+		return
+	if(!iscultist(user))
+		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
+		return
+	to_chat(user, span_danger("This is a crude mockery of the divine art you spill with blood."))
+
 /obj/effect/decal/cleanable/crayon/Initialize(mapload, main, type, e_name, graf_rot, alt_icon = null)
 	. = ..()
 	if(e_name)

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -14,6 +14,8 @@
 	. = ..()
 	if(.)
 		return
+	if(name != "rune")
+		return
 	if(!iscultist(user))
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return


### PR DESCRIPTION
# Document the changes in your pull request

Attacking cult runes with your hand says "You aren't able to understand the words of [src]."

Now attacking spray runes with your hand says the same thing unless you're a real cultist, in which it tells you that they are fake runes

# Changelog

:cl:  
tweak: Made cult runes even harder to tell apart from fake ones
/:cl:
