### PR TITLE
Removed dilithium cost from super power cell, increased glass cost to match that of hyper power cell, added silver and gold cost to half that of hyper power cell cost.

### DIFF
--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -29,7 +29,7 @@
 	desc = "A power cell that holds 20 MJ of energy."
 	id = "super_cell"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 700, /datum/material/glass = 70, /datum/material/dilithium = 250) //Yogs: added dilithium
+	materials = list(/datum/material/iron = 700, /datum/material/glass = 80)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power Designs")

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -29,7 +29,7 @@
 	desc = "A power cell that holds 20 MJ of energy."
 	id = "super_cell"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 700, /datum/material/glass = 80)
+	materials = list(/datum/material/iron = 700, /datum/material/gold = 75, /datum/material/silver = 75, /datum/material/glass = 80)
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/super/empty
 	category = list("Misc","Power Designs")


### PR DESCRIPTION
# Document the changes in your pull request

Removes dilithium cost from super power cell, and increases glass cost to match that of hyper power cell, added silver and gold cost to half that of hyper power cell cost. As of now, super power cells are the only T2 part that cannot be produced with just iron and glass. This PR allows people to get some cell upgrades even if miners are dead or non-existent. This also makes it easier for technophile chaplain to get favor without bankrupting the ore silo of its dilithium, making every else mad.

I would have tested my changes but Build.bat doesn't seem to work for me. (Even when I don't have any files changed.)


# Wiki Documentation

I don't believe the cost of super power cells (or other cells) are mentioned anywhere on the wiki.

# Changelog

:cl:
tweak: Removed super power cell dilithium cost, increased super power cell glass cost to match that of hyper power cell, added silver and gold cost to half that of hyper power cell cost.  
/:cl:
