### PR TITLE
we don't like fireaxes no we don't

### DIFF
--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -93,7 +93,7 @@
 /// Legally distinct from /obj/item/twohanded/vibro_weapon
 /obj/item/melee/transforming/vib_blade
 	name = "vibration blade"
-	desc = "A blade which has an edge that vibrates at rapid pace, enabling it to cut through armor and flesh with ease."
+	desc = "A blade with an edge that vibrates at a rapid pace, enabling it to easily cut through armor and flesh alike."
 	hitsound = "swing_hit"
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "hfrequency0"

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -93,7 +93,7 @@
 /// Legally distinct from /obj/item/twohanded/vibro_weapon
 /obj/item/melee/transforming/vib_blade
 	name = "vibration blade"
-	desc = "A blade with an edge that vibrates at a rapid pace, enabling it to easily cut through armor and flesh alike."
+	desc = "A blade with an edge that vibrates rapidly, enabling it to easily cut through armor and flesh alike."
 	hitsound = "swing_hit"
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "hfrequency0"

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -93,7 +93,7 @@
 /// Legally distinct from /obj/item/twohanded/vibro_weapon
 /obj/item/melee/transforming/vib_blade
 	name = "vibration blade"
-	desc = "A hard-light blade vibrating at rapid pace, enabling you to cut through armor and flesh with ease."
+	desc = "A blade which has an edge that vibrates at rapid pace, enabling it to cut through armor and flesh with ease."
 	hitsound = "swing_hit"
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "hfrequency0"
@@ -101,7 +101,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 0
-	force_on = 23
+	force_on = 20
 	throwforce = 0
 	throwforce_on = 10
 	wound_bonus = -10


### PR DESCRIPTION
# Document the changes in your pull request

The longsword has many names in the English language, which, aside from variant spellings, include terms such as "bastard sword" and "hand-and-a-half sword." Of these, "bastard sword" is the oldest, its use being contemporaneous with the weapon's heyday.

The French épée bâtarde and the English "bastard sword" originate in the 15th or 16th century, originally in the general sense of "irregular sword, sword of uncertain origin", but by the mid-16th century could refer to exceptionally large swords.[[3]](https://en.wikipedia.org/wiki/Longsword#cite_note-3) The "Masters of Defence" competition organised by [Henry VIII](https://en.wikipedia.org/wiki/Henry_VIII) in July 1540 listed two handed sword and bastard sword as two separate items.[[4]](https://en.wikipedia.org/wiki/Longsword#cite_note-4) It is uncertain whether the same term could still be used to other types of smaller swords, but antiquarian usage in the 19th century established the use of "bastard sword" as referring unambiguously to these large swords.[[5]](https://en.wikipedia.org/wiki/Longsword#cite_note-oakeshott-5)

The term "hand-and-a-half sword" is relatively modern (from the late 19th century);[[6]](https://en.wikipedia.org/wiki/Longsword#cite_note-6) this name was given because the balance of the sword made it usable in one hand, as well as two. During the first half of the 20th century, the term "bastard sword" was also used regularly to refer to this type of sword, while "long sword" (or "long-sword"), if used at all, referred to the [rapier](https://en.wikipedia.org/wiki/Rapier) (in the context of Renaissance or Early Modern fencing).[[7]](https://en.wikipedia.org/wiki/Longsword#cite_note-7)

Contemporary use of "long-sword" or "longsword" only resurfaced in the 2000s in the context of [reconstruction](https://en.wikipedia.org/wiki/Historical_martial_arts_reconstruction) of the [German school of fencing](https://en.wikipedia.org/wiki/German_school_of_fencing), translating the German langes schwert.[[8]](https://en.wikipedia.org/wiki/Longsword#cite_note-8)[[9]](https://en.wikipedia.org/wiki/Longsword#cite_note-9)[[10]](https://en.wikipedia.org/wiki/Longsword#cite_note-10) Prior to this the term "long sword" merely referred to any sword with a long blade; 'long' being simply an adjective rather than a classification

# Wiki Documentation

I guess I can finally add this god-forsaken item to the wiki in Guide to Combat, maybe Security Items if I feel generous (it belongs there but I don't like that page)

# Changelog

:cl:  
tweak: Vibration blade force to 20 from 23
spellcheck: Description for said item adjusted because I hate inconsistencies
/:cl:
