### PR TITLE
makes darkspawn mindshield text a little less cringe

### DIFF
--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -120,7 +120,8 @@
 		Of a vast, empty Void in the deep of space.\n\
 		Something lies in the Void. Ancient. Unknowable. It watches you with hungry eyes. \n\
 		Eyes filled with stars.</b>\n\
-		[span_boldwarning("It needs to die.")]")
+		[span_boldwarning("The creature's gaze swallows the universe into blackness.")])\n\
+		[span_boldwarning("It cannot be allowed to succeed.")]")
 		return FALSE
 	return mind.add_antag_datum(/datum/antagonist/veil)
 

--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -121,7 +121,7 @@
 		Something lies in the Void. Ancient. Unknowable. It watches you with hungry eyes. \n\
 		Eyes filled with stars.</b>\n\
 		[span_boldwarning("The creature's gaze swallows the universe into blackness.")])\n\
-		[span_boldwarning("It cannot be allowed to succeed.")]")
+		[span_boldwarning("It cannot be permitted to succeed.")]")
 		return FALSE
 	return mind.add_antag_datum(/datum/antagonist/veil)
 


### PR DESCRIPTION
# Document the changes in your pull request

i don't like what it is right now so I'm changing it

# Changelog

:cl:  
spellcheck: darkspawn veil fail text is probably better
/:cl:
