### PR TITLE
buster arm now comes in a box with 3 monkeys for the user to practice with

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -740,3 +740,11 @@
 /obj/item/storage/box/beanbag/syndie_darts/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun/dart/hidden(src)
+
+/obj/item/storage/box/syndie_kit/buster
+	real_name = "Buster kit"
+
+/obj/item/storage/box/syndie_kit/buster/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/food/snacks/monkeycube(src)
+	new /obj/item/bodypart/l_arm/robot/buster(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -323,10 +323,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/busterarm
 	name = "Buster Arm"
-	desc = "A combat-focused prosthetic left arm that can be attached on contact; It is intended for close combat and possesses immense strength. With it, the user can send people \
-	and heavy objects flying and even tear down solid objects like they're wet paper. To close the distance with ranged opponents, a grappling hook can be ejected from the arm \
-	which can even pull items right into the user's hand with a precise hit."
-	item = /obj/item/bodypart/l_arm/robot/buster
+	desc = "A box containing a combat-focused prosthetic left arm that can be attached on contact; It is intended for close combat and possesses immense strength. With it, the user\
+	can send people and heavy objects flying and even tear down solid objects like they're wet paper. To close the distance with ranged opponents, a grappling hook can be ejected\
+	from the arm which momentarily keeps victims in place. Due to its unorthodox nature, the box includes 3 monkey cubes to familiarize the user with the arm functions."
+	item = /obj/item/storage/box/syndie_kit/buster
 	cost = 15
 	manufacturer = /datum/corporation/traitor/cybersun
 	surplus = 0


### PR DESCRIPTION
# Document the changes in your pull request

seeing people use the arm hurts me so now purchasing a buster arm will give the user a box with it and 3 monkey cubes so they can get a grip on the moves before moving onto actual people


# Wiki Documentation

probably just including the bit about having it come in a box with some monkey cubes on its section on the traitor items page https://wiki.yogstation.net/wiki/Syndicate_Items

# Changelog


:cl:  
tweak: tweaked buster arm to come with test dummies
/:cl:
