### PR TITLE
Nitryl's reagent addition is now capped like every other positive atmos gas

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -286,6 +286,7 @@
 			H.adjustFireLoss(nitryl_pp/4)
 		gas_breathed = breath.get_moles(/datum/gas/nitryl)
 		if (gas_breathed > gas_stimulation_min)
+			var/existing = H.reagents.get_reagent_amount(/datum/reagent/nitryl)
 			H.reagents.add_reagent(/datum/reagent/nitryl,max(0, 1*eff - existing))
 
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -286,7 +286,7 @@
 			H.adjustFireLoss(nitryl_pp/4)
 		gas_breathed = breath.get_moles(/datum/gas/nitryl)
 		if (gas_breathed > gas_stimulation_min)
-			H.reagents.add_reagent(/datum/reagent/nitryl,1*eff)
+			H.reagents.add_reagent(/datum/reagent/nitryl,max(0, 1*eff - existing))
 
 		breath.adjust_moles(/datum/gas/nitryl, -gas_breathed)
 


### PR DESCRIPTION
# Document the changes in your pull request

Prevents gimmicky bullshit allowing a buildup of the completely harmless nitryl reagent


# Changelog


:cl:  
tweak: nitryl's reagent now has a cap when being added by the gas, similarly to healium and stimulum
/:cl:
