### PR TITLE
Fix a runtime that prevents proper sorting in holopad room listing

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -280,7 +280,7 @@ obj/machinery/holopad/secure/Initialize()
 					if(pad.padname)
 						LAZYADD(callnames[pad.padname], pad)
 				callnames -= padname
-				var/result = tgui_input_list(usr, "Choose an area to call", "Holocall", sortNames(callnames))
+				var/result = tgui_input_list(usr, "Choose an area to call", "Holocall", sortList(callnames))
 				if(QDELETED(usr) || !result || outgoing_call)
 					return
 				if(usr.loc == loc)


### PR DESCRIPTION
# Document the changes in your pull request

It was trying to sort the names of string datums (they arent datums)

# Changelog

:cl:  
bugfix: Fixed a runtime that prevented proper sorting in holopad room listing
/:cl:
