### PR TITLE
[Space Bar] More kitchen room and an oven

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -91,12 +91,23 @@
 /obj/machinery/jukebox,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"bw" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "co" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"ez" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "eC" = (
 /obj/effect/turf_decal/tile/bar{
@@ -108,6 +119,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"eD" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "eX" = (
 /obj/effect/turf_decal/tile/bar{
@@ -136,6 +154,13 @@
 "ff" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
+/area/ruin/space/has_grav/powered/spacebar)
+"fh" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = null;
+	req_access_txt = "25"
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "fy" = (
 /obj/structure/chair{
@@ -220,14 +245,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"hp" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "if" = (
 /obj/structure/urinal{
@@ -350,14 +367,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"mR" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null;
-	req_access_txt = "25"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
 "nf" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -403,14 +412,6 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"oX" = (
-/obj/structure/closet/secure_closet/freezer/fridge{
-	req_access = null;
-	req_access_txt = "25"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "pV" = (
 /obj/machinery/light{
@@ -537,6 +538,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/powered/spacebar)
+"uk" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man{
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "uD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -578,14 +590,6 @@
 /obj/item/clothing/suit/space/fragile,
 /obj/item/clothing/head/helmet/space/fragile,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/powered/spacebar)
-"vR" = (
-/obj/machinery/processor,
-/obj/effect/decal/cleanable/food/flour,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "wo" = (
 /obj/machinery/light{
@@ -673,6 +677,16 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
+"Bs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "BT" = (
 /obj/machinery/smartfridge/food,
 /turf/closed/wall,
@@ -690,6 +704,10 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"Cu" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "CP" = (
 /obj/effect/turf_decal/box/corners{
@@ -868,17 +886,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
-"IA" = (
-/obj/structure/closet/secure_closet/freezer/meat{
-	req_access = null;
-	req_access_txt = "25"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
 "IG" = (
 /obj/structure/sign/poster/contraband/eat{
 	pixel_y = 32
@@ -948,11 +955,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/powered/spacebar)
-"Mi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "Mk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1100,6 +1102,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/spacebar)
+"Qd" = (
+/obj/machinery/oven,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "Qz" = (
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
@@ -1137,6 +1143,14 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/spacebar)
+"SZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "Tw" = (
 /obj/structure/table/reinforced,
@@ -1200,6 +1214,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"VG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "VK" = (
 /obj/machinery/door/airlock/external{
 	name = "Teleporter"
@@ -1227,14 +1248,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/spacebar)
-"Wm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/ruin/space/has_grav/powered/spacebar)
 "WM" = (
 /obj/structure/closet,
 /obj/item/vending_refill/cigarette,
@@ -1260,6 +1273,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/spacebar)
+"XZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/mixbowl,
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/spacebar)
 "YH" = (
 /turf/template_noop,
 /area/template_noop)
@@ -1271,6 +1290,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/ruin/space/has_grav/powered/spacebar)
+"Zh" = (
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/food/flour,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/spacebar)
 "ZE" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1928,8 +1955,8 @@ YH
 YH
 ZN
 sM
-sM
-sM
+FB
+FB
 FB
 FB
 FB
@@ -1961,14 +1988,14 @@ YH
 YH
 YH
 sM
-sM
-sM
 FB
+bw
+Ow
+Zh
+FD
 go
 rp
-vR
-hp
-FD
+Qd
 FB
 sZ
 Qz
@@ -1994,10 +2021,10 @@ YH
 YH
 YH
 sM
-sM
-sM
 FB
 IG
+Ow
+Ow
 Ow
 Ow
 Ow
@@ -2026,15 +2053,15 @@ YH
 YH
 YH
 YH
-YH
-ZN
 oq
 ff
-Mi
-Wm
-IA
-mR
-oX
+VG
+Cu
+Cu
+SZ
+Bs
+XZ
+uk
 ff
 uD
 Rp
@@ -2060,10 +2087,10 @@ YH
 YH
 YH
 sM
-sM
-sM
 FB
-FB
+ez
+eD
+fh
 FB
 FB
 FB
@@ -2093,10 +2120,10 @@ YH
 YH
 YH
 ZN
-sM
-sM
-sM
-sM
+FB
+FB
+FB
+FB
 FB
 lS
 zE


### PR DESCRIPTION
# Document the changes in your pull request

Adds some more room in the kitchen for the bartender to work if they're making lots of food. Couple more tables to work on. Moved the fridges to be more out of the way at the rear of the kitchen.
Added an oven so bartender can make bread, buns, pizza, and other bar food staples.

![image](https://user-images.githubusercontent.com/70451213/220332200-78e7fe93-8bf9-486d-a990-3180a5d3f0f6.png)

# Changelog

:cl:  
mapping: Expanded Space Bar kitchen
mapping: Gives space bar kitchen an oven
/:cl:
