### PR TITLE
Adds a stasis bed and surgery duffel to Reebe

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -195,6 +195,11 @@
 	},
 /turf/closed/wall/clockwork,
 /area/reebe/city_of_cogs)
+"cj" = (
+/obj/structure/table/reinforced/brass,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
 "cC" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/kitchen/fork{
@@ -202,6 +207,12 @@
 	},
 /obj/item/kitchen/fork{
 	pixel_x = -4
+	},
+/turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"fi" = (
+/obj/machinery/stasis{
+	dir = 4
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
@@ -4589,7 +4600,7 @@ px
 aj
 aj
 aj
-Nw
+cj
 ah
 ah
 aH
@@ -4681,7 +4692,7 @@ aj
 aj
 aj
 aj
-Nw
+fi
 ah
 ai
 ag

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -212,7 +212,8 @@
 /area/reebe/city_of_cogs)
 "fi" = (
 /obj/machinery/stasis{
-	dir = 4
+	dir = 4;
+	color = "#FF8000"
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)


### PR DESCRIPTION
# Document the changes in your pull request

Useful for healing non-servants which was made very difficult after the removal of sleepers or extracting mindshields

The stasis bed is orange

![](https://i.imgur.com/Mem3iwT.png)

# Changelog

:cl:  
tweak: City of Cogs now has a surgical setup in the top right room
/:cl:
