### PR TITLE
Halves zombie tumor damage back to intended number

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -14,7 +14,7 @@
 	var/revive_time_max = 700
 	var/timer_id
 
-	var/damage_caused = 1
+	var/damage_caused = 0.5
 
 /obj/item/organ/zombie_infection/Initialize()
 	. = ..()

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -14,6 +14,7 @@
 	var/revive_time_max = 700
 	var/timer_id
 
+	///damage dealt per second
 	var/damage_caused = 0.5
 
 /obj/item/organ/zombie_infection/Initialize()

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -50,7 +50,7 @@
 		Remove(owner)
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)
 		if(owner.dna.species.id == "pod")
-			owner.adjustToxLoss(damage_caused + 0.5 * delta_time)	//So they cant passively out-heal it
+			owner.adjustToxLoss((damage_caused + 0.25) * delta_time)	//So they cant passively out-heal it
 		else
 			owner.adjustToxLoss(damage_caused * delta_time)
 		if(DT_PROB(5, delta_time))


### PR DESCRIPTION
# Document the changes in your pull request

Delta_time works based off real seconds rather than processed time (2 seconds) resulting in the damage number being doubled
This was not addressed in the delta time pr, apparently

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: zombie organ toxin damage is no longer doubled
/:cl:
