### PR TITLE
removes the dumb greentext bonus

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -142,7 +142,7 @@
 	min_val = 0
 
 /datum/config_entry/number/escaped_alive_bonus
-	config_entry_value = 2
+	config_entry_value = 1.5
 	integer = FALSE
 	min_val = 1
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -301,7 +301,7 @@ DEFAULT_ANTAG_TICKETS 100
 MAX_TICKETS_PER_ROLL 100
 
 ## The antag-rep multiplier bonus for escaping alive on Central Command at the end of a round
-ESCAPED_ALIVE_BONUS 2
+ESCAPED_ALIVE_BONUS 1.5
 
 ## The antag-rep multiplier bonus for being alive (and not escaping to CC) at the end of a round
 STAYED_ALIVE_BONUS 1.5


### PR DESCRIPTION
this change encouraged people to either sweat their ass off or do absolutely nothing if there's a risk to them both of which are terrible for the game, as well as punishing martyr players for simply existing

# Changelog

:cl:  
tweak: the dumb greentext antag rep bonus is gone
/:cl:
