### PR TITLE
You can now copy the access of a airlock by hitting it with airlock electronics

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1110,6 +1110,20 @@
 		update_icon()
 		user.transferItemToLoc(C, src, TRUE)
 		charge = C
+	else if(istype(C,/obj/item/electronics/airlock))
+		if(!security_level && panel_open)
+			var/obj/item/electronics/airlock/ae = C
+			if(!electronics)
+				if(req_one_access)
+					ae.one_access = 1
+					ae.accesses = req_one_access
+				else
+					ae.accesses = req_access
+			else
+				ae.one_access = electronics.one_access
+				ae.accesses = electronics.req_access
+			to_chat(user, span_notice("You copy the access of [src] to [ae]."))
+
 	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
 		if(note)
 			to_chat(user, span_warning("There's already something pinned to this airlock! Use wirecutters to remove it."))


### PR DESCRIPTION
# Document the changes in your pull request

Want to fix the emagged door without a RCD but don't know the exact access requirements? Fuck you.

Having the panel open and no reinforcement on the door lets you get the access of the airlock electronics inside, so now to fix an emagged door you need to do screwdriver -> hit with airlock electronics -> crowbar old one out -> insert new one.

# Changelog

:cl:  
rscadd: you can now copy the access of a airlock by hitting it with airlock electronics
/:cl:
