### PR TITLE
A few tweaks to nanite balance

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -175,16 +175,16 @@
 	holder.icon_state = "nanites[nanite_percent]"
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
-	nanite_volume *= (rand(0.60, 0.90))		//Lose 10-40% of nanites
-	adjust_nanites(null, -(rand(5, 50)))		//Lose 5-50 flat nanite volume
-	if(prob(40/severity))
-		cloud_id = 0
+	nanite_volume *= (rand(0.75, 0.90))		//Lose 10-25% of nanites
+	adjust_nanites(null, -(rand(5, 30)))		//Lose 5-30 flat nanite volume
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_emp(severity)
+	addtimer(VARSET_CALLBACK(src, cloud_id, cloud_id), NANITE_SYNC_DELAY, TIMER_UNIQUE)//return it to normal, intentionally missing the next sync timer
+	cloud_id = 0 //temporarily disable resyncing so rogue programs actually have a chance to do something
 
 /datum/component/nanites/proc/on_shock(datum/source, shock_damage)
-	nanite_volume *= (rand(0.45, 0.80))		//Lose 20-55% of nanites
+	nanite_volume *= (rand(0.65, 0.90))		//Lose 10-35% of nanites
 	adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -360,13 +360,6 @@
 	program_type = /datum/nanite_program/triggered/explosive
 	category = list("Weaponized Nanites")
 
-/datum/design/nanites/mind_control
-	name = "Mind Control"
-	desc = "The nanites imprint an absolute directive onto the host's brain while they're active."
-	id = "mindcontrol_nanites"
-	program_type = /datum/nanite_program/mind_control
-	category = list("Weaponized Nanites")
-
 ////////////////////SUPPRESSION NANITES//////////////////////////////////////
 
 /datum/design/nanites/shock
@@ -388,13 +381,6 @@
 	desc = "The nanites cause rapid narcolepsy when triggered."
 	id = "sleep_nanites"
 	program_type = /datum/nanite_program/triggered/sleepy
-	category = list("Suppression Nanites")
-
-/datum/design/nanites/paralyzing
-	name = "Paralysis"
-	desc = "The nanites actively suppress nervous pulses, effectively paralyzing the host."
-	id = "paralyzing_nanites"
-	program_type = /datum/nanite_program/paralyzing
 	category = list("Suppression Nanites")
 
 /datum/design/nanites/fake_death

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -383,13 +383,6 @@
 	program_type = /datum/nanite_program/triggered/sleepy
 	category = list("Suppression Nanites")
 
-/datum/design/nanites/fake_death
-	name = "Death Simulation"
-	desc = "The nanites induce a death-like coma into the host, able to fool most medical scans."
-	id = "fakedeath_nanites"
-	program_type = /datum/nanite_program/fake_death
-	category = list("Suppression Nanites")
-
 /datum/design/nanites/pacifying
 	name = "Pacification"
 	desc = "The nanites suppress the aggression center of the brain, preventing the host from causing direct harm to others."

--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -30,40 +30,40 @@
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.melee += 30
-		H.physiology.armor.bullet += 25
+		H.physiology.armor.melee += 20
+		H.physiology.armor.bullet += 15
 
 /datum/nanite_program/hardening/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.melee -= 30
-		H.physiology.armor.bullet -= 25
+		H.physiology.armor.melee -= 20
+		H.physiology.armor.bullet -= 15
 
 /datum/nanite_program/refractive
 	name = "Dermal Refractive Surface"
 	desc = "The nanites form a membrane above the host's skin, reducing the effect of laser and energy impacts."
-	use_rate = 0.50
+	use_rate = 0.5
 	rogue_types = list(/datum/nanite_program/skin_decay)
 
 /datum/nanite_program/refractive/enable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.laser += 30
-		H.physiology.armor.energy += 15
+		H.physiology.armor.laser += 20
+		H.physiology.armor.energy += 10
 
 /datum/nanite_program/refractive/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
-		H.physiology.armor.laser -= 30
-		H.physiology.armor.energy -= 15
+		H.physiology.armor.laser -= 20
+		H.physiology.armor.energy -= 10
 
 /datum/nanite_program/coagulating
 	name = "Vein Repressurization"
 	desc = "The nanites re-route circulating blood away from open wounds, dramatically reducing bleeding rate."
-	use_rate = 0.20
+	use_rate = 0.2
 	rogue_types = list(/datum/nanite_program/suffocating)
 
 /datum/nanite_program/coagulating/enable_passive_effect()

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -3,8 +3,9 @@
 /datum/nanite_program/regenerative
 	name = "Accelerated Regeneration"
 	desc = "The nanites boost the host's natural regeneration, increasing their healing speed. Does not consume nanites if the host is unharmed."
-	use_rate = 2.5
+	use_rate = 1.5
 	rogue_types = list(/datum/nanite_program/necrotic)
+	var/healing = 0.5
 
 /datum/nanite_program/regenerative/check_conditions()
 	if(!host_mob.getBruteLoss() && !host_mob.getFireLoss())
@@ -23,20 +24,20 @@
 		if(!parts.len)
 			return
 		for(var/obj/item/bodypart/L in parts)
-			if(L.heal_damage(1/parts.len, 1/parts.len, null, BODYPART_ORGANIC))
+			if(L.heal_damage(healing/parts.len, healing/parts.len, null, BODYPART_ORGANIC))
 				host_mob.update_damage_overlays()
 		if(C.getStaminaLoss() < 41) //Should just push you into the first slowdown stage before resetting after 10 seconds
 			C.adjustStaminaLoss(1) //Annoying but not lethal, and won't stop stamina regen if you're over the limit
 			if(prob(5))
 				to_chat(C, "<span class='warning'>Your injuries itch and burn as they heal.")
 	else
-		host_mob.adjustBruteLoss(-1, TRUE)
-		host_mob.adjustFireLoss(-1, TRUE)
+		host_mob.adjustBruteLoss(-healing, TRUE)
+		host_mob.adjustFireLoss(-healing, TRUE)
 
 /datum/nanite_program/temperature
 	name = "Temperature Adjustment"
 	desc = "The nanites adjust the host's internal temperature to an ideal level."
-	use_rate = 3.5
+	use_rate = 2.5
 	rogue_types = list(/datum/nanite_program/skin_decay)
 
 /datum/nanite_program/temperature/check_conditions()
@@ -107,8 +108,9 @@
 /datum/nanite_program/repairing
 	name = "Mechanical Repair"
 	desc = "The nanites fix damage in the host's mechanical limbs."
-	use_rate = 0.5 //much more efficient than organic healing
+	use_rate = 1 //much more efficient than organic healing
 	rogue_types = list(/datum/nanite_program/necrotic)
+	var/healing = 0.5
 
 /datum/nanite_program/repairing/check_conditions()
 	if(!host_mob.getBruteLoss() && !host_mob.getFireLoss())
@@ -132,13 +134,13 @@
 			return
 		var/update = FALSE
 		for(var/obj/item/bodypart/L in parts)
-			if(L.heal_damage(1/parts.len, 1/parts.len, null, BODYPART_ROBOTIC))
+			if(L.heal_damage(healing/parts.len, healing/parts.len, null, BODYPART_ROBOTIC))
 				update = TRUE
 		if(update)
 			host_mob.update_damage_overlays()
 	else
-		host_mob.adjustBruteLoss(-1, TRUE)
-		host_mob.adjustFireLoss(-1, TRUE)
+		host_mob.adjustBruteLoss(-healing, TRUE)
+		host_mob.adjustFireLoss(-healing, TRUE)
 
 /datum/nanite_program/purging_advanced
 	name = "Selective Blood Purification"
@@ -164,9 +166,10 @@
 /datum/nanite_program/regenerative_advanced
 	name = "Bio-Reconstruction"
 	desc = "The nanites manually repair and replace organic cells, acting much faster than normal regeneration. \
-			However, this program cannot detect the difference between harmed and unharmed, causing it to consume nanites even if it has no effect."
-	use_rate = 5.5
+			However, this program cannot detect the difference between harmed and unharmed, causing it to consume significant amounts of nanites even if it has no effect."
+	use_rate = 7
 	rogue_types = list(/datum/nanite_program/suffocating, /datum/nanite_program/necrotic)
+	var/healing = 2.5
 
 /datum/nanite_program/regenerative_advanced/active_effect()
 	if(iscarbon(host_mob))
@@ -176,7 +179,7 @@
 			return
 		var/update = FALSE
 		for(var/obj/item/bodypart/L in parts)
-			if(L.heal_damage(3/parts.len, 3/parts.len, null, BODYPART_ORGANIC))
+			if(L.heal_damage(healing/parts.len, healing/parts.len, null, BODYPART_ORGANIC))
 				update = TRUE
 		if(update)
 			host_mob.update_damage_overlays()
@@ -190,8 +193,8 @@
 			else
 				to_chat(C, "<span class='warning'>Your wounds burn horribly as they heal!")
 	else
-		host_mob.adjustBruteLoss(-3, TRUE)
-		host_mob.adjustFireLoss(-3, TRUE)
+		host_mob.adjustBruteLoss(-healing, TRUE)
+		host_mob.adjustFireLoss(-healing, TRUE)
 
 /datum/nanite_program/brain_heal_advanced
 	name = "Neural Reimaging"

--- a/code/modules/research/nanites/nanite_programs/rogue.dm
+++ b/code/modules/research/nanites/nanite_programs/rogue.dm
@@ -124,4 +124,4 @@
 		host_mob.drop_all_held_items()
 	else if(prob(4))
 		to_chat(host_mob, span_warning("You can't feel your legs!"))
-		host_mob.Paralyze(30)
+		host_mob.Knockdown(30)

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -87,21 +87,6 @@
 	. = ..()
 	REMOVE_TRAIT(host_mob, TRAIT_MUTE, "nanites")
 
-/datum/nanite_program/fake_death
-	name = "Death Simulation"
-	desc = "The nanites induce a death-like coma into the host, able to fool most medical scans."
-	use_rate = 4.5
-	rogue_types = list(/datum/nanite_program/nerve_decay, /datum/nanite_program/necrotic, /datum/nanite_program/brain_decay)
-	harmful = TRUE
-
-/datum/nanite_program/fake_death/enable_passive_effect()
-	. = ..()
-	host_mob.fakedeath("nanites")
-
-/datum/nanite_program/fake_death/disable_passive_effect()
-	. = ..()
-	host_mob.cure_fakedeath("nanites")
-
 //Can receive transmissions from a nanite communication remote for customized messages
 /datum/nanite_program/triggered/comm
 	var/comm_code = 0

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -15,24 +15,6 @@
 	host_mob.drowsyness += 20
 	addtimer(CALLBACK(host_mob, /mob/living.proc/Sleeping, 200), rand(60,200))
 
-/datum/nanite_program/paralyzing
-	name = "Paralysis"
-	desc = "The nanites force muscle contraction, effectively paralyzing the host."
-	use_rate = 3
-	rogue_types = list(/datum/nanite_program/nerve_decay)
-	harmful = TRUE
-
-/datum/nanite_program/paralyzing/active_effect()
-	host_mob.Stun(40)
-
-/datum/nanite_program/paralyzing/enable_passive_effect()
-	. = ..()
-	to_chat(host_mob, span_warning("Your muscles seize! You can't move!"))
-
-/datum/nanite_program/paralyzing/disable_passive_effect()
-	. = ..()
-	to_chat(host_mob, span_notice("Your muscles relax, and you can move again."))
-
 /datum/nanite_program/triggered/shocking
 	name = "Electric Shock"
 	desc = "The nanites shock the host when triggered. Destroys a large amount of nanites!"

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -212,7 +212,7 @@
 /datum/nanite_program/research
 	name = "Distributed Computing"
 	desc = "The nanites aid the research servers by performing a portion of its calculations, increasing research point generation."
-	use_rate = 0.2
+	use_rate = 0.1
 	rogue_types = list(/datum/nanite_program/toxic)
 
 /datum/nanite_program/research/active_effect()
@@ -226,7 +226,7 @@
 /datum/nanite_program/researchplus
 	name = "Neural Network"
 	desc = "The nanites link the host's brains together forming a neural research network, that becomes more efficient with the amount of total hosts."
-	use_rate = 0.3
+	use_rate = 0.2
 	rogue_types = list(/datum/nanite_program/brain_decay)
 	var/points
 

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -83,7 +83,7 @@
 /datum/nanite_program/triggered/explosive
 	name = "Chain Detonation"
 	desc = "Detonates all the nanites inside the host in a chain reaction when triggered."
-	trigger_cost = 25 //plus every idle nanite left afterwards
+	trigger_cost = 50
 	trigger_cooldown = 1 MINUTES //No spamming explosions, give the poor sap a break
 	rogue_types = list(/datum/nanite_program/toxic)
 	harmful = TRUE

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -7,13 +7,14 @@
 	use_rate = 1.5
 	rogue_types = list(/datum/nanite_program/necrotic)
 	harmful = TRUE
+	var/damage = 0.75
 
 /datum/nanite_program/flesh_eating/active_effect()
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
-		C.take_bodypart_damage(1, 0, 0)
+		C.take_bodypart_damage(damage, 0, 0)
 	else
-		host_mob.adjustBruteLoss(1, TRUE)
+		host_mob.adjustBruteLoss(damage, TRUE)
 	if(prob(3))
 		to_chat(host_mob, span_warning("You feel a stab of pain from somewhere inside you."))
 
@@ -65,9 +66,10 @@
 	use_rate = 10
 	rogue_types = list(/datum/nanite_program/glitch)
 	harmful = TRUE
+	var/damage = 2.5
 
 /datum/nanite_program/meltdown/active_effect()
-	host_mob.adjustFireLoss(3.5)
+	host_mob.adjustFireLoss(damage)
 
 /datum/nanite_program/meltdown/enable_passive_effect()
 	. = ..()
@@ -82,7 +84,7 @@
 	name = "Chain Detonation"
 	desc = "Detonates all the nanites inside the host in a chain reaction when triggered."
 	trigger_cost = 25 //plus every idle nanite left afterwards
-	trigger_cooldown = 100 //Just to avoid double-triggering
+	trigger_cooldown = 200 //No spamming explosions, give the poor sap a break
 	rogue_types = list(/datum/nanite_program/toxic)
 	harmful = TRUE
 
@@ -95,11 +97,12 @@
 
 /datum/nanite_program/triggered/explosive/proc/boom()
 	var/nanite_amount = nanites.nanite_volume
-	host_mob.adjustBruteLoss(nanite_amount/2.5) //Instead of gibbing we'll just do an asston of damage
-	var/heavy_range = FLOOR(nanite_amount/100, 1) - 1
+	host_mob.adjustBruteLoss(nanite_amount/5) //Instead of gibbing we'll just do an asston of damage
 	var/light_range = FLOOR(nanite_amount/50, 1) - 1
-	explosion(host_mob, 0, heavy_range, light_range)
-	qdel(nanites)
+	explosion(host_mob, 0, 0, light_range)
+	addtimer(VARSET_CALLBACK(nanites, nanites.cloud_id, nanites.cloud_id), NANITE_SYNC_DELAY, TIMER_UNIQUE)//return it to normal, intentionally missing the next sync timer
+	nanites.cloud_id = 0 //temporarily disable resyncing so explosion can't be immediately readded
+	qdel(src) //removes itself after the explosion
 
 //TODO make it defuse if triggered again
 
@@ -143,12 +146,12 @@
 /datum/nanite_program/pyro
 	name = "Sub-Dermal Combustion"
 	desc = "The nanites cause buildup of flammable fluids under the host's skin, then ignites them."
-	use_rate = 4
+	use_rate = 3
 	rogue_types = list(/datum/nanite_program/skin_decay, /datum/nanite_program/cryo)
 	harmful = TRUE
 
 /datum/nanite_program/pyro/check_conditions()
-	if(host_mob.fire_stacks >= 10 && host_mob.on_fire)
+	if(host_mob.on_fire)
 		return FALSE
 	return ..()
 
@@ -170,42 +173,3 @@
 
 /datum/nanite_program/cryo/active_effect()
 	host_mob.adjust_bodytemperature(-rand(15,25), 50)
-
-/datum/nanite_program/mind_control
-	name = "Mind Control"
-	desc = "The nanites imprint an absolute directive onto the host's brain while they're active."
-	use_rate = 3
-	rogue_types = list(/datum/nanite_program/brain_decay, /datum/nanite_program/brain_misfire)
-	harmful = TRUE
-
-	extra_settings = list("Directive")
-	var/cooldown = 0 //avoids spam when nanites are running low
-	var/directive = "..."
-
-/datum/nanite_program/mind_control/set_extra_setting(user, setting)
-	if(setting == "Directive")
-		var/new_directive = stripped_input(user, "Choose the directive to imprint with mind control.", "Directive", directive, MAX_MESSAGE_LEN)
-		if(!new_directive)
-			return
-		directive = new_directive
-
-/datum/nanite_program/mind_control/get_extra_setting(setting)
-	if(setting == "Directive")
-		return directive
-
-/datum/nanite_program/mind_control/copy_extra_settings_to(datum/nanite_program/mind_control/target)
-	target.directive = directive
-
-/datum/nanite_program/mind_control/enable_passive_effect()
-	if(world.time < cooldown)
-		return
-	. = ..()
-	brainwash(host_mob, directive)
-	log_game("A mind control nanite program brainwashed [key_name(host_mob)] with the objective '[directive]'.")
-
-/datum/nanite_program/mind_control/disable_passive_effect()
-	. = ..()
-	if(host_mob.mind && host_mob.mind.has_antag_datum(/datum/antagonist/brainwashed))
-		host_mob.mind.remove_antag_datum(/datum/antagonist/brainwashed)
-	log_game("[key_name(host_mob)] is no longer brainwashed by nanites.")
-	cooldown = world.time + 450

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -84,7 +84,7 @@
 	name = "Chain Detonation"
 	desc = "Detonates all the nanites inside the host in a chain reaction when triggered."
 	trigger_cost = 25 //plus every idle nanite left afterwards
-	trigger_cooldown = 200 //No spamming explosions, give the poor sap a break
+	trigger_cooldown = 1 MINUTES //No spamming explosions, give the poor sap a break
 	rogue_types = list(/datum/nanite_program/toxic)
 	harmful = TRUE
 
@@ -100,9 +100,6 @@
 	host_mob.adjustBruteLoss(nanite_amount/5) //Instead of gibbing we'll just do an asston of damage
 	var/light_range = FLOOR(nanite_amount/50, 1) - 1
 	explosion(host_mob, 0, 0, light_range)
-	addtimer(VARSET_CALLBACK(nanites, cloud_id, cloud_id), NANITE_SYNC_DELAY, TIMER_UNIQUE)//return it to normal, intentionally missing the next sync timer
-	nanites.cloud_id = 0 //temporarily disable resyncing so explosion can't be immediately readded
-	qdel(src) //removes itself after the explosion
 
 //TODO make it defuse if triggered again
 

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -7,7 +7,7 @@
 	use_rate = 1.5
 	rogue_types = list(/datum/nanite_program/necrotic)
 	harmful = TRUE
-	var/damage = 0.75
+	var/damage = 1
 
 /datum/nanite_program/flesh_eating/active_effect()
 	if(iscarbon(host_mob))
@@ -66,7 +66,7 @@
 	use_rate = 10
 	rogue_types = list(/datum/nanite_program/glitch)
 	harmful = TRUE
-	var/damage = 2.5
+	var/damage = 3
 
 /datum/nanite_program/meltdown/active_effect()
 	host_mob.adjustFireLoss(damage)

--- a/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -100,7 +100,7 @@
 	host_mob.adjustBruteLoss(nanite_amount/5) //Instead of gibbing we'll just do an asston of damage
 	var/light_range = FLOOR(nanite_amount/50, 1) - 1
 	explosion(host_mob, 0, 0, light_range)
-	addtimer(VARSET_CALLBACK(nanites, nanites.cloud_id, nanites.cloud_id), NANITE_SYNC_DELAY, TIMER_UNIQUE)//return it to normal, intentionally missing the next sync timer
+	addtimer(VARSET_CALLBACK(nanites, cloud_id, cloud_id), NANITE_SYNC_DELAY, TIMER_UNIQUE)//return it to normal, intentionally missing the next sync timer
 	nanites.cloud_id = 0 //temporarily disable resyncing so explosion can't be immediately readded
 	qdel(src) //removes itself after the explosion
 

--- a/code/modules/research/nanites/program_disks.dm
+++ b/code/modules/research/nanites/program_disks.dm
@@ -102,9 +102,6 @@
 /obj/item/disk/nanite_program/sleepy
 	program_type = /datum/nanite_program/triggered/sleepy
 
-/obj/item/disk/nanite_program/fake_death
-	program_type = /datum/nanite_program/fake_death
-
 /obj/item/disk/nanite_program/pacifying
 	program_type = /datum/nanite_program/pacifying
 

--- a/code/modules/research/nanites/program_disks.dm
+++ b/code/modules/research/nanites/program_disks.dm
@@ -102,9 +102,6 @@
 /obj/item/disk/nanite_program/sleepy
 	program_type = /datum/nanite_program/triggered/sleepy
 
-/obj/item/disk/nanite_program/paralyzing
-	program_type = /datum/nanite_program/paralyzing
-
 /obj/item/disk/nanite_program/fake_death
 	program_type = /datum/nanite_program/fake_death
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1023,7 +1023,7 @@
 	display_name = "Hazard Nanite Programs"
 	description = "Extremely advanced Nanite programs with the potential of being extremely dangerous."
 	prereq_ids = list("nanite_harmonic", "alientech")
-	design_ids = list("spreading_nanites","mindcontrol_nanites","mitosis_nanites")
+	design_ids = list("spreading_nanites","mitosis_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000, TECHWEB_POINT_TYPE_NANITES = 4000)
 
 ////////////////////////Alien technology////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1007,7 +1007,7 @@
 	display_name = "Harmonic Nanite Programming"
 	description = "Nanite programs that require seamless integration between nanites and biology."
 	prereq_ids = list("nanite_bio","nanite_smart","nanite_mesh")
-	design_ids = list("fakedeath_nanites","researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
+	design_ids = list("researchplus_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000, TECHWEB_POINT_TYPE_NANITES = 2000)
 
 /datum/techweb_node/nanite_combat

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -135,7 +135,7 @@
 	design_ids = list("engine_void", "disk_shuttle_route_void")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 /datum/techweb_node/nanite_harmonic
-	design_ids = list("fakedeath_nanites","aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
+	design_ids = list("aggressive_nanites","defib_nanites","regenerative_plus_nanites","brainheal_plus_nanites","purging_plus_nanites","nanite_heart")
 
 /datum/techweb_node/nerd_suit
 	id = "nerd_suit"


### PR DESCRIPTION
Nanites are currently in a state of being really powerful, making someone with proper nanites a nightmare to kill.
However on the flip side, one small tweak to the programs and it can instantly make everyone with them wish they were dead
(or just kill them).
I hope I don't need to explain why this isn't fun for anyone involved.
This is probably(?) the first of a couple(?) PRs that will change nanite balance.
The end goal is to make nanites less powerful in combat situations but have more fun niche programs that can be beneficial to the host.
This will involve adding new programs, both beneficial and detrimental.

Reduces nanite loss on EMP and shock
Getting EMPed temporarily disables syncing 

**Helpful Programs**
Hardening gives 20 melee and 15 bullet instead of 30 and 25
Refractive gives 20 laser and 10 energy armor instead 30 and 15
Accel regen heals 0.5 instead of 1 and costs 1.5 instead of 2.5
Mech repair heals 0.5 instead of 1 and costs 1 instead of 0.5
Bio reconstruction heals 2.5 instead of 3 and costs 7 instead of 5.5
Temperature adjustment costs 2.5 instead of 3.5
Distributed computing costs 0.1 instead of 0.2
Neural Network costs 0.2 instead of 0.3

**Harmful Programs**
Chain detonation no longer has a heavy explosion and does 1/2 damage of before with a far longer cooldown
Chain detonation no longer deletes all nanites
Sub-Dermal Combustion costs 3 instead of 4 but no longer stacks fire_stacks up to 10
Nerve Decay now knocks down instead of stuns

Deletes Mind Control nanites
Deletes Paralysis nanites
Deletes fake death nanites

:cl:  
tweak: Lots of nanite number tweaks, trust me, look at #17858
/:cl:
