### PR TITLE
Adds box of shotgun darts to the uplink for 2TC

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -735,3 +735,7 @@
 	new /obj/item/autosurgeon/upgraded_cyberlungs(src)
 	new /obj/item/autosurgeon/upgraded_cyberstomach(src)
 	new /obj/item/implanter/empshield(src)
+
+/obj/item/storage/box/beanbag/syndie_darts/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/ammo_casing/shotgun/dart/hidden(src)

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -163,6 +163,16 @@
 	if(no_react)
 		ENABLE_BITFIELD(reagents.flags, NO_REACT)
 
+/obj/item/ammo_casing/shotgun/dart/hidden
+	name = "beanbag slug"
+	desc = "A weak beanbag slug for riot control."
+	icon_state = "bshell"
+	projectile_type = /obj/item/projectile/bullet/reusable/dart/hidden
+
+/obj/item/ammo_casing/shotgun/dart/hidden/Initialize()
+	. = ..()
+	DISABLE_BITFIELD(reagents.flags, TRANSPARENT) // cant examine reagents, stealthy
+
 /obj/item/ammo_casing/shotgun/dart/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
 	if(!BB)
 		return

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -5,6 +5,16 @@
 	var/obj/item/reagent_containers/container
 	var/piercing = FALSE
 
+/obj/item/projectile/bullet/reusable/dart/hidden
+	name = "beanbag slug"
+	stamina = 5 // gotta act like we did stamina
+	sharpness = SHARP_NONE
+
+// don't want our "beanbag slugs" dropping reagent darts everywhere
+/obj/item/projectile/bullet/reusable/dart/hidden/handle_drop()
+	if(!dropped)
+		QDEL_NULL(container)
+		dropped = TRUE
 
 /obj/item/projectile/bullet/reusable/dart/Initialize()
 	. = ..()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -641,6 +641,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 50
 
+/datum/uplink_item/stealthy_weapons/dart_pistol
+	name = "Box of Chemical Shotgun Darts"
+	desc = "A box of 7 empty shotgun darts capable of holding 30 units of any reagent, cleverly \
+			disguised as non-lethal beanbag slugs. People will still notice the big dart sticking \
+			out of their arm. Be careful not to mix them up with actual beanbag slugs!"
+	item = /obj/item/storage/box/beanbag/syndie_darts
+	cost = 2
+	surplus = 0 // useless for most people
+
 /datum/uplink_item/stealthy_weapons/dehy_carp
 	name = "Dehydrated Space Carp"
 	desc = "Looks like a plush toy carp, but just add water and it becomes a real-life space carp! Activate in \


### PR DESCRIPTION
# Document the changes in your pull request

Stealthy item, disguised as beanbag slugs in a beanbag slug box

Cannot be examined for reagents

Does not drop syringe when it hits a non-carbon like normal darts

People will still figure out the syringe in their arm though

# Changelog

:cl:  
rscadd: Added box of shotgun darts disguised as beanbag slugs to the uplink for 2TC
/:cl:
