### PR TITLE
Chaplain nullrod shows 11 items per page instead of 7

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -310,8 +310,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Presents radial menu to user anchored to anchor (or user if the anchor is currently in users screen)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
+	
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE)
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, numitems)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
@@ -324,6 +325,8 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	GLOB.radial_menus[uniqueid] = menu
 	if(radius)
 		menu.radius = radius
+	if(numitems)
+		menu.min_angle = 360/numitems
 	if(istype(custom_check))
 		menu.custom_check_callback = custom_check
 	menu.anchor = anchor

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -294,7 +294,7 @@
 			nullrod_icons += list(initial(rodtype.name) = image(icon = initial(rodtype.icon), icon_state = initial(rodtype.icon_state)))
 
 	nullrod_icons = sortList(nullrod_icons)
-	var/choice = show_radial_menu(M, src , nullrod_icons, custom_check = CALLBACK(src, .proc/check_menu, M), radius = 42, require_near = TRUE, tooltips = TRUE)
+	var/choice = show_radial_menu(M, src , nullrod_icons, custom_check = CALLBACK(src, .proc/check_menu, M), radius = 64, require_near = TRUE, tooltips = TRUE, numitems = 12)
 	if(!choice || !check_menu(M))
 		return
 


### PR DESCRIPTION
there's like 5 pages of nullrods, that's kinda dumb
![image](https://user-images.githubusercontent.com/108117184/219510232-59dd3e2e-15cf-4aae-b260-12fb17f97a2f.png)

:cl:  
tweak: Chaplain nullrod now shows 11 items per page instead of 7
/:cl:
