### PR TITLE
Lings can no longer use last resort or hivemind speak while being absorbed

### DIFF
--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -15,6 +15,9 @@
 	mode = MODE_CHANGELING
 
 /datum/saymode/changeling/handle_message(mob/living/user, message, datum/language/language)
+	if(ismob(user.pulledby) && is_changeling(user.pulledby) && user.pulledby.grab_state >= GRAB_NECK)
+		to_chat(user, span_warning("Our abilities are being dampened! We cannot speak through the hivemind!"))
+		return FALSE
 	switch(user.lingcheck())
 		if(LINGHIVE_LINK)
 			var/msg = span_changeling("<b>[user.mind]:</b> [message]")

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -11,7 +11,10 @@
 
 /datum/action/changeling/headcrab/sting_action(mob/user)
 	set waitfor = FALSE
-	if(tgui_alert(usr,"Are we sure we wish to kill ourself and create a headslug?",,list("Yes", "No")) == "No")
+	if(ismob(user.pulledby) && is_changeling(user.pulledby) && user.pulledby.grab_state >= GRAB_NECK)
+		to_chat(user, span_warning("Our abilities are being dampened! We cannot use [src]!"))
+		return
+	if(tgui_alert(usr,"Are we sure we wish to kill ourself and create a headslug?",,list("Yes", "No")) != "Yes")
 		return
 	..()
 	var/datum/mind/M = user.mind


### PR DESCRIPTION
# Document the changes in your pull request

### Last resort makes it so lings cannot absorb one another. You can't absorb the dead headslug, so you get no additional chems, points, and the objective goes incomplete.

If you are being neck grabbed or higher by another ling you will be unable to use Last Resort or hivemind

Lesser Form already has restrained check so you won't be able to use it anyways

# Changelog

:cl:  
tweak: Last Resort & Hivemind Speak are now disabled while neck grabbed by another changeling. This means that you can no longer Last Resort out of an absorb or whine on hivemind about the rogue ling.
/:cl:
