### PR TITLE
Mouse traps no longer hurt robot limbs

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -49,11 +49,17 @@
 			if("feet")
 				if(!H.shoes)
 					affecting = H.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
-					H.Paralyze(60)
-			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)
+					if(affecting?.status != BODYPART_ROBOTIC)
+						H.Paralyze(60)
+					else
+						affecting = null
+			if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 				if(!H.gloves)
 					affecting = H.get_bodypart(type)
-					H.Stun(60)
+					if(affecting?.status != BODYPART_ROBOTIC)
+						H.Stun(60)
+					else
+						affecting = null
 		if(affecting)
 			if(affecting.receive_damage(1, 0))
 				H.update_damage_overlays()
@@ -72,9 +78,9 @@
 		to_chat(user, span_notice("You arm [src]."))
 	else
 		if((HAS_TRAIT(user, TRAIT_DUMB) || HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
-			var/which_hand = BODY_ZONE_PRECISE_L_HAND
+			var/which_hand = BODY_ZONE_L_ARM
 			if(!(user.active_hand_index % 2))
-				which_hand = BODY_ZONE_PRECISE_R_HAND
+				which_hand = BODY_ZONE_R_ARM
 			triggered(user, which_hand)
 			user.visible_message(span_warning("[user] accidentally sets off [src], breaking their fingers."), \
 								 span_warning("You accidentally trigger [src]!"))


### PR DESCRIPTION
# Document the changes in your pull request

Robot limbs now protect you from mouse traps, allowing preternis a way to avoid the 6-second paralyze that was previously unavoidable for them

# Changelog

:cl:  
tweak: robot limbs now protect you from mousetraps
/:cl:
