### PR TITLE
Acid Spit (THE DRINK) heals burn for Polysmorphs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -76,7 +76,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 				S.success_multiplier = max(0.1*power_multiplier, S.success_multiplier)
 				// +10% success propability on each step, useful while operating in less-than-perfect conditions
 	return ..()
- 
+
 /datum/reagent/consumable/ethanol/beer
 	name = "Beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. Still popular today."
@@ -1054,6 +1054,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "acidspitglass"
 	glass_name = "Acid Spit"
 	glass_desc = "A drink from Nanotrasen. Made from live aliens."
+
+/datum/reagent/consumable/ethanol/acid_spit/on_mob_life(mob/living/carbon/M)
+	if(ispolysmorph(M))
+		M.adjustFireLoss(-0.5)
+	return ..()
 
 /datum/reagent/consumable/ethanol/amasec
 	name = "Amasec"


### PR DESCRIPTION
# Document the changes in your pull request

Looking through some drinks and wanted to add some species related drinks for the time being, thought it would be pretty funny if Polys would heal themselves of their burn damage via drinking Acid. Yes it makes sense because they're Xenos

# Wiki Documentation

Notes: If you're a Polysmorph, you can heal a bit of Burn as you get drunk!

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Acid Spit, does 0.5 burn heal for the poly players out there.
/:cl:
