### PR TITLE
It now takes 6 seconds to cremate someone, and 3 seconds to break out if they're conscious

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -211,6 +211,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	icon_state = "crema1"
 	dir = SOUTH
 	breakout_time = 3 SECONDS
+	var/cremate_time = 3 SECONDS
 	var/cremate_timer
 	var/id = 1
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -300,8 +300,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up
 		new/obj/effect/decal/cleanable/ash/crematorium(src)
 
-	sleep(3 SECONDS)
-
 	if(!QDELETED(src))
 		locked = FALSE
 		update_icon()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		audible_message(span_italics("You hear a roar as the crematorium fires up."))
 		locked = TRUE
 		update_icon()
-		cremate_timer = addtimer(CALLBACK(src, .proc/finish_cremate, user), (breakout_time + 3 SECONDS), TIMER_STOPPABLE)
+		cremate_timer = addtimer(CALLBACK(src, .proc/finish_cremate, user), (breakout_time + cremate_time ), TIMER_STOPPABLE)
 		
 
 /obj/structure/bodycontainer/crematorium/open()


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Alternative to #17792 (somewhat, maybe)

Cremate time takes 3 seconds + how long it takes to break out. You have to be alive to resist out


# Wiki Documentation

see above

# Changelog


:cl:  
tweak: It now takes approximately 6 seconds to cremate someone, if you're stuck inside alive, resist!
/:cl:
