### PR TITLE
Removes corn syrup from catsip

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -813,7 +813,7 @@
 	name = "Catsip"
 	id = /datum/reagent/consumable/ethanol/catsip
 	results = list(/datum/reagent/consumable/ethanol/catsip = 4)
-	required_reagents = list(/datum/reagent/consumable/ethanol/sake = 2, /datum/reagent/consumable/soymilk = 2, /datum/reagent/consumable/corn_syrup = 1, /datum/reagent/consumable/grenadine = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/sake = 2, /datum/reagent/consumable/soymilk = 2, /datum/reagent/consumable/grenadine = 1)
 
 /datum/chemical_reaction/flaming_moe
 	name = "Flaming Moe"


### PR DESCRIPTION

# Document the changes in your pull request
Catsip no longer requires corn syrup
# Wiki Documentation
Catsip no longer uses corn syrup in the recipe
# Changelog

:cl:  
tweak: makes catsip healthy by removing corn syrup 
/:cl:
