### PR TITLE
merges the blue and red shieldstaff nullrods

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -360,18 +360,21 @@
 	slot_flags = ITEM_SLOT_BACK
 	block_chance = 50
 	var/shield_icon = "shield-red"
+	var/blue = FALSE
 
 /obj/item/nullrod/staff/worn_overlays(isinhands)
 	. = list()
 	if(isinhands)
 		. += mutable_appearance('icons/effects/effects.dmi', shield_icon, MOB_LAYER + 0.01)
 
-/obj/item/nullrod/staff/blue
-	icon = 'icons/obj/wizard.dmi'
-	name = "blue holy staff"
-	icon_state = "staff-blue"
-	item_state = "godstaff-blue"
-	shield_icon = "shield-old"
+/obj/item/nullrod/staff/attack_self(mob/user)
+	. = ..()
+	blue = !blue
+	to_chat(user, "You swap the [src] into [blue ? "blue" : "red"] mode.")
+	name = "[blue ? "blue" : "red"] holy staff"
+	icon_state = "staff-[blue ? "blue" : "red"]"
+	item_state = "godstaff-[blue ? "blue" : "red"]"
+	shield_icon = "shield-[blue ? "old" : "red"]"
 
 /obj/item/nullrod/claymore
 	icon = 'icons/obj/weapons/swords.dmi'


### PR DESCRIPTION
Chaplain has too many null rods that are literally just reskins
this one is quite literally just a recolour, so now you can just toggle between the colour

i plan to cull a bunch of null rods in the future once i am done making some more.
If there is a specific null rod(specifically just the reskins) you want to keep, let me know

:cl:  
tweak: merges the blue and red shieldstaff nullrods
/:cl:
