### PR TITLE
Fixes 'id in pda' preference

### DIFF
--- a/code/modules/client/preferences/pda.dm
+++ b/code/modules/client/preferences/pda.dm
@@ -31,3 +31,6 @@
 	savefile_key = "id_in_pda"
 	savefile_identifier = PREFERENCE_PLAYER
 	default_value = FALSE
+
+/datum/preference/toggle/id_in_pda/apply_to_human(mob/living/carbon/human/target, value)
+	target.id_in_pda = value

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -316,7 +316,7 @@
 
 	var/obj/item/modular_computer/PDA = new pda_type()
 	if(istype(PDA))
-		if (H.client?.prefs.read_preference(/datum/preference/toggle/id_in_pda))
+		if (H.id_in_pda)
 			PDA.InsertID(C)
 			H.equip_to_slot_if_possible(PDA, SLOT_WEAR_ID)
 		else // just in case you hate change

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -35,6 +35,7 @@
 	var/socks = "Nude" //Which socks the player wants
 	var/backbag = DBACKPACK		//Which backpack type the player has chosen.
 	var/jumpsuit_style = PREF_SUIT //suit/skirt
+	var/id_in_pda = FALSE //Whether the player wants their ID to start in their PDA
 
 	//Equipment slots
 	var/obj/item/clothing/wear_suit = null


### PR DESCRIPTION
# Document the changes in your pull request
Client is null during roundstart equip, which made this fail.

# Changelog

:cl:  
bugfix: Fix spawning with ID in PDA preference
/:cl:
