### PR TITLE
Force number will now be alongside force string on hover

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -783,7 +783,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(last_force_string_check != force && !(item_flags & FORCE_STRING_OVERRIDE))
 		set_force_string()
 	if(!(item_flags & FORCE_STRING_OVERRIDE))
-		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string]" : ""]",theme = "")
+		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string] ([force])" : ""]",theme = "")
 	else
 		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -785,7 +785,7 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	if(!(item_flags & FORCE_STRING_OVERRIDE))
 		openToolTip(user,src,params,title = name,content = "[desc]<br>[force ? "<b>Force:</b> [force_string] ([force])" : ""]",theme = "")
 	else
-		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
+		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string] [force ? "([force])" : ""]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
 	if((item_flags & IN_INVENTORY || item_flags & IN_STORAGE) && usr.client.prefs.read_preference(/datum/preference/toggle/enable_tooltips) && !QDELETED(src))


### PR DESCRIPTION
# Document the changes in your pull request

I'm tired of looking all over the code left and right to find force and force modifiers!!!!

Maybe we can get armor pen and other values on examine in another PR

# Changelog

:cl:  
rscadd: Added actual force next to force string on item hover
/:cl:
