### PR TITLE
Bible healing tweaks (nerfs?)

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -105,14 +105,11 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			to_chat(user, span_warning("[src.deity_name] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ORGANIC)
+	var/heal_amt = 20
 
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
+	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
+		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ORGANIC)
+		H.update_damage_overlays()
 		H.visible_message(span_notice("[user] heals [H] with the power of [deity_name]!"))
 		to_chat(H, span_boldnotice("May the power of [deity_name] compel you to be healed!"))
 		playsound(src.loc, "punch", 25, 1, -1)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -449,10 +449,11 @@
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
-		var/amount_healed = 0
-		amount_healed += (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
+		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
+
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()
+
 		adjust_favor(amount_healed, user)
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -87,14 +87,11 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return TRUE
 
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ORGANIC)
+	var/heal_amt = 20
 
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
+	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
+		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ORGANIC)
+		H.update_damage_overlays()
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
 		playsound(user, "punch", 25, TRUE, -1)
@@ -139,29 +136,35 @@
 		did_we_charge = TRUE
 	if(ispreternis(H))
 		var/datum/species/preternis/preternis = H.dna.species
-		preternis.charge = clamp(preternis.charge + 3, PRETERNIS_LEVEL_NONE, PRETERNIS_LEVEL_FULL)
+		preternis.charge = clamp(preternis.charge + 30, PRETERNIS_LEVEL_NONE, PRETERNIS_LEVEL_FULL)
 		did_we_charge = TRUE
 
-	//if we're not targetting a robot part we stop early
-	var/obj/item/bodypart/BP = H.get_bodypart(user.zone_selected)
-	if(BP.status != BODYPART_ROBOTIC)
-		if(!did_we_charge)
-			to_chat(user, span_warning("[GLOB.deity] scoffs at the idea of healing such fleshy matter!"))
-		else
-			H.visible_message(span_notice("[user] charges [H] with the power of [GLOB.deity]!"))
-			to_chat(H, span_boldnotice("You feel charged by the power of [GLOB.deity]!"))
-			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
-			playsound(user, 'sound/machines/synth_yes.ogg', 25, TRUE, -1)
-		return TRUE
+	//if we're not targetting someone with a robotic part we stop early
+	var/did_we_heal = FALSE
+	var/heal_amt = 40 //it's robotic limb specific
+	var/list/limbs = H.bodyparts
 
-	//charge(?) and go
-	if(BP.heal_damage(5,5,null,BODYPART_ROBOTIC))
+	for(var/X in limbs)
+		var/obj/item/bodypart/BP = X
+		if(BP.status == BODYPART_ROBOTIC)
+			did_we_heal = TRUE
+
+	if(did_we_heal && H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ROBOTIC))
 		H.update_damage_overlays()
 
-	H.visible_message(span_notice("[user] [did_we_charge ? "repairs" : "repairs and charges"] [H] with the power of [GLOB.deity]!"))
-	to_chat(H, span_boldnotice("The inner machinations of [GLOB.deity] [did_we_charge ? "repairs" : "repairs and charges"] you!"))
-	playsound(user, 'sound/effects/bang.ogg', 25, TRUE, -1)
-	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+	if(did_we_heal)
+		H.visible_message(span_notice("[user] [did_we_charge ? "repairs" : "repairs and charges"] [H] with the power of [GLOB.deity]!"))
+		to_chat(H, span_boldnotice("The inner machinations of [GLOB.deity] [did_we_charge ? "repairs" : "repairs and charges"] you!"))
+		playsound(user, 'sound/effects/bang.ogg', 25, TRUE, -1)
+		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+	else if(did_we_charge)
+		H.visible_message(span_notice("[user] charges [H] with the power of [GLOB.deity]!"))
+		to_chat(H, span_boldnotice("You feel charged by the power of [GLOB.deity]!"))
+		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+		playsound(user, 'sound/machines/synth_yes.ogg', 25, TRUE, -1)
+	else
+		to_chat(user, span_warning("[GLOB.deity] scoffs at the idea of healing such fleshy matter!"))
+				
 	return TRUE
 
 /datum/religion_sect/technophile/on_sacrifice(obj/item/I, mob/living/L)
@@ -217,14 +220,11 @@
 		user.visible_message(span_notice("[H] is too poor to receive [GLOB.deity]'s blessing!"))
 	else
 		last_dono = world.time + 15 SECONDS // healing CD is 15 seconds but your healing strength is 3x stronger
-		var/heal_amt = 30
-		var/list/hurt_limbs = H.get_damaged_bodyparts(TRUE, TRUE, null, BODYPART_ORGANIC)
+		var/heal_amt = 60
 
-		if(hurt_limbs.len)
-			for(var/X in hurt_limbs)
-				var/obj/item/bodypart/affecting = X
-				if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
-					H.update_damage_overlays()
+		if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
+			H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ORGANIC)
+			H.update_damage_overlays()
 		id_card.registered_account.adjust_money(-money_to_donate)
 		id_cardu.registered_account.adjust_money(money_to_donate)
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
@@ -269,14 +269,11 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ORGANIC)
+	var/heal_amt = 40 //literally only heals burn
 
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(0, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
+	if(H.getFireLoss() > 0)
+		H.heal_overall_damage(0, heal_amt, 0, BODYPART_ORGANIC)
+		H.update_damage_overlays()
 
 	H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 	to_chat(H, span_boldnotice("The radiance of [GLOB.deity] heals you!"))
@@ -315,7 +312,7 @@
 	if(!ishuman(L))
 		return
 	var/mob/living/carbon/human/H = L
-	if(!("vines" in H.faction) || !("plants" in H.faction))
+	if(!("vines" in H.faction) && !("plants" in H.faction))
 		to_chat(user, span_warning("[GLOB.deity] refuses to heal this fleshy creature!"))
 		return
 	for(var/X in H.bodyparts)
@@ -324,13 +321,11 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ORGANIC)
+	var/heal_amt = 40 //hyper specific target
 
-	if(hurt_limbs.len)
-		for(var/obj/item/bodypart/affecting in hurt_limbs)
-			if(affecting.heal_damage(0, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
+	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
+		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ORGANIC)
+		H.update_damage_overlays()
 
 	H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 	to_chat(H, span_boldnotice("The light of [GLOB.deity] heals you!"))
@@ -397,14 +392,12 @@
 	var/datum/mind/M = H.mind
 	if(M.assigned_role != "Clown")
 		return
-	var/heal_amt = 10
-	var/list/hurt_limbs = H.get_damaged_bodyparts(TRUE, TRUE, null, BODYPART_ORGANIC)
 
-	if(hurt_limbs.len)
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ORGANIC))
-				H.update_damage_overlays()
+	var/heal_amt = 40 //it only heals clowns
+	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
+		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
+		H.update_damage_overlays()
+
 	H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 	to_chat(H, span_boldnotice("The radiance of [GLOB.deity] heals you!"))
 	playsound(user, "sound/miscitems/bikehorn.ogg", 25, TRUE, -1)
@@ -438,7 +431,7 @@
 /datum/religion_sect/holylight/on_conversion(mob/living/L)
 	. = ..()
 	for(var/obj/item/storage/book/bible/da_bible in L.GetAllContents())
-		da_bible.success_heal_chance = 80
+		da_bible.success_heal_chance = 100
 
 /datum/religion_sect/holylight/sect_bless(mob/living/L, mob/living/user)
 	if(!ishuman(L))
@@ -452,16 +445,14 @@
 		return FALSE
 
 	var/mob/living/carbon/human/H = L
-	var/heal_amt = 20
-	var/list/hurt_limbs = H.get_damaged_bodyparts(1, 1, null, BODYPART_ANY)
-	if(hurt_limbs.len)
+	var/heal_amt = 40 //double healing, no chance to mess up, and shorter cooldown than default
+
+	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
 		var/amount_healed = 0
-		for(var/X in hurt_limbs)
-			var/obj/item/bodypart/affecting = X
-			amount_healed += (heal_amt * 2) + min(affecting.brute_dam - heal_amt, 0) + min(affecting.burn_dam - heal_amt, 0)
-			if(affecting.heal_damage(heal_amt, heal_amt, null, BODYPART_ANY))
-				H.update_damage_overlays()
+		amount_healed += (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
+		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
+		H.update_damage_overlays()
 		adjust_favor(amount_healed, user)
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -269,8 +269,8 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 20
-
+	var/heal_amt = 40 //it only heals burn
+	
 	if(H.getFireLoss() > 0)
 		H.heal_overall_damage(0, heal_amt, 0, BODYPART_ORGANIC)
 		H.update_damage_overlays()

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -139,11 +139,11 @@
 		preternis.charge = clamp(preternis.charge + 30, PRETERNIS_LEVEL_NONE, PRETERNIS_LEVEL_FULL)
 		did_we_charge = TRUE
 
-	//if we're not targetting someone with a robotic part we stop early
 	var/did_we_heal = FALSE
-	var/heal_amt = 40 //it's robotic limb specific
+	var/heal_amt = 20
 	var/list/limbs = H.bodyparts
 
+	//if we're not targetting someone with a robotic part we don't heal
 	for(var/X in limbs)
 		var/obj/item/bodypart/BP = X
 		if(BP.status == BODYPART_ROBOTIC)
@@ -269,7 +269,7 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 40 //literally only heals burn
+	var/heal_amt = 20
 
 	if(H.getFireLoss() > 0)
 		H.heal_overall_damage(0, heal_amt, 0, BODYPART_ORGANIC)
@@ -321,7 +321,7 @@
 			to_chat(user, span_warning("[GLOB.deity] refuses to heal this metallic taint!"))
 			return 0
 
-	var/heal_amt = 40 //hyper specific target
+	var/heal_amt = 20
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ORGANIC)
@@ -393,7 +393,7 @@
 	if(M.assigned_role != "Clown")
 		return
 
-	var/heal_amt = 40 //it only heals clowns
+	var/heal_amt = 20
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()


### PR DESCRIPTION
Them healing every single bodypart for a set amount means it can heal between 10 and 60 depending on how injured the person is in each limb, this makes it stupidly op against damage that either hits every part equally or hits random bodyparts, while being almost useless against focused damage.

This is made all the worse for stronger bibles like capitalism (30 per BP) or holy light (20 per BP) where it's enough to bring someone from crit to full health if the damage is distributed properly.

It has been changed to instead apply an overall body heal for a set amount, increasing consistency of the heal and allowing for more precise healing balance tweaks.

if this ends up being too much of a nerf to the holy light bible favour gain, changes can be made.

:cl:  
tweak: Bibles now heal overall damage rather than per bodypart
tweak: Default bible heals 20 brute and burn overall instead of 10 per bodypart
tweak: Tech bible heals 20 brute and burn overall overall instead of 10 to a single targeted bodypart
tweak: Plant bible heals 20 brute and burn overall instead of 10 per bodypart
tweak: Candle bible heals 40 BURN overall instead of 10 per bodypart
tweak: Clown bible heals 20 brute and burn overall instead of 10 per bodypart
tweak: Capitalism bible heals 60 brute and burn overall instead of 30 per bodypart
tweak: Holy light bible heals 40 brute and burn overall instead of 20 per bodypart
tweak: Holy light bible never fails to heal if it's off cooldown
/:cl:
