### PR TITLE
Darkspawn ascension quieter and removes abilities properly

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -359,15 +359,19 @@
 
 /datum/antagonist/darkspawn/proc/sacrament()
 	var/mob/living/carbon/human/user = owner.current
-	var/mob/living/simple_animal/hostile/darkspawn_progenitor/progenitor = new(get_turf(user))
-	user.status_flags |= GODMODE
-	user.mind.transfer_to(progenitor)
-	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	if(!SSticker.mode.sacrament_done)
 		set_security_level(SEC_LEVEL_GAMMA)
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)
 		remove_ability(abilities[V], TRUE)
+	for(var/datum/action/innate/darkspawn/leftover_ability in user.actions)
+		leftover_ability.Remove(user)
+		QDEL_NULL(leftover_ability)
+	// Spawn the cosmic progenitor
+	var/mob/living/simple_animal/hostile/darkspawn_progenitor/progenitor = new(get_turf(user))
+	user.status_flags |= GODMODE
+	user.mind.transfer_to(progenitor)
+	progenitor.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/progenitor_curse(null))
 	sound_to_playing_players('yogstation/sound/magic/sacrament_complete.ogg', 50, FALSE, pressure_affected = FALSE)
 	psi = 9999
 	psi_cap = 9999

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -291,8 +291,9 @@
 	var/datum/action/innate/darkspawn/D = abilities[id]
 	if(!silent)
 		to_chat(owner.current, span_velvet("You have lost the <b>[D.name]</b> ability."))
-	QDEL_NULL(abilities[id])
-	abilities -= abilities[id]
+	D.Remove(owner.current)
+	abilities -= D
+	QDEL_NULL(D)
 	return TRUE
 
 /datum/antagonist/darkspawn/proc/has_upgrade(id)
@@ -367,7 +368,7 @@
 		addtimer(CALLBACK(src, .proc/sacrament_shuttle_call), 50)
 	for(var/V in abilities)
 		remove_ability(abilities[V], TRUE)
-	sound_to_playing_players('yogstation/sound/magic/sacrament_complete.ogg', 70, FALSE, pressure_affected = FALSE)
+	sound_to_playing_players('yogstation/sound/magic/sacrament_complete.ogg', 50, FALSE, pressure_affected = FALSE)
 	psi = 9999
 	psi_cap = 9999
 	psi_regen = 9999

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_progenitor.dm
@@ -68,10 +68,10 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/darkspawn_progenitor/proc/roar()
-	playsound(src, 'yogstation/sound/creatures/progenitor_roar.ogg', 100, TRUE)
+	playsound(src, 'yogstation/sound/creatures/progenitor_roar.ogg', 50, TRUE)
 	for(var/mob/M in GLOB.player_list)
 		if(get_dist(M, src) > 7)
-			M.playsound_local(src, 'yogstation/sound/creatures/progenitor_distant.ogg', 75, FALSE, falloff = 5)
+			M.playsound_local(src, 'yogstation/sound/creatures/progenitor_distant.ogg', 25, FALSE, falloff = 5)
 		else if(isliving(M))
 			var/mob/living/L = M
 			if(L != src) //OH GOD OH FUCK I'M SCARING MYSELF


### PR DESCRIPTION
# Document the changes in your pull request

my ears

# Changelog

:cl:  
bugfix: Fixed darkspawn not having abilities removed when ascended
tweak: Darkspawn ascension is now quieter
/:cl:
