### PR TITLE
Disables the printing of security officers with AA

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -332,7 +332,7 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen


### PR DESCRIPTION
# Document the changes in your pull request

Dear TGStation Playerbase,

I hope this message finds you well. I am writing to you today to address a topic that has been a popular request among the playerbase: the use of security cyborgs in the server.

I understand that security cyborgs can be a lot of fun and add excitement to gameplay, but after careful consideration, it has been determined that they do not align well with the AI Asimov Laws and can lead to administrative issues during gameplay.

Therefore, it is with regret that I inform you that security cyborgs will not be re-enabled in the server configuration. While this decision may disappoint some players, I hope you understand that it has been made in the best interests of the game and its players.

If you have any questions or concerns about this decision, please don't hesitate to reach out.

Thank you for your understanding and continued support of TGStation.

Best regards,
oranges

# Changelog

:cl:  
rscdel: Security Cyborgs have been disabled
/:cl:
