### PR TITLE
Lets Overwatch be installed on any device with access

### DIFF
--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -38,6 +38,13 @@
 	)	
 	. = ..()
 
+/obj/item/modular_computer/tablet/pda/preset/paramed/mining
+/obj/item/modular_computer/tablet/pda/preset/paramed/mining/Initialize()
+	starting_files |= list(
+		new /datum/computer_file/program/secureye/mining
+	)	
+	. = ..()
+	
 /obj/item/modular_computer/tablet/pda/preset/engineering
 /obj/item/modular_computer/tablet/pda/preset/engineering/Initialize()
 	starting_files |= list(

--- a/code/modules/modular_computers/file_system/programs/security/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/security/secureye.dm
@@ -198,6 +198,7 @@
 	transfer_access = ACCESS_MINING
 	size = 5
 	program_icon = "globe"
+	usage_flags = PROGRAM_ALL //more of a paramedic thing than a security thing
 
 	network = list("mine", "auxbase")
 

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -49,7 +49,7 @@
 	name = "Mining Medic"
 	jobtype = /datum/job/miningmedic
 
-	pda_type = /obj/item/modular_computer/tablet/pda/preset/paramed
+	pda_type = /obj/item/modular_computer/tablet/pda/preset/paramed/mining
 
 	backpack_contents = list(/obj/item/roller = 1,\
 		/obj/item/kitchen/knife/combat/survival = 1)


### PR DESCRIPTION
Unlike other secureye programs, this one is more of a paramedic tool than a shitsec tool
Also lets mining medic keep an eye on miners whenever they have to pop station side for tools

:cl:  
rscadd: Mining medic starts with overwatch installed
tweak: Overwatch can be installed on any device with access
/:cl:
