### PR TITLE
Disables the centcom raven cruiser for having fucked atmos

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -498,6 +498,7 @@
 	admin_notes = "Go big or go home."
 	credit_cost = 7500
 
+/* Disabled for having fucked atmos
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
 	name = "CentCom Raven Cruiser"
@@ -506,6 +507,7 @@
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets)."
 	credit_cost = 30000
+*/
 
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"


### PR DESCRIPTION
# Document the changes in your pull request

This shuttle kills everyone on it

# Changelog

:cl:  
rscdel: Disabled CentCom Raven Cruiser
/:cl:
