### PR TITLE
Snail Donator Race Roundstart

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -15,11 +15,14 @@
 	siemens_coeff = 2 //snails are mostly water
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | SLIME_EXTRACT
 	sexes = FALSE //snails are hermaphrodites
-	var/shell_type = /obj/item/storage/backpack/snail/species
+	species_language_holder = /datum/language_holder/english // No snail language.. yet.
+	skinned_type = /obj/item/storage/backpack/snail // drop the funny backpack on gib
 
 	mutanteyes = /obj/item/organ/eyes/snail
 	mutanttongue = /obj/item/organ/tongue/snail
 	exotic_blood = /datum/reagent/lube
+
+	smells_like = "organic lubricant" // like IPCs
 
 /datum/species/snail/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(istype(chem,/datum/reagent/consumable/sodiumchloride))
@@ -48,20 +51,19 @@
 		C.temporarilyRemoveItemFromInventory(bag, TRUE)
 		qdel(bag)
 
-/obj/item/storage/backpack/snail/species
+// Unused, perhaps for "advanced snails" or something
+/obj/item/storage/backpack/snail/armored
 	name = "snail shell"
 	desc = "Worn by snails as armor and storage compartment."
-	icon_state = "snailshell"
-	item_state = "snailshell"
-	lefthand_file = 'icons/mob/inhands/equipment/backpack_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/backpack_righthand.dmi'
 	armor = list(MELEE = 40, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 0, ACID = 50)
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
-/obj/item/storage/backpack/snail/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+// Instead of losing the backpack, empty it
+/obj/item/storage/backpack/snail/doStrip(mob/stripper, mob/owner)
+	var/datum/component/storage/ST = GetComponent(/datum/component/storage)
+	ST.quick_empty(stripper)
+	return src
 
 /datum/species/snail/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -24,14 +24,6 @@
 
 	smells_like = "organic lubricant" // like IPCs
 
-/datum/species/snail/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	if(istype(chem,/datum/reagent/consumable/sodiumchloride))
-		H.adjustFireLoss(2)
-		playsound(H, 'sound/weapons/sear.ogg', 30, 1)
-		H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
-		return TRUE
-	return ..()
-
 /datum/species/snail/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
 	var/obj/item/storage/backpack/bag = C.get_item_by_slot(SLOT_BACK)
@@ -66,10 +58,10 @@
 	return src
 
 /datum/species/snail/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
-	. = ..()
-
-	if(H.reagents.has_reagent(/datum/reagent/consumable/sodiumchloride))
+	var/ouch = istype(chem, /datum/reagent/consumable/sodiumchloride) || istype(chem, /datum/reagent/medicine/salglu_solution)
+	if(ouch)
 		H.adjustFireLoss(2*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)
-
-	if(H.reagents.has_reagent(/datum/reagent/medicine/salglu_solution))
-		H.adjustFireLoss(2*REAGENTS_EFFECT_MULTIPLIER,FALSE,FALSE, BODYPART_ANY)
+		playsound(H, 'sound/weapons/sear.ogg', 30, 1)
+		chem.holder.remove_reagent(chem.type, chem.metabolization_rate)
+		return TRUE
+	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -4,7 +4,7 @@
 	id = "snail"
 	offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,4), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))
 	default_color = "336600" //vomit green
-	species_traits = list(EYECOLOR, HAIR, FACEHAIR, LIPS, MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
+	species_traits = list(EYECOLOR, LIPS, MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
 	inherent_traits = list(TRAIT_ALWAYS_CLEAN)
 	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID, MOB_BUG) // splat
 	attack_verb = "slap"

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -6,6 +6,7 @@
 	default_color = "336600" //vomit green
 	species_traits = list(EYECOLOR, HAIR, FACEHAIR, LIPS, MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
 	inherent_traits = list(TRAIT_ALWAYS_CLEAN)
+	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID, MOB_BUG) // splat
 	attack_verb = "slap"
 	say_mod = "slurs"
 	coldmod = 0.5 //snails only come out when its cold and wet

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -4,7 +4,7 @@
 	id = "snail"
 	offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,4), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))
 	default_color = "336600" //vomit green
-	species_traits = list(MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
+	species_traits = list(EYECOLOR, HAIR, FACEHAIR, LIPS, MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)
 	inherent_traits = list(TRAIT_ALWAYS_CLEAN)
 	attack_verb = "slap"
 	say_mod = "slurs"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -544,7 +544,7 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
 ROUNDSTART_RACES preternis
 ROUNDSTART_RACES polysmorph
-#ROUNDSTART_RACES snail
+ROUNDSTART_RACES snail
 ROUNDSTART_RACES ipc
 
 ## Races that are better than humans in some ways, but worse in others

--- a/yogstation/code/game/objects/items/storage/backpack.dm
+++ b/yogstation/code/game/objects/items/storage/backpack.dm
@@ -173,20 +173,19 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 60, ACID = 50)
 
 //Nick's snail shit
-
+// Additional things in code\modules\mob\living\carbon\human\species_types\snail.dm
 /obj/item/storage/backpack/snail
 	name = "snail shell"
 	desc = "You wonder who this came from."
 	icon = 'yogstation/icons/obj/storage.dmi'
 	mob_overlay_icon = 'yogstation/icons/mob/clothing/back.dmi'
-	item_state = "snail_green"
-	icon_state = "snail_green"
+	item_state = "snailshell"
+	icon_state = "snailshell"
 	slowdown = 1
-
 
 /obj/item/storage/backpack/snail/green
 	name = "green shell backpack"
-	desc = "An emerald-green snail shell converted into a backpack. Still smells of salt."
+	desc = "An emerald-green snail shell. Still smells of salt."
 	item_state = "snail_green"
 	icon_state = "snail_green"
 


### PR DESCRIPTION
# Document the changes in your pull request

Snails are now roundstart

Can choose from 2 backpacks

Intended to be donator race

![](https://i.imgur.com/PkSHlfF.png)

## Pros

- 0.5x cold modifier
- Always clean
- Lubes tiles for 2 seconds when crawling

## Neutral
- Nodrop backpack (Will be emptied on the floor on strip attempt)
- No slowdown on crawling but already moving crawl speed
- Space Lube blood

## Cons

- 2x burn modifier
- Crawl-speed run-speed
- Half punch damage
- Nearly incomprehensible
- 2x shock damage
- Takes burn damage from salt

# Changelog

:cl:  
rscadd: Added snails to the list of roundstart races
tweak: Snail backpacks can now be emptied on strip
tweak: Snails now drop their backpacks when thrown in the gibber
/:cl:
