### PR TITLE
You still get bonus antag rep if the round was force ended and you lived

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -231,7 +231,7 @@
 				continue
 			if(SSpersistence.antag_rep_change[M.ckey] < 0) // don't want to punish antags for being alive hehe
 				continue
-			else if(M.onCentCom())
+			else if(M.onCentCom() || SSticker.force_ending || SSticker.mode.station_was_nuked)
 				SSpersistence.antag_rep_change[M.ckey] *= CONFIG_GET(number/escaped_alive_bonus) // Reward for escaping alive
 			else
 				SSpersistence.antag_rep_change[M.ckey] *= CONFIG_GET(number/stayed_alive_bonus) // Reward for staying alive


### PR DESCRIPTION
# Document the changes in your pull request

Works like the escape traitor objective (minus the cuffed part)

If the round is forcibly ended early by something like all antags dying or station nuking or blob and you LIVE, you get the 2x centcom escape bonus since centcom escape is impossible

# Changelog

:cl:  
tweak: You now still get centcom bonus antag rep if the round was force ended and you lived
/:cl:
