### PR TITLE
Chameleon Envirosuit

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -640,6 +640,22 @@
 	new /obj/item/radio/headset/chameleon/syndicate(src)
 	new /obj/item/stamp/chameleon/syndicate(src)
 	new /obj/item/pda/chameleon/syndicate(src)
+	
+/obj/item/storage/box/syndie_kit/chameleon/plasmaman
+	real_name = "chameleon kit"
+
+/obj/item/storage/box/syndie_kit/chameleon/plasmaman/PopulateContents()
+	new /obj/item/clothing/under/plasmaman/chameleon/syndicate(src)
+	new /obj/item/clothing/suit/chameleon/syndicate(src)
+	new /obj/item/clothing/gloves/chameleon/syndicate(src)
+	new /obj/item/clothing/shoes/chameleon/syndicate(src)
+	new /obj/item/clothing/glasses/chameleon/syndicate(src)
+	new /obj/item/clothing/head/helmet/space/plasmaman/chameleon/syndicate(src)
+	new /obj/item/clothing/mask/chameleon/syndicate(src)
+	new /obj/item/storage/backpack/chameleon/syndicate(src)
+	new /obj/item/radio/headset/chameleon/syndicate(src)
+	new /obj/item/stamp/chameleon/syndicate(src)
+	new /obj/item/pda/chameleon/syndicate(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -485,7 +485,7 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/chameleon/Initialize()
 	. = ..()
-	chameleon_action = new(src)
+	chameleon_action = new /datum/action/item_action/chameleon/change
 	if(syndicate)
 		chameleon_action.syndicate = TRUE
 	chameleon_action.chameleon_type = /obj/item/clothing/head/helmet/space

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -471,7 +471,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 	
-	/obj/item/clothing/head/helmet/space/plasmaman/chameleon
+/obj/item/clothing/head/helmet/space/plasmaman/chameleon
 	name = "purple envirosuit helmet"
 	desc = "A generic purple envirohelm of Nanotrasen design. This updated model comes with a built-in lamp."
 	icon_state = "purple_envirohelm"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -327,7 +327,7 @@
 		chameleon_action.syndicate = TRUE
 	chameleon_action.chameleon_type = /obj/item/clothing/under
 	chameleon_action.chameleon_name = "Jumpsuit"
-	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling)), only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/under/chameleon/emp_act(severity)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -327,7 +327,7 @@
 		chameleon_action.syndicate = TRUE
 	chameleon_action.chameleon_type = /obj/item/clothing/under
 	chameleon_action.chameleon_name = "Jumpsuit"
-	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling), only_root_path = TRUE)
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling)), only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 
 /obj/item/clothing/under/chameleon/emp_act(severity)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -306,6 +306,35 @@
 /obj/item/clothing/under/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+	
+/obj/item/clothing/under/plasmaman/chameleon
+	name = "envirosuit"
+	icon_state = "plasmaman"
+	item_state = "plasmaman"
+	desc = "The latest generation of Nanotrasen-designed plasmamen envirosuits. This new version has an extinguisher built into the uniform's workings. While airtight, the suit is not EVA-rated."
+	sensor_mode = SENSOR_OFF
+	random_sensor = FALSE
+	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 95, ACID = 95)
+	var/datum/action/item_action/chameleon/change/chameleon_action
+
+/obj/item/clothing/under/plasmaman/chameleon/syndicate
+	syndicate = TRUE
+
+/obj/item/clothing/under/plasmaman/chameleon/Initialize()
+	. = ..()
+	chameleon_action = new(src)
+	if(syndicate)
+		chameleon_action.syndicate = TRUE
+	chameleon_action.chameleon_type = /obj/item/clothing/under
+	chameleon_action.chameleon_name = "Jumpsuit"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/under, /obj/item/clothing/under/color, /obj/item/clothing/under/rank, /obj/item/clothing/under/changeling), only_root_path = TRUE)
+	chameleon_action.initialize_disguises()
+
+/obj/item/clothing/under/chameleon/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	chameleon_action.emp_randomise()
 
 /obj/item/clothing/suit/chameleon
 	name = "armor"
@@ -441,6 +470,34 @@
 /obj/item/clothing/head/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+	
+	/obj/item/clothing/head/helmet/space/plasmaman/chameleon
+	name = "purple envirosuit helmet"
+	desc = "A generic purple envirohelm of Nanotrasen design. This updated model comes with a built-in lamp."
+	icon_state = "purple_envirohelm"
+	item_state = "purple_envirohelm"
+	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 100, ACID = 75)
+	actions_types = list()
+	var/datum/action/item_action/chameleon/change/chameleon_action
+
+/obj/item/clothing/head/helmet/space/plasmaman/chameleon/syndicate
+	syndicate = TRUE
+
+/obj/item/clothing/head/helmet/space/plasmaman/chameleon/Initialize()
+	. = ..()
+	chameleon_action = new(src)
+	if(syndicate)
+		chameleon_action.syndicate = TRUE
+	chameleon_action.chameleon_type = /obj/item/clothing/head/helmet/space
+	chameleon_action.chameleon_name = "Hat"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/head/changeling, only_root_path = TRUE)
+	chameleon_action.initialize_disguises()
+
+/obj/item/clothing/head/helmet/space/plasmaman/chameleon/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	chameleon_action.emp_randomise()
 
 /obj/item/clothing/head/chameleon/drone
 	// The camohat, I mean, holographic hat projection, is part of the

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1434,6 +1434,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	manufacturer = /datum/corporation/traitor/cybersun
 	exclude_modes = list(/datum/game_mode/nuclear)
+	
+/datum/uplink_item/stealthy_tools/chameleon/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
+	if(is_species(user, /datum/species/plasmaman))
+		spawn_path = /obj/item/storage/box/syndie_kit/chameleon/plasmaman
+	..()
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon Projector"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a chameleon envirosuit, and envirohelm, for plasmaman traitors. These will automatically replace the chameleon jumpsuit and hat when a plasmaman buys a chameleon kit. The suit and helm have armor equivalent to the chameleon jumpsuit and hat, and of course have all the functions of a normal envirosuit/helm- except I removed the helmet light from the envirohelm, because turning it on just changes whatever helmet you're using to a lit-up purple envirohelm, which would be not fun if you didn't know beforehand and someone noticed.

# Wiki Documentation

Mention that plasmamen get their respective clothing types in chameleon kit.

# Changelog

:cl:  
rscadd: Added chameleon envirosuit and envirohelm.
tweak: Chameleon envirosuit and helm in chamkits for plasmamen.

/:cl:
