### PR TITLE
Fixes a lethal runtime in NT-USP

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -50,6 +50,7 @@
 		// Tricks the parent proc into thinking we have a skin so it uses the laser-variant icon_state
 		// I sure hope no one tries to add skins to NT-USP in the future
 		current_skin = "ntusp-l"
+		unique_reskin = list()
 		unique_reskin[current_skin] = current_skin
 	..()
 	current_skin = null


### PR DESCRIPTION
# Document the changes in your pull request

Bad index runtime would cause the NT-USP to never update its icon when having a lethal mag

# Changelog

:cl:  
bugfix: fixed NT-USP not updating its icon when using lethal rounds
/:cl:
