### PR TITLE
More Ethereal colours

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -47,7 +47,11 @@ GLOBAL_LIST_EMPTY(ipc_chassis_list)
 GLOBAL_LIST_INIT(plasmaman_helmet_list, list("None" = "", "Slit" = "S", "Nyan" = "N", "Gassy" = "G", "Bane" = "B", "Halo" = "H", "Wizard" = "W"))
 
 GLOBAL_LIST_EMPTY(ethereal_mark_list) //ethereal face marks
-GLOBAL_LIST_INIT(color_list_ethereal, list("F Class(Green)" = "97ee63", "F2 Class (Light Green)" = "00fa9a", "F3 Class (Dark Green)" = "37835b", "M Class (Red)" = "9c3030", "M1 Class (Purple)" = "ee82ee", "G Class (Yellow)" = "fbdf56", "O Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff"))
+GLOBAL_LIST_INIT(color_list_ethereal,
+				list("O Class (Dark Green)" = "37833F", "O2 Class(Green)" = "97ee63", "O3 Class (Light Green)" = "00ff00",\
+				"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "A2 Class (Turquoise)" = "00fa9a", "F Class (White)" = "ffffff",\
+				"K Class (Yellow)" = "ffff00", "M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030",\
+				"T Class (Light Purple)" = "ff00ff", "T2 Class (Dark Purple)" = "ee82ee"))
 GLOBAL_LIST_INIT(color_list_preternis, list("Factory Default" = "FFFFFF", "Rust" = "B7410E", "Chrome" = "B0C4DE", "Overgrown" = "b2ee69", "Gunmetal Gray" = "8D918D", "Gold" = "D4AF37"))
 
 GLOBAL_LIST_EMPTY(pod_hair_list) //ethereal face marks

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_EMPTY(ipc_chassis_list)
 GLOBAL_LIST_INIT(plasmaman_helmet_list, list("None" = "", "Slit" = "S", "Nyan" = "N", "Gassy" = "G", "Bane" = "B", "Halo" = "H", "Wizard" = "W"))
 
 GLOBAL_LIST_EMPTY(ethereal_mark_list) //ethereal face marks
-GLOBAL_LIST_INIT(color_list_ethereal,
+GLOBAL_LIST_INIT(color_list_ethereal,\
 	list("O Class (Dark Green)" = "37833F", "O2 Class(Green)" = "97ee63", "O3 Class (Light Green)" = "00ff00",\
 	"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "F Class (White)" = "ffffff", "K Class (Yellow)" = "ffff00",\
 	"M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030", "T Class (Light Purple)" = "ff00ff",\

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -49,9 +49,9 @@ GLOBAL_LIST_INIT(plasmaman_helmet_list, list("None" = "", "Slit" = "S", "Nyan" =
 GLOBAL_LIST_EMPTY(ethereal_mark_list) //ethereal face marks
 GLOBAL_LIST_INIT(color_list_ethereal,
 				list("O Class (Dark Green)" = "37833F", "O2 Class(Green)" = "97ee63", "O3 Class (Light Green)" = "00ff00",\
-				"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "A2 Class (Turquoise)" = "00fa9a", "F Class (White)" = "ffffff",\
-				"K Class (Yellow)" = "ffff00", "M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030",\
-				"T Class (Light Purple)" = "ff00ff", "T2 Class (Dark Purple)" = "ee82ee"))
+				"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "F Class (White)" = "ffffff", "K Class (Yellow)" = "ffff00",\
+				"M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030", "T Class (Light Purple)" = "ff00ff",\
+				"T2 Class (Dark Purple)" = "ee82ee"))
 GLOBAL_LIST_INIT(color_list_preternis, list("Factory Default" = "FFFFFF", "Rust" = "B7410E", "Chrome" = "B0C4DE", "Overgrown" = "b2ee69", "Gunmetal Gray" = "8D918D", "Gold" = "D4AF37"))
 
 GLOBAL_LIST_EMPTY(pod_hair_list) //ethereal face marks

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -48,10 +48,10 @@ GLOBAL_LIST_INIT(plasmaman_helmet_list, list("None" = "", "Slit" = "S", "Nyan" =
 
 GLOBAL_LIST_EMPTY(ethereal_mark_list) //ethereal face marks
 GLOBAL_LIST_INIT(color_list_ethereal,
-				list("O Class (Dark Green)" = "37833F", "O2 Class(Green)" = "97ee63", "O3 Class (Light Green)" = "00ff00",\
-				"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "F Class (White)" = "ffffff", "K Class (Yellow)" = "ffff00",\
-				"M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030", "T Class (Light Purple)" = "ff00ff",\
-				"T2 Class (Dark Purple)" = "ee82ee"))
+	list("O Class (Dark Green)" = "37833F", "O2 Class(Green)" = "97ee63", "O3 Class (Light Green)" = "00ff00",\
+	"B Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff", "F Class (White)" = "ffffff", "K Class (Yellow)" = "ffff00",\
+	"M Class (Orange)" = "ff8700", "L Class (Red)" = "ff0000", "L2 Class (Dark Red)" = "9c3030", "T Class (Light Purple)" = "ff00ff",\
+	"T2 Class (Dark Purple)" = "ee82ee"))
 GLOBAL_LIST_INIT(color_list_preternis, list("Factory Default" = "FFFFFF", "Rust" = "B7410E", "Chrome" = "B0C4DE", "Overgrown" = "b2ee69", "Gunmetal Gray" = "8D918D", "Gold" = "D4AF37"))
 
 GLOBAL_LIST_EMPTY(pod_hair_list) //ethereal face marks


### PR DESCRIPTION
Ethereal colours are based off stars, and named as such
Slight problem, don't see any green on this spectral colouring graph
![image](https://user-images.githubusercontent.com/108117184/218625092-53affb6e-8edc-479e-9830-f6b3813aaf67.png)

They also don't have either white or orange despite them being prominent star colours

Adds light purple, orange, light red and white
Makes dark green slightly more green
Makes yellow less muddy
![image](https://user-images.githubusercontent.com/108117184/218625874-343c54d8-243f-48f3-b7e5-90be92dc4796.png)

:cl:  
rscadd: More Ethereal colours
tweak: Ethereal colours are (sorta) properly classified
/:cl:
