### PR TITLE
transcendent olfaction nerf

### DIFF
--- a/code/datums/mutations/olfaction.dm
+++ b/code/datums/mutations/olfaction.dm
@@ -35,7 +35,7 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	randomdir = FALSE
-	duration = 20 SECONDS
+	duration = 2 SECONDS
 	///we cannot use icon_state bc we are invisible, this is the same thing but can be not visible
 	var/image_state = "scent_trail"
 	///whomst doing the sniffing, we need this because the scent lines will only be visible to them

--- a/code/modules/antagonists/bloodsuckers/powers/olfaction.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/olfaction.dm
@@ -63,10 +63,10 @@
 		if(tracking_flags & TRACKING_SCENT)
 			scents |= samples.return_scents()
 	for(var/mob/living/carbon/C in GLOB.carbon_list)
-		if(IS_BLOODSUCKER(C)) // Bloodsuckers have no scent, and finding their lair with this during Sol would be OP
-			continue
 		if(blood_samples.Find(C.dna.unique_enzymes) && !possible.Find(C))
 			possible |= C
+		if(IS_BLOODSUCKER(C)) // Bloodsuckers have no scent, and finding their lair with this during Sol would be OP
+			continue
 		if(scents[md5(C.dna.uni_identity)] && !possible.Find(C))
 			var/datum/job/J = SSjob.GetJob(C.job)
 			if(!J)

--- a/code/modules/antagonists/bloodsuckers/powers/olfaction.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/olfaction.dm
@@ -63,6 +63,8 @@
 		if(tracking_flags & TRACKING_SCENT)
 			scents |= samples.return_scents()
 	for(var/mob/living/carbon/C in GLOB.carbon_list)
+		if(IS_BLOODSUCKER(C)) // Bloodsuckers have no scent, and finding their lair with this during Sol would be OP
+			continue
 		if(blood_samples.Find(C.dna.unique_enzymes) && !possible.Find(C))
 			possible |= C
 		if(scents[md5(C.dna.uni_identity)] && !possible.Find(C))
@@ -136,6 +138,8 @@
 		If these objects or items have been used by humanoid beings and still have their scent, you will see the option to track one of those scents.\n\
 		Selecting one of those scents will grant you a new ability to follow that scent. This will create a visible trail to follow to the owner of that scent.\n\
 		WARNING: it will be difficult to see around you while following a scent trail due to the the color being drained from all your vision except for the trail and your target."
+
+	cooldown = 60 SECONDS
 
 	follow = new /datum/action/bloodsucker/olfaction/follow_scent/lesser()
 
@@ -265,3 +269,5 @@
 	button_icon_state = "nose"
 
 	status_effect = STATUS_EFFECT_SCENT_HUNTER
+
+	cooldown = 60 SECONDS


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/28408322/219935930-19f3112e-7c43-4770-bc1d-83fca92b57e3.png)

Sanguine Olfaction unchanged

Transcendent Olfaction & Follow The Scent now has a 60 second cooldown

Smell lines now only last 2 seconds, leading you in the correct direction but not being able to track them down perfectly

Bloodsuckers can no longer be smelled

## Rationale

Transcendent Olfaction makes antag play agonizing. Antagonists, once caught or suspected by security, are forced to play this ring-around-the-rosie around the station while security perfectly tracks them 24/7. Once you're caught, it's effectively game over. Unless you murder everyone with the mutation and delete it from records, you WILL be caught. 

This makes re-entering stealth impossible, which is awfully unbalanced and an absolute migraine to play against.

Everything I just said is doubly true for bloodsuckers, who are meant to establish a **hidden** lair and use it as a safe-grounds. 

Unfortunately for them, once security catches the scent of anything the bloodsucker touched, the bloodsucker will never be able to hide again.

Once Sol inevitably comes around, the bloodsucker will either be busy fighting security due to being unable to flee and hide or they will run to their lair, cover up their tracks, and security will be led straight to their lair where they can pry open the coffin and kill them via Sol or wait out Sol and kill the bloodsucker who is now cornered.

# Changelog

:cl:  
tweak: Transcendent Olfaction now has a 60 second cooldown
tweak: Transcendent Olfaction now vanishes much faster
tweak: Transcendent Olfaction can no longer track bloodsuckers
/:cl:
