### PR TITLE
Malfunctioning AIs no longer need to kill androids or synthetics

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -463,7 +463,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return TRUE
 	for(var/mob/living/player in GLOB.player_list)
-		if(player.mind && player.stat != DEAD && !(issilicon(player) || isipc(player)))
+		if(player.mind && player.stat != DEAD && ((MOB_ORGANIC in player.mob_biotypes) || !(MOB_ROBOTIC in player.mob_biotypes)))
 			if(get_area(player) in SSshuttle.emergency.shuttle_areas)
 				return FALSE
 	return TRUE

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -343,9 +343,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 		var/turf/T = get_turf(L)
 		if(!T || !is_station_level(T.z))
 			continue
-		if(issilicon(L))
-			continue
-		if(isipc(L))
+		if((MOB_ROBOTIC in L.mob_biotypes) && !(MOB_ORGANIC in L.mob_biotypes))
 			continue
 		to_chat(L, span_userdanger("The blast wave from [src] tears you atom from atom!"))
 		L.dust()


### PR DESCRIPTION
# Document the changes in your pull request

The objective to prevent organics from escaping now requires all shuttle occupants to have the MOB_ROBOTIC biotype and not have the MOB_ORGANIC biotype. Cyborgs, IPCs, androids, synths, and clockwork golems will be allowed to escape without causing the objective to fail. The doomsday device will also work similarly.

# Wiki Documentation

Might be worth mentioning on the guide to malfunction
https://wiki.yogstation.net/wiki/Guide_to_malfunction

# Changelog

:cl:  
tweak: AI no longer needs to kill androids or synthetics
tweak: AI doomsday will now spare androids and synthetics
/:cl:
