### PR TITLE
Replaces the cyborg stun arms with a lethal plasma cutter and flamethrower

### DIFF
--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -325,3 +325,19 @@
 
 /obj/item/assembly/igniter/proc/ignite_turf(obj/item/flamethrower/F,turf/open/location,release_amount = 0.05)
 	return F.default_ignite(location,release_amount)
+
+///////////////////// Flamethrower as an energy weapon /////////////////////
+// Currently used exclusively in /obj/item/gun/energy/printer/flamethrower
+/obj/item/ammo_casing/energy/flamethrower
+	projectile_type = /obj/item/projectile/bullet/incendiary/flamethrower
+	select_name = "fire"
+	fire_sound = null
+	firing_effect_type = null
+	e_cost = 50
+
+/obj/item/projectile/bullet/incendiary/flamethrower
+	name = "waft of flames"
+	icon_state = null
+	damage = 0
+	sharpness = SHARP_NONE
+	range = 6

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -341,3 +341,4 @@
 	damage = 0
 	sharpness = SHARP_NONE
 	range = 6
+	penetration_type = 2

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -348,7 +348,7 @@
 		/obj/item/stack/cable_coil/cyborg,
 		/obj/item/barrier_taperoll/engineering)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
-	emag_modules = list(/obj/item/borg/stun)
+	emag_modules = list(/obj/item/gun/energy/printer/flamethrower)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/engineer,
 		/obj/item/clockwork/replica_fabricator/cyborg)
@@ -582,7 +582,7 @@
 		/obj/item/gps/cyborg,
 		/obj/item/stack/marker_beacon)
 	radio_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_SUPPLY)
-	emag_modules = list(/obj/item/borg/stun)
+	emag_modules = list(/obj/item/gun/energy/plasmacutter/adv/malf)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/miner,
 		/obj/item/clockwork/weapon/ratvarian_spear,

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -45,3 +45,7 @@
 	projectile_type = /obj/item/projectile/plasma/adv
 	delay = 10
 	e_cost = 15 // Might need nerfing
+
+/obj/item/ammo_casing/energy/plasma/adv/cyborg/malf
+	projectile_type = /obj/item/projectile/plasma/adv/malf
+	e_cost = 100

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -48,4 +48,4 @@
 
 /obj/item/ammo_casing/energy/plasma/adv/cyborg/malf
 	projectile_type = /obj/item/projectile/plasma/adv/malf
-	e_cost = 100
+	e_cost = 50

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -255,6 +255,14 @@
 	selfcharge = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv/cyborg)
 
+/obj/item/gun/energy/plasmacutter/adv/malf // Can't be subtype of cyborg or it will interfere with upgrades
+	name = "cyborg malfunctioning plasma cutter"
+	desc = "A mining tool capable o=#9v@3-M!a%R=KILLING AND MURDERING ORGANICS."
+	color = "red"
+	force = 15
+	selfcharge = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv/cyborg/malf)
+
 // Upgrades for plasma cutters
 /obj/item/upgrade/plasmacutter
 	name = "generic upgrade kit"
@@ -363,6 +371,15 @@
 	icon = 'icons/obj/guns/projectile.dmi'
 	cell_type = "/obj/item/stock_parts/cell/secborg"
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
+	can_charge = FALSE
+	use_cyborg_cell = TRUE
+
+/obj/item/gun/energy/printer/flamethrower
+	name = "cyborg flame projector"
+	desc = "Originally intended for cyborgs to assist in atmospherics projects, was soon scrapped due to safety concerns."
+	icon = 'yogstation/icons/obj/flamethrower.dmi'
+	icon_state = "flamethrowerbase"
+	ammo_type = list(/obj/item/ammo_casing/energy/flamethrower)
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
 

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -41,6 +41,9 @@
 	range = 5
 	mine_range = 5
 
+/obj/item/projectile/plasma/adv/malf
+	damage = 20
+
 /obj/item/projectile/plasma/adv/mega
 	range = 7
 	mine_range = 7


### PR DESCRIPTION
# Document the changes in your pull request

Engineering emagged module is now a self-charging flamethrower
Does no damage on hit, but applies 4 fire stacks

Mining emagged module is now a lethal advanced plasma cutter
Projectile does 20 damage instead of 7

# Changelog

:cl:  
rscdel: Removed cyborg stun arm from Engineering & Mining emagged modules
rscadd: Added the cyborg malfunctioning plasma cutter to the Mining emagged module which does more damage than a normal plasma cutter
rscadd: Added the cyborg flame projector to the Engineering emagged module which self-charges
/:cl:
