### PR TITLE
Protects events from being faked random by admins

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -35,6 +35,12 @@
 	/// Whether or not dynamic should hijack this event
 	var/dynamic_should_hijack = FALSE
 
+/datum/round_event_control/vv_edit_var(var_name, var_value)
+	if(var_name == NAMEOF(src, random)) // CAN'T LET YOU DO THAT, STAR FOX
+		message_admins("No, [key_name_admin(usr)], you cannot fake force a random event.")
+		return FALSE
+	. = ..()
+
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs
 		earliest_start = CEILING(earliest_start * CONFIG_GET(number/events_min_time_mul), 1)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -36,7 +36,7 @@
 	var/dynamic_should_hijack = FALSE
 
 /datum/round_event_control/vv_edit_var(var_name, var_value)
-	if(var_name == NAMEOF(src, random)) // CAN'T LET YOU DO THAT, STAR FOX
+	if(var_name == NAMEOF(src, random) && var_value) // CAN'T LET YOU DO THAT, STAR FOX
 		message_admins("No, [key_name_admin(usr)], you cannot fake force a random event.")
 		return FALSE
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Moja said I couldn't and I proved him wrong in less than a minute when I looked up the message

You could still theoretically create the event datum yourself and fake the deadchat message but at that point you may as well spawn in 7 ninjas yourself