### PR TITLE
Makes lifesteal crystal not a useless piece of necropolis loot.

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -197,10 +197,6 @@
 /obj/item/projectile/kinetic/prehit(atom/target)
 	. = ..()
 	if(.)
-		if(kinetic_gun)
-			var/list/mods = kinetic_gun.get_modkits()
-			for(var/obj/item/borg/upgrade/modkit/M in mods)
-				M.projectile_prehit(src, target, kinetic_gun)
 		if(!lavaland_equipment_pressure_check(get_turf(target)))
 			name = "weakened [name]"
 			damage = damage * pressure_decrease
@@ -209,7 +205,11 @@
 			pressure_decrease = min(pressure_decrease * 2, 1) //if you have a pressure mod you get to ignore this because uhmmmmmm tc tax
 			name = "destabilized [name]"
 			damage = damage * pressure_decrease
-			pressure_decrease_active = TRUE 
+			pressure_decrease_active = TRUE
+		if(kinetic_gun)
+			var/list/mods = kinetic_gun.get_modkits()
+			for(var/obj/item/borg/upgrade/modkit/M in mods)
+				M.projectile_prehit(src, target, kinetic_gun)
 
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()
@@ -470,7 +470,7 @@
 	name = "lifesteal crystal"
 	desc = "Causes kinetic accelerator shots to slightly heal the firer on striking a living target."
 	icon_state = "modkit_crystal"
-	modifier = 2.5 //Not a very effective method of healing.
+	modifier = 0.15 //Better at healing than it was before.
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
@@ -480,7 +480,7 @@
 		if(L.stat == DEAD)
 			return
 		L = K.firer
-		L.heal_ordered_damage(modifier, damage_heal_order)
+		L.heal_ordered_damage(modifier*K.damage, damage_heal_order, BODYPART_ANY)
 
 /obj/item/borg/upgrade/modkit/resonator_blasts
 	name = "resonator blast"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Lifesteal crystal in its current state is a bit mid and nobody ever uses it, this PR aims to increase it's usefulness by making it so that it heals you per 15 percent of damage done (so it is largely useless on station but effective on lavaland)

As a plus, the crystal is now able to heal robotic limbs (and preternis/IPCs in turn), which was decided as they already are extremely limited in terms of healing on lavaland


# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Changed the lifesteal crystal from doing a flat 2.5 healing per shot to instead a healing percentage of 15 percent per shot
tweak: lifesteal crystal can heal robotic limbs.
 

/:cl:
