### PR TITLE
Fixes a runtime error in IPC reagent processing

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -294,7 +294,7 @@ ipc martial arts stuff
 	if(chem.type == exotic_blood)
 		return FALSE
 	. = ..()
-	if(H.mind.martial_art && H.mind.martial_art.id == "ultra violence")
+	if(H.mind?.martial_art && H.mind.martial_art.id == "ultra violence")
 		if(H.reagents.has_reagent(/datum/reagent/blood, 30))//BLOOD IS FUEL eh, might as well let them drink it
 			H.adjustBruteLoss(-25, FALSE, FALSE, BODYPART_ANY)
 			H.adjustFireLoss(-25, FALSE, FALSE, BODYPART_ANY)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a runtime error that happens when an IPC without a mind has reagents in them

# Changelog

:cl:  
bugfix: fixes a runtime error when an IPC body without a mind processes reagents
/:cl:
