### PR TITLE
Holy Light bible can no longer heal soulless bodies

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -444,6 +444,9 @@
 	if(!ishuman(L))
 		return FALSE
 	
+	if(!L.client)
+		return FALSE
+
 	if(!COOLDOWN_FINISHED(src, last_heal)) // immersion broken
 		user.visible_message(span_notice("The Holy Light has exhausted its power. It may heal again in [(COOLDOWN_TIMELEFT(src, last_heal))/10] seconds."))
 		return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Talked about this pre-merge but never pushed it

No more farming monkeys for favor

# Changelog

:cl:  
tweak: You can no longer heal soulless bodies with the Holy Light sect bible
/:cl:
