### PR TITLE
Changes Antag Coefficient to increase traitor, changeling and blood brother population relative to total station population (Increases total number of atnags

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -247,9 +247,9 @@ SHUTTLE_REFUEL_DELAY 12000
 ## Variables calculate how number of antagonists will scale to population.
 ## Used as (Antagonists = Population / Coeff)
 ## Set to 0 to disable scaling and use default numbers instead.
-TRAITOR_SCALING_COEFF 7
-BROTHER_SCALING_COEFF 10
-CHANGELING_SCALING_COEFF 8
+TRAITOR_SCALING_COEFF 5
+BROTHER_SCALING_COEFF 8
+CHANGELING_SCALING_COEFF 7
 
 ## Variables calculate how number of open security officer positions will scale to population.
 ## Used as (Officers = Population / Coeff)


### PR DESCRIPTION

# Document the changes in your pull request

This pull request changes the antag cooeficient for the antags listed above in an attempt to increase total number of antags in a round, this is because I believe that there are too few antags for the population on the station. This has been echod many times in the Discord server.
![image](https://user-images.githubusercontent.com/84217619/218292143-590dd4fd-6067-4396-b84d-d9d24f619275.png)
![image](https://user-images.githubusercontent.com/84217619/218292203-b617645e-30c6-439c-9770-05a35926bea3.png)
Many more times in the discord, my search function is broken.
# Wiki Documentation

Maybe this information was on the wiki, I could not find it.
# Changelog


:cl:  
tweak: Changes antag coefficient
/:cl:
