### PR TITLE
Handheld flashes knockdown carbons instead of hardstun

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -148,10 +148,10 @@
 					trauma.on_flash(user, M)
 			else
 				to_chat(M, span_userdanger("You are blinded by [src]!"))
-			if(M.IsParalyzed())
-				M.Paralyze(rand(20,30))
+			if(M.IsParalyzed() || M.IsKnockdown())
+				M.Knockdown(rand(20,30))
 			else
-				M.Paralyze(rand(80,120))
+				M.Knockdown(rand(80,120))
 		else if(user)
 			visible_message(span_disarm("[user] fails to blind [M] with the flash!"))
 			to_chat(user, span_warning("You fail to blind [M] with the flash!"))


### PR DESCRIPTION
# Document the changes in your pull request

Revival of #17036

Flashes now apply 8-12 seconds of knockdown or 2-3 seconds if already knocked down/paralyzed. Flashes still apply 15 confusion stacks and blind on hit.

Clicking someone once and them not being able to at least struggle is bad gameplay

# Changelog

:cl:  
tweak: Handheld flashes now knockdown instead of paralyze
/:cl:
