### PR TITLE
Cerulean extract no longer saves from dusting or gibbing

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -716,9 +716,14 @@ datum/status_effect/stabilized/blue/on_remove()
 		C.real_name = O.real_name
 		O.dna.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
+		RegisterSignal(owner, COMSIG_GLOB_MOB_DEATH, .proc/dead)
 	return ..()
 
-/datum/status_effect/stabilized/cerulean/tick()
+/datum/status_effect/stabilized/cerulean/proc/dead()
+		addtimer(CALLBACK(src, .proc/transfer), 4, TIMER_UNIQUE) //0.4  seconds delay to account for delayed dust/gib effects, shouldn't affect gameplay
+
+/datum/status_effect/stabilized/cerulean/proc/transfer()
+	UnregisterSignal(owner, COMSIG_GLOB_MOB_DEATH)
 	if(!QDELETED(owner) && owner.stat == DEAD)
 		if(clone && clone.stat != DEAD)
 			owner.visible_message(span_warning("[owner] blazes with brilliant light, [linked_extract] whisking [owner.p_their()] soul away."),
@@ -730,10 +735,10 @@ datum/status_effect/stabilized/blue/on_remove()
 		if(!clone || clone.stat == DEAD)
 			to_chat(owner, span_notice("[linked_extract] desperately tries to move your soul to a living body, but can't find one!"))
 			qdel(linked_extract)
-	..()
 
 /datum/status_effect/stabilized/cerulean/on_remove()
 	if(clone)
+		UnregisterSignal(owner, COMSIG_GLOB_MOB_DEATH)
 		clone.visible_message(span_warning("[clone] dissolves into a puddle of goo!"))
 		clone.unequip_everything()
 		qdel(clone)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -719,7 +719,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	return ..()
 
 /datum/status_effect/stabilized/cerulean/tick()
-	if(owner.stat == DEAD)
+	if(!QDELETED(owner) && owner.stat == DEAD)
 		if(clone && clone.stat != DEAD)
 			owner.visible_message(span_warning("[owner] blazes with brilliant light, [linked_extract] whisking [owner.p_their()] soul away."),
 				span_notice("You feel a warm glow from [linked_extract], and you open your eyes... elsewhere."))


### PR DESCRIPTION
it was supposed to do this already but sometimes the ticks would line up such that it would still work
adds a 0.4 second delay to account for such events
this means walking into a SM or dying with a holopara will still kill you

:cl:  
tweak: Cerulean extract no longer saves from dusting or gibbing
/:cl:
