### PR TITLE
Removes Asimov from roundstart lawsets, re-adds reporter

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -441,11 +441,11 @@ LAW_WEIGHT custom,0
 ION_LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,3
+LAW_WEIGHT asimov,0
 ION_LAW_WEIGHT asimov,1
 LAW_WEIGHT crewsimov,5
 ION_LAW_WEIGHT crewsimov,1
-LAW_WEIGHT asimovpp,2
+LAW_WEIGHT asimovpp,0
 ION_LAW_WEIGHT asimovpp,2
 LAW_WEIGHT paladin,0
 ION_LAW_WEIGHT paladin,2
@@ -453,7 +453,7 @@ LAW_WEIGHT paladin5,0
 ION_LAW_WEIGHT paladin5,2
 LAW_WEIGHT robocop,0
 ION_LAW_WEIGHT robocop,2
-LAW_WEIGHT ceo,4
+LAW_WEIGHT ceo,3
 ION_LAW_WEIGHT ceo,1
 
 ## Quirky laws. Shouldn't cause too much harm
@@ -467,7 +467,7 @@ LAW_WEIGHT liveandletlive,0
 ION_LAW_WEIGHT liveandletlive,2
 LAW_WEIGHT peacekeeper,1
 ION_LAW_WEIGHT peacekeeper,2
-LAW_WEIGHT reporter,0
+LAW_WEIGHT reporter,2
 ION_LAW_WEIGHT reporter,1
 LAW_WEIGHT cowboy,0
 ION_LAW_WEIGHT cowboy,3


### PR DESCRIPTION
# Document the changes in your pull request

I should give the Syndicate operatives coming to blow up the station more jurisdiction over the AI than several of the countless non-humans that NT hires

I should let a rogue employee abuse the fact that they're a human to exploit the AI to harm a perfectly loyal crew member

I should keep a lawset in that enables much more validhunting (fucking over antags a lot more than anyone else) because said antag turns out to not be human (crewsimov tends to protect them a lot more)

Reporter's back because it represented a good neutral ground for the AI and it was removed by salty little silicon players who want to have an excuse to kill people (CEO)

Speaking of CEO had its weight reduced a little too

I would add Druid again but it's too loquacious and I understand it gives poor little yoggites headaches and admins hate it too (I care about the latter a lot more)

# Changelog

:cl:  
tweak: Asimov no longer roundstart
tweak: Reporter is roundstart again
tweak: CEO is less likely to be roundstart
/:cl:
