### PR TITLE
Weight map rotation against recently played maps

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -305,6 +305,11 @@
 	max_val = 1
 	integer = FALSE
 
+/datum/config_entry/number/map_weight_history
+	config_entry_value = 10
+	min_val = 0
+	integer = TRUE
+
 /datum/config_entry/number/soft_popcap
 	config_entry_value = null
 	min_val = 0

--- a/config/config.txt
+++ b/config/config.txt
@@ -306,6 +306,11 @@ PREFERENCE_MAP_VOTING 1
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
 MAPROTATIONCHANCEDELTA 1
 
+## Map weight history
+## This is the number of rounds into the past that should be checked for map weighting
+## Set to 0 to disable frequency based map weighting
+MAP_WEIGHT_HISTORY 10
+
 ## AUTOADMIN
 ## The default admin rank
 #AUTOADMIN_RANK Council Member


### PR DESCRIPTION
# Document the changes in your pull request

Prevents one map from becoming dominant by weighting against it if it has been played a lot recently.
Alternative to #17876 

# Changelog

:cl:  
rscadd: Added a system to increase variety in map rotations
tweak: Disallow voting for maps after rotation has happened
/:cl:
