### PR TITLE
Revert "Handheld flashes knockdown carbons instead of hardstun"

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -148,10 +148,10 @@
 					trauma.on_flash(user, M)
 			else
 				to_chat(M, span_userdanger("You are blinded by [src]!"))
-			if(M.IsParalyzed() || M.IsKnockdown())
-				M.Knockdown(rand(20,30))
+			if(M.IsParalyzed())
+				M.Paralyze(rand(20,30))
 			else
-				M.Knockdown(rand(80,120))
+				M.Paralyze(rand(80,120))
 		else if(user)
 			visible_message(span_disarm("[user] fails to blind [M] with the flash!"))
 			to_chat(user, span_warning("You fail to blind [M] with the flash!"))


### PR DESCRIPTION
Reverts yogstation13/Yogstation#18072
this pr had a negative like to dislike ratio
It also makes security a pain in the ass for no reason at all and now the brig procedure isn't correct and batons can be easily taken and used against you while you are trying to brig someone. The old way to brig someone was to flash them to take their cuffs off while they're buckled to the bed and now you have to baton someone over and over to safely take their cuffs off which can easily get you killed if you make one mistake which is making sec less appealing to newer players/those not mechanically gifted at spaceman game
This pr should be reverted because its bugging me irl thank you