### PR TITLE
should fix revolution not happening

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -13,7 +13,7 @@
 	name = "revolution"
 	config_tag = "revolution"
 	report_type = "revolution"
-	antag_flag = ROLE_REV
+	antag_flag = ROLE_REV_HEAD
 	false_report_weight = 10
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg", "Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Shaft Miner", "Mining Medic", "Brig Physician") //Yogs: Added Brig Physician
 	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Chief Engineer"=1),list("Research Director"=1),list("Chief Medical Officer"=1)) //Any head present


### PR DESCRIPTION
before tgui preferences there was a 'Be revolutionary' button which is the only reason the gamemode worked, that button is no longer there.

# Changelog
:cl:  
bugfix: revolution can roll
/:cl:
