### PR TITLE
Nanite heart processes nanites on life tick

### DIFF
--- a/yogstation/code/modules/surgery/organs/heart.dm
+++ b/yogstation/code/modules/surgery/organs/heart.dm
@@ -13,6 +13,11 @@
 
 /obj/item/organ/heart/nanite/on_life()
 	. = ..()
+	if(owner)//makes nanites tick on every life tick, only about 33% speed increase
+		var/datum/component/nan = owner.GetExactComponent(/datum/component/nanites)
+		if(nan)
+			nan.process()
+
 	if(SEND_SIGNAL(owner, COMSIG_HAS_NANITES))
 		SEND_SIGNAL(owner, COMSIG_NANITE_ADJUST_VOLUME, nanite_boost)
 	else


### PR DESCRIPTION
Nanite heart is still pretty dangerous to have, rather than reducing the downside, this makes the upside more enticing

Nanites tick more often than life, so this is only ~30% increase to tick frequency
Making it run nanites on every life tick means it will boost healing, and generation of nanites, but will also increase consumption and the speed of any negative program that the nanites might have.

:cl:  
tweak: Nanite heart runs your nanites on each life tick
/:cl:
