### PR TITLE
Wearing a null rod lets you purge cultist runes by hand

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -89,6 +89,11 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	if(.)
 		return
 	if(!iscultist(user))
+		for(var/obj/item/nullrod/antimagic in user.get_equipped_items())
+			user.say("BEGONE FOUL MAGIKS!!", forced = "nullrod")
+			to_chat(user, span_danger("You disrupt the magic of [src] with [antimagic]."))
+			qdel(src)
+			return
 		to_chat(user, span_warning("You aren't able to understand the words of [src]."))
 		return
 	if(istype(user, /mob/living/simple_animal/shade))

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -22,6 +22,11 @@
 	. = ..()
 	if(.)
 		return
+	for(var/obj/item/nullrod/antimagic in user.get_equipped_items())
+		user.say("PURGE THE HERESY!!", forced = "nullrod")
+		to_chat(user, span_danger("You cleanse the heresy of [src] with [antimagic]."))
+		qdel(src)
+		return
 	try_activate(user)
 
 /obj/effect/eldritch/proc/try_activate(mob/living/user)
@@ -33,6 +38,8 @@
 /obj/effect/eldritch/attacked_by(obj/item/I, mob/living/user)
 	. = ..()
 	if(istype(I,/obj/item/nullrod))
+		user.say("PURSE THE HERESY!!", forced = "nullrod")
+		to_chat(user, span_danger("You cleanse the heresy of [src] with [I]."))
 		qdel(src)
 
 /obj/effect/eldritch/proc/activate(mob/living/user)


### PR DESCRIPTION
Having to remove a piece of clothing nullrod to purge a rune is weird.

:cl:  
rscadd: Wearing a null rod lets you purge cultist runes by hand
/:cl:
