### PR TITLE
Revolvers can now ricochet off of coins

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1075,21 +1075,22 @@ B --><-- A
 			return target
 
 /proc/get_closest_atom(type, list, source)
-	var/closest_atom
+	var/list/closest_atoms = list()
 	var/closest_distance
 	for(var/A in list)
 		if(!istype(A, type))
 			continue
 		var/distance = get_dist(source, A)
-		if(!closest_atom)
+		if(!closest_atoms.len)
 			closest_distance = distance
-			closest_atom = A
+			closest_atoms = list(A)
 		else
 			if(closest_distance > distance)
 				closest_distance = distance
-				closest_atom = A
-	return closest_atom
-
+				closest_atoms = list(A)
+			else if(closest_distance == distance)
+				closest_atoms += A
+	return pick(closest_atoms) //if there are multiple atoms with the same distance, picks randomly from a list of them
 
 proc/pick_closest_path(value, list/matches = get_fancy_list_of_atom_types())
 	if (value == FALSE) //nothing should be calling us with a number, so this is safe

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -519,6 +519,8 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 			user.visible_message("[user] has flipped [src]. It lands on [coinflip].", \
  							 span_notice("You flip [src]. It lands on [coinflip]."), \
 							 span_italics("You hear the clattering of loose change."))
+		else
+			visible_message(span_notice("[src] lands on [coinflip]."), blind_message = span_italics("You hear the clattering of loose change."))
 	return TRUE//did the coin flip? useful for suicide_act
 
 /obj/item/coin/attack_self(mob/user)
@@ -529,10 +531,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	transform = initial(transform)
 
 /obj/item/coin/bullet_act(obj/item/projectile/P)
-	if(P.flag != LASER && P.flag != ENERGY && !istype(P, /obj/item/projectile/bullet/c38)) //only energy projectiles get deflected (also det revolver because damn thats cool)
+	if(P.flag != LASER && P.flag != ENERGY && !istype(P, /obj/item/projectile/bullet/c38) && !istype(P, /obj/item/projectile/bullet/ipcmartial)) //only energy projectiles get deflected (also det and IPC revolvers because damn thats cool)
 		return ..()
 		
-	if(cooldown >= world.time)//we ricochet the projectile
+	if(cooldown >= world.time || istype(P, /obj/item/projectile/bullet/ipcmartial))//we ricochet the projectile
 		var/list/targets = list()
 		var/turf/center = get_turf(src)
 		for(var/mob/living/T in viewers(5, src))
@@ -546,7 +548,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 			var/mob/living/target = pick(targets)
 			P.preparePixelProjectile(target, src)
 			targets -= target
-			if(targets.len)
+			if(targets.len && P.flag != BULLET)
 				P = DuplicateObject(P, sameloc=1) //split into another projectile
 				P.datum_flags = initial(P.datum_flags)	//we want to reset the projectile process that was duplicated
 				P.last_process = initial(P.last_process)
@@ -556,11 +558,19 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 				P.fire()
 		visible_message(span_danger("[P] ricochets off of [src]!"))
 		playsound(loc, 'sound/weapons/ricochet.ogg', 50, 1)
+		if(cooldown < world.time)
+			INVOKE_ASYNC(src, .proc/flip, null, TRUE) //flip the coin if it isn't already doing that
 		return BULLET_ACT_FORCE_PIERCE
 			
 	//we instead flip the coin
 	INVOKE_ASYNC(src, .proc/flip, null, TRUE) //we don't want to wait for flipping to finish in order to do the impact
 	return BULLET_ACT_TURF
+
+/obj/item/coin/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, quickstart)
+	if(cooldown < world.time) // Flip the coin when thrown
+		spin = 0 // looks weird if it spins and flips at the same time
+		INVOKE_ASYNC(src, .proc/flip, null, TRUE)
+	..()
 
 /obj/item/coinstack
 	name = "stack of coins"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -531,24 +531,24 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	transform = initial(transform)
 
 /obj/item/coin/bullet_act(obj/item/projectile/P)
-	if(P.flag != LASER && P.flag != ENERGY && !istype(P, /obj/item/projectile/bullet/c38) && !istype(P, /obj/item/projectile/bullet/ipcmartial)) //only energy projectiles get deflected (also det and IPC revolvers because damn thats cool)
+	if(P.flag != LASER && P.flag != ENERGY && !istype(P, /obj/item/projectile/bullet/c38) && !istype(P, /obj/item/projectile/bullet/a357) &&!istype(P, /obj/item/projectile/bullet/ipcmartial)) //only energy projectiles get deflected (also revolvers because damn thats cool)
 		return ..()
 		
 	if(cooldown >= world.time || istype(P, /obj/item/projectile/bullet/ipcmartial))//we ricochet the projectile
 		var/list/targets = list()
 		var/turf/center = get_turf(src)
 		for(var/mob/living/T in viewers(5, src))
-			if(T != P.firer && T.stat != DEAD)
+			if(T != P.firer && T.stat != DEAD && !(T in P.permutated)) //don't fire at someone if they're dead or if we already hit them
 				targets |= T
 		P.damage *= 1.5
 		if(!targets.len)
 			var/spr = rand(0, 360) //randomize the direction
 			P.preparePixelProjectile(src, src, spread = spr)
 		else
-			var/mob/living/target = pick(targets)
+			var/mob/living/target = get_closest_atom(/mob/living, targets, src)
 			P.preparePixelProjectile(target, src)
 			targets -= target
-			if(targets.len && P.flag != BULLET)
+			if(targets.len)
 				P = DuplicateObject(P, sameloc=1) //split into another projectile
 				P.datum_flags = initial(P.datum_flags)	//we want to reset the projectile process that was duplicated
 				P.last_process = initial(P.last_process)


### PR DESCRIPTION
# Document the changes in your pull request

Laser/energy projectiles and the detective's revolver already did this so I made the other revolvers do it as well. Also, throwing a coin will now flip the coin.

# Changelog

:cl:  
tweak: all revolvers can ricochet off of coins, ultra violence version can do so on the hit that causes the coin to flip
tweak: coins now flip when thrown
tweak: ricochet now prefers closer targets
tweak: get_closest_atom() now picks randomly from a list of closest atoms if there are multiple closest atoms with the same distance
/:cl:
