### PR TITLE
Explosives at a cheap price: Frag grenades for 3TC

### DIFF
--- a/code/game/objects/items/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/grenades/syndieminibomb.dm
@@ -18,7 +18,7 @@
 
 /obj/item/grenade/syndieminibomb/concussion/prime()
 	update_mob()
-	explosion(src.loc,0,2,3,flame_range = 3)
+	explosion(src.loc,0,2,4,flame_range = 3)
 	qdel(src)
 
 /obj/item/grenade/syndieminibomb/concussion/frag

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1254,12 +1254,20 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/explosives/frag_grenade
+	name = "Frag Grenade"
+	desc = "Simple, but lethal. Anything adjacent when it explodes will be heavily damaged. Likely to cause a small hull breach."
+	item = /obj/item/grenade/syndieminibomb/concussion/frag
+	cost = 3
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/explosives/syndicate_minibomb
 	name = "Syndicate Minibomb"
 	desc = "The minibomb is a grenade with a five-second fuse. Upon detonation, it will create a small hull breach \
 			in addition to dealing high amounts of damage to nearby personnel."
 	item = /obj/item/grenade/syndieminibomb
 	cost = 6
+	include_modes = list(/datum/game_mode/nuclear)
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 
 /datum/uplink_item/explosives/tearstache


### PR DESCRIPTION
# Document the changes in your pull request

Satisfactory

#

For a very long time I have wanted minibombs to be cheaper, but I was always told that they were set to a high price because people could use them to gib people. WHat? Who uses minibombs like that? 6TC for a gibber? Why wouldn't I just do something FUN with that 6TC instead?

So here is the compromise. Frag grenades are here to replace minibombs at half the price. The difference? No gibbing.

**Frag grenades are identical to minibombs, but have 1 extra range of flames and no devastation range.**

(Frag grenades previously had one less light range but in my opinion the explosion seemed piss small without it so they were bumped up one to match minibombs)

# Changelog

:cl:  
tweak: Frag Grenades are now in the traitor uplink for 3TC which are minibombs but without gibbing
tweak: Syndicate Minibombs are now nukie-locked
/:cl:
