### PR TITLE
Non-Human Head/Pay Revisit: Vuulen

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -12,7 +12,7 @@
 	mutanttail = /obj/item/organ/tail/lizard
 	coldmod = 1.75 //Desert-born race
 	heatmod = 0.75 //Desert-born race
-	payday_modifier = 0.5 //Negatively viewed by NT
+	payday_modifier = 0.9 //Full SIC citizens, but not quite given all the same rights- it's been an ongoing process for about half a decade
 	default_features = list("mcolor" = "0F0", "tail_lizard" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -20,8 +20,8 @@ REVIVAL_BRAIN_LIFE -1
 JOB_SPECIES_WHITELIST /datum/job/captain human
 JOB_SPECIES_WHITELIST /datum/job/hop human
 JOB_SPECIES_WHITELIST /datum/job/hos human,lizard
-JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,plasmaman,moth,ethereal,preternis,polysmorph,ipc
-JOB_SPECIES_WHITELIST /datum/job/rd human,pod,plasmaman,ethereal,preternis,polysmorph,ipc
+JOB_SPECIES_WHITELIST /datum/job/chief_engineer human,lizard,plasmaman,moth,ethereal,preternis,polysmorph,ipc
+JOB_SPECIES_WHITELIST /datum/job/rd human,lizard,pod,plasmaman,ethereal,preternis,polysmorph,ipc
 JOB_SPECIES_WHITELIST /datum/job/cmo human,lizard,pod,moth
 
 


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so lizards can be RD and CE and they're also paid slightly less than human.

# Changelog

:cl:  
tweak: Lizards can now be RD and CE
tweak: Lizards have a pay coefficient of 0.9x
/:cl:
