### PR TITLE
makes the sec esword less boring and overpowered

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -20,7 +20,8 @@
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
 		/obj/item/ammo_box/magazine/m308/laser,
-		/obj/item/modular_computer))
+		/obj/item/modular_computer,
+		/obj/item/melee/transforming/vib_blade))
 
 /obj/machinery/recharger/RefreshParts()
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -101,7 +101,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 0
-	force_on = 18
+	force_on = 20
 	throwforce = 0
 	throwforce_on = 10
 	wound_bonus = -10

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -403,7 +403,7 @@
 	id = "vib_blade"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/gold = 1000)
-	build_path = /obj/item/melee/transforming/vib_blade
+	build_path = /obj/item/melee/transforming/vib_blade/empty
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 


### PR DESCRIPTION
this powercreep stick is better than fireaxes (which there are only two of) the captain's sabre (which there is only one of) and combat knives (which have to be ordered from cargo)
also they can be mass printed for free and fit in backpacks

now they use power cells when attacking (high-cap by default, ten hits) when out of battery they lose their sharpness and a lot of damage
damage also reduced to 20 from 23 because mass printing the best melee weapon is fucking idiotic

# Changelog

:cl:  
tweak: sec esword now operates off of a battery
tweak: sec esword's damage reduced to 20
/:cl:
