### PR TITLE
[Gax] Fixes some map issues

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -70,22 +70,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"abK" = (
-/obj/structure/rack,
-/obj/item/aicard,
-/obj/item/disk/holodisk/tutorial/AICore,
-/obj/item/circuitboard/computer/ai_upload_download,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
-	dir = 8;
-	name = "RD Office APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "abO" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -248,6 +232,22 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"aeq" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "aeL" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -1915,6 +1915,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aVN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "aVS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -3063,15 +3072,6 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"bzb" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -4087,11 +4087,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/burnt/two,
 /area/science/mixing)
-"cbW" = (
-/obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "ccs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4173,16 +4168,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ceB" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "ceE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5001,6 +4986,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"cyB" = (
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "cyC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -5046,6 +5036,17 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"czC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "czG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -5114,17 +5115,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"cAX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "cAY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5384,12 +5374,6 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"cFO" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cGb" = (
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -5468,6 +5452,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/escapepodbay)
+"cIO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/deskbell/preset/sec{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "cIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -5818,18 +5826,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cRV" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	name = "Labor Shuttle Dock APC";
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "cSC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 4
@@ -6575,6 +6571,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"djJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "djO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -7500,20 +7515,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dLG" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dLO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -7623,17 +7624,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"dPL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "dPW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7662,6 +7652,17 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/office)
+"dQz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "dQN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7735,6 +7736,17 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"dTO" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dTU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -7939,15 +7951,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"dXM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "dXU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9523,6 +9526,18 @@
 "eEF" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"eEI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "eFb" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -9853,6 +9868,15 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/library)
+"eMP" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "eMS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -12141,15 +12165,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
-"fOE" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fOF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -12432,20 +12447,6 @@
 "fXo" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
-"fXs" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/structure/sign/plaques/cave{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "fXw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -12704,22 +12705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gdy" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "gdE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -12920,6 +12905,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"giF" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "giO" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -14428,6 +14417,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"gZR" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "hae" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -14593,6 +14593,10 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"heE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "heG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15486,25 +15490,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hyx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "hyE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15744,6 +15729,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"hDj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "hDn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -16274,6 +16278,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"hUk" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hUI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -17177,6 +17187,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"iwh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iwi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -17414,16 +17434,6 @@
 "izV" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"iAm" = (
-/obj/structure/rack,
-/obj/item/brace,
-/obj/item/brace,
-/obj/item/brace,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/box/firingpins,
-/obj/item/storage/box/firingpins,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "iAA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -17782,17 +17792,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"iNk" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iNn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -17847,6 +17846,26 @@
 /obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"iPv" = (
+/obj/structure/rack,
+/obj/item/aicard,
+/obj/item/disk/holodisk/tutorial/AICore,
+/obj/item/circuitboard/computer/ai_upload_download,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hor";
+	dir = 8;
+	name = "RD Office APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "iQf" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -18018,6 +18037,17 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iSN" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/item/screwdriver{
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "iTl" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -18153,6 +18183,20 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"iXH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18447,16 +18491,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"jhc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jho" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -19289,18 +19323,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jDN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jDQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19444,19 +19466,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jIh" = (
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = -25;
-	pixel_y = -35
-	},
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19567,6 +19576,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jKW" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "jLo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19598,6 +19620,16 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"jNf" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/structure/sign/plaques/cave{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "jNx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/airalarm{
@@ -19811,9 +19843,6 @@
 "jSO" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"jSU" = (
-/turf/closed/wall,
-/area/ai_monitored/secondarydatacore)
 "jSY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20426,17 +20455,6 @@
 "kju" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"kjE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "kjG" = (
 /obj/structure/reflector/box/anchored{
 	dir = 4
@@ -21087,25 +21105,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kCG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kCY" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -23014,6 +23013,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"lxg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lxh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -23540,6 +23556,19 @@
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"lHC" = (
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = -25;
+	pixel_y = -35
+	},
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "lHR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23560,20 +23589,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"lIB" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "lID" = (
 /turf/closed/wall,
 /area/science/xenobiology)
-"lIO" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/item/screwdriver{
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "lIQ" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
@@ -23664,23 +23687,6 @@
 /obj/structure/sign/barsign,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"lLJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lLV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24278,19 +24284,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
-"lYe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lYq" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 5
@@ -24407,6 +24400,15 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"mcP" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mdj" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -24416,17 +24418,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"mdu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "mdy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -26430,6 +26421,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"ndj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26514,6 +26518,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ngS" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/item/storage/box/prisoner,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "ngZ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -26677,19 +26689,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"nlv" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/guncase/shotgun,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/machinery/camera/motion/armory,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "nlP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26741,6 +26740,25 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"nmx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nmK" = (
 /obj/machinery/light{
 	dir = 1
@@ -27621,6 +27639,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"nIa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nIc" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -28138,18 +28168,6 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nWU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "nXc" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -28219,11 +28237,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nZe" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nZg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28705,6 +28718,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"onE" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "onN" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -29135,22 +29159,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"oyH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
@@ -29672,6 +29680,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"oQp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "paramed_shutters";
+	name = "Paramedic Staging shutters"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Paramedic Desk";
+	req_access_txt = "69"
+	},
+/obj/item/deskbell/preset/paramedic{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "oQr" = (
 /obj/structure/rack,
 /obj/machinery/firealarm{
@@ -30348,11 +30377,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"pjx" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "pjz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -30737,18 +30761,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
-"prl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "prE" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/cable,
@@ -31363,17 +31375,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"pKd" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/preopen{
-	id = "hosspace";
-	name = "space shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "pKn" = (
 /obj/structure/chair{
 	dir = 8
@@ -31540,11 +31541,40 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"pOe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pOz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"pOB" = (
+/obj/structure/rack,
+/obj/item/brace,
+/obj/item/brace,
+/obj/item/brace,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "pOV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -31627,19 +31657,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pQX" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "pRc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -31907,17 +31924,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
-"pWS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "pXc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -32207,26 +32213,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"qdW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "qeq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/glowstick,
@@ -32632,6 +32618,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"qnl" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "qns" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -33114,21 +33109,6 @@
 "qBn" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
-"qBI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "qCF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -33400,6 +33380,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"qKs" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "qKI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -33741,6 +33733,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"qTE" = (
+/obj/structure/closet/l3closet/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "qUn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -34066,6 +34063,22 @@
 "rcm" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
+"rcq" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rcD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -34157,6 +34170,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"rdP" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "reg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34873,6 +34896,17 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rui" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "ruw" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/shower{
@@ -35817,6 +35851,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"rUN" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/processing";
+	name = "Labor Shuttle Dock APC";
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "rVa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -36338,20 +36384,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"sip" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "siK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -36422,6 +36454,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"slG" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "slR" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -37024,6 +37074,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"sxY" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "syN" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -37046,25 +37110,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"syU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/closet/secure_closet/security/srv,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "szi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -37124,23 +37169,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/library)
-"szz" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/item/radio/off,
-/obj/item/crowbar,
-/obj/item/assembly/flash/handheld{
-	pixel_x = 6
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "szG" = (
 /obj/structure/spacepoddoor,
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
@@ -37164,6 +37192,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"sAa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sAf" = (
 /obj/structure/window/reinforced,
 /obj/structure/lattice,
@@ -37451,16 +37494,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sIs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37552,25 +37585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"sLe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "sLi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -37807,22 +37821,6 @@
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"sRB" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sRC" = (
 /obj/structure/table,
 /obj/item/beacon,
@@ -38717,6 +38715,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"toM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tpx" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -38900,6 +38903,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"twg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/guncase/shotgun,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/machinery/camera/motion/armory,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "twv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -39142,6 +39158,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"tCd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tCk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -39298,11 +39319,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tGU" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tHh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39323,23 +39339,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"tHN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39385,6 +39384,9 @@
 	dir = 8
 	},
 /area/chapel/main)
+"tJU" = (
+/turf/closed/wall,
+/area/ai_monitored/secondarydatacore)
 "tJW" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -40075,16 +40077,6 @@
 "tZp" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
-"tZx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tZB" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -40344,30 +40336,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"ugQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/deskbell/preset/sec{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "uhh" = (
 /obj/machinery/light/small,
 /obj/machinery/chem_master/condimaster{
@@ -40710,19 +40678,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"upY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uqi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41319,6 +41274,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uIy" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uIF" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41498,18 +41458,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"uLC" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/preopen{
-	id = "hosspace";
-	name = "space shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "uLY" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -42320,6 +42268,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vhc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/closet/secure_closet/security/srv,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "vhk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -42421,27 +42388,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"vjG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "paramed_shutters";
-	name = "Paramedic Staging shutters"
-	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Paramedic Desk";
-	req_access_txt = "69"
-	},
-/obj/item/deskbell/preset/paramedic{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "vjK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -42789,11 +42735,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"vsy" = (
-/obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "vsB" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -42979,11 +42920,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vxy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "vxA" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm{
@@ -43251,6 +43187,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"vEY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "vFm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43693,6 +43640,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"vPK" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -43819,24 +43777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vUo" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "vUA" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -44296,6 +44236,22 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"wgb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "wgh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -44325,6 +44281,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"wgK" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/item/radio/off,
+/obj/item/crowbar,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "wgS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44504,14 +44477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"wlK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/item/storage/box/prisoner,
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "wms" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -44957,6 +44922,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"wwI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "wxf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -45068,25 +45053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wBi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wBM" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -47290,10 +47256,6 @@
 "xEn" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
-"xEz" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "xED" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -48464,15 +48426,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"yeV" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "yfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67343,7 +67296,7 @@ tkl
 tkl
 tkl
 nKW
-vxy
+tCd
 rsZ
 uRB
 bPu
@@ -68072,12 +68025,12 @@ vRP
 aCD
 tkl
 etW
-vsy
-pjx
-bzb
+cyB
+lIB
+eMP
 oqA
-pjx
-yeV
+lIB
+qnl
 etW
 iSi
 exW
@@ -68585,7 +68538,7 @@ vRP
 vRP
 aCD
 tkl
-pQX
+jKW
 ppW
 ppW
 fXw
@@ -68843,7 +68796,7 @@ vRP
 ubS
 tkl
 iYY
-cbW
+qTE
 eom
 oAK
 pkV
@@ -69104,7 +69057,7 @@ etW
 sfE
 wOB
 nPx
-lIO
+iSN
 xYS
 etW
 vry
@@ -69376,7 +69329,7 @@ wnQ
 iMQ
 kPU
 tgi
-jIh
+lHC
 sTH
 xGP
 aCD
@@ -69621,7 +69574,7 @@ oon
 hVC
 wtF
 anb
-iAm
+pOB
 poB
 luQ
 ldq
@@ -69635,7 +69588,7 @@ dcK
 cVi
 cKG
 oUZ
-pKd
+onE
 vRP
 aCD
 onQ
@@ -69892,7 +69845,7 @@ aRM
 gaf
 rVH
 iVa
-uLC
+qKs
 aCD
 aCD
 onQ
@@ -69923,9 +69876,9 @@ mLC
 eEF
 eEF
 mki
-iNk
-lYe
-tGU
+dTO
+ndj
+uIy
 xTt
 cNu
 xZo
@@ -70129,7 +70082,7 @@ vRP
 aCD
 xbD
 dll
-ceB
+rdP
 uwK
 kAM
 qNN
@@ -70386,7 +70339,7 @@ vRP
 ubS
 tkl
 dll
-nlv
+twg
 uwK
 spY
 vVo
@@ -70396,7 +70349,7 @@ xMn
 wFZ
 pBy
 pYq
-dPL
+czC
 pjL
 dpv
 jyN
@@ -70414,7 +70367,7 @@ pyH
 bmk
 jDg
 xXU
-pWS
+dQz
 neP
 lZu
 xLG
@@ -70437,8 +70390,8 @@ xTt
 xTt
 xTt
 fWk
-cFO
-tHN
+hUk
+lxg
 xTt
 xTt
 lBF
@@ -70663,7 +70616,7 @@ jZp
 lxD
 ixB
 qRD
-ugQ
+cIO
 noh
 uKb
 cdG
@@ -70693,8 +70646,8 @@ dBO
 kPJ
 kKN
 xTt
-jhc
-sRB
+iwh
+rcq
 cuq
 xTt
 fGF
@@ -70917,10 +70870,10 @@ iBo
 grf
 moz
 gMU
-kjE
+vEY
 bTy
 vzE
-qdW
+wwI
 noh
 lnE
 fSF
@@ -71177,7 +71130,7 @@ gMU
 ycy
 neu
 vrw
-kjE
+vEY
 noh
 qQC
 mgL
@@ -71185,7 +71138,7 @@ pyH
 tBB
 lmp
 bXk
-mdu
+gZR
 aUd
 xrG
 oNX
@@ -71203,8 +71156,8 @@ uRB
 eCy
 eFb
 pOz
-dLG
-nZe
+sxY
+toM
 kKN
 xTt
 ccU
@@ -71675,7 +71628,7 @@ lnl
 lnl
 gAA
 fOd
-oyH
+wgb
 pmk
 oZJ
 vtG
@@ -71932,7 +71885,7 @@ lUn
 bSd
 qfO
 eNb
-cRV
+rUN
 gJV
 bgF
 etW
@@ -72188,8 +72141,8 @@ lnl
 gJV
 gJV
 hSt
-sLe
-wlK
+hDj
+ngS
 gJV
 lvH
 yjy
@@ -72202,7 +72155,7 @@ yjy
 mvs
 brT
 ioL
-prl
+eEI
 rfL
 qiw
 sTv
@@ -72459,7 +72412,7 @@ yjy
 yab
 hzN
 tfA
-wBi
+nmx
 cZX
 jju
 sTv
@@ -72716,7 +72669,7 @@ yjy
 gtA
 brT
 ioL
-prl
+eEI
 yfX
 kna
 sTv
@@ -73230,7 +73183,7 @@ xeh
 xLJ
 vUm
 fyG
-prl
+eEI
 rfL
 dZv
 sTv
@@ -73487,7 +73440,7 @@ iXw
 mJM
 gZq
 tfA
-kCG
+djJ
 cZX
 jju
 sTv
@@ -73744,7 +73697,7 @@ fra
 udS
 mfS
 fmz
-prl
+eEI
 yfX
 kna
 gFS
@@ -74033,9 +73986,9 @@ qru
 qRW
 qRW
 qRW
-lLJ
-upY
-tZx
+vPK
+wvU
+maX
 pQR
 pQR
 xEn
@@ -74258,7 +74211,7 @@ aTR
 udS
 mfS
 fmz
-prl
+eEI
 rfL
 dqQ
 sTv
@@ -74515,7 +74468,7 @@ ffj
 aZG
 mpq
 tfA
-hyx
+pOe
 cZX
 jju
 sTv
@@ -74772,7 +74725,7 @@ xXn
 xXn
 tRW
 bdT
-prl
+eEI
 yfX
 kna
 gFS
@@ -75532,8 +75485,8 @@ efI
 qoB
 efI
 efI
-dXM
-qBI
+aVN
+sAa
 agN
 tih
 tih
@@ -76575,10 +76528,10 @@ rDI
 ikb
 mAC
 mAC
-fOE
-jDN
+mcP
+nIa
 pQK
-vjG
+oQp
 dvZ
 ldj
 aDO
@@ -76834,7 +76787,7 @@ fcw
 mAC
 kCl
 ucY
-sip
+iXH
 kpN
 pcs
 cyK
@@ -80218,7 +80171,7 @@ eFs
 wTB
 iuV
 xNs
-jSU
+tJU
 dpf
 dpf
 dpf
@@ -81461,8 +81414,8 @@ uTb
 vtV
 kHS
 fbD
-xEz
-gdy
+giF
+aeq
 bWu
 wIe
 sQy
@@ -87919,7 +87872,7 @@ hso
 bdB
 rIB
 eRj
-abK
+iPv
 tAW
 lID
 qPM
@@ -88428,7 +88381,7 @@ aiE
 lfM
 cXu
 tAW
-fXs
+jNf
 eEB
 jlh
 jyJ
@@ -89931,7 +89884,7 @@ wpp
 dAK
 cJz
 dLk
-vUo
+slG
 hxY
 rsW
 eLb
@@ -90188,8 +90141,8 @@ sHR
 fvK
 lRA
 pqf
-cAX
-syU
+rui
+vhc
 rsW
 wCC
 wCC
@@ -91209,7 +91162,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+heE
 eqc
 adM
 amf
@@ -91465,7 +91418,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+heE
 vRP
 eqc
 wGz
@@ -91723,7 +91676,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+heE
 eqc
 adM
 kxF
@@ -92009,9 +91962,9 @@ iBC
 qAe
 yds
 hlg
-nWU
-kOY
-sIs
+ngI
+pBk
+iKT
 hVM
 hVM
 kyA
@@ -92802,7 +92755,7 @@ pEG
 pKx
 vgB
 mYp
-szz
+wgK
 pKx
 cVQ
 hjp

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -962,22 +962,6 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"avy" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "avY" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/department/bridge)
@@ -1565,20 +1549,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aOf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aOh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -2158,27 +2128,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"bbv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "paramed_shutters";
-	name = "Paramedic Staging shutters"
-	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Paramedic Desk";
-	req_access_txt = "69"
-	},
-/obj/item/deskbell/preset/paramedic{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "bbz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2503,10 +2452,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"biG" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "biH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3118,6 +3063,15 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bzb" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -3599,13 +3553,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"bOC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "bOI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4140,6 +4087,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/burnt/two,
 /area/science/mixing)
+"cbW" = (
+/obj/structure/closet/l3closet/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "ccs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4221,6 +4173,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ceB" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ceE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5152,6 +5114,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"cAX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "cAY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5411,6 +5384,12 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"cFO" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cGb" = (
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -5839,6 +5818,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"cRV" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/processing";
+	name = "Labor Shuttle Dock APC";
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "cSC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 4
@@ -6408,16 +6399,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dgq" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "dgs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6794,18 +6775,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"dpW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "dqA" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -7531,6 +7500,20 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dLG" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dLO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -7640,6 +7623,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dPL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "dPW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7945,6 +7939,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"dXM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "dXU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8408,20 +8411,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"ein" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/item/radio/off,
-/obj/item/crowbar,
-/obj/item/assembly/flash/handheld{
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "eiw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -9244,22 +9233,6 @@
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
-"ezW" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "eAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -12168,6 +12141,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"fOE" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fOF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -12637,10 +12619,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"gaY" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "gbh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -12726,6 +12704,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gdy" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "gdE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -13075,15 +13069,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"gmX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13373,25 +13358,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
-"guf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -14965,19 +14931,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hma" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "hmc" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -15533,6 +15486,25 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hyx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hyE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16653,17 +16625,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ifQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "igr" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -16819,25 +16780,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"iiY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ikb" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -17472,6 +17414,16 @@
 "izV" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"iAm" = (
+/obj/structure/rack,
+/obj/item/brace,
+/obj/item/brace,
+/obj/item/brace,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "iAA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -17830,6 +17782,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"iNk" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iNn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18190,18 +18153,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"iYM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18476,17 +18427,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jgg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "jgj" = (
 /obj/structure/chair{
 	dir = 1
@@ -18507,6 +18447,16 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"jhc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jho" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -19339,6 +19289,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jDN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jDQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19482,6 +19444,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jIh" = (
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = -25;
+	pixel_y = -35
+	},
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19814,14 +19789,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"jSf" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "jSg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -19844,6 +19811,9 @@
 "jSO" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"jSU" = (
+/turf/closed/wall,
+/area/ai_monitored/secondarydatacore)
 "jSY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20043,14 +20013,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"jWB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20338,15 +20300,6 @@
 "kfu" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"kfy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "kfL" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -20473,6 +20426,17 @@
 "kju" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"kjE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "kjG" = (
 /obj/structure/reflector/box/anchored{
 	dir = 4
@@ -20538,14 +20502,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"klo" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "klv" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -21131,6 +21087,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kCG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kCY" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
@@ -22207,19 +22182,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"lbK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "lbS" = (
 /obj/structure/chair/comfy/black{
 	dir = 4;
@@ -22799,14 +22761,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"lqd" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "lqe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -23609,6 +23563,17 @@
 "lID" = (
 /turf/closed/wall,
 /area/science/xenobiology)
+"lIO" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/obj/item/screwdriver{
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "lIQ" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
@@ -24313,6 +24278,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos_distro)
+"lYe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lYq" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 5
@@ -24438,6 +24416,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"mdu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "mdy" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -26519,21 +26508,6 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ngA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ngI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -26703,6 +26677,19 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"nlv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/guncase/shotgun,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/machinery/camera/motion/armory,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nlP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26723,13 +26710,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"nlX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "nmn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -27103,20 +27083,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
-"nxf" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nxm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -27325,28 +27291,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"nAi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "nAo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -28275,6 +28219,11 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nZe" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nZg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29186,6 +29135,22 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"oyH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
@@ -29853,30 +29818,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oWC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/deskbell/preset/sec{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -30407,6 +30348,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"pjx" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "pjz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -30791,6 +30737,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"prl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "prE" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/cable,
@@ -31225,16 +31183,6 @@
 	dir = 10
 	},
 /area/chapel/main)
-"pFl" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pFz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -31415,6 +31363,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"pKd" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "pKn" = (
 /obj/structure/chair{
 	dir = 8
@@ -31668,6 +31627,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pQX" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "pRc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -31691,26 +31663,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pRw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "pRL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -31788,10 +31740,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pTU" = (
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "pTW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -31959,6 +31907,17 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos_distro)
+"pWS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "pXc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -32248,6 +32207,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"qdW" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "qeq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/glowstick,
@@ -33135,6 +33114,21 @@
 "qBn" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
+"qBI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "qCF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -33198,11 +33192,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"qEP" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "qFR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -33443,19 +33432,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qLs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/guncase/shotgun,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/machinery/camera/motion/armory,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "qLu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33759,19 +33735,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"qSX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	dir = 4;
-	name = "Labor Shuttle Dock APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "qTe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34103,21 +34066,6 @@
 "rcm" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
-"rcs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rcD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -35869,14 +35817,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rUZ" = (
-/obj/structure/rack,
-/obj/item/brace,
-/obj/item/brace,
-/obj/item/brace,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "rVa" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -36398,6 +36338,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"sip" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "siK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -37092,6 +37046,25 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"syU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/closet/secure_closet/security/srv,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/radio/off,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "szi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -37151,6 +37124,23 @@
 /obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/library)
+"szz" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/table,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/item/radio/off,
+/obj/item/crowbar,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "szG" = (
 /obj/structure/spacepoddoor,
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
@@ -37243,13 +37233,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sBy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "sBE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -37362,13 +37345,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"sFQ" = (
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = -25;
-	pixel_y = -35
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "sGd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -37576,6 +37552,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"sLe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "sLi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -37812,14 +37807,22 @@
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"sRt" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
+"sRB" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "sRC" = (
 /obj/structure/table,
 /obj/item/beacon,
@@ -37967,13 +37970,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sUq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sUu" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt1";
@@ -39302,6 +39298,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tGU" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tHh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39322,6 +39323,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"tHN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40054,25 +40072,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tZk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tZp" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -40345,6 +40344,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"ugQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/deskbell/preset/sec{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "uhh" = (
 /obj/machinery/light/small,
 /obj/machinery/chem_master/condimaster{
@@ -40669,11 +40692,6 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"uoL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "upl" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -41152,15 +41170,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
-"uDF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uDP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41489,6 +41498,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"uLC" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "uLY" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -41625,21 +41646,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"uNU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/closet/secure_closet/security/srv,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "uOl" = (
 /obj/machinery/computer/cryopod{
 	dir = 8;
@@ -42304,13 +42310,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"vgK" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "vgU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -42422,6 +42421,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"vjG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "paramed_shutters";
+	name = "Paramedic Staging shutters"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Paramedic Desk";
+	req_access_txt = "69"
+	},
+/obj/item/deskbell/preset/paramedic{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "vjK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -42769,6 +42789,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"vsy" = (
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "vsB" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -42954,6 +42979,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vxy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vxA" = (
 /obj/structure/table/glass,
 /obj/machinery/airalarm{
@@ -43789,6 +43819,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vUo" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "vUA" = (
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -44456,8 +44504,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"wmp" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+"wlK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/item/storage/box/prisoner,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "wms" = (
@@ -45016,6 +45068,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wBi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wBM" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -45428,21 +45499,6 @@
 /obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"wKK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "wKL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -47203,24 +47259,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"xEe" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -47252,6 +47290,10 @@
 "xEn" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
+"xEz" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "xED" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -48422,6 +48464,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"yeV" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "yfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67292,7 +67343,7 @@ tkl
 tkl
 tkl
 nKW
-uoL
+vxy
 rsZ
 uRB
 bPu
@@ -67543,9 +67594,9 @@ jai
 eFb
 eFb
 eFb
-biG
+xVi
 eFb
-biG
+xVi
 eFb
 eFb
 eFb
@@ -67761,16 +67812,16 @@ vRP
 vRP
 vRP
 vRP
-vRP
 ubS
 tkl
 etW
 etW
-ors
-ors
-ors
-ors
-ors
+etW
+etW
+etW
+etW
+etW
+etW
 ors
 ors
 ors
@@ -68018,15 +68069,15 @@ vRP
 vRP
 vRP
 vRP
-vRP
 aCD
 tkl
 etW
-pTU
-lqd
+vsy
+pjx
+bzb
 oqA
-pTU
-klo
+pjx
+yeV
 etW
 iSi
 exW
@@ -68275,10 +68326,10 @@ vRP
 vRP
 vRP
 vRP
-vRP
 aCD
 tkl
 dkN
+eom
 eom
 eom
 guX
@@ -68532,10 +68583,10 @@ vRP
 vRP
 vRP
 vRP
-vRP
 aCD
 tkl
-hma
+pQX
+ppW
 ppW
 fXw
 gDg
@@ -68789,10 +68840,10 @@ vRP
 vRP
 vRP
 vRP
-vRP
 ubS
 tkl
 iYY
+cbW
 eom
 oAK
 pkV
@@ -69045,15 +69096,15 @@ vRP
 vRP
 vRP
 vRP
-vRP
 aCD
 aCD
 tkl
 etW
+etW
 sfE
 wOB
 nPx
-jSf
+lIO
 xYS
 etW
 vry
@@ -69303,8 +69354,8 @@ vRP
 vRP
 vRP
 vRP
-vRP
 ubS
+tkl
 tkl
 dll
 dll
@@ -69325,7 +69376,7 @@ wnQ
 iMQ
 kPU
 tgi
-sFQ
+jIh
 sTH
 xGP
 aCD
@@ -69570,7 +69621,7 @@ oon
 hVC
 wtF
 anb
-rUZ
+iAm
 poB
 luQ
 ldq
@@ -69584,7 +69635,7 @@ dcK
 cVi
 cKG
 oUZ
-vgK
+pKd
 vRP
 aCD
 onQ
@@ -69607,7 +69658,7 @@ uqi
 tLT
 qSJ
 uRB
-hAJ
+uRB
 iRc
 tvD
 xTt
@@ -69841,7 +69892,7 @@ aRM
 gaf
 rVH
 iVa
-sRt
+uLC
 aCD
 aCD
 onQ
@@ -69864,7 +69915,7 @@ uqi
 tLT
 siK
 uRB
-uRB
+hAJ
 iRc
 yld
 xTt
@@ -69872,9 +69923,9 @@ mLC
 eEF
 eEF
 mki
-pFl
-rcs
-jWB
+iNk
+lYe
+tGU
 xTt
 cNu
 xZo
@@ -70078,7 +70129,7 @@ vRP
 aCD
 xbD
 dll
-dgq
+ceB
 uwK
 kAM
 qNN
@@ -70335,7 +70386,7 @@ vRP
 ubS
 tkl
 dll
-qLs
+nlv
 uwK
 spY
 vVo
@@ -70345,7 +70396,7 @@ xMn
 wFZ
 pBy
 pYq
-bOC
+dPL
 pjL
 dpv
 jyN
@@ -70363,7 +70414,7 @@ pyH
 bmk
 jDg
 xXU
-sBy
+pWS
 neP
 lZu
 xLG
@@ -70386,8 +70437,8 @@ xTt
 xTt
 xTt
 fWk
-sUq
-ngA
+cFO
+tHN
 xTt
 xTt
 lBF
@@ -70612,7 +70663,7 @@ jZp
 lxD
 ixB
 qRD
-oWC
+ugQ
 noh
 uKb
 cdG
@@ -70642,8 +70693,8 @@ dBO
 kPJ
 kKN
 xTt
-gmX
-avy
+jhc
+sRB
 cuq
 xTt
 fGF
@@ -70866,10 +70917,10 @@ iBo
 grf
 moz
 gMU
-ifQ
+kjE
 bTy
 vzE
-pRw
+qdW
 noh
 lnE
 fSF
@@ -71126,7 +71177,7 @@ gMU
 ycy
 neu
 vrw
-ifQ
+kjE
 noh
 qQC
 mgL
@@ -71134,7 +71185,7 @@ pyH
 tBB
 lmp
 bXk
-nlX
+mdu
 aUd
 xrG
 oNX
@@ -71152,8 +71203,8 @@ uRB
 eCy
 eFb
 pOz
-nxf
-qEP
+dLG
+nZe
 kKN
 xTt
 ccU
@@ -71624,7 +71675,7 @@ lnl
 lnl
 gAA
 fOd
-lbK
+oyH
 pmk
 oZJ
 vtG
@@ -71881,7 +71932,7 @@ lUn
 bSd
 qfO
 eNb
-wmp
+cRV
 gJV
 bgF
 etW
@@ -72137,8 +72188,8 @@ lnl
 gJV
 gJV
 hSt
-nAi
-qSX
+sLe
+wlK
 gJV
 lvH
 yjy
@@ -72151,7 +72202,7 @@ yjy
 mvs
 brT
 ioL
-dpW
+prl
 rfL
 qiw
 sTv
@@ -72408,7 +72459,7 @@ yjy
 yab
 hzN
 tfA
-iiY
+wBi
 cZX
 jju
 sTv
@@ -72665,7 +72716,7 @@ yjy
 gtA
 brT
 ioL
-dpW
+prl
 yfX
 kna
 sTv
@@ -73179,7 +73230,7 @@ xeh
 xLJ
 vUm
 fyG
-dpW
+prl
 rfL
 dZv
 sTv
@@ -73436,7 +73487,7 @@ iXw
 mJM
 gZq
 tfA
-tZk
+kCG
 cZX
 jju
 sTv
@@ -73693,7 +73744,7 @@ fra
 udS
 mfS
 fmz
-dpW
+prl
 yfX
 kna
 gFS
@@ -74207,7 +74258,7 @@ aTR
 udS
 mfS
 fmz
-dpW
+prl
 rfL
 dqQ
 sTv
@@ -74464,7 +74515,7 @@ ffj
 aZG
 mpq
 tfA
-guf
+hyx
 cZX
 jju
 sTv
@@ -74721,7 +74772,7 @@ xXn
 xXn
 tRW
 bdT
-dpW
+prl
 yfX
 kna
 gFS
@@ -75481,8 +75532,8 @@ efI
 qoB
 efI
 efI
-kfy
-wKK
+dXM
+qBI
 agN
 tih
 tih
@@ -76524,10 +76575,10 @@ rDI
 ikb
 mAC
 mAC
-uDF
-iYM
+fOE
+jDN
 pQK
-bbv
+vjG
 dvZ
 ldj
 aDO
@@ -76783,7 +76834,7 @@ fcw
 mAC
 kCl
 ucY
-aOf
+sip
 kpN
 pcs
 cyK
@@ -80167,7 +80218,7 @@ eFs
 wTB
 iuV
 xNs
-dpf
+jSU
 dpf
 dpf
 dpf
@@ -80431,8 +80482,8 @@ ecv
 dpf
 dpf
 dpf
+dpf
 aCD
-ubS
 aCD
 vRP
 vRP
@@ -80688,8 +80739,8 @@ gYo
 wQM
 oko
 dpf
+dpf
 aCD
-ubS
 vRP
 vRP
 vRP
@@ -80945,8 +80996,8 @@ ios
 mZK
 iGe
 dpf
-vRP
-ubS
+dpf
+aCD
 vRP
 vRP
 vRP
@@ -81202,7 +81253,7 @@ ydu
 dpf
 ayE
 dpf
-aCD
+dpf
 aCD
 aCD
 aCD
@@ -81410,8 +81461,8 @@ uTb
 vtV
 kHS
 fbD
-gaY
-ezW
+xEz
+gdy
 bWu
 wIe
 sQy
@@ -81459,8 +81510,8 @@ uvK
 dpf
 gFn
 dpf
-vRP
-ubS
+dpf
+aCD
 vRP
 vRP
 vRP
@@ -89880,7 +89931,7 @@ wpp
 dAK
 cJz
 dLk
-xEe
+vUo
 hxY
 rsW
 eLb
@@ -90137,8 +90188,8 @@ sHR
 fvK
 lRA
 pqf
-jgg
-uNU
+cAX
+syU
 rsW
 wCC
 wCC
@@ -92751,7 +92802,7 @@ pEG
 pKx
 vgB
 mYp
-ein
+szz
 pKx
 cVQ
 hjp

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -7528,6 +7528,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"dNt" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -22865,13 +22875,6 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"luB" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "luE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -31666,24 +31669,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"pSb" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/guncase/shotgun,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "pSg" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -38273,6 +38258,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"tcD" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/guncase/shotgun,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/machinery/camera/motion/armory,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -70049,7 +70047,7 @@ vRP
 aCD
 xbD
 dll
-luB
+dNt
 uwK
 kAM
 qNN
@@ -70306,7 +70304,7 @@ vRP
 ubS
 tkl
 dll
-pSb
+tcD
 uwK
 spY
 vVo

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -978,21 +978,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"avA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "avY" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/department/bridge)
@@ -1580,6 +1565,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"aOf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aOh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -2159,6 +2158,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"bbv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "paramed_shutters";
+	name = "Paramedic Staging shutters"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Paramedic Desk";
+	req_access_txt = "69"
+	},
+/obj/item/deskbell/preset/paramedic{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "bbz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2454,18 +2474,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bhm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bhz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -6400,6 +6408,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dgq" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dgs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6776,6 +6794,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"dpW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "dqA" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -6916,14 +6946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dvc" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/power/emitter,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dve" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
@@ -7528,16 +7550,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"dNt" = (
-/obj/structure/closet/secure_closet/lethalshots,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -9232,6 +9244,22 @@
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
+"ezW" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "eAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -10957,13 +10985,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"fot" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "foF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12616,6 +12637,10 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"gaY" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "gbh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -13348,6 +13373,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos_distro)
+"guf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -14494,26 +14538,6 @@
 "hbW" = (
 /turf/closed/wall,
 /area/science/mixing)
-"hbZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/deskbell/preset/sec{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "hca" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15701,27 +15725,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hCb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "hCz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -16650,6 +16653,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ifQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "igr" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -16805,6 +16819,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"iiY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ikb" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -18157,6 +18190,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"iYM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18431,6 +18476,17 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jgg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "jgj" = (
 /obj/structure/chair{
 	dir = 1
@@ -18668,19 +18724,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"jnj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "jnk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -20295,6 +20338,15 @@
 "kfu" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"kfy" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kfL" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
@@ -22497,23 +22549,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"lhW" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "paramed_shutters";
-	name = "Paramedic Staging shutters"
-	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Paramedic Desk";
-	req_access_txt = "69"
-	},
-/obj/item/deskbell/preset/paramedic{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/medical/paramedic)
 "lia" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -24802,16 +24837,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"mlF" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "mlS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -26273,22 +26298,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mXO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "mXU" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -27094,6 +27103,20 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
+"nxf" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nxm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -29830,6 +29853,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"oWC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/deskbell/preset/sec{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -30096,24 +30143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"pei" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "peo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
@@ -31662,6 +31691,26 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pRw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/security/brig)
 "pRL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -31776,21 +31825,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"pUE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "pVb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32816,14 +32850,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"qrA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "qrX" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 2"
@@ -33172,6 +33198,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"qEP" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qFR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -33412,6 +33443,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qLs" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/guncase/shotgun,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/machinery/camera/motion/armory,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "qLu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35611,19 +35655,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
-/area/engine/engineering)
-"rNc" = (
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rNG" = (
 /obj/effect/turf_decal/arrows/white{
@@ -38258,19 +38289,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"tcD" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/guncase/shotgun,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/machinery/camera/motion/armory,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -40036,6 +40054,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"tZk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tZp" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -40100,18 +40137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ubB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/closet/secure_closet/security/srv,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -40754,21 +40779,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uup" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uuV" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -41142,6 +41152,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
+"uDF" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uDP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41606,6 +41625,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"uNU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/closet/secure_closet/security/srv,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "uOl" = (
 /obj/machinery/computer/cryopod{
 	dir = 8;
@@ -43118,27 +43152,6 @@
 "vBO" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"vBY" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vCh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -45415,6 +45428,21 @@
 /obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"wKK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "wKL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -45512,21 +45540,6 @@
 "wOy" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"wOz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wOB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -47190,6 +47203,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"xEe" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -70047,7 +70078,7 @@ vRP
 aCD
 xbD
 dll
-dNt
+dgq
 uwK
 kAM
 qNN
@@ -70304,7 +70335,7 @@ vRP
 ubS
 tkl
 dll
-tcD
+qLs
 uwK
 spY
 vVo
@@ -70581,7 +70612,7 @@ jZp
 lxD
 ixB
 qRD
-hbZ
+oWC
 noh
 uKb
 cdG
@@ -70835,10 +70866,10 @@ iBo
 grf
 moz
 gMU
-fot
+ifQ
 bTy
 vzE
-mXO
+pRw
 noh
 lnE
 fSF
@@ -70864,7 +70895,7 @@ hAJ
 iKZ
 mwk
 sSU
-brd
+dBO
 dBO
 xib
 xTt
@@ -71095,7 +71126,7 @@ gMU
 ycy
 neu
 vrw
-fot
+ifQ
 noh
 qQC
 mgL
@@ -71121,8 +71152,8 @@ uRB
 eCy
 eFb
 pOz
-rNc
-dvc
+nxf
+qEP
 kKN
 xTt
 ccU
@@ -72104,7 +72135,7 @@ vRP
 vRP
 lnl
 gJV
-lnl
+gJV
 hSt
 nAi
 qSX
@@ -72120,7 +72151,7 @@ yjy
 mvs
 brT
 ioL
-qrA
+dpW
 rfL
 qiw
 sTv
@@ -72361,7 +72392,7 @@ vRP
 vRP
 tkl
 aCD
-voI
+gJV
 voI
 ygu
 voI
@@ -72377,7 +72408,7 @@ yjy
 yab
 hzN
 tfA
-wOz
+iiY
 cZX
 jju
 sTv
@@ -72618,7 +72649,7 @@ vRP
 vRP
 lnl
 gJV
-lnl
+gJV
 xSZ
 woG
 vao
@@ -72634,7 +72665,7 @@ yjy
 gtA
 brT
 ioL
-qrA
+dpW
 yfX
 kna
 sTv
@@ -73148,7 +73179,7 @@ xeh
 xLJ
 vUm
 fyG
-qrA
+dpW
 rfL
 dZv
 sTv
@@ -73405,7 +73436,7 @@ iXw
 mJM
 gZq
 tfA
-avA
+tZk
 cZX
 jju
 sTv
@@ -73662,7 +73693,7 @@ fra
 udS
 mfS
 fmz
-qrA
+dpW
 yfX
 kna
 gFS
@@ -74176,7 +74207,7 @@ aTR
 udS
 mfS
 fmz
-qrA
+dpW
 rfL
 dqQ
 sTv
@@ -74433,7 +74464,7 @@ ffj
 aZG
 mpq
 tfA
-uup
+guf
 cZX
 jju
 sTv
@@ -74690,7 +74721,7 @@ xXn
 xXn
 tRW
 bdT
-qrA
+dpW
 yfX
 kna
 gFS
@@ -75450,9 +75481,9 @@ efI
 qoB
 efI
 efI
-pUE
-vBY
-mlF
+kfy
+wKK
+agN
 tih
 tih
 igE
@@ -76493,10 +76524,10 @@ rDI
 ikb
 mAC
 mAC
-kCl
-pei
-hUI
-lhW
+uDF
+iYM
+pQK
+bbv
 dvZ
 ldj
 aDO
@@ -76750,9 +76781,9 @@ nel
 nUm
 fcw
 mAC
-hly
-ptM
-dAf
+kCl
+ucY
+aOf
 kpN
 pcs
 cyK
@@ -81379,8 +81410,8 @@ uTb
 vtV
 kHS
 fbD
-jcz
-bhm
+gaY
+ezW
 bWu
 wIe
 sQy
@@ -86757,9 +86788,9 @@ vRP
 vRP
 vRP
 vRP
+aCD
 vRP
-vRP
-vRP
+aCD
 eLb
 wCC
 wCC
@@ -87016,7 +87047,7 @@ vRP
 vRP
 vRP
 vRP
-vRP
+aCD
 eLb
 wCC
 wCC
@@ -89849,7 +89880,7 @@ wpp
 dAK
 cJz
 dLk
-hCb
+xEe
 hxY
 rsW
 eLb
@@ -90106,8 +90137,8 @@ sHR
 fvK
 lRA
 pqf
-jnj
-ubB
+jgg
+uNU
 rsW
 wCC
 wCC


### PR DESCRIPTION
# Document the changes in your pull request
Fixes some of the map issues on gax, just looking all over for any glaring ones

- replaces armory cam with the right subtype
- ![image](https://user-images.githubusercontent.com/48154165/221185098-65b8f852-c059-49e4-adfb-60e378fefd41.png)
- adds firelocks to brig cells
- moves a lot of vents/scrubbers from apc tiles
- moves some firelocks in the hallways
- ![firefox_tiy8jLfVhU](https://user-images.githubusercontent.com/48154165/221188892-c441f67c-5240-4b25-90f8-327538099c42.png)
- closes #13547
- closes #17950
- sec locker room gets decals

# Changelog

:cl:  
mapping: [Gax] Fixes some map issues
/:cl:
