### PR TITLE
More mining melee buffs (concussive gauntlets)

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -237,7 +237,7 @@ obj/effect/proc_holder/swipe
 	item_state = "concussive_gauntlets"
 	mob_overlay_icon = 'icons/mob/clothing/hands/hands.dmi'
 	icon = 'icons/obj/lavaland/artefacts.dmi'
-	toolspeed = 0.01
+	toolspeed = 0
 	strip_delay = 40
 	equip_delay_other = 20
 	body_parts_covered = ARMS


### PR DESCRIPTION
Following up on the previous PR
Also buffs concussive gloves from 0.01 to 0 (doesn't really seem change anything aside from comfortability)
Mech drills are a mess and don't seem to work problem and i don't want to touch this with a nine foot pole

:cl:  
tweak: concussive gauntlets mine faster
/:cl:
