### PR TITLE
Gives onehalf a blue oxygen tank instead of a red one inside the safe

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -1020,7 +1020,7 @@
 /area/ruin/space/has_grav/onehalf/bridge)
 "cI" = (
 /obj/structure/safe/floor,
-/obj/item/tank/internals/oxygen/red,
+/obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/clothing/suit/space/hardsuit/syndi,
 /obj/item/reagent_containers/food/drinks/bottle/rum,


### PR DESCRIPTION
yes


# Document the changes in your pull request



removes 4 letters to make onehalf's (syndicate hardsuit in a safe ruin) oxygen tank blue
syndicates use blue O2 tanks on their suit storage slots (usually), visual unity (even if the tank gets ditched every time) is good




# Wiki Documentation

it's one O2 tank

# Changelog


:cl:   
rscdel: Red paint has been removed from onehalf's oxygen tank (inside the safe)
/:cl:
