### PR TITLE
Removes the Xenomorph eggsac from meteors because I died to it once.

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -324,7 +324,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	meteorgibs = /obj/effect/gibspawner/xeno
 
 /obj/effect/meteor/meaty/xeno/Initialize()
-	meteordrop += subtypesof(/obj/item/organ/alien)
+	meteordrop += (subtypesof(/obj/item/organ/alien) - /obj/item/organ/alien/eggsac) //Yogstation change: No more eggsac.
 	return ..()
 
 /obj/effect/meteor/meaty/xeno/ram_turf(turf/T)


### PR DESCRIPTION


# Document the changes in your pull request

Xeno eggsacs cannot spawn from meteors anymore.

# Justification

Too many a time xeno fetish players insert the organs into themselves and lay a bunch of eggs and then act surprised when the station results in a xeno takeover. There is literally no reason to do this as a non-antag, and as an antag no one does this anyways because a shuttle hijacking requires you to be on it and the xenos will not be aligned to you so antags don't do it either.

# Changelog

:cl:  BurgerBB
rscdel: Xeno eggsacs cannot spawn from meteors.
/:cl:
