### PR TITLE
Gives mining medic fishing rod an inhand sprite

### DIFF
--- a/yogstation/code/game/objects/items/fishing/rods.dm
+++ b/yogstation/code/game/objects/items/fishing/rods.dm
@@ -202,6 +202,7 @@
 	update_icon()
 
 /obj/item/twohanded/fishingrod/collapsable/update_icon()
+	item_state = opened ? "fishing_rod" : ""
 	icon_state = "[rod_icon_state][opened ? "" : "_c"]"
 
 /obj/item/twohanded/fishingrod/collapsable/attack_self(mob/user)


### PR DESCRIPTION
was just kinda invisible

:cl:  
bugfix: Gives mining medic fishing rod an inhand sprite
/:cl:
