### PR TITLE
Lets roboticists repair robotic bodies faster

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1042,10 +1042,11 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 /obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
 	var/delay = 2 SECONDS
 
-	if(IS_ENGINEERING(user))
-		delay *= 0.9
-	else if(IS_SCIENCE(user))
-		delay *= 0.8
+	if(H != user)
+		if(IS_ENGINEERING(user))
+			delay *= 0.9
+		else if(IS_SCIENCE(user))
+			delay *= 0.8
 
 	if(I.use_tool(H, user, delay, amount, volume))
 		if(item_heal_robotic(H, user, brute_heal, burn_heal))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1040,7 +1040,14 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 //amount is either the fuel of a welding tool, or the number of wires consumed
 //volume is how loud the sound of the item is
 /obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
-	if(I.use_tool(H, user, 2 SECONDS, amount, volume))
+	var/delay = 2 SECONDS
+
+	if(IS_ENGINEERING(user))
+		delay *= 0.9
+	else if(IS_SCIENCE(user))
+		delay *= 0.8
+
+	if(I.use_tool(H, user, delay, amount, volume))
 		if(item_heal_robotic(H, user, brute_heal, burn_heal))
 			return heal_robo_limb(I, H, user, brute_heal, burn_heal, amount, volume)
 		return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1040,15 +1040,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 //amount is either the fuel of a welding tool, or the number of wires consumed
 //volume is how loud the sound of the item is
 /obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
-	var/delay = 2 SECONDS
-
-	if(H != user)
-		if(IS_ENGINEERING(user))
-			delay *= 0.9
-		else if(IS_SCIENCE(user))
-			delay *= 0.8
-
-	if(I.use_tool(H, user, delay, amount, volume))
+	if(I.use_tool(H, user, 2 SECONDS, amount, volume, null, H != user))
 		if(item_heal_robotic(H, user, brute_heal, burn_heal))
 			return heal_robo_limb(I, H, user, brute_heal, burn_heal, amount, volume)
 		return TRUE


### PR DESCRIPTION
With Roboticists being expected to repair IPC and to a lesser extend Preterni, this gives them a slight speed increase in just the same way that being medical helps with surgery speeds.

Note, this doesn't apply to themselves

Roboticists already used certain things faster, this just extends the repairing limbs
Engi already get a 0.8 tool mod

# Wiki Documentation
Something about roboticists being faster at repairing preterni and ipc

:cl:  wondering-host#4628 @Moltijoe 
rscadd: Roboticists get a speed boost when repairing mechanical limbs
/:cl:
