### PR TITLE
Fix sinful demon spawn runtime and makes them able to spawn as more jobs

### DIFF
--- a/code/modules/events/sinfuldemon.dm
+++ b/code/modules/events/sinfuldemon.dm
@@ -11,6 +11,8 @@
 	minimum_required = 1
 	role_name = "demon of sin"
 	fakeable = FALSE
+	// LAME jobs that people typically do not care about
+	var/static/list/possible_jobs = list("Assistant", "Tourist", "Artist", "Clerk", "Lawyer")
 
 /datum/round_event/ghost_role/sinfuldemon/kill()
 	if(!success_spawn && control)
@@ -27,6 +29,27 @@
 	if(!candidates.len)
 		return NOT_ENOUGH_PLAYERS
 
+	// Select the job we spawn as
+	var/datum/job/selected_job
+	var/list/datum/job/potential_job_list = list()
+	var/list/datum/job/job_datum_list = list()
+	for(var/jobname in possible_jobs)
+		var/datum/job/job_datum = SSjob.GetJob(jobname)
+		if(!job_datum || !istype(job_datum))
+			continue
+		potential_job_list |= job_datum // Backup in case all jobs are somehow filled, just bypass job limits
+		if((job_datum.current_positions >= job_datum.total_positions) && job_datum.total_positions != -1)
+			continue
+		job_datum_list |= job_datum
+
+	if(!potential_job_list.len)
+		return "No valid possible_jobs"
+
+	if(!job_datum_list.len)
+		job_datum_list = potential_job_list
+
+	selected_job = pick(job_datum_list)
+
 	var/mob/dead/selected_candidate = pick_n_take(candidates)
 	var/key = selected_candidate.key
 
@@ -40,15 +63,18 @@
 	spawned_mobs += sinfuldemon
 	message_admins("[ADMIN_LOOKUPFLW(sinfuldemon)] has been made into a demon of sin by an event.")
 	log_game("[key_name(sinfuldemon)] was spawned as a demon of sin by an event.")
-	var/datum/job/jobdatum = SSjob.GetJob("Assistant")
+
 	if(SSshuttle.arrivals)
-		SSshuttle.arrivals.QueueAnnounce(sinfuldemon, jobdatum.title)
-	Mind.assigned_role = jobdatum.title //sets up the manifest properly
-	jobdatum.equip(sinfuldemon)
-	var/obj/item/card/id/id = sinfuldemon.get_item_by_slot(SLOT_WEAR_ID)
-	id.assignment = jobdatum.title
-	id.originalassignment = jobdatum.title
-	id.update_label()
+		SSshuttle.arrivals.QueueAnnounce(sinfuldemon, selected_job.title)
+	Mind.assigned_role = selected_job.title //sets up the manifest properly
+	selected_job.equip(sinfuldemon)
+
+	var/obj/item/card/id/id = sinfuldemon.get_idcard()
+	if(id && istype(id))
+		id.assignment = selected_job.title
+		id.originalassignment = selected_job.title
+		id.update_label()
+	
 	GLOB.data_core.manifest_inject(sinfuldemon, force = TRUE)
 	sinfuldemon.update_move_intent_slowdown() //prevents you from going super duper fast
 	return SUCCESSFUL_SPAWN


### PR DESCRIPTION
# Document the changes in your pull request

Sinful demons can now spawn as `"Assistant", "Tourist", "Artist", "Clerk", "Lawyer"` provided there are open slots for any of them

Also fixed a runtime that tried to call ID procs on the demon's PDA

# Changelog

:cl:  
tweak: Sinful Demons can now spawn as more jobs
/:cl:
