### PR TITLE
Darkspawn is now a midround instead of a gamemode

### DIFF
--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -15,14 +15,6 @@
 	var/list/candidates = get_candidates(ROLE_DARKSPAWN, null, ROLE_DARKSPAWN)
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
-
-	var/darkspawn_to_spawn = 1
-	var/datum/job/hos = SSjob.GetJob("Head of Security")
-	var/datum/job/warden = SSjob.GetJob("Warden")
-	var/datum/job/officers = SSjob.GetJob("Security Officer")
-	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
-	if(sec_amount >= 5 && candidates.len >= 2)
-		darkspawn_to_spawn = 2
 	
 	var/list/spawn_locs = list()
 	for(var/X in GLOB.xeno_spawn)
@@ -34,6 +26,14 @@
 	if(!spawn_locs.len)
 		message_admins("No valid spawn locations found, aborting...")
 		return MAP_ERROR
+	
+	var/darkspawn_to_spawn = 1
+	var/datum/job/hos = SSjob.GetJob("Head of Security")
+	var/datum/job/warden = SSjob.GetJob("Warden")
+	var/datum/job/officers = SSjob.GetJob("Security Officer")
+	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
+	if(sec_amount >= 5 && candidates.len >= 2)
+		darkspawn_to_spawn = 2
 
 	for(var/i=0,i<darkspawn_to_spawn,i++)
 		var/mob/dead/selected = pick(candidates)

--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -23,6 +23,17 @@
 	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
 	if(sec_amount >= 5 && candidates.len >= 2)
 		darkspawn_to_spawn = 2
+	
+	var/list/spawn_locs = list()
+	for(var/X in GLOB.xeno_spawn)
+		var/turf/T = X
+		var/light_amount = T.get_lumcount()
+		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
+			spawn_locs += T
+
+	if(!spawn_locs.len)
+		message_admins("No valid spawn locations found, aborting...")
+		return MAP_ERROR
 
 	for(var/i=0,i<darkspawn_to_spawn,i++)
 		var/mob/dead/selected = pick(candidates)
@@ -30,18 +41,9 @@
 		var/datum/mind/player_mind = new /datum/mind(selected.key)
 		player_mind.active = TRUE
 
-		var/list/spawn_locs = list()
-		for(var/X in GLOB.xeno_spawn)
-			var/turf/T = X
-			var/light_amount = T.get_lumcount()
-			if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
-				spawn_locs += T
-
-		if(!spawn_locs.len)
-			message_admins("No valid spawn locations found, aborting...")
-			return MAP_ERROR
-
-		var/mob/living/carbon/human/S = new ((pick(spawn_locs)))
+		var/turf/chosen_spawn = pick(spawn_locs)
+		spawn_locs -= chosen_spawn // No spawning in the same place
+		var/mob/living/carbon/human/S = new (chosen_spawn)
 		player_mind.transfer_to(S)
 		player_mind.assigned_role = "Darkspawn"
 		player_mind.special_role = "Darkspawn"

--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -42,14 +42,14 @@
 
 		var/turf/chosen_spawn = pick(spawn_locs)
 		spawn_locs -= chosen_spawn // No spawning in the same place
-		var/mob/living/carbon/human/H = new (chosen_spawn)
-		player_mind.transfer_to(H)
+		var/mob/living/carbon/human/spawned_human = new (chosen_spawn)
+		player_mind.transfer_to(spawned_human)
 		player_mind.assigned_role = "Darkspawn"
 		player_mind.special_role = "Darkspawn"
-		var/datum/antagonist/darkspawn/D = player_mind.add_antag_datum(/datum/antagonist/darkspawn)
-		D.force_divulge()
-		playsound(H, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
-		message_admins("[ADMIN_LOOKUPFLW(H)] has been made into a Darkspawn by an event.")
-		log_game("[key_name(H)] was spawned as a Darkspawn by an event.")
-		spawned_mobs += H
+		var/datum/antagonist/darkspawn/darkspawn_datum = player_mind.add_antag_datum(/datum/antagonist/darkspawn)
+		darkspawn_datum.force_divulge()
+		playsound(spawned_human, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
+		message_admins("[ADMIN_LOOKUPFLW(spawned_human)] has been made into a Darkspawn by an event.")
+		log_game("[key_name(spawned_human)] was spawned as a Darkspawn by an event.")
+		spawned_mobs += spawned_human
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -31,7 +31,7 @@
 	var/datum/job/warden = SSjob.GetJob("Warden")
 	var/datum/job/officers = SSjob.GetJob("Security Officer")
 	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
-	if(sec_amount >= 5 && candidates.len >= 2)
+	if(sec_amount >= 5 && candidates.len >= 2 && spawn_locs.len >= 2)
 		darkspawn_to_spawn = 2
 
 	for(var/i=0,i<darkspawn_to_spawn,i++)

--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -17,8 +17,7 @@
 		return NOT_ENOUGH_PLAYERS
 	
 	var/list/spawn_locs = list()
-	for(var/X in GLOB.xeno_spawn)
-		var/turf/T = X
+	for(var/turf/T in GLOB.xeno_spawn)
 		var/light_amount = T.get_lumcount()
 		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
 			spawn_locs += T
@@ -43,14 +42,14 @@
 
 		var/turf/chosen_spawn = pick(spawn_locs)
 		spawn_locs -= chosen_spawn // No spawning in the same place
-		var/mob/living/carbon/human/S = new (chosen_spawn)
-		player_mind.transfer_to(S)
+		var/mob/living/carbon/human/H = new (chosen_spawn)
+		player_mind.transfer_to(H)
 		player_mind.assigned_role = "Darkspawn"
 		player_mind.special_role = "Darkspawn"
 		var/datum/antagonist/darkspawn/D = player_mind.add_antag_datum(/datum/antagonist/darkspawn)
 		D.force_divulge()
-		playsound(S, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
-		message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Darkspawn by an event.")
-		log_game("[key_name(S)] was spawned as a Darkspawn by an event.")
-		spawned_mobs += S
+		playsound(H, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
+		message_admins("[ADMIN_LOOKUPFLW(H)] has been made into a Darkspawn by an event.")
+		log_game("[key_name(H)] was spawned as a Darkspawn by an event.")
+		spawned_mobs += H
 	return SUCCESSFUL_SPAWN

--- a/code/modules/events/darkspawn.dm
+++ b/code/modules/events/darkspawn.dm
@@ -1,0 +1,54 @@
+/datum/round_event_control/darkspawn
+	name = "Spawn Darkspawn(s)"
+	typepath = /datum/round_event/ghost_role/darkspawn
+	max_occurrences = 1
+	min_players = 30
+	dynamic_should_hijack = TRUE
+	gamemode_blacklist = list("darkspawn", "shadowling")
+
+/datum/round_event/ghost_role/darkspawn
+	minimum_required = 1
+	role_name = "darkspawn"
+	fakeable = FALSE
+
+/datum/round_event/ghost_role/darkspawn/spawn_role()
+	var/list/candidates = get_candidates(ROLE_DARKSPAWN, null, ROLE_DARKSPAWN)
+	if(!candidates.len)
+		return NOT_ENOUGH_PLAYERS
+
+	var/darkspawn_to_spawn = 1
+	var/datum/job/hos = SSjob.GetJob("Head of Security")
+	var/datum/job/warden = SSjob.GetJob("Warden")
+	var/datum/job/officers = SSjob.GetJob("Security Officer")
+	var/sec_amount = hos.current_positions + warden.current_positions + officers.current_positions
+	if(sec_amount >= 5 && candidates.len >= 2)
+		darkspawn_to_spawn = 2
+
+	for(var/i=0,i<darkspawn_to_spawn,i++)
+		var/mob/dead/selected = pick(candidates)
+
+		var/datum/mind/player_mind = new /datum/mind(selected.key)
+		player_mind.active = TRUE
+
+		var/list/spawn_locs = list()
+		for(var/X in GLOB.xeno_spawn)
+			var/turf/T = X
+			var/light_amount = T.get_lumcount()
+			if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
+				spawn_locs += T
+
+		if(!spawn_locs.len)
+			message_admins("No valid spawn locations found, aborting...")
+			return MAP_ERROR
+
+		var/mob/living/carbon/human/S = new ((pick(spawn_locs)))
+		player_mind.transfer_to(S)
+		player_mind.assigned_role = "Darkspawn"
+		player_mind.special_role = "Darkspawn"
+		var/datum/antagonist/darkspawn/D = player_mind.add_antag_datum(/datum/antagonist/darkspawn)
+		D.force_divulge()
+		playsound(S, 'sound/magic/ethereal_exit.ogg', 50, 1, -1)
+		message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Darkspawn by an event.")
+		log_game("[key_name(S)] was spawned as a Darkspawn by an event.")
+		spawned_mobs += S
+	return SUCCESSFUL_SPAWN

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -12,7 +12,7 @@
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/nightmare/spawn_role()
-	var/list/candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
+	var/list/candidates = get_candidates(ROLE_NIGHTMARE, null, ROLE_NIGHTMARE)
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/nightmare
 	max_occurrences = 1
 	min_players = 30
+	weight = 0 // Disabled in favor of darkspawn
 	earliest_start = 45 MINUTES
 	dynamic_should_hijack = TRUE
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -104,7 +104,7 @@ ALERT_DELTA Destruction of the station is imminent. All crew are instructed to o
 ## Set to 0 to disable that mode.
 
 # New
-PROBABILITY DARKSPAWN 6
+PROBABILITY DARKSPAWN 0 # Moved to midround event
 PROBABILITY HERESY 4
 PROBABILITY INFILTRATION 0
 PROBABILITY BLOODSUCKER 4


### PR DESCRIPTION
# Document the changes in your pull request

Unfortunately darkspawn rounds go way too quick. Rounds are decided in minutes to either side. Lumping them into other gamemodes should make their flow go a little smoother instead of everyone realizing it's a darkspawn round and spamming lights and validhunting.

If there is 5 or more security members present, 2 darkspawn will spawn, otherwise only 1 will spawn

Players will be forcefully divulged upon spawning

Nightmare is also disabled

# Changelog

:cl:  
tweak: Darkspawn has been moved to a midround event instead of a gamemode
rscdel: Nightmare has been removed from midround rotation
/:cl:
