### PR TITLE
Starlight fixation tweak + Toxolysis buff

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -111,7 +111,7 @@
 	var/food_conversion = FALSE
 	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream. It also heals toxin damage."
 	threshold_descs = list(
-		"Resistance 7" = "Increases chem removal speed.",
+		"Resistance 7" = "Increases toxin healing speed.",
 		"Stage Speed 6" = "Consumed chemicals feed the host.",
 	)
 
@@ -128,7 +128,7 @@
 	var/heal_amt = actual_power
 	M.adjustToxLoss(-heal_amt)//it is constantly active so it can't be too strong
 	for(var/datum/reagent/R in M.reagents.reagent_list) //Not just toxins!
-		M.reagents.remove_reagent(R.type, actual_power)
+		M.reagents.remove_reagent(R.type, actual_power / power)//doesn't speed up using power
 		if(food_conversion)
 			M.adjust_nutrition(0.3)
 		if(prob(2))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -50,7 +50,7 @@
 
 /datum/symptom/heal/starlight
 	name = "Starlight Condensation"
-	desc = "The virus reacts to direct starlight, producing regenerative chemicals. Works best against toxin-based damage."
+	desc = "The virus reacts to direct starlight, producing regenerative chemicals. More effective against burn damage"
 	stealth = -1
 	resistance = -2
 	stage_speed = 0
@@ -82,19 +82,17 @@
 				return power * nearspace_penalty
 
 /datum/symptom/heal/starlight/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = actual_power
-	if(M.getToxLoss() && prob(5))
-		to_chat(M, span_notice("Your skin tingles as the starlight seems to heal you."))
-
-	M.adjustToxLoss(-(4 * heal_amt)) //most effective on toxins
+	var/heal_amt = 2 * actual_power //active less than nocturnal regen
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
-
 	if(!parts.len)
 		return
 
+	if(prob(5))
+		to_chat(M, span_notice("Your skin tingles as the starlight seems to heal you."))
+
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, null, BODYPART_ORGANIC))
+		if(L.heal_damage(heal_amt/parts.len * 0.5, heal_amt/parts.len, null, BODYPART_ORGANIC))
 			M.update_damage_overlays()
 	return 1
 
@@ -111,7 +109,7 @@
 	transmittable = -2
 	level = 7
 	var/food_conversion = FALSE
-	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream."
+	desc = "The virus rapidly breaks down any foreign chemicals in the bloodstream. It also heals toxin damage."
 	threshold_descs = list(
 		"Resistance 7" = "Increases chem removal speed.",
 		"Stage Speed 6" = "Consumed chemicals feed the host.",
@@ -127,6 +125,8 @@
 		power = 2
 
 /datum/symptom/heal/chem/Heal(mob/living/M, datum/disease/advance/A, actual_power)
+	var/heal_amt = actual_power
+	M.adjustToxLoss(-heal_amt)//it is constantly active so it can't be too strong
 	for(var/datum/reagent/R in M.reagents.reagent_list) //Not just toxins!
 		M.reagents.remove_reagent(R.type, actual_power)
 		if(food_conversion)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -50,7 +50,7 @@
 
 /datum/symptom/heal/starlight
 	name = "Starlight Condensation"
-	desc = "The virus reacts to direct starlight, producing regenerative chemicals. More effective against burn damage"
+	desc = "The virus reacts to direct starlight, producing regenerative chemicals."
 	stealth = -1
 	resistance = -2
 	stage_speed = 0
@@ -82,7 +82,7 @@
 				return power * nearspace_penalty
 
 /datum/symptom/heal/starlight/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 2 * actual_power //active less than nocturnal regen
+	var/heal_amt = 1.5 * actual_power //active less than nocturnal regen
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 	if(!parts.len)
@@ -92,7 +92,7 @@
 		to_chat(M, span_notice("Your skin tingles as the starlight seems to heal you."))
 
 	for(var/obj/item/bodypart/L in parts)
-		if(L.heal_damage(heal_amt/parts.len * 0.5, heal_amt/parts.len, null, BODYPART_ORGANIC))
+		if(L.heal_damage(heal_amt/parts.len, heal_amt/parts.len, null, BODYPART_ORGANIC))
 			M.update_damage_overlays()
 	return 1
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -82,7 +82,7 @@
 				return power * nearspace_penalty
 
 /datum/symptom/heal/starlight/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
-	var/heal_amt = 1.5 * actual_power //active less than nocturnal regen
+	var/heal_amt = 2 * actual_power //active less than most healing viruses
 
 	var/list/parts = M.get_damaged_bodyparts(1,1, null, BODYPART_ORGANIC)
 	if(!parts.len)


### PR DESCRIPTION
Starlight fixation is used in a lot of viruses, it heals every damage type with no real downside aside from needing to be close to a window.
Toxin damage usually tends to be harder to heal, so being able to trivialize it just by taking a sip of a virus culture is a bit much
This moves toxin healing over to toxolysis (i have literally never seen this used)

also the removal of toxin healing from starlight fixation lets it be used without killing all jelly people on the station

:cl:  
tweak: Toxolysis heals toxin damage
tweak: Toxolysis resistance threshold now increases toxin heal rather than chem purge speed
tweak: Starlight fixation no longer heals toxin damage
tweak: Starlight fixation heals 2x as much non-toxin
/:cl:
