### PR TITLE
Changeling gamemode pop limit increase

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
-	required_players = 35
+	required_players = 32
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
-	required_players = 25
+	required_players = 35
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = 1


### PR DESCRIPTION
# Document the changes in your pull request
_Technically an ided._

Ever since the changeling buff, 25 people is not enough to properly fend them off.
One changeling can solo around 3 people now, and 2-3 of them spawn each changeling round. (Or even 5 with midround rolls)

# Changelog

:cl:  
tweak: Changelings now need 32 people
/:cl:
