### PR TITLE
seismic arm's overcharged emitter flight path fix

### DIFF
--- a/code/modules/mining/lavaland/seismicarm.dm
+++ b/code/modules/mining/lavaland/seismicarm.dm
@@ -241,8 +241,9 @@
 			L.adjustBruteLoss(100)
 	if(issilicon(L))
 		L.adjustBruteLoss(18)
+	var/turf/P = get_turf(user)
 	for(var/i = 2 to flightdist)
-		var/turf/T = get_ranged_target_turf(user, direction, i)
+		var/turf/T = get_ranged_target_turf(P, direction, i)
 		if(ismineralturf(T))
 			var/turf/closed/mineral/M = T
 			M.attempt_drill()


### PR DESCRIPTION

# Document the changes in your pull request

fixes a bug with the victim of the overcharged emitter attack straying from the path if the user moves around after hitting the target

# Changelog
:cl:  
bugfix: fixed a seismic arm bug  
/:cl:
