### PR TITLE
Fixes energy sword dupe exploit

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -147,7 +147,7 @@
 		drop_part(robot_arm, Tsec)
 
 	do_sparks(3, TRUE, src)
-	for(var/IS = 0 to 4)
+	for(var/IS = 0 to 3) // dont set this to 4 or itll drop 5 swords idiot
 		drop_part(baton_type, Tsec)
 	new /obj/effect/decal/cleanable/oil(Tsec)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -147,7 +147,7 @@
 		drop_part(robot_arm, Tsec)
 
 	do_sparks(3, TRUE, src)
-	for(var/IS = 0 to 3) // dont set this to 4 or itll drop 5 swords idiot
+	for(var/IS = 1 to 4) // dont set this to 4 or itll drop 5 swords idiot
 		drop_part(baton_type, Tsec)
 	new /obj/effect/decal/cleanable/oil(Tsec)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -147,7 +147,7 @@
 		drop_part(robot_arm, Tsec)
 
 	do_sparks(3, TRUE, src)
-	for(var/IS = 1 to 4) // dont set this to 4 or itll drop 5 swords idiot
+	for(var/IS = 1 to 4)
 		drop_part(baton_type, Tsec)
 	new /obj/effect/decal/cleanable/oil(Tsec)
 	qdel(src)


### PR DESCRIPTION
# Document the changes in your pull request

`0 to 4` means 0,1,2,3,4

# Changelog

:cl:  
bugfix: Fixed an exploit that let you dupe energy swords
/:cl:
