### PR TITLE
Moves wheelie and jumpboot implants behind combat cybernetics

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -493,10 +493,10 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/noslipwater
+/datum/design/cymberimp_noslipwater
 	name = "Slip Resistance Implant"
 	desc = "An implant that uses sensors and motors to detect when you are slipping and attempt to prevent it. It probably won't help if the floor is too slippery."
-	id = "noslipwater"
+	id = "ci-noslipwater"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 80
 	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1500, /datum/material/silver = 1000, /datum/material/diamond = 1000, /datum/material/uranium = 400)
@@ -504,10 +504,10 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/jumpbootsimplant
+/datum/design/cymberimp_jumpboots
 	name = "Jumpboots implant"
 	desc = "An implant with a specialized propulsion system for rapid foward movement."
-	id = "jumpbootsimplant"
+	id = "ci-jumpboots"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 80
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000, /datum/material/uranium = 1000)
@@ -515,10 +515,10 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/wheeliesimplant
+/datum/design/cymberimp_wheelies
 	name = "Wheelies implant"
 	desc = "Wicked sick wheelies, but now they're not in the heel of your shoes, they just in your heels."
-	id = "wheeliesimplant"
+	id = "ci-wheelies"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 80
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000, /datum/material/gold = 500)
@@ -526,10 +526,10 @@
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/magbootimplant
+/datum/design/cymberimp_magboot
 	name = "Magboot implant"
 	desc = "Integrated maglock implant, allows easy movement in a zero-gravity environment."
-	id = "magbootimplant"
+	id = "ci-magboots"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 80
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/gold = 500, /datum/material/diamond = 200)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -520,7 +520,7 @@
 	display_name = "Advanced Cybernetic Implants"
 	description = "Upgraded and more powerful cybernetic implants."
 	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDs")
-	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus", "jumpbootsimplant", "wheeliesimplant", "magbootimplant")
+	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus", "ci-magboots")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/combat_cyber_implants
@@ -528,7 +528,7 @@
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
 	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency")
-	design_ids = list("ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
+	design_ids = list("ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters", "ci-jumpboots", "ci-wheelies")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/illegal_cyber_implants
@@ -536,7 +536,7 @@
 	display_name = "Illegal Cybernetic Implants"
 	description = "Nanotrasen would like to remind employees that use of unlicensed cybernetic implants violates multiple employee contract clauses."
 	prereq_ids = list("combat_cyber_implants","syndicate_basic")
-	design_ids = list("ci-xray", "noslipwater")
+	design_ids = list("ci-xray", "ci-noslipwater")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 ////////////////////////Tools////////////////////////


### PR DESCRIPTION
These implants are too easy to get for how impactful they can be, especially when things are going south in a round.
Them being on-par research wise with anti-drop and CNS-rebooter seems reasonable for their power.

Also renames the ids to fit with the standard naming convention

:cl:  
tweak: wheelie and jumpboot implants are moved behind combat cybernetics
/:cl:
