### PR TITLE
Makes most borgs unable to flash other borgs.

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -31,6 +31,8 @@
 	var/last_trigger = 0
 	///can we convert people to revolution
 	var/can_convert = FALSE
+	///can we stun silicons
+	var/borgstun = TRUE
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
@@ -169,7 +171,7 @@
 	if(iscarbon(M))
 		flash_carbon(M, user, 5, 1)
 		return TRUE
-	else if(issilicon(M))
+	else if(issilicon(M) && borgstun)
 		var/mob/living/silicon/robot/R = M
 		if(!R.sensor_protection)
 			log_combat(user, R, "flashed", src)
@@ -237,6 +239,9 @@
 
 
 /obj/item/assembly/flash/cyborg
+	name = "cyborg flash"
+	desc = "A powerful and versatile flashbulb device, with applications ranging from disorienting attackers to acting as visual receptors in robot production. This variant is unable to stun cyborgs."
+	borgstun = FALSE
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
 	..()
@@ -250,6 +255,11 @@
 	return
 /obj/item/assembly/flash/cyborg/screwdriver_act(mob/living/user, obj/item/I)
 	return
+	
+/obj/item/assembly/flash/cyborg/combat
+	name = "combat cyborg flash"
+	desc = "A powerful and versatile flashbulb device, with applications ranging from disorienting attackers to acting as visual receptors in robot production. This variant is able to stun cyborgs."
+	borgstun = TRUE
 
 /obj/item/assembly/flash/memorizer
 	name = "memorizer"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -264,7 +264,7 @@
 /obj/item/robot_module/standard
 	name = "Standard"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/reagent_containers/borghypo/epi,
 		/obj/item/healthanalyzer,
 		/obj/item/weldingtool/largetank/cyborg,
@@ -360,7 +360,7 @@
 /obj/item/robot_module/security
 	name = "Security"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/melee/baton/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
@@ -396,7 +396,7 @@
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/rsf/cookiesynth,
 		/obj/item/harmalarm,
 		/obj/item/reagent_containers/borghypo/peace,
@@ -605,7 +605,7 @@
 /obj/item/robot_module/syndicate
 	name = "Syndicate Assault"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/melee/transforming/energy/sword/cyborg,
 		/obj/item/gun/energy/printer,
 		/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg,
@@ -635,7 +635,7 @@
 /obj/item/robot_module/syndicate_medical
 	name = "Syndicate Medical"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/reagent_containers/borghypo/syndicate,
 		/obj/item/twohanded/shockpaddles/syndicate,
 		/obj/item/healthanalyzer,
@@ -665,7 +665,7 @@
 /obj/item/robot_module/saboteur
 	name = "Syndicate Saboteur"
 	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
+		/obj/item/assembly/flash/cyborg/combat,
 		/obj/item/kitchen/knife/combat/cyborg,
 		/obj/item/borg/sight/thermal,
 		/obj/item/construction/rcd/borg/syndicate,


### PR DESCRIPTION
# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

- Renames the cyborg flash to "cyborg flash," and makes it unable to stun other cyborgs. Updates the description to notify the player of this.
- Adds the combat cyborg flash, which is functionally the same as old cyborg flashes. Gives this flash to standard, peacekeeper, security, and syndicate modules.

Making non combat oriented modules not able to flash other cyborgs makes cyborg vs cyborg combat much better, because weldering each other to death is more interesting than one side flashing the other and winning with one click. Combat modules keep their ability to stun other cyborgs because they specifically chose a module meant for combat and should be better at fighting non combat cyborgs. (Standard is kinda a combat module because it's an amalgamation of all modules including peacekeeper and security.)

# Wiki Documentation

https://wiki.yogstation.net/wiki/Cyborg

- Rename the flash that miner, janitor, medical, engineering, service, and clown get to "cyborg flash," and perhaps remove the text about it being able to disorient other cyborgs. (It might still be able to AOE flash other borgs to blind them, but cannot stun them.)
- Rename the flash that standard, peacekeeper, security, syndicate assault, syndicate medical, and syndicate saboteur get to "combat cyborg flash."

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: No cyborg modules except for standard, peacekeeper, security, and syndicate can flash other cyborgs now.
/:cl:
