### PR TITLE
Revert "Restricts Hypnotic Flash to Psychiatrist"

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -31,10 +31,6 @@
 /datum/uplink_item/stealthy_weapons/soap_clusterbang
 	category = "Conspicuous Weapons"
 
-/datum/uplink_item/device_tools/hypnotic_flash
-	restricted_roles = list("Psychiatrist")
-	category = "Role-Restricted"
-
 
 /datum/uplink_item/dangerous/syndicate_minibomb
 	cost = 4


### PR DESCRIPTION
# Document the changes in your pull request

Let them eat cake

Reverts https://github.com/yogstation13/Yogstation/pull/3721

# Wiki Documentation

Hypno Flash no longer role restricted and is in Misc. Gadgets section

# Changelog

:cl:  
tweak: Hypnotic Flash is no longer role restricted
/:cl:
