### PR TITLE
Diet Surrender

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -823,3 +823,21 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		to_chat(user, span_warning("[M] is too close to use [src] on."))
 		return
 	M.attack_hand(user)
+
+/obj/item/twohanded/required/raisedhands
+	name = "raised hands"
+	desc = "What are you, French?"
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "latexballon"
+	item_state = "nothing"
+	force = 0
+	throwforce = 0
+	item_flags = DROPDEL | ABSTRACT
+
+/obj/item/twohanded/required/raisedhands/attack(mob/living/M, mob/living/user)
+  return
+
+/obj/item/twohanded/required/raisedhands/dropped(mob/user)	
+	user.visible_message(span_userdanger(("[user] lowers their hands!")))
+	..()
+	

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -196,6 +196,20 @@
 	key_third_person = "grimaces"
 	message = "grimaces."
 
+/datum/emote/living/handsup
+	key = "handsup"
+	key_third_person = "raiseshands"
+	message	= "raises their hands in the air, they surrender!"
+
+/datum/emote/living/handsup/run_emote(mob/living/user, params, type_override, intentional)
+	. = ..()
+	var/obj/item/bodypart/r_arm/R = user.get_bodypart(BODY_ZONE_R_ARM)
+	var/obj/item/bodypart/l_arm/L = user.get_bodypart(BODY_ZONE_L_ARM)
+	(R?.set_disabled(TRUE)) 
+	(L?.set_disabled(TRUE)) 
+	addtimer(CALLBACK(R, /obj/item/bodypart/r_arm/.proc/set_disabled), 15 SECONDS, TRUE)
+	addtimer(CALLBACK(L, /obj/item/bodypart/l_arm/.proc/set_disabled), 15 SECONDS, TRUE)		
+
 /datum/emote/living/jump
 	key = "jump"
 	key_third_person = "jumps"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -199,16 +199,17 @@
 /datum/emote/living/handsup
 	key = "handsup"
 	key_third_person = "raiseshands"
-	message	= "raises their hands in the air, they surrender!"
+	message	= span_surrender("raises their hands in the air, they surrender!")
+	restraint_check = TRUE
 
 /datum/emote/living/handsup/run_emote(mob/living/user, params, type_override, intentional)
 	. = ..()
-	var/obj/item/bodypart/r_arm/R = user.get_bodypart(BODY_ZONE_R_ARM)
-	var/obj/item/bodypart/l_arm/L = user.get_bodypart(BODY_ZONE_L_ARM)
-	(R?.set_disabled(TRUE)) 
-	(L?.set_disabled(TRUE)) 
-	addtimer(CALLBACK(R, /obj/item/bodypart/r_arm/.proc/set_disabled), 15 SECONDS, TRUE)
-	addtimer(CALLBACK(L, /obj/item/bodypart/l_arm/.proc/set_disabled), 15 SECONDS, TRUE)		
+	if(!.)
+		return
+	for(var/obj/item/I in user.held_items)
+		user.drop_all_held_items(I, TRUE)
+	var/obj/item/twohanded/required/raisedhands/L = new(user)
+	user.put_in_hands(L)
 
 /datum/emote/living/jump
 	key = "jump"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Adds a new emote, *handsup, that creates a forcewield inhand that notifies people when you drop it, meant to be a lighter version of surrender for those who don't wish to self hardstun, and has better rp value as it still allows some form of interaction
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: adds *handsup, a *surrender alternative 

/:cl:
