### PR TITLE
Creates Psychiatrist's Locker

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -31324,6 +31324,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"jEj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "jEp" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -56917,26 +56924,6 @@
 "ses" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"sey" = (
-/obj/structure/table/wood,
-/obj/item/assembly/flash{
-	pixel_x = -1;
-	pixel_y = 10
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/assembly/flash{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "seA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -60478,6 +60465,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/physician)
+"tpx" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "tpJ" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -69323,28 +69326,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"wxa" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "wxb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -107343,7 +107324,7 @@ xVJ
 uut
 aVN
 kME
-sey
+tpx
 jOO
 ukc
 aVN
@@ -107859,7 +107840,7 @@ aVN
 cmB
 qDC
 kAU
-wxa
+jEj
 aVN
 mNt
 oQP

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -17505,6 +17505,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"cQo" = (
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/laser_pointer{
+	pixel_y = 9
+	},
+/obj/structure/table/wood,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "cQr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -66009,24 +66024,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wFq" = (
-/obj/item/assembly/flash{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/obj/item/laser_pointer{
-	pixel_y = 9
-	},
-/obj/item/assembly/flash{
-	pixel_x = 7
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/medical/psych)
 "wFr" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -67456,6 +67453,13 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xou" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/psych,
+/turf/open/floor/wood,
+/area/medical/psych)
 "xoz" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner{
@@ -68249,27 +68253,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"xFh" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "xFp" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/disposalpipe/segment,
@@ -108325,7 +108308,7 @@ jaT
 vbD
 vFJ
 jdO
-wFq
+cQo
 hpd
 hjl
 jxu
@@ -108582,7 +108565,7 @@ jdO
 jdO
 jdO
 jdO
-xFh
+xou
 fyq
 vRr
 jxu

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -53039,6 +53039,36 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos_distro)
+"fDL" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 5
+	},
+/obj/item/lighter{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/laser_pointer{
+	pixel_x = 4;
+	pixel_y = -10
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "fEQ" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -58366,6 +58396,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"jng" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/psych,
+/turf/open/floor/wood,
+/area/medical/psych)
 "jnh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -66348,38 +66385,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"okv" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = 5
-	},
-/obj/item/lighter{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/obj/item/flashlight/pen{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/laser_pointer{
-	pixel_x = 4;
-	pixel_y = -10
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "okH" = (
 /obj/machinery/camera{
 	c_tag = "Interrogation room";
@@ -78612,27 +78617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"wdP" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "wel" = (
 /obj/item/cigbutt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -106541,8 +106525,8 @@ bPc
 auQ
 gLq
 vyf
-okv
-wdP
+fDL
+jng
 mWz
 bUs
 cLa

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -184,18 +184,18 @@
 
 /obj/structure/closet/secure_closet/psych
 	name = "psychiatrist's cabinet"
-	desc = "packed with a psychiastrist's tools of the trade"
+	desc = "Packed with a psychiastrist's tools of the trade"
 	req_access = list(ACCESS_PSYCH)
 	icon_state = "cabinet"
 
 /obj/structure/closet/secure_closet/psych/PopulateContents()
 	..()
-	new /obj/item/clothing/suit/straight_jacket
-	new /obj/item/clothing/mask/muzzle
-	new /obj/item/storage/pill_bottle/happiness
-	new /obj/item/storage/pill_bottle/dice
-	new /obj/item/storage/pill_bottle/happy
-	new /obj/item/storage/pill_bottle/lsd
-	new /obj/item/storage/pill_bottle/psicodine
-	new /obj/item/assembly/flash
-	new /obj/item/assembly/flash
+	new /obj/item/clothing/suit/straight_jacket(src)
+	new /obj/item/clothing/mask/muzzle(src)
+	new /obj/item/storage/pill_bottle/happiness(src)
+	new /obj/item/storage/pill_bottle/dice(src)
+	new /obj/item/storage/pill_bottle/happy(src)
+	new /obj/item/storage/pill_bottle/lsd(src)
+	new /obj/item/storage/pill_bottle/psicodine(src)
+	new /obj/item/assembly/flash(src)
+	new /obj/item/assembly/flash(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -181,3 +181,21 @@
 	new /obj/item/storage/box/syringes/variety(src)
 	new /obj/item/storage/box/beakers/variety(src)
 	new /obj/item/clothing/glasses/science(src)
+
+/obj/structure/closet/secure_closet/psych
+	name = "psychiatrist's cabinet"
+	desc = "packed with a psychiastrist's tools of the trade"
+	req_access = list(ACCESS_PSYCH)
+	icon_state = "cabinet"
+
+/obj/structure/closet/secure_closet/psych/PopulateContents()
+	..()
+	new /obj/item/clothing/suit/straight_jacket
+	new /obj/item/clothing/mask/muzzle
+	new /obj/item/storage/pill_bottle/happiness
+	new /obj/item/storage/pill_bottle/dice
+	new /obj/item/storage/pill_bottle/happy
+	new /obj/item/storage/pill_bottle/lsd
+	new /obj/item/storage/pill_bottle/psicodine
+	new /obj/item/assembly/flash
+	new /obj/item/assembly/flash

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -184,7 +184,7 @@
 
 /obj/structure/closet/secure_closet/psych
 	name = "psychiatrist's cabinet"
-	desc = "Packed with a psychiastrist's tools of the trade"
+	desc = "Packed with a psychiatrist's tools of the trade"
 	req_access = list(ACCESS_PSYCH)
 	icon_state = "cabinet"
 


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new secure_closet for Psychiatrist. Populates it with what is currently in the live one now. Plus I moved the two flashes from the desk into the locker, and put a box of beakers on the desk in their place so said psych can actually do some chemistry.

# Changelog

:cl:  
rscadd: Adds psych locker type
mapping: Sets new psych lockers on the maps
mapping: Moved flashes from desk into locker, put box of beakers in their place
/:cl:
