### PR TITLE
text color changes for alcohol mutations

### DIFF
--- a/yogstation/code/datums/mutations/alcohol.dm
+++ b/yogstation/code/datums/mutations/alcohol.dm
@@ -2,7 +2,7 @@
 	name = "Alcohol Tolerance"
 	desc = "A hyperactive liver improves the patient's ability to metabolize alcohol."
 	quality = POSITIVE
-	text_gain_indication = span_danger("Your liver feels amazing.")
+	text_gain_indication = span_notice("Your liver feels amazing.")
 	text_lose_indication = span_danger("Your liver feels sad.")
 
 /datum/mutation/human/alcohol_tolerance/on_acquiring(mob/living/carbon/human/owner)
@@ -20,7 +20,7 @@
 	desc = "The patient's body now naturally produces alcohol into their bloodstream."
 	quality = MINOR_NEGATIVE
 	text_gain_indication = span_danger("Your liver hurts.")
-	text_lose_indication = span_danger("Your liver feels better.")
+	text_lose_indication = span_notice("Your liver feels better.")
 
 /datum/mutation/human/alcohol_generate/on_life()
 	if(prob(15))


### PR DESCRIPTION
forgot to change this in my other pr. Positive indicators are no longer red.