### PR TITLE
Adds barricading of airlocks and doors

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -100,7 +100,7 @@
 	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent != INTENT_HARM)
 		user.visible_message("[user.name] starts prying [src.name] apart.", \
 							span_notice("You start prying the barricade apart"))
-		if(I.use_tool(src, user, 190, volume=50))
+		if(I.use_tool(src, user, 100, volume=50))
 			to_chat(user, span_notice("You disassemble the barricade."))
 			new /obj/item/stack/sheet/mineral/wood(user.loc, 5)
 			qdel(src)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -100,7 +100,7 @@
 	if(I.tool_behaviour == TOOL_CROWBAR && user.a_intent != INTENT_HARM)
 		user.visible_message("[user.name] starts prying [src.name] apart.", \
 							span_notice("You start prying the barricade apart"))
-		if(I.use_tool(src, user, 100, volume=50))
+		if(I.use_tool(src, user, 10 SECONDS, volume=50))
 			to_chat(user, span_notice("You disassemble the barricade."))
 			new /obj/item/stack/sheet/mineral/wood(user.loc, 5)
 			qdel(src)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -952,18 +952,6 @@
 				return
 	add_fingerprint(user)
 
-	if(istype(C,/obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/W = C
-		if(W.amount < 5)
-			to_chat(user, span_warning("You need at least five wooden planks to barricade the airlock!"))
-			return
-		else
-			to_chat(user, span_notice("You start adding [C] to [src]..."))
-			if(do_after(user, 5 SECONDS, src))
-				W.use(5)
-				new /obj/structure/barricade/wooden/crude(get_turf(src))
-				return
-
 	if(panel_open)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -952,6 +952,18 @@
 				return
 	add_fingerprint(user)
 
+	if(istype(C,/obj/item/stack/sheet/mineral/wood))
+		var/obj/item/stack/sheet/mineral/wood/W = C
+		if(W.amount < 5)
+			to_chat(user, span_warning("You need at least five wooden planks to barricade the airlock!"))
+			return
+		else
+			to_chat(user, span_notice("You start adding [C] to [src]..."))
+			if(do_after(user, 5 SECONDS, src))
+				W.use(5)
+				new /obj/structure/barricade/wooden/crude(get_turf(src))
+				return
+
 	if(panel_open)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -240,17 +240,6 @@
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)
 	add_fingerprint(user)
 
-	if(istype(I,/obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/W = I
-		if(W.amount < 5)
-			to_chat(user, span_warning("You need at least five wooden planks to barricade the airlock!"))
-			return
-		else
-			to_chat(user, span_notice("You start adding [I] to [src]..."))
-			if(do_after(user, 5 SECONDS, src))
-				W.use(5)
-				new /obj/structure/barricade/wooden/crude(get_turf(src))
-				return
 	if(user.a_intent != INTENT_HARM && (I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/twohanded/fireaxe)))
 		try_to_crowbar(I, user)
 		return 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -238,6 +238,19 @@
 	return max_moles - min_moles > 20
 
 /obj/machinery/door/attackby(obj/item/I, mob/user, params)
+	add_fingerprint(user)
+
+	if(istype(I,/obj/item/stack/sheet/mineral/wood))
+		var/obj/item/stack/sheet/mineral/wood/W = I
+		if(W.amount < 5)
+			to_chat(user, span_warning("You need at least five wooden planks to barricade the airlock!"))
+			return
+		else
+			to_chat(user, span_notice("You start adding [I] to [src]..."))
+			if(do_after(user, 5 SECONDS, src))
+				W.use(5)
+				new /obj/structure/barricade/wooden/crude(get_turf(src))
+				return
 	if(user.a_intent != INTENT_HARM && (I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/twohanded/fireaxe)))
 		try_to_crowbar(I, user)
 		return 1

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -258,6 +258,23 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
 	recipes = GLOB.wood_recipes
 	return ..()
 
+/obj/item/stack/sheet/mineral/wood/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/structure/window) || istype(O, /obj/machinery/door/airlock) || istype(O,/obj/machinery/door)) //I hate this but reportedly there is no other way :skull:
+		for(var/obj/structure/barricade/wooden/crude/crude in get_turf(O))
+			to_chat(user, span_warning("There is already a barricade there!"))
+			return
+		var/obj/item/stack/sheet/mineral/wood/W = src
+		if(W.amount < 5)
+			to_chat(user, span_warning("You need at least five wooden planks to barricade the [O]!"))
+			return
+		else
+			to_chat(user, span_notice("You start adding [src] to [O]..."))
+			if(do_after(user, 5 SECONDS, src))
+				W.use(5)
+				new /obj/structure/barricade/wooden/crude(get_turf(O))
+				return
+	return ..()
+
 /obj/item/stack/sheet/mineral/wood/attackby(obj/item/item, mob/user, params)
 	if(item.get_sharpness())
 		user.visible_message(

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -176,18 +176,6 @@
 
 	add_fingerprint(user)
 
-	if(istype(I,/obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/W = I
-		if(W.amount < 5)
-			to_chat(user, span_warning("You need at least five wooden planks to barricade the window!"))
-			return
-		else
-			to_chat(user, span_notice("You start adding [I] to [src]..."))
-			if(do_after(user, 5 SECONDS, src))
-				W.use(5)
-				new /obj/structure/barricade/wooden/crude(get_turf(src))
-				return
-
 	if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HELP)
 		if(obj_integrity < max_integrity)
 			if(!I.tool_start_check(user, amount=0))


### PR DESCRIPTION
# Document the changes in your pull request

Allows barricading of airlocks and doors, same as with windows. I believe this is fairly reasonable seeing as a few ruins already have that as a thing and putting a few planks across a door is a thing that should be possible.

(Tested, however not tested on each special instance of doors and airlocks)

Adds some small tweaks to already existing stuff too.

# Changelog
:cl:  
rscadd: Airlocks and doors can now be barricaded
tweak: The crude barricade is now faster to crowbar than harm intenting it with it
bugfix: It is no longer possible to put multiple barricades on the same tile
/:cl:
