### PR TITLE
Space-worthy helmets allow you to use internals without a mask

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -318,6 +318,7 @@
 	name = "Toggle Paddles"
 
 /datum/action/item_action/set_internals
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN | AB_CHECK_CONSCIOUS
 	name = "Set Internals"
 
 /datum/action/item_action/set_internals/UpdateButtonIcon(status_only = FALSE, force)
@@ -424,9 +425,11 @@
 	var/scripture_index = 0 //the index of the scripture we're associated with
 
 /datum/action/item_action/toggle_helmet_flashlight
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN | AB_CHECK_CONSCIOUS
 	name = "Toggle Helmet Flashlight"
 
 /datum/action/item_action/toggle_helmet_mode
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN | AB_CHECK_CONSCIOUS
 	name = "Toggle Helmet Mode"
 
 /datum/action/item_action/toggle
@@ -479,6 +482,7 @@
 	name = "Toggle Human Head"
 
 /datum/action/item_action/toggle_helmet
+	check_flags = AB_CHECK_RESTRAINED | AB_CHECK_STUN | AB_CHECK_CONSCIOUS
 	name = "Toggle Helmet"
 
 /datum/action/item_action/toggle_jetpack

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -32,7 +32,7 @@
 		H.internal = null
 		H.update_internals_hud_icon(0)
 	else
-		if(!H.getorganslot(ORGAN_SLOT_BREATHING_TUBE))
+		if(!(H.getorganslot(ORGAN_SLOT_BREATHING_TUBE) || (H.head && (H.head.clothing_flags & STOPSPRESSUREDAMAGE))))
 			if(!H.wear_mask)
 				to_chat(H, span_warning("You need a mask!"))
 				return
@@ -41,7 +41,6 @@
 			if(!(H.wear_mask.clothing_flags & MASKINTERNALS))
 				to_chat(H, span_warning("[H.wear_mask] can't use [src]!"))
 				return
-
 		if(H.internal)
 			to_chat(H, span_notice("You switch your internals to [src]."))
 		else

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -33,7 +33,6 @@
 		H.update_internals_hud_icon(0)
 	else
 		if(!H.update_internals())
-			//if(!(H.getorganslot(ORGAN_SLOT_BREATHING_TUBE) || (H.head && (H.head.clothing_flags & STOPSPRESSUREDAMAGE) && (H.head.flags_cover & HEADCOVERSMOUTH))))
 			if(!H.wear_mask)
 				to_chat(H, span_warning("You need a mask!"))
 				return

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -32,7 +32,8 @@
 		H.internal = null
 		H.update_internals_hud_icon(0)
 	else
-		if(!(H.getorganslot(ORGAN_SLOT_BREATHING_TUBE) || (H.head && (H.head.clothing_flags & STOPSPRESSUREDAMAGE))))
+		if(!H.update_internals())
+			//if(!(H.getorganslot(ORGAN_SLOT_BREATHING_TUBE) || (H.head && (H.head.clothing_flags & STOPSPRESSUREDAMAGE) && (H.head.flags_cover & HEADCOVERSMOUTH))))
 			if(!H.wear_mask)
 				to_chat(H, span_warning("You need a mask!"))
 				return

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
@@ -7,6 +7,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACE
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	armor = list(MELEE = 50, BULLET = 60, LASER = 0, ENERGY = 0, BOMB = 60, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 
 /obj/item/clothing/head/helmet/clockwork/Initialize()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -17,6 +17,19 @@
 		var/mob/living/carbon/human/H = loc
 		H.update_hair()
 
+/obj/item/clothing/head/equipped(mob/user, slot)
+	..()
+	if(slot != SLOT_HEAD)
+		var/mob/living/carbon/C = user
+		if(istype(C))
+			C.update_internals()
+
+/obj/item/clothing/head/dropped(mob/user)
+	..()
+	var/mob/living/carbon/C = user
+	if(istype(C))
+		C.update_internals()
+
 /obj/item/clothing/head/worn_overlays(isinhands = FALSE)
 	. = list()
 	if(!isinhands)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -107,6 +107,7 @@
 	desc = "A firefighter's helmet, able to keep the user cool in any situation."
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	cold_protection = HEAD

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -171,6 +171,7 @@
 			helmet.attack_self(H)
 		H.transferItemToLoc(helmet, src, TRUE)
 		H.update_inv_wear_suit()
+		H.update_internals()
 		to_chat(H, span_notice("The helmet on the hardsuit disengages."))
 		playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
 	else

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -883,7 +883,7 @@
 /mob/living/carbon/proc/update_internals()
 	if(getorganslot(ORGAN_SLOT_BREATHING_TUBE))
 		return TRUE
-	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal.loc && internal.loc = src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
+	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal.loc && internal.loc == src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
 		return TRUE
 	if(head && (head.clothing_flags & STOPSPRESSUREDAMAGE))
 		return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -263,8 +263,7 @@
 							span_userdanger("[usr] tries to [internal ? "close" : "open"] the valve on [src]'s [ITEM.name]."))
 			if(do_mob(usr, src, POCKET_STRIP_DELAY))
 				if(internal)
-					internal = null
-					update_internals_hud_icon(0)
+					update_internals()
 				else if(ITEM && istype(ITEM, /obj/item/tank))
 					if((wear_mask && (wear_mask.clothing_flags & MASKINTERNALS)) || getorganslot(ORGAN_SLOT_BREATHING_TUBE))
 						internal = ITEM
@@ -880,6 +879,18 @@
 				hud_used.healths.icon_state = "health6"
 		else
 			hud_used.healths.icon_state = "health7"
+
+/mob/living/carbon/proc/update_internals()
+	if(getorganslot(ORGAN_SLOT_BREATHING_TUBE))
+		return TRUE
+	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal.loc && internal.loc = src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
+		return TRUE
+	if(head && (head.clothing_flags & STOPSPRESSUREDAMAGE))
+		return TRUE
+	update_internals_hud_icon(0)
+	update_action_buttons_icon()
+	internal = null
+	return FALSE
 
 /mob/living/carbon/proc/update_internals_hud_icon(internal_state = 0)
 	if(hud_used && hud_used.internals)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -885,7 +885,7 @@
 		return TRUE
 	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal.loc && internal.loc == src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
 		return TRUE
-	if(head && (head.clothing_flags & STOPSPRESSUREDAMAGE))
+	if(head && (head.clothing_flags & STOPSPRESSUREDAMAGE) && (head.flags_cover & HEADCOVERSMOUTH))
 		return TRUE
 	update_internals_hud_icon(0)
 	update_action_buttons_icon()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -228,8 +228,7 @@
 	if((I.flags_inv & (HIDEHAIR|HIDEFACIALHAIR)) || (initial(I.flags_inv) & (HIDEHAIR|HIDEFACIALHAIR)))
 		update_hair()
 	if(toggle_off && internal && !getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-		update_internals_hud_icon(0)
-		internal = null
+		update_internals()
 	if(I.flags_inv & HIDEEYES)
 		update_inv_glasses()
 	sec_hud_set_security_status()
@@ -246,6 +245,7 @@
 		update_inv_glasses()
 	if(I.flags_inv & HIDEEARS || forced)
 		update_body()
+	update_internals()
 	sec_hud_set_security_status()
 	..()
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -327,7 +327,7 @@
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
 	if(internal)
-		if(update_internals(FALSE)) // returns TRUE if able to use internals, turns off internals and returns
+		if(update_internals()) // returns TRUE if able to use internals, turns off internals and returns
 			update_internals_hud_icon(1)
 			. = internal.remove_air_volume(volume_needed)
 			if(!.)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -327,13 +327,7 @@
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
 	if(internal)
-		if(internal.loc != src && !(wear_mask.clothing_flags & MASKEXTENDRANGE)) // If the mask has extended range, do not check for internal.loc
-			internal = null
-			update_internals_hud_icon(0)
-		else if ((!wear_mask || !(wear_mask.clothing_flags & MASKINTERNALS)) && !getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-			internal = null
-			update_internals_hud_icon(0)
-		else
+		if(update_internals(FALSE)) // returns TRUE if able to use internals, turns off internals and returns
 			update_internals_hud_icon(1)
 			. = internal.remove_air_volume(volume_needed)
 			if(!.)


### PR DESCRIPTION
# Document the changes in your pull request

Wearing a space-worthy helmet now allows you to use internals without a mask. Also lets you activate hardsuit helmets and internals tanks while lying down.

# Changelog

:cl:  
tweak: space-worthy helmets let you use internals without a mask
tweak: hardsuit helmets and internals can be toggled while lying down
/:cl:
