### PR TITLE
Buffs the ebow to be faster

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -96,7 +96,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt)
 	weapon_weight = WEAPON_LIGHT
 	obj_flags = 0
-	overheat_time = 20 SECONDS
+	overheat_time = 10 SECONDS
 	holds_charge = TRUE
 	unique_frequency = TRUE
 	can_flashlight = FALSE

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -7,9 +7,8 @@
 /obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(ishuman(target))
-		target.reagents.add_reagent(/datum/reagent/toxin/polonium/ebow, 5)
-		target.reagents.add_reagent(/datum/reagent/toxin/relaxant, 8)
-		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 8)
+		target.reagents.add_reagent(/datum/reagent/toxin/relaxant, 6)
+		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6)
 		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 4)
 
 /obj/item/projectile/energy/bolt/halloween

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -415,12 +415,6 @@
 	M.radiation += radpower
 	..()
 
-/datum/reagent/toxin/polonium/ebow
-	name = "Potent Polonium"
-	description = "A more potent form of Polonium. It is purged more quickly from the body, but also significantly more deadly."
-	metabolization_rate = 0.8 * REAGENTS_METABOLISM
-	radpower = 80
-
 /datum/reagent/toxin/histamine
 	name = "Histamine"
 	description = "Histamine's effects become more dangerous depending on the dosage amount. They range from mildly annoying to incredibly lethal."


### PR DESCRIPTION
# Document the changes in your pull request

Ebow chemicals reduced from 8 units to 6 units, reducing their lifespan from ~13 to ~8 chem ticks (~16 seconds)
Ebow cooldown reduced from 20 seconds to 10 seconds
Ebow polonium removed from reality for being annoying and giving the weapon an identity crisis


# Wiki Documentation

I am going to get wiki vetoed for this

# Changelog

:cl:  
tweak: Ebow chemicals reduced from 8 units to 6 units, reducing their lifespan from ~13 to ~8 chem ticks (~16 seconds)
tweak: Ebow cooldown reduced from 20 seconds to 10 seconds
tweak: Ebow polonium removed from reality for being annoying and giving the weapon an identity crisis
/:cl:
