### PR TITLE
Fixes Ultra Violence dash not working correctly while flying

### DIFF
--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -235,8 +235,7 @@
 	else
 		playsound(H, 'sound/effects/dodge.ogg', 50)
 		dash_timer = addtimer(CALLBACK(src, .proc/regen_dash, H), 4 SECONDS, TIMER_LOOP|TIMER_UNIQUE|TIMER_STOPPABLE)//start regen
-		REMOVE_TRAIT(H, TRAIT_STUNIMMUNE, "martial") //can't immobilize if has stun immune, technically means they can be stunned mid-dash
-		H.Immobilize(30 SECONDS) //to prevent cancelling the dash
+		H.Immobilize(30 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the dash
 		dashing = TRUE
 		H.throw_at(A, MAX_DASH_DIST, 1.5, H, FALSE, TRUE, callback = CALLBACK(src, .proc/dash_end, H))
 		dashes -= 1
@@ -244,8 +243,7 @@
 
 /datum/martial_art/ultra_violence/proc/dash_end(mob/living/carbon/human/H)
 	dashing = FALSE
-	H.SetImmobilized(0 SECONDS)
-	ADD_TRAIT(H, TRAIT_STUNIMMUNE, "martial")
+	H.SetImmobilized(0 SECONDS, ignore_canstun = TRUE)
 
 /datum/martial_art/ultra_violence/handle_throw(atom/hit_atom, mob/living/carbon/human/A)
 	if(!dashing)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2125,11 +2125,13 @@ GLOBAL_LIST_EMPTY(features_by_species)
 ////////////
 
 /datum/species/proc/spec_stun(mob/living/carbon/human/H,amount)
-	if(flying_species && H.movement_type & FLYING)
-		ToggleFlight(H)
-		flyslip(H)
-	. = stunmod * H.physiology.stun_mod * amount
-	stop_wagging_tail(H)
+	if(!HAS_TRAIT(H, TRAIT_STUNIMMUNE))
+		if(flying_species && H.movement_type & FLYING)
+			ToggleFlight(H)
+			flyslip(H)
+		stop_wagging_tail(H)
+	return stunmod * H.physiology.stun_mod * amount
+	
 
 //////////////
 //Space Move//


### PR DESCRIPTION
# Document the changes in your pull request

Fixes an issue where the ultra violence dash would make you slip in a random direction if you used it while flying

# Changelog

:cl:  
bugfix: fixes ultra violence dash not working correctly while flying
/:cl:
