### PR TITLE
makes ammo boxes versatile

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -16306,7 +16306,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/ammo_box/n762,
+/obj/item/ammo_box/no_direct/n762,
 /obj/item/ammo_box/c9mm,
 /obj/item/ammo_box/c45,
 /obj/item/ammo_box/c10mm,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -646,7 +646,7 @@
 	contraband = TRUE
 	contains = list(/obj/item/reagent_containers/food/snacks/rationpack,
 					/obj/item/ammo_box/a762,
-					/obj/item/ammo_box/n762,
+					/obj/item/ammo_box/no_direct/n762,
 					/obj/item/storage/toolbox/ammo,
 					/obj/item/clothing/suit/armor/vest/russian,
 					/obj/item/clothing/head/helmet/rus_helmet,

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -87,7 +87,7 @@
 
 ///puts a round into the magazine
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/R, replace_spent = 0)
-	// Boxes don't have a caliber type, magazines do. Not sure if it's intended or not, but if we fail to find a caliber, then we fall back to ammo_type.
+	// If we fail to find a caliber, then we fall back to ammo_type.
 	if(!R || (caliber && R.caliber != caliber) || (!caliber && R.type != ammo_type))
 		return FALSE
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -3,6 +3,7 @@
 	desc = "A seven-shot speed loader designed for .357 revolvers."
 	icon_state = "357"
 	ammo_type = /obj/item/ammo_casing/a357
+	caliber = "357"
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
@@ -12,6 +13,13 @@
 	icon_state = "357box"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 20
+
+/obj/item/ammo_box/no_direct/n762
+	name = "ammo box (7.62x38mmR)"
+	icon_state = "10mmbox"
+	ammo_type = /obj/item/ammo_casing/n762
+	caliber = "n762"
+	max_ammo = 14
 
 /obj/item/ammo_box/a357/ironfeather
 	name = "speed loader (.357 Ironfeather)"
@@ -53,6 +61,7 @@
 	desc = "A six-shot speed loader designed for .38 revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
+	caliber = "38"
 	max_ammo = 6
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	materials = list(/datum/material/iron = 20000)
@@ -84,6 +93,7 @@
 			These needle-like rounds deal miniscule damage, but inject a tracking implant upon burrowing into a target's body. Implant lifespan is five minutes."
 	icon_state = "32trac"
 	ammo_type = /obj/item/ammo_casing/tra32
+	caliber = "32trac"
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
@@ -91,24 +101,28 @@
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"
 	ammo_type = /obj/item/ammo_casing/c9mm
+	caliber = "9mm"
 	max_ammo = 30
 
 /obj/item/ammo_box/c10mm
 	name = "ammo box (10mm)"
 	icon_state = "10mmbox"
 	ammo_type = /obj/item/ammo_casing/c10mm
+	caliber = "10mm"
 	max_ammo = 20
 
 /obj/item/ammo_box/c45
 	name = "ammo box (.45)"
 	icon_state = "45box"
 	ammo_type = /obj/item/ammo_casing/c45
+	caliber = ".45"
 	max_ammo = 20
 
 /obj/item/ammo_box/a40mm
 	name = "ammo box (40mm grenades)"
 	icon_state = "40mm"
 	ammo_type = /obj/item/ammo_casing/a40mm
+	caliber = "40mm"
 	max_ammo = 4
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
@@ -117,20 +131,16 @@
 	desc = "A stripper clip holding 7.62mm rounds."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
+	caliber = "a762"
 	max_ammo = 5
 	multiple_sprites = AMMO_BOX_PER_BULLET
-
-/obj/item/ammo_box/n762
-	name = "ammo box (7.62x38mmR)"
-	icon_state = "10mmbox"
-	ammo_type = /obj/item/ammo_casing/n762
-	max_ammo = 14
 
 /obj/item/ammo_box/foambox
 	name = "ammo box (Foam Darts)"
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
+	caliber = "foam_force"
 	max_ammo = 40
 	materials = list(/datum/material/iron = 500)
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1144,7 +1144,7 @@
 	id = "n762"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 15000)
-	build_path = /obj/item/ammo_box/n762
+	build_path = /obj/item/ammo_box/no_direct/n762
 	category = list("hacked", "Security")
 
 /datum/design/decal_painter

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -173,7 +173,7 @@
 			new /obj/item/clothing/suit/armor/riot(src)
 			return
 		else if(prob(10))
-			new /obj/item/ammo_box/n762(src)
+			new /obj/item/ammo_box/no_direct/n762(src)
 			new /obj/item/ammo_box/foambox/riot
 			new /obj/item/clothing/suit/space/hardsuit/ert/sec(src)
 			new /obj/item/storage/firstaid(src)
@@ -187,7 +187,7 @@
 			new /obj/item/ammo_box/c45(src)
 			new /obj/item/ammo_box/a40mm(src)
 			new /obj/item/ammo_box/a762(src)
-			new /obj/item/ammo_box/n762(src)
+			new /obj/item/ammo_box/no_direct/n762(src)
 			new /obj/item/ammo_box/foambox/riot
 			new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 			new /obj/item/storage/firstaid(src)


### PR DESCRIPTION
# Document the changes in your pull request

this was kinda stupid and easily preventable however people are scared of things they don't understand

# Changelog

:cl:  
tweak: Nagant ammo box made more formally an ammo box that can't load the revolver directly
bugfix: All variants of ammo_box (including speed loaders) should now have a caliber tag that permits them to carry ammo of the same caliber, even if it's an alternative ammo. This means alternative ammo speed loaders can load normal rounds now and normal ammo boxes can be filled with spare alternative ammos (but you won't be able to tell the difference unless you drop the bullets on the ground)
/:cl:
