### PR TITLE
cremator doesn't work on alive or soulful mobs

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -250,6 +250,14 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	// Make sure we don't delete the actual morgue and its tray
 	var/list/conts = GetAllContents() - src - connected
 
+	for(var/mob/i in conts)
+		if(i.stat != DEAD)
+			say("Living creature detected. Aborting.")
+			return
+		if(i.key && i.get_ghost())
+			say("Revival is possible. Aborting.")
+			return
+
 	if(!conts.len)
 		audible_message(span_italics("You hear a hollow crackle."))
 		return


### PR DESCRIPTION
cremator is zero effort instantaneous round removal that deletes your brain, hard removing you from the round. this changes it to not cremate if there's a living person or a dead person who still has a ghost attached to them inside.

tl;dr round removal bad

:cl:  
tweak: cremator does not work on living mobs or dead mobs with ghosts still attached
/:cl:
