### PR TITLE
Bath salts nerf and psychotic brawling tweaks

### DIFF
--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -13,13 +13,15 @@
 
 /datum/martial_art/psychotic_brawling/proc/psycho_attack(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	var/atk_verb
+	var/stun_mult = A.reagents.has_reagent(/datum/reagent/drug/bath_salts) ? 10 : 1	//Multiply all the stun values by 10 if we get this from bath salts
+	var/armor_block = 0
 	switch(rand(1,8))
 		if(1)
 			D.help_shake_act(A)
 			atk_verb = "helped"
 		if(2)
 			A.emote("cry")
-			A.Stun(20)
+			A.Stun(20 * stun_mult)
 			atk_verb = "cried looking at"
 		if(3)
 			if(A.grab_state >= GRAB_AGGRESSIVE)
@@ -43,24 +45,27 @@
 			D.visible_message(span_danger("[A] [atk_verb] [D]!"), \
 					  span_userdanger("[A] [atk_verb] you!"))
 			playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, 1, -1)
-			var/headbutt_damage = rand(A.get_punchdamagehigh() - 5, A.get_punchdamagehigh()) //5-10 damage
-			D.apply_damage(headbutt_damage, A.dna.species.attack_type, BODY_ZONE_HEAD)
-			A.apply_damage(headbutt_damage, A.dna.species.attack_type, BODY_ZONE_HEAD)
+			var/headbutt_damage = rand(A.get_punchdamagehigh() + rand(-5,5))	//5-15 damage
+			armor_block = D.run_armor_check(BODY_ZONE_HEAD, MELEE, armour_penetration = 20)		//20 AP
+			var/user_armor_block = A.run_armor_check(BODY_ZONE_HEAD, MELEE, armour_penetration = 20)	//for fairness
+			D.apply_damage(headbutt_damage, A.dna.species.attack_type, BODY_ZONE_HEAD, armor_block)
+			A.apply_damage(headbutt_damage, A.dna.species.attack_type, BODY_ZONE_HEAD, user_armor_block)
 			if(!istype(D.head,/obj/item/clothing/head/helmet/) && !istype(D.head,/obj/item/clothing/head/hardhat))
 				D.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-			A.Stun(rand(10,45))
-			D.Stun(rand(5,30))
+			A.Stun(rand(10,45) * stun_mult)			//No I'm not making wearing helmets reduce this
+			D.Stun(rand(5,30) * armor_block / 100)	//But I will for the defender. This martial art is OSHA-approved.
 		if(5,6)
 			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 			atk_verb = pick("punches", "kicks", "hits", "slams into")
 			var/punch_damage = rand(A.get_punchdamagehigh() + 5 , 2 * A.get_punchdamagehigh() + 10)	//15-30 damage
+			armor_block = D.run_armor_check(BODY_ZONE_CHEST, MELEE, armour_penetration = 20)
 			D.visible_message(span_danger("[A] [atk_verb] [D] with inhuman strength, sending [D.p_them()] flying backwards!"), \
 							  span_userdanger("[A] [atk_verb] you with inhuman strength, sending you flying backwards!"))
-			D.apply_damage(punch_damage, A.dna.species.attack_type)
+			D.apply_damage(punch_damage, A.dna.species.attack_type, BODY_ZONE_CHEST, armor_block)
 			playsound(get_turf(D), 'sound/effects/meteorimpact.ogg', 25, 1, -1)
 			var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
 			D.throw_at(throwtarget, 4, 2, A)//So stuff gets tossed around at the same time.
-			D.Paralyze(60)
+			D.Paralyze(60 * armor_block / 100)
 		if(7,8)
 			basic_hit(A,D)
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -281,16 +281,22 @@
 
 /datum/reagent/drug/bath_salts/on_mob_metabolize(mob/living/L)
 	..()
-	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
+	
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	if(iscarbon(L))
-		var/mob/living/carbon/C = L
+		var/mob/living/carbon/human/H = L
 		rage = new()
-		C.gain_trauma(rage, TRAUMA_RESILIENCE_ABSOLUTE)
+		H.gain_trauma(rage, TRAUMA_RESILIENCE_ABSOLUTE)
+		H.physiology.stun_mod *= 0.1
+		H.physiology.stamina_mod *= 0.2
 
 /datum/reagent/drug/bath_salts/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
+
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.physiology.stun_mod *= 10	//Dividing by small numbers is scawy :(
+		H.physiology.stamina_mod *= 5
 	if(rage)
 		QDEL_NULL(rage)
 	..()


### PR DESCRIPTION
BATH SALTS:
No longer give complete stun immunity, just ALMOST complete (90%!) stun immunity. Complete stun immunity allows you to do all sorts of really stupid things and just ignore important game mechanics like not being able to take a rocket to the face and actually falling over when you slip. Also grants 80% stamina damage resistance. If you get stamcrit with this then you probably deserved it. Sleep immunity remains the same.

PSYCHOTIC BRAWLING:
Headbutt and slam now respect melee armor (with 20 AP, quit your whining). Also, melee armor reduces stun duration from the headbutt and slam for the defender. Headbutt also now has slightly increased damage range (5-15 instead of 5-10). The self-stuns now actually stun you like they're SUPPOSED TO.

:cl:  

tweak: Bath salts now give 90% stun resistance and 80% stamina resistance instead of absolute stun immunity
tweak: Psychotic brawling attacks now respects armor
tweak: Psychotic brawling headbutt damage range increased from (5-10) to (5-15) (baseline)
tweak: Psychotic brawling self-stuns now actually work
/:cl:
