### PR TITLE
Tumors are no longer infinite healing to jelly people

### DIFF
--- a/code/modules/surgery/organs/tumors.dm
+++ b/code/modules/surgery/organs/tumors.dm
@@ -37,8 +37,8 @@
 	if(!(src in owner.internal_organs))
 		Remove(owner)
 	if(helpful)
-		if(owner.getBruteLoss() + owner.getFireLoss() > 0)
-			owner.adjustToxLoss(strength/2, TRUE, TRUE)
+		if(owner.getBruteLoss() + owner.getFireLoss() > 0 && !(TRAIT_TOXINLOVER in owner?.dna?.species?.inherent_traits))
+			owner.adjustToxLoss(strength/2)
 			owner.adjustBruteLoss(-(strength/2))
 			owner.adjustFireLoss(-(strength/2))
 	else

--- a/code/modules/surgery/organs/tumors.dm
+++ b/code/modules/surgery/organs/tumors.dm
@@ -42,7 +42,7 @@
 			owner.adjustBruteLoss(-(strength/2))
 			owner.adjustFireLoss(-(strength/2))
 	else
-		owner.adjustToxLoss(strength, TRUE, TRUE) //just take toxin damage
+		owner.adjustToxLoss(strength) //just take toxin damage
 		//regeneration
 	if(regeneration && prob(spread_chance))
 		var/list/missing_limbs = owner.get_missing_limbs() - list(BODY_ZONE_HEAD, BODY_ZONE_CHEST) //don't regenerate the head or chest

--- a/code/modules/surgery/organs/tumors.dm
+++ b/code/modules/surgery/organs/tumors.dm
@@ -38,11 +38,11 @@
 		Remove(owner)
 	if(helpful)
 		if(owner.getBruteLoss() + owner.getFireLoss() > 0)
-			owner.adjustToxLoss(strength/2)
+			owner.adjustToxLoss(strength/2, TRUE, TRUE)
 			owner.adjustBruteLoss(-(strength/2))
 			owner.adjustFireLoss(-(strength/2))
 	else
-		owner.adjustToxLoss(strength) //just take toxin damage
+		owner.adjustToxLoss(strength, TRUE, TRUE) //just take toxin damage
 		//regeneration
 	if(regeneration && prob(spread_chance))
 		var/list/missing_limbs = owner.get_missing_limbs() - list(BODY_ZONE_HEAD, BODY_ZONE_CHEST) //don't regenerate the head or chest


### PR DESCRIPTION
tumors are ridiculously good on jelly people since they heal brute and burn, converting it into toxin 
but with their inverted toxin damage that just means all the tumors do is heal

:cl:  
tweak: Tumors no longer convert damage for toxin lovers
/:cl:
