### PR TITLE
Makes zombie scaling infection chance simpler and more consistent

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -18,12 +18,7 @@
 	damtype = "brute"
 	var/inserted_organ = /obj/item/organ/zombie_infection
 	var/infect_chance = 100 //Before armor calculations
-	var/scaled_infect_chance = FALSE //Does infection chance scale with damage? (100% of infect chance at 50% health(Crit, humans have 200% health!), 0% at max health)
-	//Approx chances, with 100 infect_chance
-	//20% at 40 damage
-	//40% at 60 damage
-	//70% at 80 damage
-	//100% at 100 damage
+	var/scaled_infect_chance = FALSE //Do we use steeper armor infection block chance or linear?
 
 /obj/item/zombie_hand/Initialize()
 	. = ..()
@@ -76,19 +71,10 @@
 			if(H.health <= HEALTH_THRESHOLD_FULLCRIT || (L && L.status != BODYPART_ROBOTIC))//no more infecting via metal limbs unless they're in hard crit and probably going to die
 				var/flesh_wound = ran_zone(user.zone_selected)
 				if(scaled_infect_chance)
-					var/mob/living/mob_target = M
-					var/total_damage = mob_target.get_damage_amount(BRUTE)
-
-					var/infect_modifier = (total_damage ** 2) / 100
-
-					infect_modifier = clamp(infect_modifier, 0, 100)
-
-					if(prob(infect_modifier))
-						if(prob(infect_chance - H.getarmor(flesh_wound, MELEE)))
-							if(!H.stat)
-								try_to_zombie_infect(M, inserted_organ)
-
-				else
+					var/scaled_infection = ((100 - H.getarmor(flesh_wound, MELEE))/100) ^ 1.5	//20 armor -> 71.5% chance of infection
+					if(prob(infect_chance * scaled_infection))									//40 armor -> 46.5% chance
+						try_to_zombie_infect(M, inserted_organ)									//60 armor -> 25.3% chance
+				else																			//80 armor -> 8.9% chance
 					if(prob(infect_chance - H.getarmor(flesh_wound, MELEE)))
 						try_to_zombie_infect(M, inserted_organ)
 			else


### PR DESCRIPTION
Current zombie infection chance is overcomplicated and janky and actually gives you really really low chance of being infected by a bite even if you have no armor. This pr changes the scaled_infection_chance path to just effectively the normal armor block to the power of 1.5 which gives technically better infection blocking than the linear one while also making single attacks still have decent chance of infecting people. Really high armor will of course make you a lot harder to infect but the chance is still there if you get hit a lot.

# Wiki Documentation

Infect chance for scaled infection is now (1 - armor block fraction) ^ 1.5 for scaled infection, if the math is relevant.

# Changelog

:cl:  

tweak: Scaling infection chance for zombie bites is now less overcomplicated and more consistent

/:cl:
