### PR TITLE
Disables Sentient Disease

### DIFF
--- a/code/modules/antagonists/disease/disease_event.dm
+++ b/code/modules/antagonists/disease/disease_event.dm
@@ -2,7 +2,7 @@
 /datum/round_event_control/sentient_disease
 	name = "Spawn Sentient Disease"
 	typepath = /datum/round_event/ghost_role/sentient_disease
-	weight = 7
+	weight = 0
 	max_occurrences = 1
 	min_players = 5
 


### PR DESCRIPTION
# Document the changes in your pull request
talked about this on the discord for the last few days and no one has the will to rework this to a fun to play state. sucks to let this one go but it really doesn't mesh well with how viruses work nowadays.

if anyone manages to fix this up your welcome to reenable just a simple number change.

this is an unmaintained piece of shit who should have been gone a long time ago it never adds anything to the round theres better things that threat could be spent on that would be significantly better use of the roll.
# Wiki Documentation
note that sentient disease is disabled to reflect this.

# Changelog
:cl:    
rscdel: Disabled sentient disease from naturally spawning midround
/:cl:
