### PR TITLE
Adds tiny fans to Arrivals shuttles

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -5,20 +5,6 @@
 "b" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"c" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "d" = (
 /obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/white,
@@ -47,6 +33,21 @@
 	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/arrival)
+"h" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/arrival)
 "i" = (
 /obj/structure/closet/wardrobe/black,
@@ -279,13 +280,13 @@ x
 H
 "}
 (6,1,1) = {"
-c
+h
 f
 r
 r
 r
 f
-c
+h
 "}
 (7,1,1) = {"
 b
@@ -342,13 +343,13 @@ z
 b
 "}
 (13,1,1) = {"
-c
+h
 f
 S
 S
 S
 f
-c
+h
 "}
 (14,1,1) = {"
 b

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -172,6 +172,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "o" = (

--- a/_maps/shuttles/arrival_gax.dmm
+++ b/_maps/shuttles/arrival_gax.dmm
@@ -5,6 +5,17 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
+"c" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Arrivals Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "g" = (
 /obj/machinery/light{
 	dir = 4
@@ -147,16 +158,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
-"S" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Arrivals Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "T" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -221,7 +222,7 @@ b
 s
 "}
 (5,1,1) = {"
-S
+c
 K
 K
 K
@@ -239,7 +240,7 @@ b
 s
 "}
 (7,1,1) = {"
-S
+c
 K
 K
 K

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -20,6 +20,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "e" = (

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -83,22 +83,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
-"j" = (
-/obj/machinery/door/airlock/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "k" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -273,6 +257,23 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
+"N" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 "Q" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -292,14 +293,14 @@
 a
 d
 f
-j
+N
 f
 R
 A
 d
 A
 A
-j
+N
 F
 f
 a


### PR DESCRIPTION
# Document the changes in your pull request

As title states. This allows for people who are arriving to the station not to have a shuttle full of toxic gases, or no air whatsoever.

![image](https://user-images.githubusercontent.com/70451213/221356865-dc5d6c78-c8aa-4c42-8bea-8023fad64157.png)


# Changelog

:cl:  
mapping: Tiny fans added to all arrivals shuttle airlocks so people can breathe when late-joining.
/:cl:
