### PR TITLE
Robotic species now have flavoured examines

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1,3 +1,8 @@
+#define ORGANIC_BRUTE "bruising"
+#define ORGANIC_BURN "burns"
+#define ROBOTIC_BRUTE "denting"
+#define ROBOTIC_BURN "charring"
+
 /mob/living/carbon/human/examine(mob/user)
 //this is very slightly better than it was because you can use it more places. still can't do \his[src] though.
 	var/t_He = p_they(TRUE)
@@ -7,6 +12,9 @@
 	var/t_has = p_have()
 	var/t_is = p_are()
 	var/obscure_name
+	var/robotic = FALSE //robotic mobs look different under certain circumstances
+	if(MOB_ROBOTIC in mob_biotypes)//please someone tell me this is stupid and i can do it all in one line
+		robotic = TRUE
 
 	if(isliving(user))
 		var/mob/living/L = user
@@ -210,22 +218,22 @@
 	if(!(user == src && src.hal_screwyhud == SCREWYHUD_HEALTHY)) //fake healthy
 		if(temp)
 			if(temp < 25)
-				msg += "[t_He] [t_has] minor bruising.\n"
+				msg += "[t_He] [t_has] minor [robotic ? ROBOTIC_BRUTE : ORGANIC_BRUTE].\n"
 			else if(temp < 50)
-				msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
+				msg += "[t_He] [t_has] <b>moderate</b> [robotic ? ROBOTIC_BRUTE : ORGANIC_BRUTE]!\n"
 			else if(src.dna.species.id == "egg" && temp >= 200)
 				msg += "[t_He] look[p_s()] ready to crack into a million pieces!"
 			else
-				msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
+				msg += "<B>[t_He] [t_has] severe [robotic ? ROBOTIC_BRUTE : ORGANIC_BRUTE]!</B>\n"
 
 		temp = getFireLoss()
 		if(temp)
 			if(temp < 25)
-				msg += "[t_He] [t_has] minor burns.\n"
+				msg += "[t_He] [t_has] minor [robotic ? ROBOTIC_BURN : ORGANIC_BURN].\n"
 			else if (temp < 50)
-				msg += "[t_He] [t_has] <b>moderate</b> burns!\n"
+				msg += "[t_He] [t_has] <b>moderate</b> [robotic ? ROBOTIC_BURN : ORGANIC_BURN]!\n"
 			else
-				msg += "<B>[t_He] [t_has] severe burns!</B>\n"
+				msg += "<B>[t_He] [t_has] severe [robotic ? ROBOTIC_BURN : ORGANIC_BURN]!</B>\n"
 
 		temp = getCloneLoss()
 		if(temp)
@@ -617,3 +625,6 @@
 		. += span_warning("[msg.Join("")]")
 
 	. += "</span>"
+
+#undef ORGANIC_BRUTE
+#undef ROBOTIC_BRUTE

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -700,8 +700,22 @@
 
 	if(status == BODYPART_ROBOTIC)
 		disable_threshold = 1
+		light_brute_msg = "marred"
+		medium_brute_msg = "dented"
+		heavy_brute_msg = "falling apart"
+
+		light_burn_msg = "scorched"
+		medium_burn_msg = "charred"
+		heavy_burn_msg = "smoldering"
 	else
 		disable_threshold = 0
+		light_brute_msg = "bruised"
+		medium_brute_msg = "battered"
+		heavy_brute_msg = "mangled"
+
+		light_burn_msg = "numb"
+		medium_burn_msg = "blistered"
+		heavy_burn_msg = "peeling away"
 
 	if(change_icon_to_default)
 		if(status == BODYPART_ORGANIC)


### PR DESCRIPTION
Robotic species don't bruise and burn, but they do dent and char.
Should help with telling robotic and non-robotic species apart with just examines (i'm looking at you medbay lizards putting preterni in cryotubes)
Also changes bodypart damage text when using `change_bodypart_status()` all this affects is self examine, which people don't use

:cl:  
rscadd: Robotic species now have flavoured examines
/:cl:
