### PR TITLE
swaps indicators for alcohol tolerance and auto-brewery syndrome

### DIFF
--- a/yogstation/code/datums/mutations/alcohol.dm
+++ b/yogstation/code/datums/mutations/alcohol.dm
@@ -2,7 +2,7 @@
 	name = "Alcohol Tolerance"
 	desc = "A hyperactive liver improves the patient's ability to metabolize alcohol."
 	quality = POSITIVE
-	text_gain_indication = span_danger("Your liver hurts.")
+	text_gain_indication = span_danger("Your liver feels amazing.")
 	text_lose_indication = span_danger("Your liver feels sad.")
 
 /datum/mutation/human/alcohol_tolerance/on_acquiring(mob/living/carbon/human/owner)
@@ -19,8 +19,8 @@
 	name = "Auto-brewery Syndrome"
 	desc = "The patient's body now naturally produces alcohol into their bloodstream."
 	quality = MINOR_NEGATIVE
-	text_gain_indication = span_danger("Your liver feels amazing.")
-	text_lose_indication = span_danger("Your liver feels sad.")
+	text_gain_indication = span_danger("Your liver hurts.")
+	text_lose_indication = span_danger("Your liver feels better.")
 
 /datum/mutation/human/alcohol_generate/on_life()
 	if(prob(15))


### PR DESCRIPTION
They were swapped with each other, not sure why. changes the lose indicator for auto-brewery syndrome too.

# Wiki Documentation

I'll do this, indicators need swapping.


:cl:  Ktlwjec
tweak: Alcohol Tolerance and Auto-brewery Syndrome indicators swapped.
/:cl: