### PR TITLE
Reduces body temp increase from being on fire

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2106,7 +2106,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
 			H.adjust_bodytemperature(11)
 		else
-			H.adjust_bodytemperature(BODYTEMP_HEATING_MAX + (H.fire_stacks * 12))
+			H.adjust_bodytemperature(BODYTEMP_HEATING_MAX + (H.fire_stacks * 3))
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "on_fire", /datum/mood_event/on_fire)
 
 /datum/species/proc/CanIgniteMob(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2106,7 +2106,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
 			H.adjust_bodytemperature(11)
 		else
-			H.adjust_bodytemperature(BODYTEMP_HEATING_MAX + (H.fire_stacks * 3))
+			H.adjust_bodytemperature(BODYTEMP_HEATING_MAX + (H.fire_stacks * 2))
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "on_fire", /datum/mood_event/on_fire)
 
 /datum/species/proc/CanIgniteMob(mob/living/carbon/human/H)


### PR DESCRIPTION
It had a base of 30, with an additional `Fire_Stacks * 12`

it takes just 50 temp to start taking additional damage from the heat rather than just the fire
This meant that with even 2 fire stacks, one would instantly start taking damage in a single tick
Also, having 20 fire stacks mean that each life tick, bodytemp would increase by 270, this basically makes a corpse not worth reviving since after a bit they'll be so hot that it will take forever for them to cool down unless you have a shower.

Reducing it to `Fire_Stacks * 2` means that the victim will take 3 life ticks to be at max heat damage from a full fire, but 5 from minor ones rather than being instant anywhere above 10 fire stacks.


I also considered making it `15 + (Fire_Stacks * 6)` or something similar, with reduced flat heat, but increase scaling, will change the PR if someone can convince me

:cl:  
tweak: Fire is less hot
/:cl:
