### PR TITLE
Improves Lizard and Polysmorph lisp

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -100,8 +100,8 @@
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_ecks.Replace(message, "cksss")
-		message = lizard_eckS.Replace(message, "CKSSS")
+		message = lizard_ecks.Replace(message, "ksss")
+		message = lizard_eckS.Replace(message, "KSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -314,8 +314,8 @@
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")
 		message = polysmorph_hiSS.Replace(message, "SSSSSS")
-		message = polysmorph_ecks.Replace(message, "ckssssss")
-		message = polysmorph_eckS.Replace(message, "CKSSSSSS")
+		message = polysmorph_ecks.Replace(message, "kssssss")
+		message = polysmorph_eckS.Replace(message, "KSSSSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/polysmorph/Initialize(mapload)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,14 +94,14 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
-	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
+	var/static/regex/lizard_ecks = new("x+", "g")
+	var/static/regex/lizard_eckS = new("X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_ecks.Replace(message, "ecks$1")
-		message = lizard_eckS.Replace(message, "ECKS$1")
+		message = lizard_ecks.Replace(message, "ecksss")
+		message = lizard_eckS.Replace(message, "ECKSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -308,14 +308,14 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
-	var/static/regex/polysmorph_ecks = new(@"\bx([\-|r|R]|\b)", "g")
-	var/static/regex/polysmorph_eckS = new(@"\bX([\-|r|R]|\b)", "g")
+	var/static/regex/polysmorph_ecks = new("x+", "g")
+	var/static/regex/polysmorph_eckS = new("X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")
 		message = polysmorph_hiSS.Replace(message, "SSSSSS")
-		message = polysmorph_ecks.Replace(message, "ecks$1")
-		message = polysmorph_eckS.Replace(message, "ECKS$1")
+		message = polysmorph_ecks.Replace(message, "eckssssss")
+		message = polysmorph_eckS.Replace(message, "ECKSSSSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/polysmorph/Initialize(mapload)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -100,8 +100,8 @@
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_ecks.Replace(message, "ecksss")
-		message = lizard_eckS.Replace(message, "ECKSSS")
+		message = lizard_ecks.Replace(message, "cksss")
+		message = lizard_eckS.Replace(message, "CKSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -314,8 +314,8 @@
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")
 		message = polysmorph_hiSS.Replace(message, "SSSSSS")
-		message = polysmorph_ecks.Replace(message, "eckssssss")
-		message = polysmorph_eckS.Replace(message, "ECKSSSSSS")
+		message = polysmorph_ecks.Replace(message, "ckssssss")
+		message = polysmorph_eckS.Replace(message, "CKSSSSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/polysmorph/Initialize(mapload)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,10 +94,14 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
+	var/static/regex/lizard_ecks = new(@"\bx([\-|r|R]|\b)", "g")
+	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
+		message = lizard_ecks.Replace(message, "ecks$1")
+		message = lizard_eckS.Replace(message, "ECKS$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -304,10 +308,14 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
+	var/static/regex/polysmorph_ecks = new(@"\bx([\-|r|R]|\b)", "g")
+	var/static/regex/polysmorph_eckS = new(@"\bX([\-|r|R]|\b)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")
 		message = polysmorph_hiSS.Replace(message, "SSSSSS")
+		message = polysmorph_ecks.Replace(message, "ecks$1")
+		message = polysmorph_eckS.Replace(message, "ECKS$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/polysmorph/Initialize(mapload)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->
Added some things to the Lizard and Polysmorph hiss. They would now have their X's affected by their lisp. Some other servers already have something like this so I thought it would be a nice little detail to have here. It also makes sense because S and X have similar pronunciation in the english language at least. 


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Lizardpeople and Polysmorphs pronounce the letter 'x' as 'ksss' and 'kssssss' respectively
/:cl:
