### PR TITLE
Enables donator communism (No more ckey-locked donator items/skins)

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -432,3 +432,5 @@
 
 /datum/config_entry/number/max_shuttle_size
 	config_entry_value = 250
+
+/datum/config_entry/flag/ckey_locked_donator_items

--- a/code/modules/client/preferences/donor.dm
+++ b/code/modules/client/preferences/donor.dm
@@ -24,14 +24,15 @@
 
 	var/list/key_locked = list()
 
-	for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
-		if(S.slot != SLOT_HEAD && !S.plush)
-			continue
+	if(CONFIG_GET(flag/ckey_locked_donator_items))
+		for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
+			if(S.slot != SLOT_HEAD && !S.plush)
+				continue
 
-		if (!S.ckey)
-			continue
+			if (!S.ckey)
+				continue
 
-		key_locked[S.name] = lowertext(S.ckey)
+			key_locked[S.name] = lowertext(S.ckey)
 
 	data[CHOICED_PREFERENCE_KEY_LOCKED] = key_locked
 
@@ -64,14 +65,15 @@
 
 	var/list/key_locked = list()
 
-	for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
-		if(S.slot == SLOT_HEAD)
-			continue
+	if(CONFIG_GET(flag/ckey_locked_donator_items))
+		for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
+			if(S.slot == SLOT_HEAD)
+				continue
 
-		if (!S.ckey)
-			continue
+			if (!S.ckey)
+				continue
 
-		key_locked[S.name] = lowertext(S.ckey)
+			key_locked[S.name] = lowertext(S.ckey)
 
 	data[CHOICED_PREFERENCE_KEY_LOCKED] = key_locked
 
@@ -102,17 +104,18 @@
 
 	var/list/key_locked = list()
 
-	for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
-		if(S.slot == SLOT_HEAD)
-			continue
+	if(CONFIG_GET(flag/ckey_locked_donator_items))
+		for(var/datum/donator_gear/S as anything in GLOB.donator_gear.donor_items)
+			if(S.slot == SLOT_HEAD)
+				continue
 
-		if(!S.plush)
-			continue
+			if(!S.plush)
+				continue
 
-		if (!S.ckey)
-			continue
+			if (!S.ckey)
+				continue
 
-		key_locked[S.name] = lowertext(S.ckey)
+			key_locked[S.name] = lowertext(S.ckey)
 
 	data[CHOICED_PREFERENCE_KEY_LOCKED] = key_locked
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -288,7 +288,7 @@
 
 	if(is_donator(client))
 		for(var/datum/ai_skin/S in GLOB.DonorBorgHolder.skins)
-			if(S.owner == client.ckey || !S.owner) //We own this skin.
+			if(S.owner == client.ckey || !S.owner || !CONFIG_GET(flag/ckey_locked_donator_items)) //We own this skin.
 				iconstates[S] = image(icon = S.icon, icon_state = S.icon_state)
 
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -452,3 +452,5 @@ MAX_SHUTTLE_SIZE 300
 ## Enable/disable roundstart station traits
 #STATION_TRAITS
 
+## Enable ckey-locked donator items (Donator items/skins can be locked to only be used by specified ckeys)
+#CKEY_LOCKED_DONATOR_ITEMS

--- a/yogstation/code/modules/mob/living/silicon/robot/robot.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot.dm
@@ -15,7 +15,7 @@
 		for(var/T in GLOB.DonorBorgHolder.skins)
 			if(istype(T, /datum/borg_skin))
 				var/datum/borg_skin/S = T
-				if(S.owner == client.ckey || !S.owner) //We own this skin.
+				if(S.owner == client.ckey || !S.owner || !CONFIG_GET(flag/ckey_locked_donator_items)) //We own this skin.
 					if(!S.module_locked || S.module_locked == module.name)
 						skins[S] = image(icon = S.icon, icon_state = S.icon_state) //So add it to the temp list which we'll iterate through
 		var/datum/borg_skin/A //Defining A as a borg_skin datum so we can pick out the vars we want and reskin the unit


### PR DESCRIPTION
# Document the changes in your pull request

Makes a config option to enable ckey-locked donator items/skins- and disables it

# Changelog

:cl:  
tweak: All donators now have universal access to previously ckey-locked donator items
/:cl:
