### PR TITLE
fake bloodsucker lair 3x3 random maint

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair.dmm
@@ -12,6 +12,12 @@
 /obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/template_noop)
+"o" = (
+/obj/structure/closet/crate/coffin/metalcoffin{
+	anchored = 1
+	},
+/turf/open/floor/plating/broken/three,
+/area/template_noop)
 "E" = (
 /obj/item/restraints/handcuffs/cable,
 /obj/item/stack/sheet/mineral/wood,
@@ -21,10 +27,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/template_noop)
-"P" = (
-/obj/structure/closet/crate/coffin/metalcoffin,
-/turf/open/floor/plating/broken/three,
 /area/template_noop)
 "Z" = (
 /turf/open/floor/plating,
@@ -41,7 +43,7 @@ b
 Z
 "}
 (3,1,1) = {"
-P
+o
 j
 m
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair.dmm
@@ -1,0 +1,47 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/template_noop)
+"j" = (
+/obj/item/restraints/handcuffs/cable/zipties/used,
+/turf/open/floor/plating,
+/area/template_noop)
+"m" = (
+/obj/item/reagent_containers/blood/random,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/template_noop)
+"E" = (
+/obj/item/restraints/handcuffs/cable,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"P" = (
+/obj/structure/closet/crate/coffin/metalcoffin,
+/turf/open/floor/plating/broken/three,
+/area/template_noop)
+"Z" = (
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+E
+Z
+Z
+"}
+(2,1,1) = {"
+Z
+b
+Z
+"}
+(3,1,1) = {"
+P
+j
+m
+"}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair2.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair2.dmm
@@ -1,16 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"f" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"F" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/template_noop)
-"k" = (
-/turf/open/floor/plating,
-/area/template_noop)
-"m" = (
-/obj/item/restraints/handcuffs/cable/zipties/used,
-/turf/open/floor/plating,
-/area/template_noop)
-"r" = (
+"G" = (
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
@@ -18,35 +14,41 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/broken/three,
 /area/template_noop)
-"C" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/stack/sheet/mineral/wood,
+"K" = (
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/template_noop)
-"R" = (
-/obj/structure/closet/crate/coffin,
+"M" = (
+/obj/structure/closet/crate/coffin{
+	anchored = 1
+	},
 /obj/item/restraints/handcuffs/cable,
 /obj/item/restraints/handcuffs/cable,
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/template_noop)
-"T" = (
-/obj/structure/table,
+"S" = (
+/obj/item/restraints/handcuffs/cable/zipties/used,
+/turf/open/floor/plating,
+/area/template_noop)
+"W" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/template_noop)
 
 (1,1,1) = {"
-T
-a
-R
+K
+F
+M
 "}
 (2,1,1) = {"
-C
-k
-k
+W
+f
+f
 "}
 (3,1,1) = {"
-r
-m
-k
+G
+S
+f
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair2.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair2.dmm
@@ -1,0 +1,52 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating,
+/area/template_noop)
+"k" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"m" = (
+/obj/item/restraints/handcuffs/cable/zipties/used,
+/turf/open/floor/plating,
+/area/template_noop)
+"r" = (
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/item/restraints/handcuffs/cable,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/broken/three,
+/area/template_noop)
+"C" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating,
+/area/template_noop)
+"R" = (
+/obj/structure/closet/crate/coffin,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/plating,
+/area/template_noop)
+"T" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+T
+a
+R
+"}
+(2,1,1) = {"
+C
+k
+k
+"}
+(3,1,1) = {"
+r
+m
+k
+"}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair3.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair3.dmm
@@ -1,40 +1,42 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"m" = (
-/turf/open/floor/wood/broken/four,
-/area/template_noop)
-"r" = (
-/obj/structure/closet/crate/coffin/securecoffin,
+"a" = (
+/obj/structure/closet/crate/coffin/securecoffin{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/item/restraints/handcuffs/cable/zipties,
 /turf/open/floor/wood,
 /area/template_noop)
-"t" = (
+"u" = (
+/turf/open/floor/wood/broken/three,
+/area/template_noop)
+"v" = (
+/turf/open/floor/wood,
+/area/template_noop)
+"H" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood,
 /area/template_noop)
-"x" = (
-/turf/open/floor/wood,
+"K" = (
+/turf/open/floor/wood/broken/four,
 /area/template_noop)
-"A" = (
+"O" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood/broken/six,
 /area/template_noop)
-"X" = (
-/turf/open/floor/wood/broken/three,
-/area/template_noop)
 
 (1,1,1) = {"
-x
-m
-t
+v
+K
+H
 "}
 (2,1,1) = {"
-A
-r
-x
+O
+a
+v
 "}
 (3,1,1) = {"
-x
-x
-X
+v
+v
+u
 "}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair3.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair3.dmm
@@ -1,0 +1,40 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"m" = (
+/turf/open/floor/wood/broken/four,
+/area/template_noop)
+"r" = (
+/obj/structure/closet/crate/coffin/securecoffin,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/item/restraints/handcuffs/cable/zipties,
+/turf/open/floor/wood,
+/area/template_noop)
+"t" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/wood,
+/area/template_noop)
+"x" = (
+/turf/open/floor/wood,
+/area/template_noop)
+"A" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/wood/broken/six,
+/area/template_noop)
+"X" = (
+/turf/open/floor/wood/broken/three,
+/area/template_noop)
+
+(1,1,1) = {"
+x
+m
+t
+"}
+(2,1,1) = {"
+A
+r
+x
+"}
+(3,1,1) = {"
+x
+x
+X
+"}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair4dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair4dmm
@@ -1,0 +1,50 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"s" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/item/clothing/glasses/welding,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"z" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"N" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/coffin/metalcoffin,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/restraints/handcuffs/cable/red,
+/turf/open/floor/plasteel,
+/area/template_noop)
+
+(1,1,1) = {"
+N
+c
+w
+"}
+(2,1,1) = {"
+s
+s
+Y
+"}
+(3,1,1) = {"
+Y
+z
+c
+"}

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair4dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_lair4dmm
@@ -1,13 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"c" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/template_noop)
-"s" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"w" = (
+"f" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -15,36 +7,46 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/template_noop)
+"x" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/coffin/metalcoffin{
+	anchored = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
 "z" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"K" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/restraints/handcuffs/cable/red,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"R" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"S" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/template_noop)
-"N" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/coffin/metalcoffin,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"Y" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/restraints/handcuffs/cable/red,
-/turf/open/floor/plasteel,
-/area/template_noop)
 
 (1,1,1) = {"
-N
-c
-w
+x
+R
+f
 "}
 (2,1,1) = {"
-s
-s
-Y
+z
+z
+K
 "}
 (3,1,1) = {"
-Y
-z
-c
+K
+S
+R
 "}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -549,6 +549,12 @@
 	suffix = "3x3_donut.dmm"
 	name = "Maint donut"
 
+///Author: Marmio64
+/datum/map_template/ruin/station/maint/threexthree/lair
+	id = "lair" 
+	suffix = "3x3_lair.dmm"
+	name = "Maint lair"
+
 ///The base for the 3x5 rooms.
 /datum/map_template/ruin/station/maint/threexfive
 	prefix = "_maps/RandomRuins/StationRuins/maint/3x5/"

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -555,6 +555,24 @@
 	suffix = "3x3_lair.dmm"
 	name = "Maint lair"
 
+///Author: Marmio64
+/datum/map_template/ruin/station/maint/threexthree/lair2
+	id = "lair2" 
+	suffix = "3x3_lair2.dmm"
+	name = "Maint lair2"
+
+///Author: Marmio64
+/datum/map_template/ruin/station/maint/threexthree/lair3
+	id = "lair3" 
+	suffix = "3x3_lair3.dmm"
+	name = "Maint lair3"
+
+///Author: Marmio64
+/datum/map_template/ruin/station/maint/threexthree/lair4
+	id = "lair4" 
+	suffix = "3x3_lair4.dmm"
+	name = "Maint lair4"
+
 ///The base for the 3x5 rooms.
 /datum/map_template/ruin/station/maint/threexfive
 	prefix = "_maps/RandomRuins/StationRuins/maint/3x5/"

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Maint 2storage", "Maint 9storage", "Maint airstation", "Maint biohazard", "Maint boxbedroom", "Maint boxchemcloset", "Maint boxclutter2", "Maint boxclutter3", "Maint boxclutter4", "Maint boxclutter5", "Maint boxclutter6", "Maint boxclutter8",
 	"Maint boxwindow", "Maint bubblegumaltar", "Maint deltajanniecloset", "Maint deltaorgantrade", "Maint donutcapgun", "Maint dronehole", "Maint gibs", "Maint hazmat", "Maint hobohut", "Maint hullbreach", "Maint kilolustymaid", "Maint kilomechcharger", "Maint kilotheatre",
 	"Maint medicloset", "Maint memorial", "Maint metaclutter2", "Maint metaclutter4", "Maint metagamergear", "Maint owloffice", "Maint plasma", "Maint pubbyartism", "Maint pubbyclutter1", "Maint pubbyclutter2", "Maint pubbyclutter3", "Maint radspill", "Maint shrine", "Maint singularity",
-	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident", "Maint donut")
+	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident", "Maint donut", "Maint lair")
 
 /obj/effect/landmark/stationroom/maint/threexfive
 	template_names = list("Maint airlockstorage", "Maint boxclutter7", "Maint boxkitchen", "Maint boxmaintfreezers", "Maint canisterroom", "Maint checkpoint", "Maint hank", "Maint junkcloset", "Maint kilomobden", "Maint laststand", "Maint monky", "Maint onioncult", "Maint pubbyclutter5",

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Maint 2storage", "Maint 9storage", "Maint airstation", "Maint biohazard", "Maint boxbedroom", "Maint boxchemcloset", "Maint boxclutter2", "Maint boxclutter3", "Maint boxclutter4", "Maint boxclutter5", "Maint boxclutter6", "Maint boxclutter8",
 	"Maint boxwindow", "Maint bubblegumaltar", "Maint deltajanniecloset", "Maint deltaorgantrade", "Maint donutcapgun", "Maint dronehole", "Maint gibs", "Maint hazmat", "Maint hobohut", "Maint hullbreach", "Maint kilolustymaid", "Maint kilomechcharger", "Maint kilotheatre",
 	"Maint medicloset", "Maint memorial", "Maint metaclutter2", "Maint metaclutter4", "Maint metagamergear", "Maint owloffice", "Maint plasma", "Maint pubbyartism", "Maint pubbyclutter1", "Maint pubbyclutter2", "Maint pubbyclutter3", "Maint radspill", "Maint shrine", "Maint singularity",
-	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident", "Maint donut", "Maint lair")
+	"Maint tanning", "Maint tranquility", "Maint wash", "Maint command", "Maint dummy", "Maint spaceart", "Maint containmentcell", "Maint naughtyroom", "Maint vendoraccident", "Maint donut", "Maint lair" = 0.25, "Maint lair2" = 0.25, "Maint lair3" = 0.25, "Maint lair4" = 0.25)
 
 /obj/effect/landmark/stationroom/maint/threexfive
 	template_names = list("Maint airlockstorage", "Maint boxclutter7", "Maint boxkitchen", "Maint boxmaintfreezers", "Maint canisterroom", "Maint checkpoint", "Maint hank", "Maint junkcloset", "Maint kilomobden", "Maint laststand", "Maint monky", "Maint onioncult", "Maint pubbyclutter5",


### PR DESCRIPTION
A fake bloodsucker lair. Has a coffin, some of the building materials for a persuasion rack, and a bloodbag. Both terrifies maint goers and gives bloodsuckers some useful stuff if they explore maint and find it.
![lair](https://user-images.githubusercontent.com/60946370/221368918-43f1ba06-3fb0-44b3-862a-0816c680a4fb.png)


# Changelog

:cl:  
rscadd: Adds bloodsucker lair random maint 3x3 template
/:cl:
