### PR TITLE
Highers population for Shadow based TEAM antags. 26 and 3 were lings? lol

### DIFF
--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -9,7 +9,7 @@
 	name = "darkspawn"
 	config_tag = "darkspawn"
 	antag_flag = ROLE_DARKSPAWN
-	required_players = 26
+	required_players = 38
 	required_enemies = 3
 	recommended_enemies = 3
 	enemy_minimum_age = 15

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -51,7 +51,7 @@ Made by Xhuis
 	name = "shadowling"
 	config_tag = "shadowling"
 	antag_flag = ROLE_SHADOWLING
-	required_players = 32
+	required_players = 38
 	required_enemies = 3
 	recommended_enemies = 3
 	enemy_minimum_age = 14


### PR DESCRIPTION
Makes sure there are at least some crew to fight on these modes, its kinda dumb on low pop, they just steam roll

Alternative to: #17782

Closes: #17782

:cl:  
tweak: Highers pop limit for shadow antags
/:cl:
