### PR TITLE
Filter invalid quirks upon loading character

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -62,13 +62,19 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /// be valid.
 /// If no changes need to be made, will return the same list.
 /// Expects all quirk names to be unique, but makes no other expectations.
-/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, client/C)
+/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, client_or_prefs)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
 	var/balance = 0
 
+	var/datum/preferences/prefs = client_or_prefs
+
+	if (istype(client_or_prefs, /client))
+		var/client/client = client_or_prefs
+		prefs = client.prefs
+
 	// If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
-	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (C.prefs.yogtoggles & PREF_MOOD))
+	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (prefs.yogtoggles & PREF_MOOD))
 
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = SSquirks.quirks[quirk_name]
@@ -80,7 +86,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 		// Returns error string, FALSE if quirk is okay to have
 		var/datum/quirk/quirk_obj = new quirk(no_init = TRUE)
-		if (quirk_obj?.check_quirk(C.prefs))
+		if (quirk_obj?.check_quirk(prefs))
 			continue
 		qdel(quirk_obj)
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -330,7 +330,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(job_preferences[j] != JP_LOW && job_preferences[j] != JP_MEDIUM && job_preferences[j] != JP_HIGH)
 			job_preferences -= j
 
-	//all_quirks = SSquirks.filter_invalid_quirks(all_quirks, parent)
+	all_quirks = SSquirks.filter_invalid_quirks(all_quirks, src)
 	validate_quirks()
 
 	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request
I didn't originally do this because our quirk code is special. This should hopefully fix any issues with people having invalid quirks


# Changelog

:cl:  
bugfix: Invalid quirks will not be filtered when you load a character
/:cl:
