### PR TITLE
Prevents wormholes from spawning in syndicate shuttles

### DIFF
--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -188,10 +188,12 @@
 /area/shuttle/syndicate_scout
 	name = "Syndicate Scout"
 	blob_allowed = FALSE
+	noteleport = TRUE
 
 /area/shuttle/caravan
 	blob_allowed = FALSE
 	requires_power = TRUE
+	noteleport = TRUE
 
 /area/shuttle/caravan/syndicate1
 	name = "Syndicate Fighter"

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -23,8 +23,14 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 
 /datum/round_event/wormholes/start()
 	for(var/turf/open/floor/T in world)
-		if(is_station_level(T.z))
-			pick_turfs += T
+		if(!is_station_level(T.z))
+			continue
+
+		var/area/area = get_area(T)
+		if (!area || area.noteleport)
+			continue
+
+		pick_turfs += T
 
 	for(var/i = 1, i <= number_of_wormholes, i++)
 		var/turf/T = pick(pick_turfs)


### PR DESCRIPTION
# Document the changes in your pull request
Seems kind of cheesy that you can just go into a wormhole and potentially get teleported onto a syndicate shuttle. They have guns on the outside for a reason.

# Changelog

:cl:  
tweak: Wormholes will no longer spawn in, or teleport you to, syndicate shuttles
/:cl:
