### PR TITLE
L6 re-tweak (we're rolling it back (kinda))

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -233,8 +233,8 @@
 	var/cover_open = FALSE
 	can_suppress = FALSE
 	fire_delay = 1
-	burst_size = 2
-	spread = 7
+	burst_size = 3
+	spread = 14
 	pin = /obj/item/firing_pin/implant/pindicate
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -25,21 +25,21 @@
 
 /obj/item/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
-	damage = 35
+	damage = 40
 	armour_penetration = 5
 	wound_bonus = -40				//hurt a lot but still mostly pointy
 	wound_falloff_tile = 0
 
 /obj/item/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
-	damage = 30
+	damage = 35
 	wound_bonus = -45				//they go straight through with little damage to surrounding tissue
-	armour_penetration = 60
+	armour_penetration = 45
 	bare_wound_bonus = -10			//flesh wont stop these very effectively but armor might make it tumble a bit before it enters
 
 /obj/item/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
-	damage = 50
+	damage = 55
 	armour_penetration = -35		//bulletproof armor almost totally stops these, but you're still getting hit in the chest by a supersonic nugget of lead
 	sharpness = SHARP_EDGED
 	wound_bonus = -35				//odds are you'll be shooting at someone with armor so you don't have a great chance for wounds
@@ -47,5 +47,5 @@
 
 /obj/item/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
-	damage = 22
+	damage = 27
 	fire_stacks = 2


### PR DESCRIPTION
# Document the changes in your pull request

I should blindly nerf a weapon with zero consideration

BASICALLY makes this thing lethal again but armor should ACTUALLY help against AP (not a one-shot but still a LOT better against armor) (you're basically dead but you don't eat an instant crit unless you have a funky brute mod in which case you were going to die during nukies anyway)

also makes it more inaccurate because you're fucking running around two-handing a high-caliber LMG I would do something about how you could take time to set up a bipod to have accurate fire but I'm lazy and this will do for now

I should probably make L6 AP cheaper but I don't care to rn

Closes https://github.com/yogstation13/Yogstation/pull/17771

# Wiki Documentation

Damage values and inaccuracy should be noted in Guide to Combat

# Changelog

:cl:  
tweak: L6 has three round burst again
tweak: All L6 bullet damage has been increased by 5
tweak: L6 AP has 45 AP, down from 60
tweak: L6 has 14 spread, up from 7
/:cl:
