### PR TITLE
Polysmorph tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -18,6 +18,8 @@
 	acidmod = 0.2 //Their blood is literally acid
 	action_speed_coefficient = 1.1 //claws aren't dextrous like hands
 	speedmod = -0.1 //apex predator humanoid hybrid
+	punchdamagehigh = 11 //slightly better high end of damage
+	punchstunthreshold = 11 //technically slightly worse stunchance
 	payday_modifier = 0.6 //Negatively viewed by NT
 	damage_overlay_type = "polysmorph"
 	deathsound = 'sound/voice/hiss6.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -2,34 +2,37 @@
 	//Human xenopmorph hybrid
 	name = "Polysmorph"
 	id = "polysmorph"
+	species_traits = list(NOEYESPRITES, FGENDER, MUTCOLORS, NOCOLORCHANGE, DIGITIGRADE, HAS_FLESH, HAS_TAIL)
+	inherent_traits = list(TRAIT_ACIDBLOOD, TRAIT_SKINNY)
+	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
 	exotic_blood = /datum/reagent/toxin/acid //Hell yeah sulphuric acid blood
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
 	liked_food = GROSS | MEAT | MICE
 	disliked_food = GRAIN | DAIRY | VEGETABLES | FRUIT
 	say_mod = "hisses"
 	species_language_holder = /datum/language_holder/polysmorph
+	brutemod = 0.9 //exoskeleton protects against brute
+	burnmod = 1.35 //residual plasma inside them, highly flammable
 	coldmod = 0.75
 	heatmod = 1.5
 	acidmod = 0.2 //Their blood is literally acid
-	burnmod = 1.25
+	action_speed_coefficient = 1.1 //claws aren't dextrous like hands
+	speedmod = -0.1 //apex predator humanoid hybrid
 	payday_modifier = 0.6 //Negatively viewed by NT
 	damage_overlay_type = "polysmorph"
 	deathsound = 'sound/voice/hiss6.ogg'
 	screamsound = 'sound/voice/hiss5.ogg'
-	species_traits = list(NOEYESPRITES, FGENDER, MUTCOLORS, NOCOLORCHANGE, DIGITIGRADE, HAS_FLESH, HAS_BONE, HAS_TAIL)
-	inherent_traits = list(TRAIT_ACIDBLOOD, TRAIT_SKINNY)
-	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
 	mutanteyes = /obj/item/organ/eyes/polysmorph
 	mutantliver = /obj/item/organ/liver/alien
+	mutanttongue = /obj/item/organ/tongue/polysmorph
+	mutanttail = /obj/item/organ/tail/polysmorph
+	mutantlungs = /obj/item/organ/lungs/xeno
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	fixed_mut_color = "444466" //don't mess with this if you don't feel like manually adjusting the mutant bodypart sprites
 	mutant_bodyparts = list("tail_polysmorph", "dome", "dorsal_tubes", "teeth", "legs")
 	default_features = list("tail_polysmorph" = "Polys", "dome" = "None", "dorsal_tubes" = "No", "teeth" = "None", "legs" = "Normal Legs")
-	mutanttongue = /obj/item/organ/tongue/polysmorph
-	mutanttail = /obj/item/organ/tail/polysmorph
-	mutantlungs = /obj/item/organ/lungs/xeno
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 
 	smells_like = "charred, acidic meat"
@@ -46,12 +49,12 @@
 	.=..()
 	var/mob/living/carbon/human/H = C
 	if(H.physiology)
-		H.physiology.armor.wound += 10	//Pseudo-exoskeleton makes them harder to wound
+		H.physiology.armor.wound += 5	//Pseudo-exoskeleton makes them harder to wound
 
 /datum/species/polysmorph/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
 	.=..()
 	if(C.physiology)
-		C.physiology.armor.wound -= 10
+		C.physiology.armor.wound -= 5
 
 /datum/species/polysmorph/get_species_description()
 	return ""//"TODO: This is polysmorph description"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -102,7 +102,7 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(islist(data) && (method == INGEST || method == INJECT))
+	if(islist(data) && method == INJECT)
 		for(var/thing in L.diseases)
 			var/datum/disease/D = thing
 			if(D.GetDiseaseID() in data)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -102,7 +102,7 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(islist(data) && method == INJECT)
+	if(islist(data) && (method == INGEST || method == INJECT))
 		for(var/thing in L.diseases)
 			var/datum/disease/D = thing
 			if(D.GetDiseaseID() in data)


### PR DESCRIPTION
Polysmorph have a lacklustre identity, they're pretty much just reskinned lizards with acid blood
These are just a few tweaks to try and give them a bit of a niche following the idea of "they're basically just xeno human hybrid experiments"
So they're going to be more physically capable, but worse at doing regular tasks
since these are all just stat tweaks, it won't change the regular gameplay loop much, but there's not any other ideas i have currently.

:cl:  
rscdel: polysmorph no longer have bones (this is a good thing)
tweak: polysmorph do tasks slower
tweak: polysmorph move slightly faster
tweak: polysmorph have less innate wound armour
tweak: polysmorph have 0.9 brutemod from 1
tweak: polysmorph have 1.35 burnmod from 1.25
tweak: polysmorph have a high-end punch damage of 11 from 10
/:cl:
