### PR TITLE
Makes APCs a bit more intuitive to repair

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -531,6 +531,15 @@
 			opened = APC_COVER_OPENED
 			update_icon()
 			return
+	else
+		W.play_tool_sound(src)
+		to_chat(user, span_notice("You attempt to pry off the broken cover..."))
+		if(W.use_tool(src, user, 3 SECONDS))
+			W.play_tool_sound(src)
+			to_chat(user, span_notice("You pry the broken cover off of [src]."))
+			opened = APC_COVER_REMOVED
+			update_icon()
+			return
 
 /obj/machinery/power/apc/screwdriver_act(mob/living/user, obj/item/W)
 	if(..())


### PR DESCRIPTION
# Document the changes in your pull request

You can now pry the broken cover off an APC with a crowbar, instead of having to break it more to fix it.

# Wiki Documentation

Mention that you can pry off broken APC covers on the guide to construction
https://wiki.yogstation.net/wiki/Guide_to_Construction

# Changelog

:cl:  
tweak: you can pry off broken APC covers with a crowbar now
/:cl:
