### PR TITLE
Beekit buff 2: electric beegaloo

### DIFF
--- a/code/datums/diseases/beesease.dm
+++ b/code/datums/diseases/beesease.dm
@@ -27,13 +27,15 @@
 					affected_mob.adjustToxLoss(2)
 					affected_mob.updatehealth()
 		if(4)
-			if(prob(10))
+			if(prob(7))
 				affected_mob.visible_message(span_danger("[affected_mob] buzzes."), \
-												span_userdanger("Your stomach buzzes violently!"))
+												span_danger("Your stomach buzzes violently!"))
 			if(prob(5))
 				to_chat(affected_mob, span_danger("You feel something moving in your throat."))
-			if(prob(1))
+			if(prob(3))
 				affected_mob.visible_message(span_danger("[affected_mob] coughs up a swarm of bees!"), \
 													span_userdanger("You cough up a swarm of bees!"))
+				new /mob/living/simple_animal/hostile/poison/bees(affected_mob.loc)
+				new /mob/living/simple_animal/hostile/poison/bees(affected_mob.loc)
 				new /mob/living/simple_animal/hostile/poison/bees(affected_mob.loc)
 	return

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -218,12 +218,12 @@
 
 		if("bee") // bee sword too based so its priceless
 			new /obj/item/paper/fluff/bee_objectives(src) // 0 tc (motivation)
-			new /obj/item/clothing/suit/hooded/bee_costume(src) // 0 tc
+			new /obj/item/clothing/suit/hooded/bee_costume/authentic(src) // 0 tc
 			new /obj/item/clothing/mask/rat/bee(src) // 0 tc
 			new /obj/item/storage/belt/fannypack/yellow(src) // 0 tc
-			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 15 tc
+			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 6 tc
 			new /obj/item/reagent_containers/glass/bottle/beesease(src) // 10 tc?
-			new /obj/item/melee/beesword(src) //priceless
+			new /obj/item/gun/magic/staff/spellblade/beesword(src) //priceless
 
 		if("mr_freeze") // ~17 tc
 			new /obj/item/clothing/glasses/cold(src) // 0 tc

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -337,7 +337,7 @@
 	dynamic_hair_suffix = ""
 	
 /obj/item/clothing/suit/hooded/bee_costume/authentic
-	name = "authentic bee costume"
+	name = "bee costume"
 	desc = "Bee the true Queen! Smells like honey..."
 	icon_state = "bee"
 	item_state = "labcoat"
@@ -349,7 +349,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/bee_hood/authentic
 
 /obj/item/clothing/head/hooded/bee_hood/authentic
-	name = "authentic bee hood"
+	name = "bee hood"
 	desc = "A hood attached to a bee costume. It's buzzing quietly."
 	icon_state = "bee"
 	body_parts_covered = HEAD

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -335,6 +335,28 @@
 	clothing_flags = THICKMATERIAL
 	flags_inv = HIDEHAIR|HIDEEARS
 	dynamic_hair_suffix = ""
+	
+/obj/item/clothing/suit/hooded/bee_costume/authentic
+	name = "authentic bee costume"
+	desc = "Bee the true Queen! Smells like honey..."
+	icon_state = "bee"
+	item_state = "labcoat"
+	body_parts_covered = CHEST|GROIN|ARMS
+	clothing_flags = THICKMATERIAL
+	armor = list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
+	slowdown = -0.35
+	allowed = list(/obj/item/gun/magic/staff/spellblade/beesword)
+	hoodtype = /obj/item/clothing/head/hooded/bee_hood/authentic
+
+/obj/item/clothing/head/hooded/bee_hood/authentic
+	name = "authentic bee hood"
+	desc = "A hood attached to a bee costume. It's buzzing quietly."
+	icon_state = "bee"
+	body_parts_covered = HEAD
+	clothing_flags = THICKMATERIAL
+	armor = list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)
+	flags_inv = HIDEHAIR|HIDEEARS
+	dynamic_hair_suffix = ""
 
 /obj/item/clothing/suit/hooded/bloated_human	//OH MY GOD WHAT HAVE YOU DONE!?!?!?
 	name = "bloated human suit"

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -44,6 +44,9 @@
 
 /obj/item/ammo_casing/magic/spellblade/weak
 	projectile_type = /obj/item/projectile/magic/spellblade/weak
+	
+/obj/item/ammo_casing/magic/spellblade/beesword
+	projectile_type = /obj/item/projectile/magic/spellblade/beesword
 
 /obj/item/ammo_casing/magic/arcane_barrage
 	projectile_type = /obj/item/projectile/magic/arcane_barrage

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -141,7 +141,7 @@
 	user.changeNext_move(CLICK_CD_RAPID)
 	if(iscarbon(target) && proximity_flag)
 		var/mob/living/carbon/H = target
-		H.reagents.add_reagent(/datum/reagent/toxin/venom, 3)
+		H.reagents.add_reagent(/datum/reagent/toxin/venom, 2)
 
 /obj/item/gun/magic/staff/spellblade/beesword/shoot_with_empty_chamber(mob/living/user as mob|obj)
 	to_chat(user, span_warning("The Stinger buzzes quietly."))

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -113,6 +113,44 @@
 		final_block_chance = 0
 	return ..()
 
+/obj/item/gun/magic/staff/spellblade/beesword
+	name = "The Stinger"
+	desc = "Taken from a giant bee and folded over one thousand times in pure honey. Can sting through anything."
+	fire_sound = 'sound/weapons/sound_weapons_bowfire.ogg'
+	ammo_type = /obj/item/ammo_casing/magic/spellblade/beesword
+	icon = 'icons/obj/weapons/swords.dmi'
+	icon_state = "beesword"
+	item_state = "stinger"
+	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_BULKY
+	sharpness = SHARP_EDGED
+	force = 7
+	throwforce = 10
+	block_chance = 20
+	armour_penetration = 85
+	sharpness = SHARP_POINTY
+	max_charges = 6
+	recharge_rate = 1
+	attack_verb = list("slashed", "stung", "prickled", "poked")
+	hitsound = 'sound/weapons/rapierhit.ogg'
+
+/obj/item/gun/magic/staff/spellblade/beesword/afterattack(target, mob/user, proximity_flag)
+	. = ..()
+	user.changeNext_move(CLICK_CD_RAPID)
+	if(iscarbon(target) && proximity_flag)
+		var/mob/living/carbon/H = target
+		H.reagents.add_reagent(/datum/reagent/toxin/venom, 3)
+
+/obj/item/gun/magic/staff/spellblade/beesword/shoot_with_empty_chamber(mob/living/user as mob|obj)
+	to_chat(user, span_warning("The Stinger buzzes quietly."))
+
+/obj/item/gun/magic/staff/spellblade/beesword/suicide_act(mob/living/user)
+	user.visible_message(span_suicide("[user] is stabbing [user.p_them()]self in the throat with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(get_turf(src), hitsound, 75, 1, -1)
+	return TOXLOSS
+
 /obj/item/gun/magic/staff/locker
 	name = "staff of the locker"
 	desc = "An artefact that expells encapsulating bolts, for incapacitating thy enemy."

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -116,7 +116,7 @@
 /obj/item/gun/magic/staff/spellblade/beesword
 	name = "The Stinger"
 	desc = "Taken from a giant bee and folded over one thousand times in pure honey. Can sting through anything."
-	fire_sound = 'sound/weapons/sound_weapons_bowfire.ogg'
+	fire_sound = 'sound/items/syringeproj.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/spellblade/beesword
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "beesword"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -376,6 +376,18 @@
 /obj/item/projectile/magic/spellblade/weak
 	damage = 15
 	dismemberment = 20
+	
+/obj/item/projectile/magic/spellblade/beesword
+	name = "stinger"
+	icon_state = "syringeproj"
+	damage = 1
+	damage_type = BRUTE
+	dismemberment = 0
+	
+/obj/item/projectile/magic/spellblade/beesword/on_hit(atom/target, blocked = FALSE)
+	..()
+	if(ishuman(target))
+		target.reagents.add_reagent(/datum/reagent/toxin/venom, 2)
 
 /obj/item/projectile/magic/arcane_barrage
 	name = "arcane bolt"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -379,7 +379,7 @@
 	
 /obj/item/projectile/magic/spellblade/beesword
 	name = "stinger"
-	icon_state = "syringeproj"
+	icon_state = "bee"
 	damage = 1
 	damage_type = BRUTE
 	dismemberment = 0


### PR DESCRIPTION
# Document the changes in your pull request

Improves the bee kit by making some of its gear better and buffing beesease.

THE STINGER:
New version of the stinger added, as a subtype of the spellblade. Same stats as the old stinger, but it now injects 2u of venom instead of 4u histamine, and fires projectiles that also inject 2u venom. Projectiles recharge quickly and only do 1 brute damage on hit, like the bee simplemob, because venom itself is a pretty nasty poison. Has a "buzzes" message when empty instead of "whizzes." Also fixed a bug having to do with the stinger's reagents not injecting how they were supposed to.

THE BEE COSTUME:
New "authentic" bee costume added and used in the syndikit. 20 armor for basic damage types and gives a -0.35 speedmod. Protects from bee stings like the regular costume, and you can put your stinger in the suit storage slot instead of having to use your belt slot (now you can wear your yellow fannypack!)

BEESEASE:
Beesease has had its bee-spawning increased from a probability of 1 to 3, and you now cough up 3 bees at a time, so now the "You cough up a swarm of bees!" text is more accurate and you have more friends!

All tested and should work unless I forgot to do something when making this pr

# Wiki Documentation

change "bee costume" to "authentic bee costume" in syndikit item list

# Changelog

:cl:  
rscadd: Added an improved version of the Stinger that fires projectiles
rscadd: Added an improved version of the bee costume
bugfix: fixed an issue with the Stinger's poison injection
tweak: Bee syndikit contains improved stinger & bee costume
tweak: Beesease makes more bees
/:cl:
