### PR TITLE
Gives mining medic a laptop to keep track of bodycams

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
@@ -25,7 +25,13 @@
 	. = ..()
 
 /obj/item/modular_computer/laptop/preset/paramedic/mining_medic
-	desc = "A low-end laptop often used by mining medics."
+	desc = "A low-end laptop often used by mining medics. Comes with an upgraded network card to allow for use while off Station."
+	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+								/obj/item/stock_parts/cell/computer,
+								/obj/item/computer_hardware/hard_drive,
+								/obj/item/computer_hardware/network_card/advanced,
+								/obj/item/computer_hardware/card_slot)
+
 /obj/item/modular_computer/laptop/preset/paramedic/mining_medic/Initialize()
 	starting_files |= list(
 		new /datum/computer_file/program/secureye/mining

--- a/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop/laptop_presets.dm
@@ -8,6 +8,26 @@
 /obj/item/modular_computer/laptop/preset/civillian
 	desc = "A low-end laptop often used for personal recreation."
 
-/obj/item/modular_computer/laptop/preset/brig_physician
+/obj/item/modular_computer/laptop/preset/paramedic//not actually given to a paramedic, just a base-line for the brig phys and mining medic laptops
+/obj/item/modular_computer/laptop/preset/paramedic/Initialize()
+	starting_files |= list(
+		new /datum/computer_file/program/crew_monitor,
+		new /datum/computer_file/program/radar/lifeline
+	)	
+	. = ..()
+
+/obj/item/modular_computer/laptop/preset/paramedic/brig_physician
 	desc = "A low-end laptop often used by brig physicians."
-	starting_files = list(new /datum/computer_file/program/secureye)
+/obj/item/modular_computer/laptop/preset/paramedic/brig_physician/Initialize()
+	starting_files |= list(
+		new /datum/computer_file/program/secureye
+	)
+	. = ..()
+
+/obj/item/modular_computer/laptop/preset/paramedic/mining_medic
+	desc = "A low-end laptop often used by mining medics."
+/obj/item/modular_computer/laptop/preset/paramedic/mining_medic/Initialize()
+	starting_files |= list(
+		new /datum/computer_file/program/secureye/mining
+	)
+	. = ..()

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -57,7 +57,7 @@
 	uniform_skirt = /obj/item/clothing/under/yogs/rank/physician/white/skirt
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular
-	r_hand = /obj/item/modular_computer/laptop/preset/brig_physician
+	r_hand = /obj/item/modular_computer/laptop/preset/paramedic/brig_physician
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	head = /obj/item/clothing/head/soft/emt/phys
 	backpack = /obj/item/storage/backpack/medic

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -52,7 +52,8 @@
 	pda_type = /obj/item/modular_computer/tablet/pda/preset/paramed
 
 	backpack_contents = list(/obj/item/roller = 1,\
-		/obj/item/kitchen/knife/combat/survival = 1)
+		/obj/item/kitchen/knife/combat/survival = 1,\
+		/obj/item/modular_computer/laptop/preset/paramedic/mining_medic = 1)
 	belt = /obj/item/storage/belt/medical/mining
 	ears = /obj/item/radio/headset/headset_medcargo
 	glasses = /obj/item/clothing/glasses/hud/health/meson


### PR DESCRIPTION
Apparently brig physician gets a laptop with secureye, probably to keep track of secoff bodycams
So i've given one to mining medic to let them keep track of their miner's bodycams

:cl:  
rscadd: Mining medic now gets a laptop with overwatch installed
tweak:  Brig physician laptop also starts with lifeline and crew monitor
/:cl:
