### PR TITLE
Bloodsucker Brawn knockdown patch

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
@@ -130,7 +130,7 @@
 				span_danger("[user] lands a vicious punch, sending [target] away!"), \
 				span_userdanger("[user] has landed a horrifying punch on you, sending you flying!"),
 			)
-			target.Knockdown(max(5, rand(10, 10 * powerlevel)))
+			target.Knockdown(min(5 SECONDS, rand(10, 10 * powerlevel)))
 		// Attack!
 		to_chat(owner, span_warning("You punch [target]!"))
 		playsound(get_turf(target), 'sound/weapons/punch4.ogg', 60, TRUE, -1)

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
@@ -130,7 +130,7 @@
 				span_danger("[user] lands a vicious punch, sending [target] away!"), \
 				span_userdanger("[user] has landed a horrifying punch on you, sending you flying!"),
 			)
-			target.Knockdown(min(5, rand(10, 10 * powerlevel)))
+			target.Knockdown(max(5, rand(10, 10 * powerlevel)))
 		// Attack!
 		to_chat(owner, span_warning("You punch [target]!"))
 		playsound(get_turf(target), 'sound/weapons/punch4.ogg', 60, TRUE, -1)

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
@@ -130,7 +130,7 @@
 				span_danger("[user] lands a vicious punch, sending [target] away!"), \
 				span_userdanger("[user] has landed a horrifying punch on you, sending you flying!"),
 			)
-			target.Knockdown(min(5 SECONDS, rand(10, 10 * powerlevel)))
+			target.Knockdown(min(5 SECONDS, rand(1 SECONDS, 1 SECONDS * powerlevel)))
 		// Attack!
 		to_chat(owner, span_warning("You punch [target]!"))
 		playsound(get_turf(target), 'sound/weapons/punch4.ogg', 60, TRUE, -1)


### PR DESCRIPTION
# Document the changes in your pull request

Current: Chooses the smallest number between `5` and `10 to powerlevel*10`

Always chooses `5` for obvious reasons

Theos theorizes it was supposed to be 5 seconds not 5 deciseconds

New thing is that it knock downs for your level and caps out at 5 seconds knockdown

The alternative is that it was supposed to be `max()` instead of `min()` which means Brawn would knockdown for a minimum of 5 seconds and then infinitely scale

# Changelog

:cl:  
bugfix: Fixed an oversight that made all brawn knockdowns last for 0.5 seconds regardless of level
/:cl:
