### PR TITLE
The Big Species Drink Off

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1239,7 +1239,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(ispreternis(M))
 		for(var/obj/O in orange(2,M))
 			if(!O.anchored && (O.flags_1 & CONDUCT_1))
-				step_towards(O, M)
+				step_towards(O, get_turf(M))
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1228,11 +1228,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 
 /datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/M)
-	for(var/obj/item/stack/ore/O in orange(2, M))
+	for(var/obj/item/stack/ore/O in orange(3, M))
 		step_towards(O, get_turf(M))
 
 	if(ispreternis(M))
-		for(var/obj/M in orange(3, M))
+		for(var/obj/M in orange(2, M))
 			if(!M.anchored && (M.flags_1 & CONDUCT_1))
 				step_towards(M)
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1233,7 +1233,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 	if(ispreternis(M))
 		for(var/obj/M in orange(3, M))
-			if(!M,anchored && (M.flags_1 & CONDUCT_1))
+			if(!M.anchored && (M.flags_1 & CONDUCT_1))
 				step_towards(M)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(get_reagent_amount(2 * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER))
+			stomach.adjust_charge(get_reagent * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -824,7 +824,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.set_drugginess(30)
 	return ..()
 
-/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/M)
+/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	if(ispretenis(M))
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1437,7 +1437,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustFireLoss(-1)
 		M.adjustToxLoss(-0.5)
 		M.adjustOxyLoss(-3)
-	..()
+	return ..()
 
 /datum/reagent/consumable/ethanol/eggnog
 	name = "Eggnog"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -822,9 +822,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
-	return ..()
-
-/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	if(isethereal(M))
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(amount / 70)
+			stomach.adjust_charge(get_reagent_amount(2 * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER))
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1230,6 +1230,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/M)
 	for(var/obj/item/stack/ore/O in orange(3, M))
 		step_towards(O, get_turf(M))
+
+	if(ispreternis(M))
+		for(var/obj/M in orange(3, M))
+			if(!M,anchored && (M.flags_1 & CONDUCT_1))
+				step_towards(M)
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1232,9 +1232,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		step_towards(O, get_turf(M))
 
 	if(ispreternis(M))
-		for(var/obj/M in orange(2, M))
-			if(!M.anchored && (M.flags_1 & CONDUCT_1))
-				step_towards(M)
+		for(var/obj/O in orange(2,M))
+			if(!O.anchored && (O.flags_1 & CONDUCT_1))
+				step_towards(O, get_turf(M)
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -823,6 +823,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
 	return ..()
+
 /datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=INGEST, reac_volume)
 	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))
 		var/mob/living/carbon/C = M
@@ -830,6 +831,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		if(istype(stomach))
 			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
+
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
 	description = "For the more refined griffon."

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1433,6 +1433,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 				. = 1
 	..()
 
+/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/M)
+	if(ispodperson(M))
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
+		M.adjustToxLoss(-0.5)
+		M.adjustOxyLoss(-3)
+
 /datum/reagent/consumable/ethanol/eggnog
 	name = "Eggnog"
 	description = "For enjoying the most wonderful time of the year."

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1228,7 +1228,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 
 /datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/M)
-	for(var/obj/item/stack/ore/O in orange(3, M))
+	for(var/obj/item/stack/ore/O in orange(2, M))
 		step_towards(O, get_turf(M))
 
 	if(ispreternis(M))

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1431,9 +1431,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			if(prob(30))
 				M.adjustToxLoss(2, 0)
 				. = 1
-	..()
-
-/datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/M)
+	
 	if(ispodperson(M))
 		M.adjustBruteLoss(-1)
 		M.adjustFireLoss(-1)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -824,12 +824,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.set_drugginess(30)
 	return ..()
 
-/datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=INGEST, reac_volume)
-	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))
+/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/M)
+	if(ispretenis(M))
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(amount / 70)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1234,7 +1234,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(ispreternis(M))
 		for(var/obj/O in orange(2,M))
 			if(!O.anchored && (O.flags_1 & CONDUCT_1))
-				step_towards(O, get_turf(M)
+				step_towards(O, M)
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -825,7 +825,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)	
 	if(isethereal(M))
-		M.adjust_charge(amount/ 70)
+		M.adjust_charge(amount / 70)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(M.get_reagent_amount("manhattan_proj") * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(M.get_reagent_amount(/datum/reagent/consumable/ethanol/manhattan_proj = 10) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1439,6 +1439,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustFireLoss(-1)
 		M.adjustToxLoss(-0.5)
 		M.adjustOxyLoss(-3)
+	..()
 
 /datum/reagent/consumable/ethanol/eggnog
 	name = "Eggnog"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -822,8 +822,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
+	return ..()
+/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)	
 	if(isethereal(M))
-	M.adjust_charge(amount/ 70)
+		M.adjust_charge(amount/ 70)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(get_reagent * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(get_reagent(/datum/reagent/consumable/ethanol/manhattan_proj) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -822,6 +822,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
+	if(isethereal(M))
+	M.adjust_charge(amount/ 70)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -823,11 +823,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
 	return ..()
-/datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)	
-	if(isethereal(M))
-		M.adjust_charge(amount / 70)
+/datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=INGEST, reac_volume)
+	if((method == INGEST || method == INJECT || method == PATCH) && iscarbon(M))
+		var/mob/living/carbon/C = M
+		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
+		if(istype(stomach))
+			stomach.adjust_charge(reac_volume * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
-
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
 	description = "For the more refined griffon."

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(get_reagent_amount("manhattan_proj") * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(M.get_reagent_amount("manhattan_proj") * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -825,7 +825,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
-	if(ispretenis(M))
+	if(isethereal(M))
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(M.get_reagent_amount(/datum/reagent/consumable/ethanol/manhattan_proj = 10) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(M.reagents.get_reagent_amount(/datum/reagent/consumable/ethanol/manhattan_proj) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -829,7 +829,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
-			stomach.adjust_charge(get_reagent(/datum/reagent/consumable/ethanol/manhattan_proj) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
+			stomach.adjust_charge(get_reagent_amount("manhattan_proj") * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskeysoda

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -781,6 +781,12 @@
 	glass_name = "chocolate pudding"
 	glass_desc = "Tasty."
 
+/datum/reagent/consumable/chocolate/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+		M.heal_bodypart_damage(2.0,0, 0)
+	..()
+	. = 1
+
 /datum/reagent/consumable/vanillapudding
 	name = "Vanilla Pudding"
 	description = "A great dessert for vanilla lovers."
@@ -791,6 +797,12 @@
 	glass_icon_state = "vanillapudding"
 	glass_name = "vanilla pudding"
 	glass_desc = "Tasty."
+
+/datum/reagent/consumable/vanillapudding/on_mob_life(mob/living/carbon/M)
+	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+		M.heal_bodypart_damage(2.0,0, 0)
+	..()
+	. = 1
 
 /datum/reagent/consumable/cherryshake
 	name = "Cherry Shake"
@@ -803,6 +815,12 @@
 	glass_name = "cherry shake"
 	glass_desc = "A cherry flavored milkshake."
 
+/datum/reagent/consumable/ethanol/cherryshake/on_mob_life(mob/living/carbon/C)
+	if(isjellyperson(C))
+		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
+			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
+	..()
+
 /datum/reagent/consumable/bluecherryshake
 	name = "Blue Cherry Shake"
 	description = "An exotic milkshake."
@@ -813,6 +831,12 @@
 	glass_icon_state = "bluecherryshake"
 	glass_name = "blue cherry shake"
 	glass_desc = "An exotic blue milkshake."
+
+/datum/reagent/consumable/ethanol/bluecherryshake/on_mob_life(mob/living/carbon/C)
+	if(isjellyperson(C))
+		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
+			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
+	..()
 
 /datum/reagent/consumable/pumpkin_latte
 	name = "Pumpkin Latte"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -802,7 +802,7 @@
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
-	. = 1
+	. = TRUE
 
 /datum/reagent/consumable/cherryshake
 	name = "Cherry Shake"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -815,7 +815,7 @@
 	glass_name = "cherry shake"
 	glass_desc = "A cherry flavored milkshake."
 
-/datum/reagent/consumable/ethanol/cherryshake/on_mob_life(mob/living/carbon/C)
+/datum/reagent/consumable/cherryshake/on_mob_life(mob/living/carbon/C)
 	if(isjellyperson(C))
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
@@ -832,7 +832,7 @@
 	glass_name = "blue cherry shake"
 	glass_desc = "An exotic blue milkshake."
 
-/datum/reagent/consumable/ethanol/bluecherryshake/on_mob_life(mob/living/carbon/C)
+/datum/reagent/consumable/bluecherryshake/on_mob_life(mob/living/carbon/C)
 	if(isjellyperson(C))
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -785,7 +785,7 @@
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
-	. = 1
+	. = TRUE
 
 /datum/reagent/consumable/vanillapudding
 	name = "Vanilla Pudding"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1061,8 +1061,7 @@
 	glass_name = "glass of mushroom tea"
 	glass_desc = "Oddly savoury for a drink."
 
-/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(islizard(M))
-		M.adjustOxyLoss(-0.5 * REM * delta_time, 0)
+/datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/C)
+	if(islizard(C))
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2.5*REM)
 	..()
-	. = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

The species drinks are upon us, the year of Barkeep is now!

These are the current changes so far:
Blue/Cherry Shake - Jelly people - Restore blood levels
Fetching Fizz - Pretenis - Temp Magnitis
Chocolate/Vanilla Pudding - Plasmaman -  Like Milk but a bit stronger
Hippie's Delight - Podpeople drink - Small overall heal
Manhattan Project - Ethereal - Give some charge
Mushroom tea- Lizard - No longer heals Oxygen but now heals some brain damage

# Wiki Documentation

Blue Cherry Shake: Restores some blood levels for Jelly people
Cherry Shake: Restores some blood levels for Jelly people
Fetching Fizz: Gives Pretenis temporary magnetism which pulls metals towards them
Chocolate Pudding: For Plasma people or avid milk drinking enjoyers, gives them slightly stronger heals
Vanilla Pudding: For Plasma people or avid milk drinking enjoyers, gives them slightly stronger heals
Hippie's Delight: Pod-people gain overall heals from this non-alcoholic drink
Manhattan Project: Ethereal's gain some charge from drinking this
Mushroom Tea: Heals some Brain damage in Lizards

# Changelog

:cl:
rscadd: Blue Cherry Shake- Restores blood levels in jelly people
rscadd: Cherry shake- Restores blood levels in Jelly people
rscadd: Chocolate pudding- Plasma/Skeletons get more healing from this drink
rscadd: Vanilla Pudding- Plasma/Skeletons get more healing from this drink
tweak: Fetching Fizz- Gives Pretenis temp magnetism
tweak: Hippie's Delight- Pod people gain overall heal
tweak: Manhattan Project- Ethereal gains some charge
tweak: Mushroom Tea- Instead of Oxy damage it is now Brain damage that gets healed for Lizards 
/:cl: