### PR TITLE
Removes autolathe boards from most department protolathes

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -488,7 +488,7 @@
 	id = "autolathe"
 	build_path = /obj/item/circuitboard/machine/autolathe
 	category = list ("Misc. Machinery")
-	departmental_flags = DEPARTMENTAL_FLAG_ALL		//Lets be honest here half the maps have public ones.
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENT_FLAG_SCIENCE | DEPARTMENT_FLAG_CARGO		//Lets be honest here half the maps have public ones.
 
 /datum/design/board/recharger
 	name = "Machine Design (Weapon Recharger Board)"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -488,7 +488,7 @@
 	id = "autolathe"
 	build_path = /obj/item/circuitboard/machine/autolathe
 	category = list ("Misc. Machinery")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENT_FLAG_SCIENCE | DEPARTMENT_FLAG_CARGO		//Lets be honest here half the maps have public ones.
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO		//Lets be honest here half the maps have public ones.
 
 /datum/design/board/recharger
 	name = "Machine Design (Weapon Recharger Board)"


### PR DESCRIPTION
people can't fucking restrain themselves from powergaming so instead of making admins police this shit it can be fixed through code

tl;dr autolathes can only be made by departments that get them (service, science, cargo) instead of everyone because sec and medbay making their own autolathes is stupid

# Changelog

:cl:  
tweak: autolathe boards are limited to the the departments that start with them
/:cl:
