### PR TITLE
Alternate Gax Arrivals design for free miner ship

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -165,25 +165,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"adu" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ady" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 8
 	},
@@ -191,6 +173,12 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -886,16 +874,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"atT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aua" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -1048,18 +1026,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"axt" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gax;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "axz" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -1471,6 +1437,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"aJn" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "aJz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -1590,15 +1565,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aNH" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "aOh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -1856,13 +1822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aSG" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aSQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
@@ -2364,6 +2323,15 @@
 "bez" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
+"beM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bfj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3028,16 +2996,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/mob/living/simple_animal/crab/kreb{
-	desc = "Here to lay down the hard claws of the law!";
-	health = 50;
-	name = "Officer Kreb";
-	real_name = "Officer Kreb"
-	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "bwL" = (
@@ -3504,11 +3462,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bJT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
@@ -3590,12 +3543,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"bND" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bOi" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -3635,13 +3582,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bPm" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bPs" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -4072,14 +4012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bYN" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cac" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4454,12 +4386,6 @@
 /obj/effect/landmark/start/depsec/service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"ckA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ckJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -5061,6 +4987,10 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"czu" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "czG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -5911,15 +5841,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"cUR" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cUY" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -6294,6 +6215,15 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"deA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "deH" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -6938,7 +6868,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/depsec/service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "dvJ" = (
@@ -7377,24 +7308,6 @@
 "dIB" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
-"dJf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "dJv" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -8333,10 +8246,14 @@
 "ein" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/item/radio/off,
 /obj/item/crowbar,
-/obj/item/assembly/flash/handheld,
-/obj/machinery/light_switch{
-	pixel_y = -25
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -9231,6 +9148,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"eBm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eBt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -9643,18 +9575,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eKr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eKx" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three";
@@ -9711,6 +9631,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"eLA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eLQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -10071,6 +10001,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "eUo" = (
@@ -10142,15 +10074,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
-"eVX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eVZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -10192,6 +10115,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"eXj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eXm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -10210,6 +10142,19 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"eXG" = (
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eXJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -10733,6 +10678,19 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"flE" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "flO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -12778,6 +12736,11 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"giq" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "giB" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -13112,6 +13075,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/security/prison)
+"gsE" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gsG" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -13525,13 +13492,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"gCL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gCR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/camera{
@@ -13763,6 +13723,27 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"gHO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gIn" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 3;
+	height = 15;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/gax;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "gIp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -13772,6 +13753,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"gIq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gIT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -14023,6 +14013,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"gRR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone,
+/area/hallway/secondary/entry)
 "gRV" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4;
@@ -14644,6 +14640,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hjs" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -14697,6 +14705,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hkv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hkC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14907,6 +14922,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"hnL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -15499,6 +15526,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hAq" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 2;
+	height = 13;
+	id = "ferry_home";
+	name = "port bay 2";
+	width = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "hBz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -15601,13 +15639,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hDt" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hDE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -15658,6 +15689,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"hFy" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hFO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16111,6 +16149,8 @@
 /area/crew_quarters/kitchen)
 "hTG" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hTN" = (
@@ -17017,6 +17057,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ivM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -17262,6 +17311,13 @@
 "izV" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"iAA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iAE" = (
 /obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1
@@ -17281,13 +17337,6 @@
 "iBt" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
-"iBB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iBC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -17371,22 +17420,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"iFa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "iGa" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -17490,6 +17523,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iIZ" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "iJg" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera{
@@ -17497,7 +17534,9 @@
 	dir = 1;
 	network = list("ss13","chpt")
 	},
-/obj/structure/closet/secure_closet/security,
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "iJF" = (
@@ -17860,6 +17899,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"iSq" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space)
 "iSv" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -18085,6 +18135,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"jam" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "jaK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -18489,6 +18552,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jmC" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 4"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "jmK" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -18694,7 +18769,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jsn" = (
@@ -19321,15 +19395,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jJf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jJq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -19857,11 +19922,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jWH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hallway/secondary/entry)
 "jXz" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20054,21 +20117,9 @@
 /area/library)
 "kbG" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/hallway/secondary/entry";
-	dir = 8;
-	name = "Arrivals APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
-	dir = 4
-	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kbY" = (
@@ -20134,22 +20185,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"ken" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "keq" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -20524,16 +20559,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kqi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kqo" = (
@@ -20541,13 +20570,6 @@
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"kqq" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kqt" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -20627,6 +20649,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ktG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kup" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -21261,12 +21290,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"kJv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kJw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -21338,10 +21361,8 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "kMb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -21567,13 +21588,6 @@
 /obj/effect/spawner/lootdrop/techstorage/command,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"kPZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kQd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -22835,6 +22849,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"lwC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lwO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22892,6 +22913,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lxF" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "lxG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23967,6 +24000,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"lVK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lVT" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -24629,6 +24671,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"mmo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -25348,15 +25403,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"mDo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mDz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25699,6 +25745,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mPt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mPw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26082,10 +26134,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/depsec/service,
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "mYt" = (
@@ -26287,6 +26335,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"neX" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "nfl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 5
@@ -26407,6 +26459,17 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"niF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "niO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26689,6 +26752,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"nrp" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "nrB" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos_distro)
@@ -27200,6 +27278,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nBO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nBT" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -27746,6 +27832,13 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"nOX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nPb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/service";
@@ -27760,11 +27853,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "nPi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
@@ -27797,17 +27885,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"nQs" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "nQW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -27951,6 +28028,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nVI" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "nWu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27986,11 +28069,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nXc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nXs" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/chair/office/light,
+/mob/living/simple_animal/crab/kreb{
+	desc = "Here to lay down the hard claws of the law!";
+	health = 50;
+	name = "Officer Kreb";
+	real_name = "Officer Kreb"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -28135,11 +28231,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "oaC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "oaJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -28304,7 +28397,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ofj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ogh" = (
@@ -28336,13 +28432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"ohh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ohv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -29063,6 +29152,12 @@
 /area/hallway/primary/starboard)
 "oAE" = (
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oAK" = (
@@ -29084,6 +29179,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"oBB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "oBJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29530,10 +29634,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "oRf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oRt" = (
@@ -30400,6 +30503,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pnP" = (
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "pnQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -30975,7 +31081,7 @@
 /area/engine/atmos)
 "pFz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -31841,6 +31947,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"qcn" = (
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qcr" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -32540,6 +32658,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"qrX" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qsS" = (
 /turf/open/floor/grass,
 /area/medical/genetics)
@@ -32555,6 +32681,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qto" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qtt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -32719,6 +32855,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"qzb" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qzW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -32825,6 +32974,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"qEh" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qEC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -32874,13 +33035,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qGF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qGI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -33340,16 +33494,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qSn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qSJ" = (
 /obj/structure/cable/yellow{
@@ -33878,6 +34025,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"ren" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rez" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -34151,12 +34308,14 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -34451,6 +34610,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"rrx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "rrG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -34470,11 +34633,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/structure/table,
-/obj/item/radio/off,
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32;
 	pixel_y = -3
+	},
+/obj/machinery/computer/security{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -34589,6 +34753,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"rvb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/checkpoint/customs)
 "rvK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -34696,13 +34878,13 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ryX" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/hallway/secondary/entry";
+	name = "Arrivals APC";
+	pixel_y = -23
 	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rza" = (
 /obj/machinery/hydroponics/constructable,
@@ -34818,7 +35000,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/modular_computer/console/preset/command,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -34826,6 +35007,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
+/obj/structure/closet/secure_closet/security,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "rBC" = (
@@ -34851,8 +35033,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "rCa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35631,6 +35812,13 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"rWP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rWQ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
@@ -36159,6 +36347,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"sod" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "sog" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/airalarm{
@@ -38141,21 +38333,13 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "tjM" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tkg" = (
@@ -38470,6 +38654,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"tvO" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tvP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -38560,18 +38754,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tyo" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "tyI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -38764,6 +38946,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"tDj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tDw" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = 32
@@ -38775,22 +38966,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tDz" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/hallway/secondary/entry)
 "tDW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -39736,6 +39916,18 @@
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
+"ucn" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ucp" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/flasher/portable,
@@ -40139,6 +40331,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"unc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uni" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -40438,6 +40636,13 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos_distro)
+"uxf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uxw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41775,7 +41980,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/computer/secure_data,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
@@ -42058,6 +42262,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vmy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vmI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -42745,9 +42955,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/computer/security{
-	dir = 1
-	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "vDI" = (
@@ -43704,19 +43912,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"wbP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wbW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -43786,6 +43981,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wdp" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "wdr" = (
 /obj/structure/displaycase/captain,
 /turf/open/floor/wood,
@@ -44157,17 +44358,14 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "wod" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
@@ -44220,26 +44418,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"wph" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint/customs)
 "wpp" = (
 /obj/structure/chair{
 	dir = 4
@@ -45053,6 +45231,14 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"wMM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wNm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -45342,6 +45528,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"wUk" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wUH" = (
 /obj/structure/chair{
 	dir = 8
@@ -45475,6 +45670,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wYh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wYp" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -45777,6 +45985,11 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"xfz" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xfT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -46041,6 +46254,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"xlo" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay 3 & 4";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xlu" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
@@ -46068,6 +46292,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"xme" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xmi" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -46180,6 +46419,21 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"xoB" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xoT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -46229,6 +46483,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"xpQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xqy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -46410,13 +46670,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "xus" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xut" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -46907,6 +47163,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xHB" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "xHC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -47766,6 +48027,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "ybJ" = (
@@ -47816,6 +48086,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ycX" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/railing,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "ydf" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -88410,9 +88685,9 @@ vIw
 vIw
 vIw
 uzX
-tkl
-tkl
-tkl
+vRP
+vRP
+vRP
 tkl
 tkl
 tkl
@@ -88668,8 +88943,8 @@ vIw
 vIw
 uzX
 tkl
-aCD
-aCD
+tkl
+tkl
 ubS
 ubS
 ubS
@@ -88925,7 +89200,7 @@ uli
 vIw
 uzX
 tkl
-vRP
+aCD
 aCD
 vRP
 aCD
@@ -89425,23 +89700,23 @@ eMS
 vRP
 aCD
 tkl
-aCD
-seF
+tkl
+hkv
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
+xTV
 uqY
-xTV
-xTV
-xTV
-xTV
-xTV
-xTV
-xTV
-xTV
-xTV
-xTV
+uqY
 xNw
-ubS
-ubS
-aCD
 ubS
 tTD
 tTD
@@ -89677,29 +89952,29 @@ oYc
 oYc
 oYc
 qZW
-gCc
+cka
 eMS
 aCD
 aCD
-tkl
-tkl
-tkl
-tkl
-tkl
-aCD
 vRP
 vRP
-axt
 vRP
-vRP
-aCD
 tkl
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+tkl
+vRP
 ubS
-jta
+pCt
 aCD
-vRP
-vRP
-vRP
 vRP
 vRP
 vRP
@@ -89934,28 +90209,28 @@ pQE
 pQE
 fhN
 xzo
-cka
-eMS
-vRP
-vRP
-aCD
-vRP
-aCD
-vRP
+tSW
+tSW
+tSW
+tSW
+tSW
+lMA
 tkl
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
 tkl
 ubS
-aCD
-ubS
-vRP
-vRP
+jta
 vRP
 vRP
 vRP
@@ -90192,29 +90467,29 @@ tSW
 tSW
 tSW
 tSW
+uxf
+gIq
+nXc
+neX
 lMA
-sqz
-sqz
-sqz
-lMA
-sqz
+aCD
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+aCD
+aCD
 aCD
 tkl
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-tkl
-ubS
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
+aCD
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -90448,15 +90723,18 @@ gUI
 lLz
 gAq
 asc
-wbP
+tSW
 kbG
-iBB
-kPZ
+vvd
+vaq
 oaC
-atT
 sqz
-sqz
-sqz
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -90466,10 +90744,7 @@ vRP
 vRP
 tkl
 ubS
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 vRP
@@ -90702,18 +90977,21 @@ gbh
 ady
 bJT
 nPi
-lzE
-lzE
-eKr
+vvd
+vmy
+vvd
 qSn
 kMb
-aAR
-gCL
-aAR
-eVX
-bYN
-aNH
-hDt
+vvd
+vaq
+pnP
+sqz
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -90723,9 +91001,6 @@ vRP
 vRP
 tkl
 aCD
-vRP
-vRP
-vRP
 vRP
 vRP
 vRP
@@ -90957,20 +91232,23 @@ lzE
 lDT
 vds
 pFz
-bND
+aAR
 hTG
-vvd
+nOX
 ofj
-qGF
+aAR
 jWH
-kJv
+aAR
 oAE
-ckA
-vvd
 vaq
-cjI
-tSW
+pnP
 sqz
+gIn
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -90979,10 +91257,7 @@ vRP
 vRP
 vRP
 tkl
-aCD
-vRP
-vRP
-vRP
+ubS
 vRP
 vRP
 vRP
@@ -91213,21 +91488,24 @@ ahf
 vvd
 eDL
 tpx
-ken
-waL
-adu
+ovx
 vvd
 vvd
-mDo
+mPt
+vvd
+vvd
 xus
 rCa
-aAR
-blt
-aAR
-jJf
-bYN
-cUR
-hDt
+lVK
+vaq
+pnP
+sqz
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -91236,7 +91514,7 @@ vRP
 vRP
 vRP
 tkl
-ubS
+aCD
 vRP
 vRP
 vRP
@@ -91253,10 +91531,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
+cFo
 vRP
 vRP
 vRP
@@ -91470,21 +91745,24 @@ kyA
 rpt
 dmY
 iMU
-iFa
-tSW
+ovx
+iIZ
 tjM
 jrO
 jrO
-jrO
+iAA
 tDz
 oRf
-sfo
+eXj
 kqi
-sfo
-ohh
+sod
 sqz
-sqz
-sqz
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -91493,10 +91771,7 @@ vRP
 vRP
 vRP
 tkl
-ubS
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 vRP
@@ -91727,21 +92002,19 @@ kyA
 iTl
 nou
 bcr
-iFa
-tSW
+ovx
+xfz
 pKx
 faQ
-wph
 faQ
-uhZ
-bPm
-sqz
-tyo
-sqz
-kqq
-sqz
+faQ
+pKx
+oRf
+lVK
+vaq
+xHB
+lMA
 aCD
-tkl
 vRP
 vRP
 vRP
@@ -91749,6 +92022,11 @@ vRP
 vRP
 vRP
 vRP
+vRP
+vRP
+aCD
+aCD
+aCD
 tkl
 ubS
 vRP
@@ -91762,9 +92040,6 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-cFo
 vRP
 vRP
 vRP
@@ -91984,33 +92259,33 @@ kyA
 aeL
 dxR
 lvU
-dJf
-aSG
+ovx
+pEG
 pKx
 rBq
 bwD
 vDA
-uhZ
-sqz
-sqz
-bpR
-tSW
-sqz
-sqz
-aCD
+pKx
+lwC
+rWP
+nBO
+lMA
+lMA
 tkl
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
 tkl
-aCD
-vRP
-vRP
-vRP
+tkl
+sqz
+ivM
+sqz
+ivM
+sqz
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+ubS
 vRP
 vRP
 vRP
@@ -92247,35 +92522,35 @@ pKx
 vgB
 mYp
 ein
-uhZ
-aCD
-cjI
+pKx
+qto
+hjp
 ryX
+lMA
+aCD
+aCD
+vRP
+aCD
+sqz
+jam
+tSW
+qEh
 sqz
 aCD
-vRP
+aCD
 aCD
 tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
+tkl
 tkl
 aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+flE
+aCD
+aCD
+flE
+aCD
+aCD
+aCD
+eXG
 vRP
 vRP
 vRP
@@ -92504,24 +92779,24 @@ lEl
 vrX
 eUd
 iJg
-uhZ
-vRP
-vRP
-nQs
-vRP
-aCD
-aCD
+faQ
+nVI
+hnL
+vaq
+lMA
+lMA
+sqz
+sqz
+sqz
+sqz
+lxF
+cjI
+lxF
+sqz
+lMA
+lMA
 aCD
 tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-ubS
 vRP
 vRP
 vRP
@@ -92761,24 +93036,24 @@ pKx
 wod
 dvp
 nXs
-uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-aCD
-tkl
-aCD
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-ubS
+rvb
+ycX
+hnL
+unc
+xpQ
+mmo
+xpQ
+xpQ
+tDj
+xpQ
+eBm
+xpQ
+xme
+ktG
+eLA
+lMA
+lMA
+sqz
 vRP
 vRP
 vRP
@@ -93018,25 +93293,25 @@ uhZ
 ybr
 rjN
 rrI
-uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-ubS
-vRP
+faQ
+czu
+wYh
+wMM
+aAR
+blt
+aAR
+aAR
+ofj
+aAR
+deA
+aAR
+giq
+nOX
+wUk
+qrX
+aJn
+hFy
+hAq
 vRP
 vRP
 vRP
@@ -93276,23 +93551,23 @@ gBR
 uhZ
 uhZ
 uhZ
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-ubS
-ubS
-aCD
-aCD
-ubS
-ubS
-ubS
-aCD
-aCD
-ubS
-ubS
+wdp
+gRR
+beM
+sfo
+qzb
+sfo
+rCa
+vvd
+vvd
+gsE
+sfo
+qzb
+oBB
+niF
+sqz
+sqz
+cjI
 vRP
 vRP
 vRP
@@ -93532,24 +93807,24 @@ hrW
 wja
 noP
 sDq
-xut
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aLl
+tSW
+tSW
+tSW
+rrx
+xoB
+rrx
+oRf
+vvd
+vvd
+vaq
+rrx
+nrp
+rrx
+lMA
+lMA
+aCD
+tkl
 vRP
 vRP
 vRP
@@ -93789,35 +94064,35 @@ xrK
 hNn
 aMP
 ddu
-xut
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aLl
+aCD
+aCD
+aCD
+sqz
+bpR
+tSW
+tvO
+xlo
+gHO
+ren
+tSW
+qcn
+sqz
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+aCD
+flE
+aCD
+aCD
+flE
+aCD
+aCD
+aCD
+eXG
 vRP
 vRP
 vRP
@@ -94047,20 +94322,20 @@ xut
 aLl
 aLl
 aLl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
+sqz
+ucn
+sqz
+sqz
+sqz
+sqz
+sqz
+sqz
+jmC
+sqz
+aCD
 vRP
 vRP
 vRP
@@ -94315,7 +94590,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+iSq
 vRP
 vRP
 vRP
@@ -94560,7 +94835,7 @@ wjS
 vRP
 aLl
 aCD
-vRP
+aCD
 vRP
 vRP
 vRP
@@ -94817,7 +95092,7 @@ vRP
 vRP
 aLl
 aCD
-aCD
+vRP
 vRP
 vRP
 vRP
@@ -96885,7 +97160,7 @@ vRP
 vRP
 vRP
 vRP
-cFo
+vRP
 vRP
 vRP
 vRP
@@ -98706,7 +98981,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+cFo
 vRP
 vRP
 vRP
@@ -99456,7 +99731,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+cFo
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -2910,6 +2910,14 @@
 /obj/effect/spawner/lootdrop/tanks,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"btB" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "btL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -4992,14 +5000,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"czu" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/red/arrow_ccw{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
 "czG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -5909,6 +5909,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cVQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "cWe" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -11830,6 +11842,15 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/starboard/fore)
+"fKf" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "fKD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -24698,6 +24719,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mmw" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -28044,12 +28072,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"nVI" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
-	dir = 4
-	},
-/area/hallway/secondary/entry)
 "nWu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32704,15 +32726,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qto" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "qtt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -44049,16 +44062,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"wdp" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/red/arrow_ccw{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
 "wdr" = (
 /obj/structure/displaycase/captain,
 /turf/open/floor/wood,
@@ -44629,6 +44632,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wtt" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "wtF" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/machinery/airalarm{
@@ -48155,14 +48167,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ycX" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/trimline/red/arrow_ccw{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
 "ydf" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -92595,7 +92599,7 @@ vgB
 mYp
 ein
 pKx
-qto
+cVQ
 hjp
 ryX
 lMA
@@ -92852,7 +92856,7 @@ vrX
 eUd
 iJg
 faQ
-nVI
+wtt
 lVK
 gsE
 lMA
@@ -93109,7 +93113,7 @@ wod
 dvp
 nXs
 rvb
-ycX
+mmw
 lVK
 unc
 xpQ
@@ -93366,7 +93370,7 @@ ybr
 rjN
 rrI
 faQ
-czu
+btB
 wYh
 aAR
 aAR
@@ -93623,7 +93627,7 @@ gBR
 uhZ
 uhZ
 uhZ
-wdp
+fKf
 gRR
 beM
 sfo

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -181,6 +181,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adH" = (
@@ -852,6 +855,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"atx" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "atI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -2324,10 +2331,8 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "beM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4989,6 +4994,10 @@
 /area/chapel/office)
 "czu" = (
 /obj/structure/railing,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "czG" = (
@@ -7255,6 +7264,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"dGz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dGA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -9636,9 +9658,7 @@
 	dir = 10
 	},
 /obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eLQ" = (
@@ -10121,6 +10141,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -11089,7 +11112,7 @@
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -13205,7 +13228,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -13728,7 +13751,7 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -13754,10 +13777,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gIq" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14016,6 +14039,9 @@
 "gRR" = (
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 4
 	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_alone,
 /area/hallway/secondary/entry)
@@ -14641,14 +14667,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hjp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -14922,18 +14948,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"hnL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -16151,6 +16165,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hTN" = (
@@ -16229,7 +16246,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16475,7 +16492,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -17000,7 +17017,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -19924,6 +19941,9 @@
 "jWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hallway/secondary/entry)
 "jXz" = (
@@ -20116,10 +20136,10 @@
 /turf/open/floor/carpet,
 /area/library)
 "kbG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kbY" = (
@@ -20559,10 +20579,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kqi" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kqo" = (
@@ -21360,12 +21380,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"kMb" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kMj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -22828,7 +22842,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -22850,10 +22864,10 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "lwC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lwO" = (
@@ -24672,15 +24686,15 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "mmo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -27279,10 +27293,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nBO" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -28070,12 +28086,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nXc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -28
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -29158,6 +29175,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oAK" = (
@@ -29634,8 +29654,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "oRf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -31090,6 +31110,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -32682,11 +32705,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "qto" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -32700,6 +32722,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"qub" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "quA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -34029,10 +34061,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/light,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rez" = (
@@ -34878,12 +34910,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ryX" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/hallway/secondary/entry";
 	name = "Arrivals APC";
 	pixel_y = -23
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rza" = (
@@ -35389,6 +35421,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rKC" = (
+/obj/structure/sign/warning/vacuum/external,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "rKM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35645,6 +35682,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"rRY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rSg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -35817,6 +35866,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rWQ" = (
@@ -36303,6 +36355,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"smm" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Customs"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "smR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38659,9 +38720,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tvP" = (
@@ -40637,10 +40695,10 @@
 /turf/open/space/basic,
 /area/engine/atmos_distro)
 "uxf" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uxw" = (
@@ -40708,7 +40766,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -43939,6 +43997,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wcy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wcG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43984,6 +44052,10 @@
 "wdp" = (
 /obj/structure/railing/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -45127,7 +45199,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45231,12 +45303,16 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"wMM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"wMY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Arrivals Bay"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "wNm" = (
@@ -45671,9 +45747,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wYh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -46255,10 +46328,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xlo" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -48087,8 +48156,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ycX" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/railing,
+/obj/effect/turf_decal/trimline/red/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "ydf" = (
@@ -90726,7 +90798,7 @@ asc
 tSW
 kbG
 vvd
-vaq
+atx
 oaC
 sqz
 vRP
@@ -90981,9 +91053,9 @@ vvd
 vmy
 vvd
 qSn
-kMb
+nPi
 vvd
-vaq
+atx
 pnP
 sqz
 vRP
@@ -91232,15 +91304,15 @@ lzE
 lDT
 vds
 pFz
-aAR
+lzE
 hTG
-nOX
-ofj
-aAR
+qub
+wcy
+lzE
 jWH
-aAR
+lzE
 oAE
-vaq
+atx
 pnP
 sqz
 gIn
@@ -91495,9 +91567,9 @@ mPt
 vvd
 vvd
 xus
-rCa
-lVK
-vaq
+vvd
+rRY
+atx
 pnP
 sqz
 vRP
@@ -92009,9 +92081,9 @@ faQ
 faQ
 faQ
 pKx
-oRf
-lVK
-vaq
+smm
+rRY
+atx
 xHB
 lMA
 aCD
@@ -92781,8 +92853,8 @@ eUd
 iJg
 faQ
 nVI
-hnL
-vaq
+lVK
+gsE
 lMA
 lMA
 sqz
@@ -92790,9 +92862,9 @@ sqz
 sqz
 sqz
 lxF
-cjI
+rKC
 lxF
-sqz
+rrx
 lMA
 lMA
 aCD
@@ -93038,7 +93110,7 @@ dvp
 nXs
 rvb
 ycX
-hnL
+lVK
 unc
 xpQ
 mmo
@@ -93296,7 +93368,7 @@ rrI
 faQ
 czu
 wYh
-wMM
+aAR
 aAR
 blt
 aAR
@@ -93555,7 +93627,7 @@ wdp
 gRR
 beM
 sfo
-qzb
+dGz
 sfo
 rCa
 vvd
@@ -93565,7 +93637,7 @@ sfo
 qzb
 oBB
 niF
-sqz
+rrx
 sqz
 cjI
 vRP
@@ -93813,8 +93885,8 @@ tSW
 tSW
 rrx
 xoB
-rrx
-oRf
+tSW
+wMY
 vvd
 vvd
 vaq


### PR DESCRIPTION
# Document the changes in your pull request

Adds a "chode" style arrivals to Gax. Aquizit wanted the ability for the free miner ship to dock, this is a good compromise of not adding too much extra space to die in while giving that ability. Special thanks to @Aquizit for the original version in which I stole a lot from.

![chrome_c1Fa9vDHNI](https://user-images.githubusercontent.com/5091394/216721986-b36f292e-8f12-486f-8370-a6b232c2e9bc.png)


Closes https://github.com/yogstation13/Yogstation/pull/17740


# Wiki Documentation

Arrivals looks different and has a docking port for Gax.

# Changelog
:cl:  Aquizit, ToasterBiome
mapping: NVS Gax Arrivals redesigned to allow free miner ship
/:cl:
