### PR TITLE
Temporarily Removes MALF from rotation because I died to it once.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -129,7 +129,7 @@ PROBABILITY CLOCKWORK_CULT 5
 PROBABILITY SHADOWLING 6
 PROBABILITY WIZARD 8
 PROBABILITY NUCLEAR 9
-PROBABILITY MALF 8
+PROBABILITY MALF 0
 PROBABILITY CLOWNOPS 0 #Broke
 
 # Special
@@ -187,7 +187,7 @@ MIDROUND_ANTAG CLOCKWORK_CULT
 MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 #MIDROUND_ANTAG  MONKEY
-MIDROUND_ANTAG MALF
+#MIDROUND_ANTAG MALF
 
 ## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes


### PR DESCRIPTION

# Document the changes in your pull request

MALF can no longer occur. Traitor MALF can still occur.

# Justification

Here is what happens nearly every MALF round.

- AI does nothing for the first 30-60 minutes except research everything they need for doomsday. It is effectively a greenshift because there are no other antagonists. A majority of people at this point are no longer invested in the round and sometimes just alt-tab to do something else.
- A suspicious amount of positronic brains start activating, significantly more than usual.
- AI unlocks doomsday and what they need.
- Comms are cut.
- Plasma is pumped into distro.
- Borgs start killing everyone and dragging people into plasmafloods because they're fire immune.
- Everyone without a hardsuit/firesuit dies or is effectively locked out from participating in the round.

This is not healthy gameplay design. There is an upcoming rework to MALF by a coder but as it stands, MALF is currently the worst gamemode in rotation right now (yes, even worse than wizard) because nearly every round is the same thing over and over again. I know people in the comments will tell me that they had a good MALF round once because the AI decided not to plasmaflood, but those types of rounds are the exception rather than the rule.

I also know that people are going to tell me to improve, don't remove. The problem with this is that I tried improving MALF but I kept getting told that someone else is working on it and that tweaks to solve the issue of plasmaflood aren't needed, and that it's just best to wait. That was 3 months ago. I don't want to wait anymore. Here is a temporary solution.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Guide_to_malfunction

# Changelog

:cl:  BurgerBB
tweak: MALF can no longer occur. Traitor MALF can still occur.
/:cl:
