### PR TITLE
Adds a syringe and hand labeler to the medical area of mining base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/miningbase.dmm
+++ b/_maps/RandomRuins/LavaRuins/miningbase.dmm
@@ -1202,6 +1202,22 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"mk" = (
+/obj/structure/table,
+/obj/item/storage/lockbox/vialbox/blood{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/book/random{
+	pixel_x = -4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel/white,
+/area/mine/infirmary)
 "mr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1590,20 +1606,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
-"tM" = (
-/obj/structure/table,
-/obj/item/storage/lockbox/vialbox/blood{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/book/random{
-	pixel_x = -4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/mine/infirmary)
 "tQ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -5108,7 +5110,7 @@ YH
 wu
 UI
 kD
-tM
+mk
 Er
 Ch
 kD


### PR DESCRIPTION
The idea of the vial box is that you take a blood sample of all the miners to pod clone in case a megafauna deletes them
Slight problem, there's no syringe to take the blood with
Also, adds a labeler to make it possible to keep track of bloods
![image](https://user-images.githubusercontent.com/108117184/217170214-3d1f81dc-5fa7-4a64-bde6-de9bd10ad7a5.png)

:cl:  
mapping: Adds a syringe and hand labeler to mining base
/:cl:
