### PR TITLE
Buffs gummybears and fixes chemmaster ui

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -305,7 +305,7 @@ const PackagingControls = (props, context) => {
           label="Gummy Bears"
           amount={gummyAmount}
           amountUnit="gummies"
-          sideNote="max 15u"
+          sideNote="max 30u"
           onChangeAmount={(e, value) => setGummyAmount(value)}
           onCreate={() => act('create', {
             type: 'gummy',

--- a/yogstation/code/modules/reagents/reagent_containers/gummies.dm
+++ b/yogstation/code/modules/reagents/reagent_containers/gummies.dm
@@ -11,7 +11,7 @@
 	var/apply_type = INGEST
 	var/apply_method = "chew"
 	var/rename_with_volume = FALSE
-	var/self_delay = 1.5 SECONDS
+	var/self_delay = 1 SECONDS
 	var/dissolvable = TRUE
 
 /obj/item/reagent_containers/gummy/Initialize()
@@ -179,7 +179,7 @@
 	color = null
 
 /obj/item/reagent_containers/gummy/floorbear/Initialize()
-	list_reagents = list(get_random_reagent_id() = 15)
+	list_reagents = list(get_random_reagent_id() = 30)
 	. = ..()
 	name = pick(names2)
 	if(prob(20))


### PR DESCRIPTION
Gummy bears are underwhelming as is, with syringe guns "removed", it's fair that chemists can get some power back in the chemical consumption department

floorbears were still generated for 15u

also, they were already 30u cap, but the chemmaster only said 15u

:cl:  
tweak: Gummy bears are eaten in 1 second instead of 1.5
tweak: Floor gummy bears now spawn with 30u of reagents in them
spellcheck: Chemmaster accurately shows that gummy bears are 30u max
/:cl:
