### PR TITLE
Borg flash removal

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -8,9 +8,9 @@
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	var/charge_cost = 250
-	var/stunforce = 60
-	var/stamina_damage = 20
+	var/charge_cost = 1000
+	var/stunforce = 30
+	var/stamina_damage = 15
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -56,9 +56,8 @@
 	
 /obj/item/borg/stun/heavy
 	name = "heavy electrically-charged arm"
-	charge_cost = 300
-	stunforce = 100
-	stamina_damage = 25
+	stunforce = 60
+	stamina_damage = 20
 
 /obj/item/borg/cyborghug
 	name = "hugging module"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -8,9 +8,9 @@
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	var/charge_cost = 750
-	var/stunforce = 100
-	var/stamina_damage = 90
+	var/charge_cost = 250
+	var/stunforce = 60
+	var/stamina_damage = 20
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))
@@ -53,6 +53,12 @@
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 
 	log_combat(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
+	
+/obj/item/borg/stun/heavy
+	name = "heavy electrically-charged arm"
+	charge_cost = 300
+	stunforce = 100
+	stamina_damage = 25
 
 /obj/item/borg/cyborghug
 	name = "hugging module"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -290,7 +290,6 @@
 /obj/item/robot_module/medical
 	name = "Medical"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/healthanalyzer,
 		/obj/item/reagent_containers/borghypo,
 		/obj/item/reagent_containers/glass/beaker/large,
@@ -323,7 +322,6 @@
 /obj/item/robot_module/engineering
 	name = "Engineering"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,
@@ -422,7 +420,6 @@
 /obj/item/robot_module/janitor
 	name = "Janitor"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/crowbar/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
@@ -473,7 +470,6 @@
 /obj/item/robot_module/clown
 	name = "Clown"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/toy/crayon/rainbow,
 		/obj/item/instrument/bikehorn,
 		/obj/item/stamp/clown,
@@ -505,7 +501,6 @@
 /obj/item/robot_module/butler
 	name = "Service"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
 		/obj/item/reagent_containers/food/condiment/enzyme,
 		/obj/item/pen,
@@ -569,7 +564,6 @@
 /obj/item/robot_module/miner
 	name = "Miner"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
 		/obj/item/storage/bag/ore/cyborg,
 		/obj/item/pickaxe/drill/cyborg,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -278,7 +278,8 @@
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/soap/infinite, //yogs - changed soap type
-		/obj/item/borg/cyborghug)
+		/obj/item/borg/cyborghug,
+		/obj/item/borg/stun/heavy)
 	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg,
@@ -308,7 +309,8 @@
 		/obj/item/stack/medical/gauze/cyborg,
 		/obj/item/stack/medical/bone_gel/cyborg,
 		/obj/item/organ_storage,
-		/obj/item/borg/lollipop)
+		/obj/item/borg/lollipop,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_MEDICAL)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/hacked)
 	ratvar_modules = list(
@@ -344,7 +346,8 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
 		/obj/item/stack/cable_coil/cyborg,
-		/obj/item/barrier_taperoll/engineering)
+		/obj/item/barrier_taperoll/engineering,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(/obj/item/gun/energy/printer/flamethrower)
 	ratvar_modules = list(
@@ -401,7 +404,8 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
-		/obj/item/borg/projectile_dampen)
+		/obj/item/borg/projectile_dampen,
+		/obj/item/borg/stun/heavy)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	ratvar_modules = list(
@@ -432,7 +436,8 @@
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/holosign_creator/janibarrier,
-		/obj/item/reagent_containers/spray/cyborg_drying)
+		/obj/item/reagent_containers/spray/cyborg_drying,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
 	ratvar_modules = list(
@@ -485,7 +490,8 @@
 		/obj/item/borg/lollipop/clown,
 		/obj/item/picket_sign/cyborg,
 		/obj/item/reagent_containers/borghypo/clown,
-		/obj/item/extinguisher/mini)
+		/obj/item/extinguisher/mini,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(
 		/obj/item/reagent_containers/borghypo/clown/hacked,
@@ -517,7 +523,8 @@
 		/obj/item/reagent_containers/borghypo/borgshaker,
 		/obj/item/borg/lollipop,
 		/obj/item/reagent_containers/glass/rag,
-		/obj/item/soap/infinite)
+		/obj/item/soap/infinite,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/borgshaker/hacked)
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/service,
@@ -574,7 +581,8 @@
 		/obj/item/storage/bag/sheetsnatcher/borg,
 		/obj/item/gun/energy/kinetic_accelerator/cyborg,
 		/obj/item/gps/cyborg,
-		/obj/item/stack/marker_beacon)
+		/obj/item/stack/marker_beacon,
+		/obj/item/borg/stun)
 	radio_channels = list(RADIO_CHANNEL_SCIENCE, RADIO_CHANNEL_SUPPLY)
 	emag_modules = list(/obj/item/gun/energy/plasmacutter/adv/malf)
 	ratvar_modules = list(

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -688,6 +688,7 @@
 		/obj/item/stack/cable_coil/cyborg,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/borg_chameleon,
+		/obj/item/borg/stun
 		)
 	ratvar_modules = list(
 		/obj/item/clockwork/slab/cyborg/engineer,

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -375,7 +375,7 @@
 /obj/item/organ/cyberimp/arm/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
-	contents = newlist(/obj/item/borg/stun)
+	contents = newlist(/obj/item/borg/stun/heavy)
 
 /obj/item/organ/cyberimp/arm/combat
 	name = "combat cybernetics implant"


### PR DESCRIPTION
# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->
Removes flashes from most cyborg modules, and gives a weakened stun arm to compensate.

- Flashes from all modules except security, peacekeeper, standard, and syndicate have been removed.
- Nerfed stun arms have been given to janitor, medical, clown, service, engineering, mining, saboteur, (15 damage, 30 stunforce.) Slightly less nerfed stun arms given to standard and peacekeeper (20 damage, 60 stunforce.) 1000 power cost for both.
- The baton arm implant was given the less nerfed variant of the stun arm as this PR isn't meant to nerf the baton implant. (It's admin only anyways I think.)

My reasoning for letting standard/peacekeeper keep their flashes and get better stun arms is that standard is an amalgamation of all modules including security, and peacekeeper is meant to keep the peace. (Security keeps their flash because flashes are a security tool, and syndicate modules keep them because they are nukie syndicate antags.)

Removing flashes from most cyborg modules and replacing them with stun arms will improve many things. This gives non-sec borgs something to do against people with flash protection, and makes cyborgs in general less deadly against people who don't have flash protection. This also improves the state of cyborg vs cyborg combat since now it isn't just whoever flashes the other first (unless one of them is a combat oriented module.) 

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->
https://wiki.yogstation.net/wiki/Cyborg
Remove flash from everything but security, standard, peacekeeper, and syndicate modules.
Add electrically-charged arms to janitor, medical, clown, service, engineering, mining, saboteur modules. (15 stamina damage)
Add heavy electrically-charged arms to standard, peacekeeper modules. (20 stamina damage)
Both arms cost 1000 power to use.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Gives nerfed stun arms to most cyborg modules, with standard and peacekeeper getting slightly less nerfed stun arms.
rscdel: Removes flashes from most cyborg modules.
tweak: Baton arm implant gets the slightly less nerfed stun arm. (Admin only.)
/:cl:
