### PR TITLE
No slips are no longer population restricted

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1481,7 +1481,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	manufacturer = /datum/corporation/traitor/waffleco
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-	player_minimum = 20
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	item = /obj/item/clothing/shoes/chameleon/noslip/syndicate


### PR DESCRIPTION
# Document the changes in your pull request
of all the things wrong with lowpop traitors shoes with banana immunity is not one of them
# Wiki Documentation
remove the population cap
# Changelog
:cl:  
tweak: No slip chameleon shoes are no longer player population restricted  
/:cl:
