### PR TITLE
[YogsMeta] Corrects R&D door access

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -23097,6 +23097,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"eXU" = (
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area)
 "eYk" = (
 /obj/machinery/door/poddoor{
 	id = "Shuttle Construction Storage";
@@ -54197,13 +54204,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rTC" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "rTL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -109190,7 +109190,7 @@ cdh
 nxT
 cKt
 nEH
-rTC
+eXU
 tTO
 jte
 pkP

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -40740,38 +40740,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"cpp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research{
-	name = "Research and Development Lab";
-	req_one_access_txt = "7;29"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "cpq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59180,6 +59148,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jxS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Research and Development Lab";
+	req_access_txt = "47";
+	req_one_access_txt = "0"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "jzO" = (
 /obj/machinery/light/small,
 /obj/machinery/computer/ai_resource_distribution{
@@ -111604,7 +111605,7 @@ cnX
 cgd
 cgd
 cnX
-cpp
+jxS
 cnX
 cgd
 bGj


### PR DESCRIPTION
# Oh I deleted the wrong line

Changes R&D door from TOX and ROBO_CONTROL to just RESEARCH so the Network Admin can get in there like they're supposed to

# Changelog

:cl:  
tweak: [Meta] Tweaks R&D door access so Network Admin can get in
/:cl:
