### PR TITLE
pickpocketing puts the item in your hand

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -300,6 +300,7 @@
 			if(pocket_item)
 				if(pocket_item == (pocket_id == SLOT_R_STORE ? r_store : l_store)) //item still in the pocket we search
 					dropItemToGround(pocket_item)
+					usr.put_in_hands(pocket_item)
 			else
 				if(place_item)
 					if(place_item.mob_can_equip(src, usr, pocket_id, FALSE, TRUE))


### PR DESCRIPTION
# Document the changes in your pull request

taking an item from someones pocket puts it in your hand
no more sneakily taking someones stuff just for it to drop onto the floor in front of them

only affects pockets because stripping other stuff is obvious already, and putting something in your hand resets item-strip progress so doing it for everything would make fullstrips have to be done one item at a time

Edit: video example

https://user-images.githubusercontent.com/74697056/224428157-78d673ba-70d6-4f1a-a2f9-d575411a3a60.mp4


# Changelog

:cl:  
tweak: pickpocketing puts the item in your hand
/:cl:
