### PR TITLE
Buffs szlachta

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
@@ -8,6 +8,7 @@
 	siemens_coeff = 0
 	brutemod = 0.5
 	burnmod = 0.75
+	stunmod = 0.5
 	punchdamagelow = 12
 	punchdamagehigh = 19 //hardcore
 	punchstunthreshold = 17

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/szlachta.dm
@@ -6,9 +6,10 @@
 	nojumpsuit = TRUE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	siemens_coeff = 0
-	brutemod = 0.8
-	heatmod = 0.8
-	punchdamagehigh = 17 //hardcore
+	brutemod = 0.5
+	burnmod = 0.75
+	punchdamagelow = 12
+	punchdamagehigh = 19 //hardcore
 	punchstunthreshold = 17
 	no_equip = list(SLOT_WEAR_MASK, SLOT_WEAR_SUIT, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM, SLOT_S_STORE, SLOT_HEAD)
 	species_traits = list(NO_UNDERWEAR,NO_DNA_COPY,NOTRANSSTING,NOEYESPRITES,NOFLASH)


### PR DESCRIPTION
right away, if you dont know what a Szlachta is, it is the species a Tzimisce vassal gets turned into when favorited.

I decided to check in on these finally and discovered they're actually really weak all things considered. They have good species traits like nohardcrit and all that stuff (like bloodsuckers do), but they're permanently obviously a monster and valid. Their punch high is pretty nice but their punchlow is still a measly 1. In addition they only resist 20% of brute damage and can't wear any armor nor can they use guns. Basically like a sling empowered thrall where they give up a bunch of crap for some good upsides, but it's overall not really worth it most of the time.

This buff is pretty dang big but you'll rarely see this and a tzimisce can only have one at a time, so it should be fine.

Removes 0.8 heatmod
Adds 0.75 burnmod
Brutemod changed from 0.8 to 0.5
Punchlow upped to 12
Punchhigh upped to 19

# Changelog

:cl:  
tweak: Large Szlachta buff
/:cl:
