### PR TITLE
Bloodsucker tasks will no longer lie to you about their requirements

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -61,6 +61,8 @@
 	var/obj/structure/closet/crate/coffin
 	var/total_blood_drank = 0
 	var/frenzy_blood_drank = 0
+	var/task_heart_required = 0
+	var/task_blood_required = 0
 	var/task_blood_drank = 0
 	var/frenzies = 0
 

--- a/code/modules/antagonists/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/code/modules/antagonists/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -122,18 +122,19 @@
 		to_chat(user, span_notice("You have done all tasks for the night, come back tomorrow for more."))
 		return
 	var/task //just like amongus
-	var/suckamount = 0
-	var/heartamount = 0
-	switch(bloodsuckerdatum.bloodsucker_level + bloodsuckerdatum.bloodsucker_level_unspent)
-		if(0 to 3)
-			suckamount = rand(100, 200)
-			heartamount = rand(1,2)
-		if(3 to 8)
-			suckamount = rand(200, 300)
-			heartamount = rand(1,2)
-		if(8 to INFINITY)
-			suckamount = rand(500, 600)
-			heartamount = rand(5,6)
+	var/suckamount = bloodsuckerdatum.task_blood_required
+	var/heartamount = bloodsuckerdatum.task_heart_required
+	if(suckamount == 0 && heartamount == 0) // Generate random amounts if we don't already have them set
+		switch(bloodsuckerdatum.bloodsucker_level + bloodsuckerdatum.bloodsucker_level_unspent)
+			if(0 to 3)
+				suckamount = rand(100, 200)
+				heartamount = rand(1,2)
+			if(3 to 8)
+				suckamount = rand(200, 300)
+				heartamount = rand(1,2)
+			if(8 to INFINITY)
+				suckamount = rand(500, 600)
+				heartamount = rand(5,6)
 	if(bloodsuckerdatum.task_blood_drank >= suckamount || sacrifices >= heartamount)
 		task_completed = TRUE
 	if(task_completed)
@@ -142,6 +143,8 @@
 		bloodsuckerdatum.bloodsucker_level_unspent++
 		bloodsuckerdatum.altar_uses++
 		bloodsuckerdatum.task_blood_drank = 0
+		bloodsuckerdatum.task_blood_required = 0
+		bloodsuckerdatum.task_heart_required = 0
 		sacrifices = 0
 		to_chat(user, span_notice("You have sucessfully done a task and gained a rank!"))
 		task_completed = FALSE
@@ -161,8 +164,10 @@
 		C.blood_volume -= 50
 		switch(rand(1, 3))
 			if(1,2)
+				bloodsuckerdatum.task_blood_required = suckamount
 				task = "Suck [suckamount] units of pure blood."
 			if(3)
+				bloodsuckerdatum.task_heart_required = heartamount
 				task = "Sacrifice [heartamount] hearts by using them on the altar."
 				sacrificialtask = TRUE
 		bloodsuckerdatum.task_memory += "<B>Current Rank Up Task</B>: [task]<br>"


### PR DESCRIPTION
# Document the changes in your pull request

A task is generated. It tells you "Go suck 123 units of blood." You would expect `123` to get stored somewhere, right? It didn't. It would just generate a random number each time you checked based on your bloodsucker rank and compare that against how much task blood you had gotten. This means you could be told to suck 190 units of blood and only need to suck 110, or vice versa.

Additionally, if you had dared ranked up in the time since you got the task, you could be in a whole new bracket, so instead of 100-200 blood, it would roll for 200-300 blood, but still tell you that you needed to suck 123 units of blood to complete it.

Coded by chimps

# Changelog

:cl:  
bugfix: fixed bloodsucker blood altar tasks randomly generating themselves at will
/:cl:
