### PR TITLE
Vaccines must be administered via injection

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -102,7 +102,7 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(islist(data) && (method == INGEST || method == INJECT))
+	if(islist(data) && method == INJECT)
 		for(var/thing in L.diseases)
 			var/datum/disease/D = thing
 			if(D.GetDiseaseID() in data)


### PR DESCRIPTION
literally just #15251

0.1u pills to cure diseases is boring and makes little logical sense since vaccines shouldn't work when ingested
I literally worked at a covid vaccination site for a bit over a year, I was one of those weird guys asking questions that no sane person would, if you drank the vaccine, your stomach would break it down before it has any chance to take effect.
It needs to be injected intra-muscular to properly ensure it can properly get into the blood stream without being damaged in any way.

This gives medbay something to actually do that isn't just surgery
Also buffs traitor viros and sentient diseases as the entire station doesn't become immune in like 10 seconds now

:cl:  @ynot01 
tweak: Vaccines can only be injected, not eaten
/:cl:
