### PR TITLE
Splits special species preferences into their own preference

### DIFF
--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -28,7 +28,7 @@
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 
 	preferences.update_static_data(user)
-	preferences.parent?.set_macros()
+	user.client.update_special_keybinds()
 
 	return TRUE
 
@@ -43,11 +43,11 @@
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 
 	preferences.update_static_data(user)
-	preferences.parent?.set_macros()
+	user.client.update_special_keybinds()
 
 	return TRUE
 
-/datum/preference_middleware/keybindings/proc/set_keybindings(list/params)
+/datum/preference_middleware/keybindings/proc/set_keybindings(list/params, mob/user)
 	var/keybind_name = params["keybind_name"]
 
 	if (isnull(GLOB.keybindings_by_name[keybind_name]))
@@ -75,7 +75,8 @@
 
 	preferences.key_bindings[keybind_name] = hotkeys
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
-	preferences.parent?.set_macros()
+	
+	user.client.update_special_keybinds()
 
 	return TRUE
 

--- a/code/modules/client/preferences/species_features/ipc.dm
+++ b/code/modules/client/preferences/species_features/ipc.dm
@@ -14,7 +14,7 @@
 
 /datum/preference/color_legacy/ipc_screen_color
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	savefile_key = "eye_color"
+	savefile_key = "feature_ipc_screen_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	relevant_mutant_bodypart = "ipc_screen"
 	unique = TRUE
@@ -45,7 +45,7 @@
 
 /datum/preference/color_legacy/ipc_antenna_color
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	savefile_key = "hair_color"
+	savefile_key = "feature_ipc_antenna_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	relevant_mutant_bodypart = "ipc_antenna"
 	unique = TRUE

--- a/code/modules/client/preferences/species_features/pod.dm
+++ b/code/modules/client/preferences/species_features/pod.dm
@@ -35,7 +35,7 @@
 
 /datum/preference/color_legacy/pod_hair_color
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	savefile_key = "hair_color"
+	savefile_key = "feature_pod_hair_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	relevant_mutant_bodypart = "pod_hair"
 	unique = TRUE
@@ -54,7 +54,7 @@
 
 /datum/preference/color_legacy/pod_flower_color
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	savefile_key = "facial_hair_color"
+	savefile_key = "feature_pod_flower_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	relevant_mutant_bodypart = "pod_flower"
 	unique = TRUE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -1,11 +1,11 @@
 //This is the lowest supported version, anything below this is completely obsolete and the entire savefile will be wiped.
-#define SAVEFILE_VERSION_MIN	18
+#define SAVEFILE_VERSION_MIN	30
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	40
+#define SAVEFILE_VERSION_MAX	41
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -42,12 +42,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //if your savefile is 3 months out of date, then 'tough shit'.
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	// Fixes savefile corruption caused by https://github.com/yogstation13/Yogstation/pull/9767
-	if(current_version < 25) // This is the only thing that makes V25 different.
-		if(LAZYFIND(be_special,"Ragin"))
-			be_special -= "Ragin"
-			be_special += "Ragin Mages"
-
 	if (current_version < 35)
 		toggles |= SOUND_ALT
 
@@ -55,7 +49,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		chat_toggles |= CHAT_TYPING_INDICATOR
 	
 	if (current_version < 39)
-		write_preference(/datum/preference/toggle/hotkeys, TRUE)
+		write_preference(GLOB.preference_entries[/datum/preference/toggle/hotkeys], TRUE)
 		key_bindings = deepCopyList(GLOB.default_hotkeys)
 		key_bindings_by_key = get_key_bindings_by_key(key_bindings)
 		parent.set_macros()
@@ -66,66 +60,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
-	if(current_version < 22)
-		job_preferences = list() //It loaded null from nonexistant savefile field.
-		var/job_civilian_high = 0
-		var/job_civilian_med = 0
-		var/job_civilian_low = 0
-
-		var/job_medsci_high = 0
-		var/job_medsci_med = 0
-		var/job_medsci_low = 0
-
-		var/job_engsec_high = 0
-		var/job_engsec_med = 0
-		var/job_engsec_low = 0
-
-		READ_FILE(S["job_civilian_high"], job_civilian_high)
-		READ_FILE(S["job_civilian_med"], job_civilian_med)
-		READ_FILE(S["job_civilian_low"], job_civilian_low)
-		READ_FILE(S["job_medsci_high"], job_medsci_high)
-		READ_FILE(S["job_medsci_med"], job_medsci_med)
-		READ_FILE(S["job_medsci_low"], job_medsci_low)
-		READ_FILE(S["job_engsec_high"], job_engsec_high)
-		READ_FILE(S["job_engsec_med"], job_engsec_med)
-		READ_FILE(S["job_engsec_low"], job_engsec_low)
-
-		//Can't use SSjob here since this happens right away on login
-		for(var/job in subtypesof(/datum/job))
-			var/datum/job/J = job
-			var/new_value
-			var/fval = initial(J.flag)
-			switch(initial(J.department_flag))
-				if(CIVILIAN)
-					if(job_civilian_high & fval)
-						new_value = JP_HIGH
-					else if(job_civilian_med & fval)
-						new_value = JP_MEDIUM
-					else if(job_civilian_low & fval)
-						new_value = JP_LOW
-				if(MEDSCI)
-					if(job_medsci_high & fval)
-						new_value = JP_HIGH
-					else if(job_medsci_med & fval)
-						new_value = JP_MEDIUM
-					else if(job_medsci_low & fval)
-						new_value = JP_LOW
-				if(ENGSEC)
-					if(job_engsec_high & fval)
-						new_value = JP_HIGH
-					else if(job_engsec_med & fval)
-						new_value = JP_MEDIUM
-					else if(job_engsec_low & fval)
-						new_value = JP_LOW
-			if(new_value)
-				job_preferences[initial(J.title)] = new_value
-	if(current_version < 23)
-		all_quirks -= "Physically Obstructive"
-		all_quirks -= "Neat"
-		all_quirks -= "NEET"
-	if(current_version < 28)
-		if(!job_preferences)
-			job_preferences = list()
 	if(current_version < 31) //Someone doesn't know how to code and make jukebox and autodeadmin the same thing
 		toggles &= ~DEADMIN_ALWAYS
 		toggles &= ~DEADMIN_ANTAGONIST
@@ -137,7 +71,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	
 	if (current_version < 40)
 		migrate_character_to_tgui_prefs_menu()
-		
+
+	if (current_version < 41)
+		write_preference(GLOB.preference_entries[/datum/preference/color_legacy/pod_hair_color], read_preference(/datum/preference/color_legacy/hair_color))
+		write_preference(GLOB.preference_entries[/datum/preference/color_legacy/ipc_antenna_color], read_preference(/datum/preference/color_legacy/hair_color))
+		write_preference(GLOB.preference_entries[/datum/preference/color_legacy/pod_flower_color], read_preference(/datum/preference/color_legacy/facial_hair_color))
+		write_preference(GLOB.preference_entries[/datum/preference/color_legacy/ipc_screen_color], read_preference(/datum/preference/color_legacy/eye_color))
 
 /// checks through keybindings for outdated unbound keys and updates them
 /datum/preferences/proc/check_keybindings()
@@ -323,6 +262,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Sanitize
 	randomise = SANITIZE_LIST(randomise)
+	job_preferences = SANITIZE_LIST(job_preferences)
 	all_quirks = SANITIZE_LIST(all_quirks)
 
 	//Validate job prefs

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
@@ -55,9 +55,19 @@ export const feature_ipc_screen: FeatureChoiced = {
   component: FeatureDropdownInput,
 };
 
+export const feature_ipc_screen_color: Feature<string> = {
+  name: "Screen color",
+  component: FeatureColorInput,
+};
+
 export const feature_ipc_antenna: FeatureChoiced = {
   name: "Antenna",
   component: FeatureDropdownInput,
+};
+
+export const feature_ipc_antenna_color: Feature<string> = {
+  name: "Antenna color",
+  component: FeatureColorInput,
 };
 
 export const feature_ipc_chassis: FeatureChoiced = {
@@ -88,6 +98,16 @@ export const feature_polysmorph_dorsal_tubes: FeatureChoiced = {
 export const feature_pod_hair: FeatureChoiced = {
   name: "Pod hair style",
   component: FeatureDropdownInput,
+};
+
+export const feature_pod_hair_color: Feature<string> = {
+  name: "Hair color",
+  component: FeatureColorInput,
+};
+
+export const feature_pod_flower_color: Feature<string> = {
+  name: "Flower color",
+  component: FeatureColorInput,
 };
 
 export const feature_plasmaman_helmet: FeatureChoiced = {


### PR DESCRIPTION
# Document the changes in your pull request
One of the issues when porting over our special species prefs was that they are stored as (facial) hair colour. This PR switches them over to save to their own preference key. As a result, the code works better and fixes humans selecting dark hair colours.

I have also bumped up ``SAVEFILE_VERSION_MIN`` to 30, which is still *very* old and removed some old code related to it. I have **also** fixed an issue when changing say keybind.

# Spriting
![image](https://user-images.githubusercontent.com/24573384/221021547-adf386e7-6ff8-4b7b-9704-78191e24256d.png)

# Changelog

:cl:  
bugfix: Humans can now select dark (facial) hair colours again
bugfix: Fixed issues that could have interfered with converting old preferences
bugfix: Fixed an issue when changing say keybind
tweak: Better labels in character preferences
/:cl:
