### PR TITLE
Antag Reputation Redux

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -224,6 +224,26 @@
 
 	CHECK_TICK
 
+	// Reward people who stayed alive and escaped
+	if(CONFIG_GET(flag/use_antag_rep))
+		var/list/sorted_mobs = sortmobs()
+		for(var/p_ckey in SSpersistence.antag_rep_change)
+			for(var/mob/M in sorted_mobs) // This looks unperformant but it's better than get_mob_by_ckey()
+				if(M.stat == DEAD || !M.ckey) // Skip dead or clientless players
+					sorted_mobs -= M
+					continue
+				if(M.ckey == p_ckey)
+					sorted_mobs -= M
+					if(SSpersistence.antag_rep_change[p_ckey] < 0) // don't want to punish antags for being alive hehe
+						continue
+					else if(is_centcom_level(M.z))
+						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/escaped_alive_bonus) // Reward for escaping alive
+					else
+						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/stayed_alive_bonus) // Reward for staying alive
+					SSpersistence.antag_rep_change[p_ckey] = round(SSpersistence.antag_rep_change[p_ckey]) // rounds down
+	
+	CHECK_TICK
+
 	//Now print them all into the log!
 	log_game("Antagonists at round end were...")
 	for(var/antag_name in total_antagonists)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -236,7 +236,7 @@
 					sorted_mobs -= M
 					if(SSpersistence.antag_rep_change[p_ckey] < 0) // don't want to punish antags for being alive hehe
 						continue
-					else if(is_centcom_level(M.z))
+					else if(M.onCentCom())
 						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/escaped_alive_bonus) // Reward for escaping alive
 					else
 						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/stayed_alive_bonus) // Reward for staying alive

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -226,7 +226,7 @@
 
 	// Reward people who stayed alive and escaped
 	if(CONFIG_GET(flag/use_antag_rep))
-		var/list/sorted_mobs = sortmobs()
+		var/list/sorted_mobs = GLOB.player_list.Copy()
 		for(var/p_ckey in SSpersistence.antag_rep_change)
 			for(var/mob/M in sorted_mobs) // This looks unperformant but it's better than get_mob_by_ckey()
 				if(M.stat == DEAD || !M.ckey) // Skip dead or clientless players

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -226,21 +226,16 @@
 
 	// Reward people who stayed alive and escaped
 	if(CONFIG_GET(flag/use_antag_rep))
-		var/list/sorted_mobs = GLOB.player_list.Copy()
-		for(var/p_ckey in SSpersistence.antag_rep_change)
-			for(var/mob/M in sorted_mobs) // This looks unperformant but it's better than get_mob_by_ckey()
-				if(M.stat == DEAD || !M.ckey) // Skip dead or clientless players
-					sorted_mobs -= M
-					continue
-				if(M.ckey == p_ckey)
-					sorted_mobs -= M
-					if(SSpersistence.antag_rep_change[p_ckey] < 0) // don't want to punish antags for being alive hehe
-						continue
-					else if(M.onCentCom())
-						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/escaped_alive_bonus) // Reward for escaping alive
-					else
-						SSpersistence.antag_rep_change[p_ckey] *= CONFIG_GET(number/stayed_alive_bonus) // Reward for staying alive
-					SSpersistence.antag_rep_change[p_ckey] = round(SSpersistence.antag_rep_change[p_ckey]) // rounds down
+		for(var/mob/M in GLOB.player_list)
+			if(M.stat == DEAD || !M.ckey) // Skip dead or clientless players
+				continue
+			if(SSpersistence.antag_rep_change[M.ckey] < 0) // don't want to punish antags for being alive hehe
+				continue
+			else if(M.onCentCom())
+				SSpersistence.antag_rep_change[M.ckey] *= CONFIG_GET(number/escaped_alive_bonus) // Reward for escaping alive
+			else
+				SSpersistence.antag_rep_change[M.ckey] *= CONFIG_GET(number/stayed_alive_bonus) // Reward for staying alive
+			SSpersistence.antag_rep_change[M.ckey] = round(SSpersistence.antag_rep_change[M.ckey]) // rounds down
 	
 	CHECK_TICK
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -141,6 +141,16 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/number/escaped_alive_bonus
+	config_entry_value = 2
+	integer = FALSE
+	min_val = 1
+
+/datum/config_entry/number/stayed_alive_bonus
+	config_entry_value = 1.5
+	integer = FALSE
+	min_val = 1
+
 /datum/config_entry/number/midround_antag_time_check	// How late (in minutes you want the midround antag system to stay on, setting this to 0 will disable the system)
 	config_entry_value = 60
 	integer = FALSE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -70,7 +70,7 @@
 	/// Department XP required YOGS THIS IS NOT FUCKING SET FOR EVERY JOB I HATE WHOEVER DID THIS
 	var/exp_type_department = ""
 	/// How much antag rep this job gets increase antag chances next round unless its overriden in antag_rep.txt
-	var/antag_rep = 10
+	var/antag_rep = 3
 	/// Base pay of the job
 	var/paycheck = PAYCHECK_MINIMAL
 	/// Where to pull money to pay people
@@ -146,7 +146,7 @@
 	return TRUE
 
 /datum/job/proc/GetAntagRep()
-	. = CONFIG_GET(keyed_list/antag_rep)[lowertext(title)]
+	. = CONFIG_GET(keyed_list/antag_rep)[replacetext(lowertext(title)," ", "_")]
 	if(. == null)
 		return antag_rep
 

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -61,4 +61,5 @@ ANTAG_REP Clerk 5
 ANTAG_REP Mining_Medic 6
 ANTAG_REP Network_Admin 6
 ANTAG_REP Paramedic 6
+ANTAG_REP Psychiatrist 5
 ANTAG_REP Tourist 3

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -19,7 +19,7 @@
 ## Default is currently 3, as listed in code/modules/jobs/job_types/_job.dm
 
 ## Heads are important and envied roles, we should reward people for playing them
-ANTAG_REP AI 8 # AI is an important role but will survive 80% of rounds
+ANTAG_REP AI 6 # AI is an important role but will survive 80% of rounds
 ANTAG_REP Captain 15
 ANTAG_REP Chief_Engineer 10
 ANTAG_REP Chief_Medical Officer 10

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -42,6 +42,7 @@ ANTAG_REP Cargo_Technician 5
 ANTAG_REP Chaplain 6
 ANTAG_REP Chemist 5
 ANTAG_REP Clown 4
+ANTAG_REP Cook 5
 ANTAG_REP Curator 5
 ANTAG_REP Cyborg 4
 ANTAG_REP Geneticist 5

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -7,8 +7,8 @@
 ## ANTAG_REP Assistant 0
 
 ## Short explanation of antag rep rewards:
-##	- When a player joins as a station job, they are set to earn that job's antag reputation
 ##	- Players that are antagonist are set to lose antag reputation
+##	- When a player joins as a station job, they are set to earn that job's antag reputation
 ##	- At a certain time into the round, all players are checked
 ##	- Players that are dead, dying, or AFK are set to earn no antag reputation for that round
 ##	- When the round ends, all players are checked again

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -1,8 +1,63 @@
 ## Custom antag reputation values
 ## List of job titles followed by antag rep value, all prefixed with ANTAG_REP. See code/modules/jobs/job_types for titles
+## Jobs with spaces in them must have an underscore instead
 ## e.g. 
 ## ANTAG_REP Captain 10
+## ANTAG_REP Security_Officer 5
 ## ANTAG_REP Assistant 0
 
-ANTAG_REP Assistant 10
-## Like everyone else :)
+## Short explanation of antag rep rewards:
+##	- When a player joins as a station job, they are set to earn that job's antag reputation
+##	- At a certain time into the round, all players are checked
+##	- Players that are dead, dying, or AFK are set to earn no antag reputation for that round
+##	- Players that are antagonist are set to lose antag reputation
+##	- When the round ends, all players are checked again
+##	- Players that are on centcom and alive receive 2x antag reputation
+##	- Players that are not on centcom and alive receive 1.5x antag reputation
+## Antag reputation is always rounded down
+
+## Default is currently 3, as listed in code/modules/jobs/job_types/_job.dm
+
+## Heads are important and envied roles, we should reward people for playing them
+ANTAG_REP AI 8 # AI is an important role but will survive 80% of rounds
+ANTAG_REP Captain 15
+ANTAG_REP Chief_Engineer 10
+ANTAG_REP Chief_Medical Officer 10
+ANTAG_REP Head_of_Personnel 12
+ANTAG_REP Head_of_Security 14
+ANTAG_REP Research_Director 8 # Basically scientist++
+
+## Security also gets bonus rep, play sec to roll antag more!
+ANTAG_REP Detective 9
+ANTAG_REP Security_Officer 12
+ANTAG_REP Warden 13
+
+## Certain civilian jobs are more important than others and get more rep
+ANTAG_REP Artist 3
+ANTAG_REP Assistant 3
+ANTAG_REP Atmospheric_Technician 5
+ANTAG_REP Bartender 5
+ANTAG_REP Botanist 5
+ANTAG_REP Cargo_Technician 5
+ANTAG_REP Chaplain 6
+ANTAG_REP Chemist 5
+ANTAG_REP Clown 4
+ANTAG_REP Curator 5
+ANTAG_REP Cyborg 4
+ANTAG_REP Geneticist 5
+ANTAG_REP Janitor 5
+ANTAG_REP Lawyer 5
+ANTAG_REP Medical_Doctor 7 # God bless our med staff
+ANTAG_REP Mime 4
+ANTAG_REP Quartermaster 6
+ANTAG_REP Roboticist 5
+ANTAG_REP Scientist 5
+ANTAG_REP Shaft_Miner 5
+ANTAG_REP Station_Engineer 6
+ANTAG_REP Virologist 5
+ANTAG_REP Brig_Physician 6
+ANTAG_REP Clerk 5
+ANTAG_REP Mining_Medic 6
+ANTAG_REP Network_Admin 6
+ANTAG_REP Paramedic 6
+ANTAG_REP Tourist 3

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -52,7 +52,7 @@ ANTAG_REP Mime 4
 ANTAG_REP Quartermaster 6
 ANTAG_REP Roboticist 5
 ANTAG_REP Scientist 5
-ANTAG_REP Shaft_Miner 5
+ANTAG_REP Shaft_Miner 6
 ANTAG_REP Station_Engineer 6
 ANTAG_REP Virologist 5
 ANTAG_REP Brig_Physician 6

--- a/config/antag_rep.txt
+++ b/config/antag_rep.txt
@@ -8,9 +8,9 @@
 
 ## Short explanation of antag rep rewards:
 ##	- When a player joins as a station job, they are set to earn that job's antag reputation
+##	- Players that are antagonist are set to lose antag reputation
 ##	- At a certain time into the round, all players are checked
 ##	- Players that are dead, dying, or AFK are set to earn no antag reputation for that round
-##	- Players that are antagonist are set to lose antag reputation
 ##	- When the round ends, all players are checked again
 ##	- Players that are on centcom and alive receive 2x antag reputation
 ##	- Players that are not on centcom and alive receive 1.5x antag reputation

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -300,6 +300,12 @@ DEFAULT_ANTAG_TICKETS 100
 ## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
 MAX_TICKETS_PER_ROLL 100
 
+## The antag-rep multiplier bonus for escaping alive on Central Command at the end of a round
+ESCAPED_ALIVE_BONUS 2
+
+## The antag-rep multiplier bonus for being alive (and not escaping to CC) at the end of a round
+STAYED_ALIVE_BONUS 1.5
+
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 SHOW_GAME_TYPE_ODDS
 


### PR DESCRIPTION
# Document the changes in your pull request

Being alive at the end of the round = 1.5x gain

Being alive and escaping to CC at the end of the round = 2x gain

Used to be 10 antag rep across the board, now has been changed

![](https://i.imgur.com/caYQ6CR.png)

<details>

  <summary>New Job Antag Rep</summary>

  ## Heads are important and envied roles, we should reward people for playing them
  ANTAG_REP AI 6 # AI is an important role but will survive 80% of rounds
  ANTAG_REP Captain 15
  ANTAG_REP Chief_Engineer 10
  ANTAG_REP Chief_Medical Officer 10
  ANTAG_REP Head_of_Personnel 12
  ANTAG_REP Head_of_Security 14
  ANTAG_REP Research_Director 8 # Basically scientist++
  
  ## Security also gets bonus rep, play sec to roll antag more!
  ANTAG_REP Detective 9
  ANTAG_REP Security_Officer 12
  ANTAG_REP Warden 13
  
  ## Certain civilian jobs are more important than others and get more rep
  ANTAG_REP Artist 3
  ANTAG_REP Assistant 3
  ANTAG_REP Atmospheric_Technician 5
  ANTAG_REP Bartender 5
  ANTAG_REP Botanist 5
  ANTAG_REP Cargo_Technician 5
  ANTAG_REP Chaplain 6
  ANTAG_REP Chemist 5
  ANTAG_REP Clown 4
  ANTAG_REP Cook 5
  ANTAG_REP Curator 5
  ANTAG_REP Cyborg 4
  ANTAG_REP Geneticist 5
  ANTAG_REP Janitor 5
  ANTAG_REP Lawyer 5
  ANTAG_REP Medical_Doctor 7 # God bless our med staff
  ANTAG_REP Mime 4
  ANTAG_REP Quartermaster 6
  ANTAG_REP Roboticist 5
  ANTAG_REP Scientist 5
  ANTAG_REP Shaft_Miner 6
  ANTAG_REP Station_Engineer 6
  ANTAG_REP Virologist 5
  ANTAG_REP Brig_Physician 6
  ANTAG_REP Clerk 5
  ANTAG_REP Mining_Medic 6
  ANTAG_REP Network_Admin 6
  ANTAG_REP Paramedic 6
  ANTAG_REP Psychiatrist 5
  ANTAG_REP Tourist 3

</details>

# Changelog

:cl:  
experimental: Antagonist reputation has been tweaked for all jobs, being alive or escaping alive increases antag rep gain!
/:cl:
