### PR TITLE
CNS Rebooter 12TC ->4TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1944,7 +1944,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/anti_stun
-	cost = 12
+	cost = 4
 	surplus = 0
 
 /datum/uplink_item/implants/freedom


### PR DESCRIPTION
# Document the changes in your pull request
A STATION AVAILABLE IMPLANT FOR 12TC WHAT WERE WE THINKING CUT THAT SHIT TO 4TC.

# Wiki Documentation
change price on https://wiki.yogstation.net/wiki/Syndicate_Items#Implants to reflect change.

# Changelog
:cl:  
tweak: CNS REBOOTER WAS 12TC NOW ITS 4TC RIP THE GENE WHO GOT SCAMMED BY HIS BOSS
/:cl:
