### PR TITLE
Gax SM Update

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -4028,6 +4028,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "bXn" = (
@@ -12802,9 +12805,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ggE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -15644,6 +15644,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"hAJ" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hBa" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -26465,6 +26469,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "neX" = (
@@ -33045,11 +33050,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -41865,6 +41870,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uWk" = (
@@ -68800,7 +68806,7 @@ qxw
 crb
 nkd
 teI
-uRB
+hAJ
 pzD
 rYc
 oIA
@@ -69045,7 +69051,7 @@ jjH
 lFk
 onQ
 eIR
-uRB
+hAJ
 aJZ
 tzQ
 fQa
@@ -69572,7 +69578,7 @@ uqi
 tLT
 qSJ
 uRB
-uRB
+hAJ
 iRc
 tvD
 xTt
@@ -70856,7 +70862,7 @@ jEp
 vov
 vov
 ail
-uRB
+hAJ
 iKZ
 mwk
 sSU

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -242,9 +242,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aej" = (
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+	dir = 10
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -897,7 +897,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aua" = (
 /obj/machinery/holopad,
@@ -1892,9 +1896,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aUe" = (
@@ -2388,15 +2389,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bfZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "bgd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2989,9 +2981,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bvH" = (
@@ -3159,6 +3149,12 @@
 /obj/machinery/seed_extractor,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"bBo" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bBt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4028,6 +4024,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -5606,7 +5605,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/structure/closet/radiation,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cLq" = (
@@ -6148,13 +6149,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/port/aft)
-"cZC" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "cZF" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -6433,13 +6427,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/carpet,
 /area/library)
-"dgS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dhw" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -7514,8 +7501,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -8060,13 +8047,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"eaW" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -9352,7 +9332,9 @@
 	pixel_y = -23;
 	req_access_txt = "11"
 	},
-/obj/structure/closet/radiation,
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "eCE" = (
@@ -10578,9 +10560,10 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "ffr" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/power/emitter/anchored{
+	state = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ffv" = (
@@ -12822,8 +12805,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/chair/office/light{
+/obj/machinery/power/terminal{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -15658,6 +15644,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"hBa" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hBz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -15798,13 +15796,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hER" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
+/obj/structure/girder,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "hFy" = (
@@ -17730,8 +17725,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
 "iLz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Output to Waste"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -18211,10 +18207,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "jai" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "jam" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
@@ -18856,6 +18853,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"jtS" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 1;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jun" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -19922,13 +19929,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"jUU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "jUV" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
 	dir = 6
@@ -20390,10 +20390,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "kjc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cooling Loop to Gas"
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kjq" = (
@@ -21033,11 +21033,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "kBk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -21278,9 +21282,13 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
+	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 6;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -21702,13 +21710,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kRf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kRi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
@@ -21924,6 +21925,15 @@
 "kYl" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
+"kYn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23127,8 +23137,14 @@
 	name = "Engineering External Access";
 	req_access_txt = "10;13"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -23158,7 +23174,7 @@
 "lzf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -23710,13 +23726,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"lNK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lNO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -24159,7 +24168,7 @@
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -26102,6 +26111,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mTX" = (
@@ -26129,13 +26141,13 @@
 /area/crew_quarters/heads/hop)
 "mUh" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Gas to Cooling Loop"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "mUA" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
@@ -26214,14 +26226,18 @@
 /turf/open/floor/carpet,
 /area/library)
 "mWl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Output Release"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mWF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/chair/office/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -26443,23 +26459,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/power/smes/engineering{
-	output_attempt = 0
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -26519,12 +26523,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ngR" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ngZ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -26617,9 +26615,6 @@
 "njs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "njv" = (
@@ -26753,6 +26748,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nnn" = (
@@ -26768,20 +26766,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "nom" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "nou" = (
 /obj/effect/turf_decal/plaque{
@@ -27381,11 +27372,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "nBw" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/meter,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "nBB" = (
 /obj/effect/landmark/xeno_spawn,
@@ -27874,12 +27865,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nMW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer2,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -28341,13 +28341,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"oaJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oaM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -30936,10 +30929,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "pzp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pzt" = (
@@ -31136,7 +31130,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pCu" = (
-/obj/structure/closet/radiation,
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/item/pipe_dispenser,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pCv" = (
@@ -32206,13 +32203,10 @@
 /area/maintenance/starboard/fore)
 "qcX" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "qdi" = (
 /obj/structure/chair/comfy/black{
@@ -32894,6 +32888,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "quC" = (
@@ -33014,6 +33009,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qxw" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qxA" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
@@ -33038,6 +33047,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -33249,6 +33261,12 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qGQ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qHC" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -34858,8 +34876,8 @@
 /area/maintenance/disposal/incinerator)
 "rtX" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -35245,11 +35263,11 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "rEq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -35598,6 +35616,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "rNc" = (
@@ -35913,14 +35935,12 @@
 /turf/open/floor/wood,
 /area/library)
 "rWc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/space/basic,
+/area/space/nearstation)
 "rWi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -36427,6 +36447,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"slR" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "smm" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs"
@@ -36751,6 +36777,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -37195,6 +37224,9 @@
 /area/engine/atmos)
 "sBy" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "sBE" = (
@@ -37378,9 +37410,9 @@
 /area/engine/atmos_distro)
 "sHi" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/structure/girder,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "sHD" = (
@@ -37971,11 +38003,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sVW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sWa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -38674,7 +38707,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tpA" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "tpB" = (
@@ -39273,11 +39308,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -40260,8 +40295,12 @@
 /area/hallway/primary/starboard)
 "ugy" = (
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ugA" = (
@@ -41682,6 +41721,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"uSr" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uSv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -41813,8 +41859,12 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "uWi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uWk" = (
@@ -42690,6 +42740,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vsH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vsK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -43002,10 +43061,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "vAZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 1
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "vBd" = (
@@ -43033,11 +43092,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "vBx" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
+/obj/machinery/meter,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "vBz" = (
 /obj/machinery/computer/arcade,
@@ -43483,10 +43542,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "vNb" = (
-/obj/machinery/power/emitter/anchored{
-	state = 2
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "vNq" = (
@@ -43971,6 +44033,13 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"waI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "waJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -44598,11 +44667,12 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "wqE" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44980,11 +45050,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "wDL" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/turf/open/space/basic,
+/area/space/nearstation)
 "wEc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45935,6 +46006,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"xaN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "xaO" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/machinery/camera{
@@ -47936,12 +48014,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "xXU" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 6;
-	pixel_y = 8
+/obj/machinery/power/smes/engineering{
+	output_attempt = 0
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "xYi" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -65111,11 +65191,11 @@ tkl
 ubS
 tkl
 tkl
-oaJ
-vAZ
-vAZ
-vAZ
-pzp
+aCD
+aCD
+aCD
+aCD
+aCD
 aCD
 aCD
 tkl
@@ -65367,13 +65447,13 @@ aCD
 tkl
 ubS
 tkl
-oaJ
-kRf
-oaJ
+aCD
 vAZ
+waI
 vAZ
-kRf
-tkl
+waI
+vAZ
+waI
 aCD
 tkl
 uGF
@@ -65624,13 +65704,13 @@ vRP
 tkl
 aCD
 tkl
-eaW
-oaJ
-dgS
-oaJ
 vAZ
 pzp
-tkl
+pzp
+pzp
+pzp
+pzp
+xaN
 aCD
 tkl
 uGF
@@ -65881,13 +65961,13 @@ vRP
 tkl
 aCD
 tkl
-eaW
-lNK
-jUU
-kRf
-cZC
-kRf
-tkl
+aej
+pzp
+pzp
+pzp
+pzp
+pzp
+waI
 aCD
 tkl
 uGF
@@ -66136,15 +66216,15 @@ vRP
 vRP
 vRP
 tkl
-ubS
-tkl
-eaW
-oaJ
-jUU
-vAZ
-dgS
 aCD
 tkl
+vAZ
+pzp
+pzp
+pzp
+pzp
+pzp
+xaN
 aCD
 tkl
 orF
@@ -66393,15 +66473,15 @@ vRP
 vRP
 vRP
 tkl
-ubS
+aCD
 tkl
-eaW
-lNK
-jUU
-vAZ
-jUU
+sVW
 pzp
-tkl
+pzp
+pzp
+pzp
+pzp
+waI
 aCD
 tkl
 nti
@@ -66653,12 +66733,12 @@ tkl
 tkl
 tkl
 lzf
-tkl
-tkl
-oaJ
-jUU
-kRf
-tkl
+pzp
+pzp
+pzp
+pzp
+pzp
+xaN
 aCD
 tkl
 orF
@@ -66907,15 +66987,15 @@ ozS
 eFb
 aCD
 eFb
+kBk
 eFb
-lyq
 wDL
-eFb
-tkl
-lNK
+wqE
 aej
+xaN
+aej
+xaN
 aCD
-tkl
 aCD
 tkl
 aCD
@@ -67165,12 +67245,12 @@ eFb
 xVi
 eFb
 nMW
-kBk
-rWc
 eFb
+rWc
+rWc
 tkl
 tkl
-lzf
+tkl
 tkl
 tkl
 tkl
@@ -67421,13 +67501,13 @@ rrj
 tkz
 qaX
 eFb
+lyq
 eFb
-nom
+jai
 jai
 eFb
 eFb
 eFb
-wDL
 biG
 eFb
 biG
@@ -67678,21 +67758,21 @@ rbT
 yek
 mPB
 eFb
-pCu
 kQd
-ngR
+uRB
+nBw
 nBw
 sHi
-vNb
+hER
 ffr
 azX
 kjG
 hKH
-wYp
+jtS
 hER
-sHi
-vBx
-mWl
+uSr
+uRB
+qGQ
 rtX
 bPu
 knf
@@ -67935,21 +68015,21 @@ kTS
 ooF
 xoT
 bUw
-kIc
+nom
 uWi
 kjc
 mUh
 vNb
-wYp
 ffr
+wYp
 azX
 kjG
 hKH
 wYp
-wYp
+slR
 ugy
 qcX
-mWl
+kYn
 iLz
 bPu
 jjX
@@ -68194,20 +68274,20 @@ fhj
 eFb
 nmK
 kQd
-ngR
+vBx
 atR
-bfZ
+eFb
 tpA
-wqE
+brd
 deH
 soS
 wcb
 brd
-brd
 mPB
-atR
-mWl
-iLz
+eFb
+lZu
+vsH
+bBo
 cLo
 pCu
 eFb
@@ -68708,7 +68788,7 @@ yaL
 kLw
 onQ
 iSd
-sVW
+uRB
 lVD
 lLV
 jho
@@ -68716,7 +68796,7 @@ gRH
 xjL
 wvP
 jUF
-gRH
+qxw
 crb
 nkd
 teI
@@ -70248,12 +70328,12 @@ pyH
 bmk
 jDg
 xXU
-pyH
+sBy
 neP
 lZu
 xLG
 bbS
-bbS
+hBa
 fQa
 uRb
 tQK
@@ -70505,7 +70585,7 @@ pyH
 ocj
 qUn
 ggE
-sBy
+pyH
 tIL
 lZu
 uIk


### PR DESCRIPTION
# Changes
Makes Gax sm more in line with box sm:

−Output to loop overhauled
![image](https://user-images.githubusercontent.com/64857565/220892283-8cd707bf-3b51-4532-b411-f099f46844ca.png)

−Added fire-safety closet and engineering closet in the chamber −Anchored all the closets to avoid equipment flying around
![image](https://user-images.githubusercontent.com/64857565/220892406-4f269e02-9421-4c08-9617-680e641d9fc8.png)

−Added fire alarms
![image](https://user-images.githubusercontent.com/64857565/220892559-77f2831b-2b16-4794-9da9-71737cfbcfac.png)

−Moved the emitter smes from main chamber to smes room
![image](https://user-images.githubusercontent.com/64857565/220892637-21b7fdff-19bb-4bb7-baff-4c1ffa83f3ac.png)

−Added another fire extinguisher
![image](https://user-images.githubusercontent.com/64857565/220892690-6fdc0958-96a2-4331-99ec-d352fcd3d986.png)

−Changed emitter wiring
−Added output to waste valve
![image](https://user-images.githubusercontent.com/64857565/220892492-724e4fd6-3f94-457b-9e12-70027a1bc8c2.png)

The space loop is experimental.
Its technically more space efficient and prettier but people may get confused by the novelty.
![image](https://user-images.githubusercontent.com/64857565/220893130-e5931338-af40-4ca4-af76-19828a11ce3f.png)

Globaly:
![image](https://user-images.githubusercontent.com/64857565/220893248-e34d3129-5274-459a-b3c3-d263dad74e40.png)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: makes gax sm more similar to box sm by fixing and adding a few things.
/:cl:
