### PR TITLE
Disables antiglow because it doesn't work

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -25,10 +25,6 @@
 	required = "/datum/mutation/human/shock; /datum/mutation/human/telekinesis"
 	result = SHOCKTOUCHFAR
 
-/datum/generecipe/antiglow
-	required = "/datum/mutation/human/glow; /datum/mutation/human/void"
-	result = ANTIGLOWY
-
 /datum/generecipe/cerebral
 	required = "/datum/mutation/human/insulated; /datum/mutation/human/mindreader"
 	result = CEREBRAL


### PR DESCRIPTION
The new lighting system, while great, doesn't currently support negative light powers.
This disables it until someone wants to tweak the lighting system to make it work

# Wiki Documentation

remove antiglow from the mutations page

:cl:  
rscdel: Disabled antiglow genetic recipe (antiglow doesn't work)
/:cl:
