### PR TITLE
Encourages higher-level RP by re-adding dab brain damage

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -21,6 +21,7 @@
 	var/decoy_override = FALSE	//if it's a fake brain with no brainmob assigned. Feedback messages will be faked as if it does have a brainmob. See changelings & dullahans.
 	//two variables necessary for calculating whether we get a brain trauma or not
 	var/damage_delta = 0
+	var/dabbed = 0
 
 	var/list/datum/brain_trauma/traumas = list()
 
@@ -226,7 +227,7 @@
 			gain_trauma_type(BRAIN_TRAUMA_MILD)
 	if(damage > BRAIN_DAMAGE_SEVERE)
 		if(prob(damage_delta * (1 + max(0, (damage - BRAIN_DAMAGE_SEVERE)/100)))) //Base chance is the hit damage; for every point of damage past the threshold the chance is increased by 1%
-			if(prob(20))
+			if(!dabbed && prob(20))
 				gain_trauma_type(BRAIN_TRAUMA_SPECIAL)
 			else
 				gain_trauma_type(BRAIN_TRAUMA_SEVERE)
@@ -381,3 +382,7 @@
 	var/list/traumas = get_traumas_type(resilience = resilience)
 	for(var/X in traumas)
 		qdel(X)
+
+///remove dab special trauma prevention
+/obj/item/organ/brain/proc/undab()
+	dabbed = 0

--- a/yogstation/code/modules/mob/living/emote.dm
+++ b/yogstation/code/modules/mob/living/emote.dm
@@ -81,4 +81,5 @@
 		var/light_dab_angle = rand(35,55)
 		var/light_dab_speed = rand(3,7)
 		H.DabAnimation(angle = light_dab_angle , speed = light_dab_speed)
+		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
 		SSachievements.unlock_achievement(/datum/achievement/dab,H.client)

--- a/yogstation/code/modules/mob/living/emote.dm
+++ b/yogstation/code/modules/mob/living/emote.dm
@@ -81,5 +81,9 @@
 		var/light_dab_angle = rand(35,55)
 		var/light_dab_speed = rand(3,7)
 		H.DabAnimation(angle = light_dab_angle , speed = light_dab_speed)
-		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		var/obj/item/organ/brain/B = H.getorganslot(ORGAN_SLOT_BRAIN)
+		if(B)
+			B.dabbed = 1
+			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+			addtimer(CALLBACK(B, /obj/item/organ/brain.proc/undab), 40)
 		SSachievements.unlock_achievement(/datum/achievement/dab,H.client)


### PR DESCRIPTION
# Document the changes in your pull request
readds 5 brain damage each time you dab

# Why is this good for the game?
Adding brain damage back to dabbing encourages less LRP behavior by negative reinforcement.

# Wiki Documentation
dabbing gives you brain damage
# Changelog

:cl:  
rscadd: dabbing gives you brain damage again
/:cl:
