### PR TITLE
Nerfs Preternis because I want to be the only one that plays them

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -26,7 +26,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	burnmod = 1.1 //The plasteel has a really high heat capacity, however, if the heat does get through it will REALLY burn the flesh on the inside
 	coldmod = 3 //The plasteel around them saps their body heat quickly if it gets cold
 	heatmod = 2 //Once the heat gets through it's gonna BURN
-	tempmod = 0.1 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
+	tempmod = 0.15 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
 	stunmod = 1.1 //Big metal body has difficulty getting back up if it falls down
 	staminamod = 1.1 //Big metal body has difficulty holding it's weight if it gets tired
 	action_speed_coefficient = 0.9 //worker drone do the fast
@@ -232,7 +232,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		H.add_movespeed_modifier("preternis_water", update = TRUE, priority = 102, multiplicative_slowdown = 4, blacklisted_movetypes=(FLYING|FLOATING))
 		//damage has a flat amount with an additional amount based on how wet they are
 		H.adjustStaminaLoss(11 - (H.fire_stacks / 2))
-		H.adjustFireLoss(5 - (H.fire_stacks / 2))
+		H.adjustFireLoss(6 - (H.fire_stacks / 2))
 		H.Jitter(100)
 		H.stuttering = 1
 		if(!soggy)//play once when it starts
@@ -270,7 +270,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 /datum/species/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)//make them attack slower
 	. = ..()
 	if(ispreternis(user) && !attacker_style?.nonlethal && !user.mind.has_martialart())
-		user.next_move += 2 //adds 0.2 second delay to combat
+		user.next_move += 3 //adds 0.3 second delay to combat
 
 /datum/species/preternis/has_toes()//their toes are mine, they shall never have them back
 	return FALSE

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -68,9 +68,11 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		BP.render_like_organic = TRUE 	// Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		BP.burn_reduction = 2
 		BP.brute_reduction = 1
-		if(istype(BP,/obj/item/bodypart/chest) || istype(BP,/obj/item/bodypart/head))
+		if(istype(BP,/obj/item/bodypart/l_arm) || istype(BP,/obj/item/bodypart/r_arm))//reasonable
+			BP.max_damage = 40
 			continue
-		BP.max_damage = 35
+		if(istype(BP,/obj/item/bodypart/l_leg) || istype(BP,/obj/item/bodypart/r_leg))//stick legs
+			BP.max_damage = 25
 
 	if(ishuman(C))
 		maglock = new

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -69,10 +69,10 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		BP.burn_reduction = 2
 		BP.brute_reduction = 1
 		if(istype(BP,/obj/item/bodypart/l_arm) || istype(BP,/obj/item/bodypart/r_arm))
-			BP.max_damage = 45
+			BP.max_damage = 40
 			continue
 		if(istype(BP,/obj/item/bodypart/l_leg) || istype(BP,/obj/item/bodypart/r_leg))//my dudes skip leg day
-			BP.max_damage = 25
+			BP.max_damage = 30
 
 	if(ishuman(C))
 		maglock = new

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -26,7 +26,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	burnmod = 1.1 //The plasteel has a really high heat capacity, however, if the heat does get through it will REALLY burn the flesh on the inside
 	coldmod = 3 //The plasteel around them saps their body heat quickly if it gets cold
 	heatmod = 2 //Once the heat gets through it's gonna BURN
-	tempmod = 0.15 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
+	tempmod = 0.1 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
 	stunmod = 1.1 //Big metal body has difficulty getting back up if it falls down
 	staminamod = 1.1 //Big metal body has difficulty holding it's weight if it gets tired
 	action_speed_coefficient = 0.9 //worker drone do the fast

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -68,10 +68,10 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		BP.render_like_organic = TRUE 	// Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		BP.burn_reduction = 2
 		BP.brute_reduction = 1
-		if(istype(BP,/obj/item/bodypart/l_arm) || istype(BP,/obj/item/bodypart/r_arm))//reasonable
-			BP.max_damage = 40
+		if(istype(BP,/obj/item/bodypart/l_arm) || istype(BP,/obj/item/bodypart/r_arm))
+			BP.max_damage = 45
 			continue
-		if(istype(BP,/obj/item/bodypart/l_leg) || istype(BP,/obj/item/bodypart/r_leg))//stick legs
+		if(istype(BP,/obj/item/bodypart/l_leg) || istype(BP,/obj/item/bodypart/r_leg))//my dudes skip leg day
 			BP.max_damage = 25
 
 	if(ishuman(C))

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -232,7 +232,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		H.add_movespeed_modifier("preternis_water", update = TRUE, priority = 102, multiplicative_slowdown = 4, blacklisted_movetypes=(FLYING|FLOATING))
 		//damage has a flat amount with an additional amount based on how wet they are
 		H.adjustStaminaLoss(11 - (H.fire_stacks / 2))
-		H.adjustFireLoss(6 - (H.fire_stacks / 2))
+		H.adjustFireLoss(5 - (H.fire_stacks / 2))
 		H.Jitter(100)
 		H.stuttering = 1
 		if(!soggy)//play once when it starts


### PR DESCRIPTION
I just played a round where there were FOUR preterni, this is UNACCEPTABLE as everyone knows this is my personal snowflake species that no one else should play.

Jokes aside
I initially went and overtuned them a bit initially, just to get a feeling of how they'd play and perhaps get actual feedback rather than no one playing them still.
Hoped they wouldn't be needing of a bit of a nerf, seems I was wrong.
The downside of attacking slower doesn't actually feel noticeable, so i've increased it by 0.1 (might increase it by another 0.1 in the future)
Also, reduces leg health, but increases arm health. makes them easier to bring to the ground, but not easier to nugget.

:cl:  
tweak: Preterni attack 0.1 second slower
tweak: Preterni arms have 5 more health (40)
tweak: Preterni legs have 5 less health (30)
/:cl:
