### PR TITLE
Removes the x lisp for lizards

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -94,14 +94,10 @@
 	..()
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
-	var/static/regex/lizard_ecks = new("(?<!^)x+", "g")
-	var/static/regex/lizard_eckS = new("(?<!^)X+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = lizard_hiss.Replace(message, "sss")
 		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_ecks.Replace(message, "kss")
-		message = lizard_eckS.Replace(message, "KSS")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/tongue/fly


### PR DESCRIPTION
It looks awful, genuinely. If I wanted to look like an idiot that can't spell I can do that on my own just fine, I don't need the game doing that for me. Polys lisp can stay because the excessively long sssss fits better and doesn't just look like a mistake.



# Changelog


:cl:  

rscdel: Removes the awful lizard "ekss" lisp

/:cl:
