### PR TITLE
Revert "Bluespace Locker can now also be a crate"

### DIFF
--- a/yogstation/code/controllers/subsystem/bluespace_locker.dm
+++ b/yogstation/code/controllers/subsystem/bluespace_locker.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(bluespace_locker)
 	// basically any normal-looking locker that isn't a secure one
 	var/list/valid_lockers = typecacheof(typesof(/obj/structure/closet) - typesof(/obj/structure/closet/body_bag)\
 	- typesof(/obj/structure/closet/secure_closet) - typesof(/obj/structure/closet/cabinet)\
-	- typesof(/obj/structure/closet/cardboard)\
+	- typesof(/obj/structure/closet/cardboard) - typesof(/obj/structure/closet/crate)\
 	- typesof(/obj/structure/closet/supplypod) - typesof(/obj/structure/closet/stasis)\
 	- typesof(/obj/structure/closet/abductor) - typesof(/obj/structure/closet/bluespace), only_root_path = TRUE)
 


### PR DESCRIPTION
Reverts yogstation13/Yogstation#17613 because I think it's a stupid idea, the locker's power has already been reduced and I think that making it possibly be ANY CRATE when it's already hard to find just makes it completely unreasonable for anyone to find it - especially because, frankly, I don't think anyone enjoys climbing onto crates, just to close them and check if it's the bluespace crate.
Since the locker now has to have an energy supply brought to it, I think that ALSO making it rarer is too severe a nerf.