### PR TITLE
Cult tiles now block atmos like everyone though it did

### DIFF
--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -135,6 +135,7 @@
 	desc = "The air smells strangely over this sinister flooring."
 	icon_state = "plating"
 	floor_tile = null
+	CanAtmosPass = ATMOS_PASS_NO // cant be spaced or flooded that easily
 	var/obj/effect/clockwork/overlay/floor/bloodcult/realappearance
 
 
@@ -167,6 +168,7 @@
 
 /turf/open/floor/engine/cult/airless
 	initial_gas_mix = AIRLESS_ATMOS
+	CanAtmosPass = ATMOS_PASS_PROC // same as /turf/open/floor/engine
 
 /turf/open/floor/engine/vacuum
 	name = "vacuum floor"

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -453,7 +453,7 @@
 	for(var/turf/T in range(5,src))
 		var/dist = get_dist(src, T)
 		if (dist <= 2)
-			T.ChangeTurf(/turf/open/floor/engine/cult)
+			T.ChangeTurf(/turf/open/floor/engine/cult, flags = CHANGETURF_IGNORE_AIR)
 			for (var/obj/structure/S in T)
 				if(!istype(S,/obj/structure/destructible/cult))
 					S.ex_act(EXPLODE_DEVASTATE)
@@ -461,7 +461,7 @@
 				qdel(M)
 		else if (dist <= 4)
 			if (istype(T,/turf/open/space))
-				T.ChangeTurf(/turf/open/floor/engine/cult)
+				T.ChangeTurf(/turf/open/floor/engine/cult, flags = CHANGETURF_IGNORE_AIR)
 			else
 				T.narsie_act(TRUE, TRUE)
 		else if (dist <= 5)

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -223,9 +223,9 @@
 		var/turf/T = safepick(validturfs)
 		if(T)
 			if(istype(T, /turf/open/floor/plating))
-				T.PlaceOnTop(/turf/open/floor/engine/cult, flags = CHANGETURF_INHERIT_AIR)
+				T.PlaceOnTop(/turf/open/floor/engine/cult, flags = CHANGETURF_IGNORE_AIR)
 			else
-				T.ChangeTurf(/turf/open/floor/engine/cult, flags = CHANGETURF_INHERIT_AIR)
+				T.ChangeTurf(/turf/open/floor/engine/cult, flags = CHANGETURF_IGNORE_AIR)
 		else
 			var/turf/open/floor/engine/cult/F = safepick(cultturfs)
 			if(F)


### PR DESCRIPTION
# Document the changes in your pull request

I don't exactly remember why but it's in everyone's headspace that this is how cult pylons work when they actually don't. So I'm making it do this because not worrying about atmos is nice and rewarding for pylons and spacing cult areas is really common and effective (or dumb when a juggernaut/arti decides to).

# Changelog

:cl:  
tweak: Cult tiles now block atmos, making it harder to space or flood them
/:cl:
