### PR TITLE
Adds a chemical that purges nanites

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1866,3 +1866,18 @@
 	M.Jitter(10 SECONDS)
 	M.emote("gasp")
 
+/datum/reagent/medicine/naniteremover
+	name = "Nanite Destabilizer"
+	description = "Creates an environment that in unsuitable for nanites, causing them to rapidly break down."
+	reagent_state = LIQUID
+	color = "#ff00d4"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	taste_description = "acidic oil"
+	process_flags = ORGANIC | SYNTHETIC
+	var/nanite_reduction = -50
+
+/datum/reagent/medicine/naniteremover/on_mob_life(mob/living/carbon/M)
+	if(SEND_SIGNAL(M, COMSIG_HAS_NANITES))
+		SEND_SIGNAL(M, COMSIG_NANITE_ADJUST_VOLUME, nanite_reduction)
+	..()
+	

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1867,7 +1867,7 @@
 	M.emote("gasp")
 
 /datum/reagent/medicine/naniteremover
-	name = "Nanite Destabilizer"
+	name = "Nanolytic Agent"
 	description = "Creates an environment that in unsuitable for nanites, causing them to rapidly break down."
 	reagent_state = LIQUID
 	color = "#ff00d4"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1879,5 +1879,5 @@
 /datum/reagent/medicine/naniteremover/on_mob_life(mob/living/carbon/M)
 	if(SEND_SIGNAL(M, COMSIG_HAS_NANITES))
 		SEND_SIGNAL(M, COMSIG_NANITE_ADJUST_VOLUME, nanite_reduction)
-	..()
+	return ..()
 	

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -12,7 +12,7 @@
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 
 /datum/chemical_reaction/naniteremover
-	name = "Nanite Remover"
+	name = "Nanolytic Agent"
 	id = /datum/reagent/medicine/naniteremover
 	results = list(/datum/reagent/medicine/naniteremover = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/ammonia = 1)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -11,6 +11,12 @@
 	results = list(/datum/reagent/lube = 4)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 
+/datum/chemical_reaction/naniteremover
+	name = "Nanite Remover"
+	id = /datum/reagent/medicine/naniteremover
+	results = list(/datum/reagent/medicine/naniteremover = 3)
+	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/ammonia = 1)
+
 /datum/chemical_reaction/itching_powder
 	name = "Itching Powder"
 	id = /datum/reagent/itching_powder


### PR DESCRIPTION
Currently, removing nanites once you have them is almost impossible since it can only be done using a chamber linked to a console or rapidly EMPing yourself multiple times.
This adds a chemical that's pretty easy to make that rapidly purges nanites from the host.
Can either be used as an "OH SHIT" in case the nanites start killing you (doesn't help with the instant negative programs)
or as a weapon to remove healing nanites from someone using them to become nigh unkillable.
Carrying around a pill of this is definitely powergaming unless you're a scientist messing around with nanites.

### Wiki documentation
Just say what it is, and how it's made
![image](https://user-images.githubusercontent.com/108117184/217093623-d7a1f04e-d42e-4094-9aac-d9646d1c78ae.png)


:cl:  
rscadd: Added a chemical that purges nanites
/:cl:
