### PR TITLE
Hand teleporter portals now take 4 seconds to dispel

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -148,9 +148,11 @@
 
 /obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user)
 	if(is_parent_of_portal(target))
-		qdel(target)
-		to_chat(user, span_notice("You dispel [target] with \the [src]!"))
-		return TRUE
+		balloon_alert(user, "Dispelling portal...")
+		if(do_after(user, 4 SECONDS, target))
+			qdel(target)
+			to_chat(user, span_notice("You dispel [target] with \the [src]!"))
+			return TRUE
 	return FALSE
 
 /obj/item/hand_tele/afterattack(atom/target, mob/user)


### PR DESCRIPTION
# Document the changes in your pull request

Prevents people from simply instantly teleporting 200 tiles and removing any way to easily follow them outside walking, which basically allows a risk-free get out of jail free card when in a fight you don't want to be in
now the exit location has to actually be defensible or whatever rather than just a long distance


# Wiki Documentation

Undocumented, probably, hand teleporter portals can be hit with the hand teleporter to dispel them. This takes four (4) seconds.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: hand teleporter portals now take 4 seconds to dispel, up from 0.
/:cl:
