### PR TITLE
Gives jelly people a「LORE ACCURATE™」reduction to pay

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -17,6 +17,7 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 1 // = regular burn damage unlike other slimes
+	payday_modifier = 0.6 //literally a pile of toxic ooze walking around, definitely a health hazard
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly
 	swimming_component = /datum/component/swimming/dissolve


### PR DESCRIPTION
I completely forgot this when adding them as a species
as we know, only humans can be paid 1.0

:cl:  
tweak: Jelly people are paid 40% less like the subhumans they are
/:cl:
