### PR TITLE
Revert "NASA Space suit flash protection removal"

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -57,7 +57,6 @@ Contains:
 	desc = "An old, NASA CentCom branch designed, dark red space suit helmet."
 	icon_state = "void"
 	item_state = "void"
-	flash_protect = 0 // Flimsy film on the helmet shouldnt protect you from bright lights.
 
 /obj/item/clothing/suit/space/nasavoid
 	name = "NASA Voidsuit"
@@ -71,7 +70,6 @@ Contains:
 	desc = "A CentCom engineering dark red space suit helmet. While old and dusty, it still gets the job done."
 	icon_state = "void"
 	item_state = "void"
-	flash_protect = 2
 
 /obj/item/clothing/suit/space/nasavoid/old
 	name = "Engineering Voidsuit"


### PR DESCRIPTION
Reverts yogstation13/Yogstation#17233

# But Why?

## Gameplay
It is inconsistent, was unliked by everyone, has clear visual indication same as any other helmet (unlike welding shield eyes, which are way worse). Why it shouldn't be flash and welding protected thus doesn't make sense gameplaywise (The curator will also most likely use welding equipment in space).

## "But muh realism!"
NASA has been using UV shielded lenses on their suits ever since 1980s (And also showcased their tech on Spinoff2006), UV shielding prevents welding from causing eye damage. The ingame spacesuit is not from the 1980s anyhow, so why should it be like that?

# Changelog
:cl: 
tweak: The NASA space suit has welding protection again
/:cl: