### PR TITLE
Fix crew monitor runtime

### DIFF
--- a/code/modules/modular_computers/file_system/programs/medical/crew_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/crew_monitor.dm
@@ -33,21 +33,28 @@
 /datum/computer_file/program/crew_monitor/proc/update_overlay()
 	if(!computer)
 		return
-	var/z = computer.z
-	if(!z)
-		var/turf/T = get_turf(computer)
-		z = T.z
-	var/list/death_list = GLOB.crewmonitor.death_list?["[z]"]
+
+	var/turf/computer_turf = get_turf(computer)
+	if (!computer_turf)
+		return
+	
+	var/computer_z = computer_turf.z
+	if (!computer_z)
+		return
+
+	var/list/death_list = GLOB.crewmonitor.death_list?["[computer_z]"]
 	if(death_list && death_list.len > 0)
 		alarm = TRUE
 	else
 		alarm = FALSE
+
 	if(alarm)
 		program_icon_state = program_icon_state_alarm
 		ui_header = "health_red.gif"
 	else
 		program_icon_state = initial(program_icon_state)
 		ui_header = "health_green.gif"
+
 	if(istype(computer))
 		computer.update_icon()
 


### PR DESCRIPTION
# Document the changes in your pull request
Fixes runtime

```
[11:57:12] Runtime in crew_monitor.dm, line 39: Cannot read null.z
proc name: update overlay (/datum/computer_file/program/crew_monitor/proc/update_overlay)
src: /datum/computer_file/program/c... (/datum/computer_file/program/crew_monitor)
call stack:
/datum/computer_file/program/c... (/datum/computer_file/program/crew_monitor): update overlay(/datum/crewmonitor (/datum/crewmonitor))
/datum/crewmonitor (/datum/crewmonitor): SendSignal("machinery_crewmon_update", /list (/list))
/datum/crewmonitor (/datum/crewmonitor): update data(2)
/datum/crewmonitor (/datum/crewmonitor): ui data(Hislyna Chu (/mob/living/carbon/human))
/datum/computer_file/program/c... (/datum/computer_file/program/crew_monitor): ui data(Hislyna Chu (/mob/living/carbon/human))
/datum/tgui (/datum/tgui): get payload(null, 1, null)
/datum/tgui (/datum/tgui): send update(null, null)
tgui (/datum/controller/subsystem/tgui): try update ui(Hislyna Chu (/mob/living/carbon/human), /datum/computer_file/program/c... (/datum/computer_file/program/crew_monitor), /datum/tgui (/datum/tgui))
/datum/computer_file/program/c... (/datum/computer_file/program/crew_monitor): ui interact(Hislyna Chu (/mob/living/carbon/human), /datum/tgui (/datum/tgui))
/datum/tgui (/datum/tgui): process(0.9, 0)
tgui (/datum/controller/subsystem/tgui): fire(0)
tgui (/datum/controller/subsystem/tgui): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```