### PR TITLE
RPD now builds even when clicked on another pipe

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -389,12 +389,12 @@ GLOBAL_LIST_INIT(fluid_duct_recipes, list(
 	//make sure what we're clicking is valid for the current category
 	var/static/list/make_pipe_whitelist
 	if(!make_pipe_whitelist)
-		make_pipe_whitelist = typecacheof(list(/obj/structure/lattice, /obj/structure/girder, /obj/item/pipe, /obj/structure/window, /obj/structure/grille))
+		make_pipe_whitelist = typecacheof(list(/obj/structure/lattice, /obj/structure/girder, /obj/item/pipe, /obj/structure/window, /obj/structure/grille, /obj/machinery/atmospherics/pipe))
 	var/can_make_pipe = (isturf(A) || is_type_in_typecache(A, make_pipe_whitelist))
 
 	. = FALSE
 
-	if((mode&DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
+	if((mode & DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
 	// yogs start - disposable check
 		if(istype(A, /obj/item/pipe))
 			var/obj/item/pipe/P = A
@@ -409,7 +409,7 @@ GLOBAL_LIST_INIT(fluid_duct_recipes, list(
 			qdel(A)
 		return
 
-	if((mode&PAINT_MODE))
+	if (mode & PAINT_MODE)
 		if(istype(A, /obj/machinery/atmospherics/pipe) && !istype(A, /obj/machinery/atmospherics/pipe/layer_manifold))
 			var/obj/machinery/atmospherics/pipe/P = A
 			to_chat(user, span_notice("You start painting \the [P] [paint_color]..."))
@@ -427,14 +427,16 @@ GLOBAL_LIST_INIT(fluid_duct_recipes, list(
 				user.visible_message(span_notice("[user] paints \the [A] [paint_color]."),span_notice("You paint \the [A] [paint_color]."))
 			return
 
-	if(mode&BUILD_MODE)
+	if (mode & BUILD_MODE)
 		if(istype(get_area(user), /area/reebe/city_of_cogs))
 			to_chat(user, span_notice("You cannot build on Reebe.."))
 			return
+
 		switch(category) //if we've gotten this var, the target is valid
 			if(ATMOS_CATEGORY) //Making pipes
 				if(!can_make_pipe)
 					return ..()
+
 				playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 				if (recipe.type == /datum/pipe_info/meter)
 					to_chat(user, span_notice("You start building a meter..."))


### PR DESCRIPTION
# Document the changes in your pull request
Building multiple layered space loops has always been annoying before. This change just allows you to click on the previous pipe with paint mode disabled.

![2023-02-07_23-35-20_dreamseeker](https://user-images.githubusercontent.com/24573384/217371120-1be42079-3033-4f3f-a506-2345e9d569c3.gif)


# Changelog

:cl:  
tweak: RPD with paint mode disabled will now allow building when clicking on pipes
/:cl:
