### PR TITLE
Reworks Cult Mirror Shield

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -937,7 +937,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bumped", "prodded")
 	hitsound = 'sound/weapons/smash.ogg'
-	block_chance = 75 //Yogstation change. 50% to 75%.
+	block_chance = 60 //Yogstation change. 50% to 60%.
 	var/illusions = 5
 
 //Start of Yogstation Change: Refactors mirror shield.
@@ -965,7 +965,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	. = ..()
 
 	if(.)
-		if(illusions > 0)
+		if(illusions >= 1)
 			playsound(src, 'sound/weapons/parry.ogg', 100, 1)
 			illusions--
 			addtimer(CALLBACK(src, /obj/item/shield/mirror.proc/readd), 450)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -957,7 +957,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 
 	if(istype(hitby, /obj/item/projectile))
 		var/obj/item/projectile/P = hitby
-		if(P.damage_type != BURN)
+		if(P.flag != ENERGY)
 			final_block_chance = 0
 		else if(P.reflectable & REFLECT_NORMAL)
 			return FALSE //To avoid reflection chance double-dipping with block chance

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -926,7 +926,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 
 /obj/item/shield/mirror
 	name = "mirror shield"
-	desc = "An infamous shield used by Nar'sien sects to confuse and disorient enemies who prefer ranged weapons. Its edges are weighted for use as a throwing weapon - capable of disabling multiple foes with preternatural accuracy. The shield cannot block melee or unarmed attacks."
+	desc = "An infamous shield used by Nar'sien sects to confuse and disorient enemies who prefer ranged weapons. Its edges are weighted for use as a throwing weapon - capable of disabling multiple foes with preternatural accuracy. The shield can only block ranged laser or energy attacks."
 	icon_state = "mirror_shield" // eshield1 for expanded
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
@@ -957,7 +957,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 
 	if(istype(hitby, /obj/item/projectile))
 		var/obj/item/projectile/P = hitby
-		if(P.flag != ENERGY)
+		if(!(P.flag & (ENERGY|LASER)))
 			final_block_chance = 0
 		else if(P.reflectable & REFLECT_NORMAL)
 			return FALSE //To avoid reflection chance double-dipping with block chance


### PR DESCRIPTION
# Document the changes in your pull request

Cult mirror shields can only block ranged energy/laser projectiles, with a 60% chance to block. (Previously, 50% chance to block all damage sources.)
Negative effects when using the cultist mirror shield as a non-cultist have a 100% chance to occur. (Previously 50% chance to occur.)
Removed cult mirror shattering when it takes more than 30 damage at once.


Justifcation:
Cultists are extremely powerful in melee combat. The shield should only serve to block energy projectiles as cult armor has poor laser resistance.

# Wiki Documentation
https://wiki.yogstation.net/wiki/Blood_Cult

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  BurgerBB
tweak: Cult mirror shields can only block ranged energy/laser projectiles, with a 60% chance to block.
tweak: Negative effects when using the cultist mirror shield as a non-cultist have a 100% chance to occur.
del: Removed cult mirror shattering when it takes more than 30 damage at once.
/:cl:
