### PR TITLE
Thralled or Veiled Ethereals create a light void

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -88,9 +88,17 @@
 	. = ..()
 	if(H.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(H.health, 0) / 100
+		var/range = (4 * healthpercent) + 1
+		var/power = healthpercent + 1
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
-		ethereal_light.set_light_range_power_color(1 + (4 * healthpercent), 1 + (1 * healthpercent), current_color)
+
+		if(isveil(H) || is_thrall(H))//bad boy coming through
+			range = (6 * healthpercent) + 1
+			power = -((2 * healthpercent) + 1)
+			current_color = "#000000"
+
+		ethereal_light.set_light_range_power_color(range, power, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else

--- a/yogstation/code/game/gamemodes/darkspawn/veil.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/veil.dm
@@ -12,6 +12,7 @@
 	owner.special_role = "veil"
 	message_admins("[key_name_admin(owner.current)] was veiled by a darkspawn!")
 	log_game("[key_name(owner.current)] was veiled by a darkspawn!")
+	owner.current.updatehealth()
 
 /datum/antagonist/veil/on_removal()
 	SSticker.mode.update_darkspawn_icons_removed(owner)
@@ -28,6 +29,7 @@
 		to_chat(M,span_userdanger("A piercing white light floods your eyes. Your mind is your own again! Though you try, you cannot remember anything about the darkspawn or your time under their command..."))
 		to_chat(owner, span_notice("As your mind is released from their grasp, you feel your strength returning."))
 	M.update_sight()
+	M.updatehealth()
 	return ..()
 
 /datum/antagonist/veil/apply_innate_effects(mob/living/mob_override)

--- a/yogstation/code/modules/antagonists/shadowling/thrall.dm
+++ b/yogstation/code/modules/antagonists/shadowling/thrall.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_INIT(thrall_spell_types, typecacheof(list(/obj/effect/proc_holder/sp
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_glare(null))
 	owner.AddSpell(new /obj/effect/proc_holder/spell/self/lesser_shadow_walk(null))
 	owner.AddSpell(new /obj/effect/proc_holder/spell/self/thrall_night_vision(null))
+	owner.current.updatehealth()
 
 /datum/antagonist/thrall/on_removal()
 	SSticker.mode.update_shadow_icons_removed(owner)
@@ -51,6 +52,7 @@ GLOBAL_LIST_INIT(thrall_spell_types, typecacheof(list(/obj/effect/proc_holder/sp
 		M.visible_message(span_big("[M] looks like their mind is their own again!"))
 		to_chat(M,span_userdanger("A piercing white light floods your eyes. Your mind is your own again! Though you try, you cannot remember anything about the shadowlings or your time under their command..."))
 	M.update_sight()
+	M.updatehealth()
 	return ..()
 
 /datum/antagonist/thrall/greet()


### PR DESCRIPTION
Ethereals are notoriously difficult to thrall or veil
If a sling or dspawn is suicidal enough to try and pulls it off, might as well reward them
Ethereals that are thralled or veiled create giant dark zones for their masters to walk around in safely
![image](https://user-images.githubusercontent.com/108117184/218633591-9c928a44-dd95-48ad-a81d-eb6f32def5a3.png)

:cl:  
rscadd: Thralled or Veiled Ethereals succ light
/:cl:
