### PR TITLE
Makes brain implants less noobbait

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	var/stun_amount = 200/severity
+	var/stun_amount = 100/severity
 	owner.Stun(stun_amount)
 	to_chat(owner, span_warning("Your body seizes up!"))
 
@@ -110,15 +110,15 @@
 
 	var/stun_cap_amount = 4 SECONDS
 
-/obj/item/organ/cyberimp/brain/anti_stun/Remove(mob/living/carbon/M, special = FALSE)
-	. = ..()
-	UnregisterSignal(M, signalCache)
-	UnregisterSignal(M, COMSIG_CARBON_STATUS_STAMCRIT)
-
 /obj/item/organ/cyberimp/brain/anti_stun/Insert()
 	. = ..()
 	RegisterSignal(owner, signalCache, .proc/on_signal)
 	RegisterSignal(owner, COMSIG_CARBON_STATUS_STAMCRIT, .proc/on_signal_stamina)
+
+/obj/item/organ/cyberimp/brain/anti_stun/Remove(mob/living/carbon/M, special = FALSE)
+	. = ..()
+	UnregisterSignal(M, signalCache)
+	UnregisterSignal(M, COMSIG_CARBON_STATUS_STAMCRIT)
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/on_signal(datum/source, amount)
 	if(!(organ_flags & ORGAN_FAILING) && amount > 0)
@@ -137,9 +137,10 @@
 	if((organ_flags & ORGAN_FAILING) || . & EMP_PROTECT_SELF)
 		return
 	organ_flags |= ORGAN_FAILING
-	addtimer(CALLBACK(src, .proc/reboot), 90 / severity)
+	addtimer(CALLBACK(src, .proc/reboot), stun_cap_amount * 2 / severity)
 
 /obj/item/organ/cyberimp/brain/anti_stun/proc/reboot()
+	clear_stuns()
 	organ_flags &= ~ORGAN_FAILING
 
 //[[[[MOUTH]]]]


### PR DESCRIPTION
Did you know?
Getting emped with a brain implant stuns either 10 or 20 seconds depending on the EMP strength.
The CNS rebooter hypothetically would reduce this as it reboots after 4.5 or 9 seconds.
However, it doesn't trigger the stun purge effect unless a new stun is applied AFTER it reboots.

Reduces default brain implant stun to 5 or 10 seconds
CNS rebooter reboots after 4 or 8 seconds
CNS rebooter purges CC the moment it reboots

:cl:  
tweak: Halved stun duration from EMPed brain implant
tweak: CNS rebooter purges CC immediately when it reboots from EMP
/:cl:
