### PR TITLE
fully_heal() removes changeling succ BADDNA trait

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -607,8 +607,8 @@
 	stuttering = 0
 	slurring = 0
 	jitteriness = 0
-	if(HAS_TRAIT_FROM(target, TRAIT_BADDNA, CHANGELING_DRAIN))
-		REMOVE_TRAIT(target, TRAIT_BADDNA, CHANGELING_DRAIN)
+	if(HAS_TRAIT_FROM(src, TRAIT_BADDNA, CHANGELING_DRAIN))
+		REMOVE_TRAIT(src, TRAIT_BADDNA, CHANGELING_DRAIN)
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if (mood)
 		mood.remove_temp_moods(admin_revive)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -607,6 +607,8 @@
 	stuttering = 0
 	slurring = 0
 	jitteriness = 0
+	if(HAS_TRAIT_FROM(target, TRAIT_BADDNA, CHANGELING_DRAIN))
+		REMOVE_TRAIT(target, TRAIT_BADDNA, CHANGELING_DRAIN)
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if (mood)
 		mood.remove_temp_moods(admin_revive)


### PR DESCRIPTION
Calling revive with full heal will revive someone with BADDNA and remove the husk
if they proceed to die again they can be revived normally with a defib
However, they won't be cloneable and can't use dna injectors

:cl:  
tweak: Aheal removes changeling succ BADDNA trait
/:cl:
