### PR TITLE
Improves improved Lizard and Polysmorph lisp

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,8 +94,8 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_ecks = new("+x+", "g")
-	var/static/regex/lizard_eckS = new("+X+", "g")
+	var/static/regex/lizard_ecks = new("(?<!^)x", "g")
+	var/static/regex/lizard_eckS = new("(?<!^)X", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
@@ -308,8 +308,8 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
-	var/static/regex/polysmorph_ecks = new("+x+", "g")//only affects Xs in the middle of a sentence
-	var/static/regex/polysmorph_eckS = new("+X+", "g")
+	var/static/regex/polysmorph_ecks = new("(?<!^)x", "g")//only affects Xs in the middle of a sentence
+	var/static/regex/polysmorph_eckS = new("(?<!^)X", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,8 +94,8 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_ecks = new("x+", "g")
-	var/static/regex/lizard_eckS = new("X+", "g")
+	var/static/regex/lizard_ecks = new("+x+", "g")
+	var/static/regex/lizard_eckS = new("+X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
@@ -308,8 +308,8 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
-	var/static/regex/polysmorph_ecks = new("x+", "g")
-	var/static/regex/polysmorph_eckS = new("X+", "g")
+	var/static/regex/polysmorph_ecks = new("+x+", "g")
+	var/static/regex/polysmorph_eckS = new("+X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,8 +94,8 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_ecks = new("(?<!^)x", "g")
-	var/static/regex/lizard_eckS = new("(?<!^)X", "g")
+	var/static/regex/lizard_ecks = new("(?<!^)x+", "g")
+	var/static/regex/lizard_eckS = new("(?<!^)X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
@@ -308,8 +308,8 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
-	var/static/regex/polysmorph_ecks = new("(?<!^)x", "g")//only affects Xs in the middle of a sentence
-	var/static/regex/polysmorph_eckS = new("(?<!^)X", "g")
+	var/static/regex/polysmorph_ecks = new("(?<!^)x+", "g")//only affects Xs in the middle of a sentence
+	var/static/regex/polysmorph_eckS = new("(?<!^)X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -100,8 +100,8 @@
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_ecks.Replace(message, "ksss")
-		message = lizard_eckS.Replace(message, "KSSS")
+		message = lizard_ecks.Replace(message, "kss")
+		message = lizard_eckS.Replace(message, "KSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly
@@ -314,8 +314,8 @@
 	if(message[1] != "*")
 		message = polysmorph_hiss.Replace(message, "ssssss")
 		message = polysmorph_hiSS.Replace(message, "SSSSSS")
-		message = polysmorph_ecks.Replace(message, "kssssss")
-		message = polysmorph_eckS.Replace(message, "KSSSSSS")
+		message = polysmorph_ecks.Replace(message, "ksssss")
+		message = polysmorph_eckS.Replace(message, "KSSSSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/polysmorph/Initialize(mapload)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -308,7 +308,7 @@
 	..()
 	var/static/regex/polysmorph_hiss = new("s+", "g")
 	var/static/regex/polysmorph_hiSS = new("S+", "g")
-	var/static/regex/polysmorph_ecks = new("+x+", "g")
+	var/static/regex/polysmorph_ecks = new("+x+", "g")//only affects Xs in the middle of a sentence
 	var/static/regex/polysmorph_eckS = new("+X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")


### PR DESCRIPTION
X doesn't always make an "ecks" sound, it it's the first letter of a sentence it usually makes a "z" sound
i also removed an s so it has the same number of character as the s lisp, just with one being a k

:cl:  
tweak: Lizards and Polys only replace x with kss if it's in the middle of a sentence
tweak: Lizards and Polys x lisp now has 1 less s
/:cl:
