### PR TITLE
Fixes honkmother sect not being able to heal anyone

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -390,7 +390,7 @@
 	altar_icon_state = "convertaltar-red"
 
 //honkmother bible is supposed to only cure clowns, honk, and be slippery. I don't know how I'll do that
-/datum/religion_sect/honkmother/sect_bless/sect_bless(mob/living/blessed, mob/living/user)
+/datum/religion_sect/honkmother/sect_bless(mob/living/blessed, mob/living/user)
 	if(!ishuman(blessed))
 		return
 	var/mob/living/carbon/human/H = blessed


### PR DESCRIPTION
# Document the changes in your pull request

why would anyone make a sect that can only heal 1 person on the station

and i thought kudzu/technophile was bad

# Changelog

:cl:  
bugfix: fixed Honkmother sect not healing clowns
/:cl:
