### PR TITLE
Chasm maze ruin now actually gives loot

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_maze.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_maze.dmm
@@ -8,12 +8,12 @@
 "j" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/template_noop)
+"l" = (
+/obj/structure/closet/crate/necropolis/tendril,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/template_noop)
 "B" = (
 /turf/open/chasm/lavaland,
-/area/template_noop)
-"F" = (
-/obj/structure/closet/crate/necropolis,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/template_noop)
 "P" = (
 /turf/template_noop,
@@ -467,7 +467,7 @@ j
 B
 B
 j
-F
+l
 j
 B
 B


### PR DESCRIPTION
carefully walking through the maze to not die
at the end > no loot

:cl:  
bugfix: Chasm maze ruin now gives loot
/:cl:
