### PR TITLE
Moves antimagic from nullrod to chaplain

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -253,10 +253,6 @@
 	var/reskinned = FALSE
 	var/chaplain_spawnable = TRUE
 
-/obj/item/nullrod/Initialize()
-	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
-
 /obj/item/nullrod/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is killing [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to get closer to god!"))
 	playsound(user, 'sound/effects/pray.ogg', 50)

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -20,6 +20,7 @@
 	base_access = list(ACCESS_MORGUE, ACCESS_CHAPEL_OFFICE, ACCESS_CREMATORIUM, ACCESS_THEATRE)
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_CIV
+	mind_traits = list(TRAIT_HOLY, TRAIT_ANTIMAGIC)
 
 	display_order = JOB_DISPLAY_ORDER_CHAPLAIN
 	minimal_character_age = 18 //My guy you are literally just a priest


### PR DESCRIPTION
Lets a late-join chaplain with a stolen null rod still have antimagic
Lets a chaplain actually swap between items without risking getting bopped by magic
Miners can get extra nullrods (the spirit and armblade ones), this makes it so cults and wizards only ever need to worry about one antimagic person

# Wiki Documentation

Remove text about nullrod giving antimagic
add text about chaplain having antimagic

:cl:  
rscadd: Adds antimagic to chaplain
rscdel: Removes antimagic from nullrod
/:cl:
