### PR TITLE
IPC don't take hard crit damage if they have NOHARDCRIT trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -238,7 +238,7 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	if(H.oxyloss)
 		H.setOxyLoss(0)
 		H.losebreath = 0
-	if(H.health <= HEALTH_THRESHOLD_FULLCRIT && H.stat != DEAD) // So they die eventually instead of being stuck in crit limbo.
+	if(H.health <= HEALTH_THRESHOLD_FULLCRIT && H.stat != DEAD && !HAS_TRAIT(H, TRAIT_NOHARDCRIT)) // So they die eventually instead of being stuck in crit limbo.
 		H.adjustFireLoss(6) // After bodypart_robotic resistance this is ~2/second
 		if(prob(5))
 			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")


### PR DESCRIPTION
Should not bypass the trait literally meant to prevent it

:cl:  
bugfix: IPC don't take hard crit damage if they have NOHARDCRIT trait
/:cl:
