### PR TITLE
Makes SM the only roundstart engine, moves singulo/tesla to secure storage

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -14004,6 +14004,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"dLa" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dLg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -25526,6 +25530,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hEr" = (
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hEy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -116304,7 +116313,7 @@ tYf
 ozg
 wRS
 ozg
-oAU
+hEr
 ruw
 aJj
 dPt
@@ -116561,7 +116570,7 @@ bZf
 oAU
 ozg
 ozg
-ozg
+dLa
 ruw
 aJj
 peF

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -73169,6 +73169,19 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/construction)
+"xLZ" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xMe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Hallway"
@@ -116310,7 +116323,7 @@ pJZ
 afp
 tYf
 tYf
-ozg
+xLZ
 wRS
 ozg
 hEr

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -74,9 +74,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "aay" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/atmos/distro)
+/obj/effect/turf_decal/box,
+/obj/structure/frame/machine,
+/turf/open/floor/engine,
+/area/construction)
 "aaz" = (
 /obj/structure/sign/poster/contraband/communist_state,
 /turf/closed/wall,
@@ -136,7 +137,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "abe" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -404,7 +405,7 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "acX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/simple_animal/butterfly,
@@ -763,7 +764,7 @@
 /area/security/processing)
 "agi" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "agk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -865,6 +866,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"agR" = (
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "agS" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
@@ -930,6 +934,10 @@
 /obj/item/twohanded/required/pool/pool_noodle,
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
+"ahn" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/hallway/secondary/exit)
 "ahu" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
@@ -967,14 +975,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ahJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/turf/closed/wall,
+/area/engine/atmos)
 "ahN" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ahR" = (
 /obj/structure/window{
 	dir = 8
@@ -1261,6 +1266,12 @@
 "akh" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"akk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "akl" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -1290,7 +1301,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "akz" = (
 /obj/structure/rack,
 /obj/item/stock_parts/subspace/transmitter,
@@ -1316,7 +1327,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "akP" = (
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/yellowsiding{
@@ -1622,12 +1633,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"any" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "anC" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/yellowsiding{
@@ -1756,7 +1761,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "aoA" = (
 /obj/structure/window{
 	dir = 8
@@ -1878,23 +1883,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"apA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/operating,
-/obj/machinery/flasher{
-	id = "briginfirmary";
-	pixel_x = 8;
-	pixel_y = 28
-	},
-/obj/machinery/button/flasher{
-	id = "briginfirmary";
-	pixel_x = -8;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/security/physician)
 "apB" = (
 /turf/closed/wall/r_wall,
 /area/bridge/meeting_room)
@@ -2025,11 +2013,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "aqD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/construction)
 "aqF" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -2202,6 +2190,12 @@
 "arE" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"arG" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id = "escapepodbay"
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "arK" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -2227,11 +2221,6 @@
 "arQ" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
-"arR" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "arS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -2367,7 +2356,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "asO" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -2506,7 +2495,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "atJ" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -2945,7 +2934,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "axH" = (
@@ -3446,7 +3434,7 @@
 /area/crew_quarters/fitness)
 "aBu" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "aBw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3704,7 +3692,7 @@
 /area/tcommsat/server)
 "aCQ" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aCS" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -4586,7 +4574,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aJG" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -4648,7 +4636,7 @@
 "aKe" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "aKh" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -4684,6 +4672,15 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/library)
+"aKw" = (
+/obj/machinery/button/door{
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "aKE" = (
 /obj/structure/chair{
 	dir = 1
@@ -4937,11 +4934,8 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "aNM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "aNO" = (
 /obj/machinery/door/window/westright{
 	dir = 1;
@@ -4956,12 +4950,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"aNQ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "aNR" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -5084,12 +5072,6 @@
 "aOP" = (
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"aOQ" = (
-/obj/machinery/camera{
-	c_tag = "Escape Podbay"
-	},
-/turf/open/floor/engine,
-/area/escapepodbay)
 "aOR" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteenXnineteen{
@@ -5122,6 +5104,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"aPc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "aPg" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -5140,7 +5134,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aPq" = (
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -5187,7 +5181,7 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aPy" = (
 /turf/closed/wall,
 /area/medical/patients_rooms/room_a)
@@ -5206,12 +5200,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aPI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "aPK" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -5662,7 +5650,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aTS" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window{
@@ -5676,7 +5664,7 @@
 "aTU" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aUa" = (
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -5955,7 +5943,7 @@
 /area/security/brig)
 "aXb" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "aXd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
@@ -6056,17 +6044,6 @@
 /obj/machinery/electrolyzer,
 /turf/open/floor/engine,
 /area/science/storage)
-"aXI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "aXJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -6289,12 +6266,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"aZF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "aZG" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6466,14 +6437,11 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "bbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "bcn" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -7110,7 +7078,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bnm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable/orange{
@@ -7256,7 +7224,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "bqm" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
@@ -7565,11 +7533,12 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "buK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/mob/living/simple_animal/cockroach,
+/turf/open/floor/plasteel,
+/area/construction)
 "buL" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -7806,7 +7775,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "byL" = (
 /obj/structure/closet/ammunitionlocker,
 /obj/effect/turf_decal/bot_red,
@@ -8358,10 +8327,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bJo" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bJr" = (
@@ -8379,11 +8348,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bJy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/construction)
 "bJD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -8445,7 +8411,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bLB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/closet/firecloset,
@@ -8490,7 +8456,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bMl" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -8883,8 +8849,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
 "bTo" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bTF" = (
@@ -8947,9 +8913,8 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "bVb" = (
 /obj/machinery/smartfridge/disks,
 /obj/structure/table,
@@ -8967,10 +8932,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bVj" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 1
@@ -9097,12 +9062,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYr" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_x = -15
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/construction)
 "bYy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9403,7 +9370,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cdm" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -9548,6 +9515,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"ceW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cfi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -9561,7 +9540,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cfq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -9595,7 +9574,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "cfJ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering South";
@@ -10391,7 +10370,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "cuW" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -10947,8 +10926,8 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cEa" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cEb" = (
@@ -11074,7 +11053,7 @@
 "cGf" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "cGi" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11090,15 +11069,11 @@
 /obj/structure/sign/poster/ripped{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Output to Space"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "cGC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -11313,10 +11288,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cKX" = (
-/obj/effect/turf_decal/arrows/white,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
 "cLe" = (
 /obj/machinery/light{
 	dir = 8
@@ -11517,7 +11488,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cNA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11536,7 +11507,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "cNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -11556,27 +11527,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"cNV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "cOs" = (
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /obj/machinery/camera{
 	c_tag = "Construction Area North";
 	dir = 0
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "cOF" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -11614,7 +11575,7 @@
 	opacity = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cOK" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -11758,11 +11719,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cRU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12523,7 +12481,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "dft" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/line{
@@ -12973,7 +12931,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dof" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12981,11 +12939,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dom" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/construction)
 "dot" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/boozeomat,
@@ -13164,17 +13125,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dte" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "dtk" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -13203,7 +13153,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "dtM" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -13235,7 +13185,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "duS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -13257,7 +13207,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "dvu" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -13267,11 +13217,11 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dvR" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dvT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -13342,7 +13292,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dxo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13418,6 +13368,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"dyv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dyD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -13450,7 +13415,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "dzz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
@@ -13555,7 +13520,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "dAN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13567,7 +13532,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "dBf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -13659,7 +13624,7 @@
 /obj/item/clothing/mask/breath,
 /obj/structure/rack,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "dDU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -13759,14 +13724,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
-"dFE" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dFN" = (
 /obj/machinery/computer/robotics,
 /obj/machinery/newscaster{
@@ -13882,6 +13839,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dHK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "dIa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -13968,7 +13934,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "dJH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13990,10 +13956,6 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/space/nearstation)
-"dKd" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/escapepodbay)
 "dKg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
@@ -14041,7 +14003,11 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
+"dLa" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dLg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -14476,7 +14442,7 @@
 /area/maintenance/port/fore)
 "dSr" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dSE" = (
 /obj/structure/statue/snow/snowman,
 /turf/open/floor/grass/snow/safe,
@@ -14615,6 +14581,25 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"dUD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dUL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14772,7 +14757,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dYI" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -14837,15 +14822,15 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "eab" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "eaw" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eaJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -14874,11 +14859,8 @@
 /area/medical/sleeper)
 "eaS" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eaY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -15131,7 +15113,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eem" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15290,22 +15272,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ehz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Engine"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "ehV" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -15376,6 +15342,9 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "eiC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
@@ -15502,7 +15471,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ekl" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -15574,24 +15543,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"elw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "elG" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -15604,7 +15555,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eme" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -16034,7 +15985,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "etS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16188,25 +16139,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ewm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ews" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ewA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "exb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16258,7 +16202,7 @@
 	},
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "eyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16369,7 +16313,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eAk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16421,7 +16365,7 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eBg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16454,9 +16398,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eBw" = (
-/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/cockroach{
+	desc = "Virtually unkillable.";
+	name = "Becquerel";
+	sentience_type = 5;
+	status_flags = 16
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "eBD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -16571,7 +16520,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eEj" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -16835,16 +16784,21 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eIf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/construction";
+	dir = 4;
+	name = "Construction Area Apc";
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/construction)
 "eIg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -17102,7 +17056,7 @@
 	name = "N2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eLZ" = (
 /obj/machinery/door/airlock{
 	name = "Gift Shop";
@@ -17144,14 +17098,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eMp" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "eMs" = (
 /obj/machinery/papershredder,
 /obj/machinery/camera{
@@ -17208,23 +17154,26 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eNk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eNu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
+"eNI" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "eNL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel{
@@ -17308,7 +17257,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eQo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -17465,16 +17414,6 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"eTf" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/start/assistant,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eTm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -17578,7 +17517,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eVh" = (
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
@@ -17745,7 +17684,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eYe" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -17802,13 +17741,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "eZU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eZW" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -17855,6 +17794,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"fbB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "fbQ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -18102,6 +18050,17 @@
 /obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"feK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "feL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/camera{
@@ -18119,7 +18078,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "feZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -18508,7 +18467,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "fln" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
@@ -18625,7 +18584,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fnN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18634,7 +18593,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "fnU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18656,7 +18615,7 @@
 	},
 /obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "fod" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -18834,7 +18793,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fsA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -18860,11 +18819,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fta" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "ftc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -19015,7 +18975,7 @@
 "fvV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "fwl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -19034,14 +18994,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/construction)
 "fwF" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -19254,14 +19208,11 @@
 	},
 /area/crew_quarters/kitchen)
 "fzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "fzB" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -19270,6 +19221,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fzM" = (
+/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fzW" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -19412,7 +19370,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "fCN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19465,7 +19423,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fDR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -19484,17 +19442,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "fEm" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/core,
-/obj/item/paper/guides/jobs/atmos/hypertorus,
+/mob/living/simple_animal/cockroach,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "fEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19546,7 +19499,7 @@
 	name = "CO2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fFs" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -19701,7 +19654,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fId" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -19785,7 +19738,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "fKn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -19873,7 +19826,7 @@
 	name = "nitrous oxide input injector"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fMa" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/window/reinforced{
@@ -19983,7 +19936,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fOm" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
@@ -20034,7 +19987,7 @@
 "fPx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "fPC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -20505,7 +20458,7 @@
 	req_one_access_txt = "11;24"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "fWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -20548,20 +20501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fWL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Distro"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "fXa" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -20733,7 +20672,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "gah" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -20766,6 +20705,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"gba" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "gbl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -20845,7 +20805,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gbZ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -20880,7 +20840,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "gdp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -21200,7 +21160,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/toy/snappop{
@@ -21254,30 +21214,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
-"gjQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "gkb" = (
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
@@ -21330,7 +21266,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "gkG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -21438,7 +21374,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gmW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
@@ -21488,19 +21424,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"gnD" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "gnM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gnT" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel{
@@ -21897,12 +21824,11 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "gvI" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "gvX" = (
 /obj/structure/chair{
 	dir = 4
@@ -21931,7 +21857,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "gwP" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -21975,19 +21901,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gxD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gxF" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/security/armory";
@@ -22031,7 +21944,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gyh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
 	dir = 1
@@ -22178,7 +22091,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gzP" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/toxins{
@@ -22213,7 +22126,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "gAA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -22439,7 +22352,7 @@
 	},
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "gDx" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -22771,7 +22684,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gJN" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -22938,7 +22851,7 @@
 /area/hallway/primary/central)
 "gMM" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gMO" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -23016,9 +22929,8 @@
 "gOc" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "gOt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -23195,12 +23107,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "gRf" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#00AAFF";
-	pixel_y = 15
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow,
+/turf/open/floor/engine,
+/area/construction)
 "gRp" = (
 /obj/item/stack/marker_beacon{
 	anchored = 1;
@@ -23384,7 +23294,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gUX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23527,7 +23437,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gYH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -23639,7 +23549,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "haC" = (
 /obj/structure/table/wood,
 /obj/item/lipstick/random{
@@ -24114,7 +24024,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hig" = (
 /obj/effect/turf_decal/sand,
 /mob/living/carbon/monkey/punpun,
@@ -24176,6 +24086,9 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "hiF" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -24183,7 +24096,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "hiL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "chemistry_shutters";
@@ -24208,7 +24121,7 @@
 /area/hallway/primary/starboard)
 "hiX" = (
 /turf/closed/wall,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "hjo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/gloves,
@@ -24236,7 +24149,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hjO" = (
 /obj/structure/bed{
 	pixel_x = 1;
@@ -24377,18 +24290,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hlS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks West";
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/turf/open/floor/plating,
+/area/construction)
 "hlU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -24606,6 +24512,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"hoX" = (
+/obj/machinery/camera{
+	c_tag = "Escape Podbay"
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "hpr" = (
 /turf/closed/indestructible/riveted,
 /area/ruin/space/has_grav/listeningstation)
@@ -24626,11 +24538,12 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "hpE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "hpU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -24665,11 +24578,9 @@
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
 "hqt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/construction)
 "hqB" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -24792,10 +24703,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "hrE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "hrR" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/sand,
@@ -24906,7 +24820,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hts" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -24959,7 +24873,7 @@
 /area/security/main)
 "huC" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "huG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25330,7 +25244,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hAq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -25471,7 +25385,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "hCM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -25616,6 +25530,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hEr" = (
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hEy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25638,7 +25557,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "hEY" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -25681,6 +25600,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hFK" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Podbay"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hFQ" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -26016,7 +25947,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "hMo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -26109,7 +26040,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hNo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -26380,7 +26311,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "hSh" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -26551,9 +26482,17 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "hVs" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/construction)
 "hVP" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -26694,7 +26633,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hZf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -26783,7 +26722,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "iaw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -26815,20 +26754,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iaT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/flasher{
-	id = "brigentry";
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ibk" = (
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -26856,7 +26781,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ibs" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -26927,6 +26852,19 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"icR" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Engine"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "ida" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27030,7 +26968,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ifs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -27070,7 +27008,7 @@
 "ifU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ifZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -27183,16 +27121,11 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "ihY" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "iic" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -27242,17 +27175,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"ijb" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ijd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -27377,7 +27299,7 @@
 	name = "carbon dioxide tank input injector"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ilt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27657,7 +27579,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iqQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27749,7 +27671,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "isM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27911,7 +27833,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "iux" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/royalblack,
@@ -28296,7 +28218,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "iBN" = (
 /obj/effect/overlay/palmtree_l{
 	pixel_y = 29
@@ -28596,7 +28518,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iJz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28629,6 +28551,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
+"iJP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/stairs,
+/area/hallway/secondary/exit)
 "iJT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light,
@@ -28637,7 +28564,7 @@
 "iKd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "iKj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -28662,21 +28589,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"iKH" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Podbay"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "iLj" = (
 /obj/structure/statue/silver/medborg,
 /obj/structure/window/reinforced{
@@ -28726,22 +28638,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iMr" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "iMH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "iMI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -28779,7 +28686,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "iNz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -28924,7 +28831,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iQC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -28958,7 +28865,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "iRg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29083,9 +28990,6 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"iTA" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "iTX" = (
 /obj/item/shard,
 /obj/item/shard,
@@ -29193,7 +29097,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iVi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29607,7 +29511,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "jaz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -30124,7 +30028,7 @@
 "jhF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30156,7 +30060,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jis" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -30265,6 +30169,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"jjq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "jjG" = (
@@ -30477,7 +30386,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jmq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30547,23 +30456,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"joj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Escape North";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "joq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -30595,7 +30487,7 @@
 "joF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "joS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -30672,7 +30564,7 @@
 /area/hallway/primary/central)
 "jqA" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jqF" = (
 /obj/effect/turf_decal/tile/darkblue,
 /obj/effect/turf_decal/tile/darkblue{
@@ -30702,7 +30594,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "jqV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30732,7 +30624,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "jrt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -30793,7 +30685,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jsv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -30961,7 +30853,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jwj" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -31058,15 +30950,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jxK" = (
-/obj/machinery/button/door{
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
-/area/escapepodbay)
 "jxV" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -31235,7 +31118,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jBf" = (
 /obj/item/gun/energy/disabler,
 /obj/item/gun/energy/disabler{
@@ -31435,6 +31318,21 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"jEg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to filter"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "jEj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/window/reinforced/tinted{
@@ -31742,16 +31640,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
-"jKm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/variation/box/sec/brig_cell/perma,
-/obj/machinery/flasher{
-	id = "PCell 1";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/engine/atmos)
 "jKr" = (
 /obj/effect/turf_decal/tile/black{
 	dir = 1
@@ -31833,7 +31722,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jMe" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -31922,7 +31811,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jNN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31941,7 +31830,12 @@
 	},
 /obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
+"jOl" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "jOn" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -31999,7 +31893,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "jPv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -32256,7 +32150,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jTI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -32609,6 +32503,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kaH" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "kbb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32682,11 +32580,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kcm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -32694,7 +32589,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kcI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -32778,7 +32673,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kfl" = (
 /obj/item/reagent_containers/glass/bottle/drugs,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -32927,7 +32822,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kgy" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -33015,10 +32910,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"kiq" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "kit" = (
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/port/fore)
@@ -33491,15 +33382,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"kqQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	light_color = "#c1caff"
-	},
-/turf/open/floor/engine,
-/area/escapepodbay)
 "kqT" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -33635,7 +33517,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ksJ" = (
 /obj/effect/mine/stun{
 	icon = 'icons/obj/assemblies.dmi';
@@ -33734,7 +33616,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ktA" = (
 /obj/structure/window{
 	dir = 1
@@ -33890,7 +33772,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kxk" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -34116,7 +33998,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kBW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34162,7 +34044,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "kDf" = (
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
@@ -34341,11 +34223,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kFb" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -34384,10 +34263,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kFx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "kFT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -34436,7 +34318,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kGE" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -34446,7 +34328,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kHg" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -34464,10 +34346,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"kHx" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "kHy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -34481,7 +34359,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kHO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/chapel/main";
@@ -34501,7 +34379,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kHT" = (
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
@@ -34774,38 +34652,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"kOl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = 2;
-	prison_radio = 1
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -27;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kOr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks West";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kOw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -35103,10 +34962,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"kUc" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "kUk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -35184,7 +35039,7 @@
 "kVH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -35370,7 +35225,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kZM" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/preopen{
@@ -35385,7 +35240,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "lad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -35453,7 +35308,7 @@
 	name = "nitrogen tank input injector"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lbP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35481,7 +35336,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "lcg" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35526,7 +35381,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lcG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -35538,7 +35393,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lcL" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -35604,7 +35459,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ldt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35683,6 +35538,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
+"lfG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lfU" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
@@ -35732,8 +35595,8 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "lhk" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lhs" = (
@@ -35742,24 +35605,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"lhu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 8;
-	name = "Atmospherics Distribution APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "lhK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -35827,7 +35672,7 @@
 /area/crew_quarters/locker)
 "ljF" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ljH" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -36100,8 +35945,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lrf" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/construction)
 "lrg" = (
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced{
@@ -36111,7 +35959,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "lri" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36119,9 +35967,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "lrr" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
@@ -36193,38 +36040,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lsT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ltl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ltn" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -36569,9 +36388,10 @@
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/construction)
 "lzi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36720,11 +36540,11 @@
 	},
 /area/maintenance/port/aft)
 "lBg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "lBs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -36803,7 +36623,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "lDV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36915,7 +36735,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lHj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
@@ -37019,18 +36839,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/hfr";
-	dir = 8;
-	name = "Atmospherics HFR Room APC";
-	pixel_x = -25
+/obj/structure/sign/poster/random{
+	pixel_x = -32
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "lJE" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -37279,7 +37092,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lMQ" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
@@ -37299,7 +37112,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lNd" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -37384,10 +37197,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lOJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "lOL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Disposal Exit";
@@ -37585,7 +37394,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lRU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -37742,7 +37551,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lUe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
@@ -37784,7 +37593,7 @@
 "lUG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lVv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -37953,6 +37762,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -38157,7 +37969,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mbl" = (
 /obj/machinery/light_switch{
 	pixel_y = 27
@@ -38268,7 +38080,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mdk" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -38432,7 +38244,7 @@
 "mfZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mgd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -38501,10 +38313,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/bridge)
-"mgZ" = (
-/obj/structure/spacepoddoor,
-/turf/open/floor/engine,
-/area/escapepodbay)
 "mhj" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -38543,7 +38351,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mhN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38589,8 +38397,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "mit" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/construction)
 "miz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38766,12 +38577,6 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mlN" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "mmc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -39054,7 +38859,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "mqk" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -39100,7 +38905,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mqC" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -39114,6 +38919,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"mqE" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -27;
+	pixel_y = -7
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = 2;
+	prison_radio = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mqS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -39213,17 +39041,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"msW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs,
-/area/escapepodbay)
 "mtn" = (
 /obj/machinery/light{
 	dir = 8
@@ -39529,7 +39346,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mzm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39586,7 +39403,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mAn" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -39594,14 +39411,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"mAp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "mAs" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -40426,7 +40235,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "mNt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -40498,7 +40307,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -40618,7 +40427,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mQy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -40850,8 +40659,14 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "mUS" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "mUV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40892,7 +40707,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mVk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41221,7 +41036,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mYt" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -41361,7 +41176,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mZO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -41765,7 +41580,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ngX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41828,7 +41643,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "niG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -41870,12 +41685,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"njk" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "njm" = (
 /obj/machinery/light{
 	dir = 1
@@ -41886,6 +41695,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"njp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white,
+/area/security/physician)
 "njw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -42120,7 +41936,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "nmW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42249,7 +42065,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "npT" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/bluespace,
@@ -42513,12 +42329,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nuw" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "nuz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42729,11 +42544,13 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "nxO" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/construction)
 "nxX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -42742,7 +42559,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "nya" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42763,18 +42580,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nyn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"nyp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
 "nys" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42834,18 +42646,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered)
-"nzV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "nzW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42859,7 +42659,7 @@
 /area/science/research)
 "nAg" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/hfr)
+/area/construction)
 "nAi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42927,7 +42727,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nAX" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -43055,6 +42855,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"nCY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "nDf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43154,7 +42961,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nFe" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -43195,10 +43002,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
-"nFP" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "nFT" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
@@ -43234,18 +43037,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"nGH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nHc" = (
 /obj/structure/sign/poster/contraband/cc64k_ad,
 /turf/closed/wall/r_wall,
@@ -43389,11 +43180,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"nJH" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "nJL" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
@@ -43483,7 +43269,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nMf" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -43518,6 +43304,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"nMP" = (
+/obj/structure/rack,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/twentyfive,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "nNs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine,
@@ -43604,7 +43399,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nOQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -43678,7 +43473,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nQE" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -43779,7 +43574,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "nRV" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/window/reinforced,
@@ -43915,21 +43710,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"nTM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/cockroach{
-	desc = "Virtually unkillable.";
-	name = "Becquerel";
-	sentience_type = 5;
-	status_flags = 16
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "nUc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
@@ -44006,7 +43786,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nVd" = (
 /obj/machinery/vending/sovietsoda,
 /obj/effect/decal/cleanable/dirt,
@@ -44155,11 +43935,9 @@
 /turf/open/floor/wood,
 /area/vacant_room)
 "nXU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/item/stack/cable_coil/red,
+/turf/open/floor/engine,
+/area/construction)
 "nXY" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -44233,7 +44011,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "nZw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -44269,7 +44047,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oao" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -44412,7 +44190,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "obR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -44537,7 +44315,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "oeo" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
@@ -44595,7 +44373,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ofC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44772,13 +44550,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"oiI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ojt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Research Division";
@@ -44823,7 +44594,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ojR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -45109,7 +44880,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "opf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45165,12 +44936,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "oqQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "oqX" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -45361,7 +45132,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oua" = (
 /obj/machinery/light{
 	dir = 8
@@ -45478,7 +45249,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ovH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -45538,7 +45309,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oxt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45633,12 +45404,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/listeningstation)
-"ozN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/escapepodbay)
 "ozT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -45732,7 +45497,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "oBF" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/structure/disposalpipe/segment{
@@ -45765,7 +45530,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "oBQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -45928,32 +45693,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oEH" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
-"oEI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = 2;
-	prison_radio = 1
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -27;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/construction)
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45982,7 +45725,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oFo" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
@@ -46089,7 +45832,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oHB" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -46194,17 +45937,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
-"oIL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "oJe" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -46289,6 +46021,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"oLb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "oLd" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel/showroomfloor,
@@ -46396,7 +46137,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oNd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/landmark/event_spawn,
@@ -46961,12 +46702,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"oWp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "oWB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -47021,17 +46756,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oXP" = (
-/obj/machinery/light{
+/obj/machinery/light/broken{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "oYb" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -47053,10 +46782,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oYF" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oYY" = (
@@ -47320,16 +47049,16 @@
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "pbT" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 1;
+	name = "toxins space injector"
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/science/mixing/chamber)
 "pbU" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "pbV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
@@ -47339,7 +47068,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pce" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/psych";
@@ -47663,7 +47392,7 @@
 	name = "plasma tank input injector"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "phV" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
@@ -47701,6 +47430,15 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"piL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "piV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47877,7 +47615,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pmj" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -48075,7 +47813,7 @@
 "poB" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/hfr)
+/area/construction)
 "poD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -48250,7 +47988,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "pqt" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Incinerator";
@@ -48499,24 +48237,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"puq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Distro to filter"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "puW" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/dark,
@@ -48618,7 +48338,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -48910,6 +48630,12 @@
 /obj/machinery/computer/ai_server_console,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pAM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/hallway/secondary/exit)
 "pAX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -49190,7 +48916,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pGu" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49409,6 +49135,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"pJP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pJZ" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -49439,7 +49170,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -49450,13 +49181,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pKp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "pKr" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -49471,7 +49205,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "pLe" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -49873,7 +49607,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "pQu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50074,16 +49808,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
 "pTx" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/rglass{
-	amount = 5
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 5
-	},
-/obj/item/pipe_dispenser,
-/obj/item/wrench,
-/obj/item/multitool,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -50092,7 +49816,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "pTT" = (
 /obj/machinery/computer/telecomms/traffic{
 	network = "tcommsat"
@@ -50119,12 +49843,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"pUg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "pUj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
@@ -50147,7 +49865,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pUv" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -50388,7 +50106,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pXg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -50535,9 +50253,8 @@
 "pYC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "pYJ" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -50617,7 +50334,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qac" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
@@ -50959,7 +50676,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "qfA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -51031,24 +50748,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"qgN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qhb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51402,9 +51101,8 @@
 "qmU" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "qnl" = (
 /obj/machinery/light{
 	dir = 8
@@ -51590,23 +51288,11 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qqO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qre" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "qri" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -51668,6 +51354,18 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"qsq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "qsu" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -51727,24 +51425,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"qtN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "qtP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/power/apc/highcap/five_k{
@@ -51776,7 +51456,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "qum" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -51867,7 +51547,7 @@
 	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qvy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -51947,7 +51627,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qxT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51971,7 +51651,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qxY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -52057,17 +51737,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qzA" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 10
-	},
-/obj/machinery/button/flasher{
-	id = "brigentry";
-	pixel_x = -28;
-	pixel_y = -8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qzO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -52091,7 +51760,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qAN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52386,7 +52055,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qEH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -52565,6 +52234,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qHo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -52572,13 +52244,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "qHp" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -52653,7 +52322,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "qHX" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -53120,7 +52789,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qRr" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
@@ -53329,7 +52998,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "qWF" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -53716,7 +53385,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "rcz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53734,7 +53403,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "rcD" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
@@ -53886,21 +53555,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ren" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "reo" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -53922,18 +53576,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
-"rez" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos_distro)
 "reA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54112,12 +53755,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "rhk" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "rhT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54179,7 +53821,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "riS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -54187,9 +53829,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "riV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54499,7 +54140,7 @@
 	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rng" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -54536,14 +54177,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "rnZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "rog" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -54698,7 +54335,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rqO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54790,17 +54427,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rsq" = (
-/obj/machinery/light{
+/obj/machinery/light/built{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "rsR" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth{
@@ -55046,6 +54677,19 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"rvE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Distro"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "rvH" = (
 /obj/effect/spawner/lootdrop/techstorage/rnd,
 /obj/structure/rack,
@@ -55445,15 +55089,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"rDy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "rDJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -55682,7 +55317,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rFu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -55949,7 +55584,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "rLN" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -56040,6 +55675,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rNl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "rNE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -56130,7 +55778,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "rPd" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -56514,12 +56162,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
-"rUZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
-/area/escapepodbay)
 "rVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -56535,7 +56177,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "rVl" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/bait/worm/leech,
@@ -56723,8 +56365,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "rXt" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
+/area/construction)
 "rXC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56887,6 +56530,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"rZx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "rZz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/station_engineer,
@@ -57017,7 +56669,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sbR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -57152,7 +56804,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "scG" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -57334,7 +56986,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sgi" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/light/small{
@@ -57360,7 +57012,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "shu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57372,14 +57024,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
-"shY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sia" = (
 /obj/machinery/button/door{
 	id = "Dorm1";
@@ -57479,7 +57123,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "skV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -57494,7 +57138,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -57642,7 +57286,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"sou" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "sov" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -57671,6 +57322,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"soA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "soS" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -57727,9 +57387,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "sqh" = (
 /obj/structure/table/glass,
 /obj/item/stack/packageWrap,
@@ -57803,9 +57462,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"srH" = (
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "srI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -57876,7 +57532,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ssK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -58033,7 +57689,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "swd" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/turf_decal/bot_white,
@@ -58268,7 +57924,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sAd" = (
 /obj/structure/chair{
 	dir = 4
@@ -58283,7 +57939,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sAZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58320,7 +57976,7 @@
 "sBP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sBX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -58413,7 +58069,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sCR" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Break Room";
@@ -58519,7 +58175,7 @@
 "sEj" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sEL" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
@@ -58641,7 +58297,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sGf" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mine/stun{
@@ -58719,7 +58375,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sHS" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -58837,7 +58493,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sJB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59092,7 +58748,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sMq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -59131,9 +58787,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/foyer";
+	areastring = "/area/engine/atmos";
 	dir = 1;
-	name = "Atmospherics Foyer APC";
+	name = "Atmospherics Wing APC";
 	pixel_y = 23
 	},
 /obj/structure/cable{
@@ -59166,7 +58822,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sMU" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -59434,7 +59090,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sRv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59477,7 +59133,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sSc" = (
 /obj/machinery/ai/server_cabinet/prefilled,
 /turf/open/floor/circuit,
@@ -59626,7 +59282,7 @@
 	sensors = list("tox_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sTC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -59737,20 +59393,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sVl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/escapepodbay";
-	dir = 8;
-	name = "Podbay APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "sVB" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -59816,10 +59458,10 @@
 /turf/open/floor/carpet/exoticgreen,
 /area/hallway/secondary/entry)
 "sXl" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sXo" = (
@@ -59847,6 +59489,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"sXP" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "sXS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59905,7 +59555,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sYY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -59938,7 +59588,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sZm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -60091,6 +59741,15 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tbM" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "tbS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -60197,6 +59856,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"tdH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tdI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -60252,6 +59920,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "teA" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -60371,7 +60042,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "tgE" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -60390,7 +60061,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "thu" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "ai_core_airlock_interior"
@@ -60465,7 +60136,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "tic" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -60520,7 +60191,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tiX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/orange{
@@ -60557,11 +60228,14 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "tkI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "tld" = (
 /obj/structure/rack,
 /obj/item/multitool{
@@ -60722,14 +60396,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tnN" = (
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/construction)
 "toa" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "tob" = (
@@ -60787,7 +60463,7 @@
 	name = "Pure to Mix"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "tpe" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60852,8 +60528,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tqi" = (
-/turf/closed/wall,
-/area/engine/atmos/pumproom)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/construction)
 "tqO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -60954,13 +60634,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ttb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "O2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ttk" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -61005,7 +60685,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ttL" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
@@ -61076,7 +60756,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tvh" = (
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
@@ -61243,7 +60923,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "txw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -61273,7 +60953,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "tyi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61339,13 +61019,27 @@
 /obj/item/pen,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"tzO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Escape North";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tzQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "tAc" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -61400,17 +61094,7 @@
 "tAQ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"tAS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
-"tBa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "tBi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -61540,8 +61224,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "tEi" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "tEI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -61753,7 +61440,7 @@
 	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tHP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -61927,13 +61614,13 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tKo" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tKx" = (
 /obj/item/soap/syndie,
 /turf/open/floor/plasteel/freezer,
@@ -62017,10 +61704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tNx" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
 "tOe" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -62336,7 +62019,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tUl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -62603,12 +62286,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"tYa" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "tYf" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plasteel/dark,
@@ -62705,9 +62382,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
-"uam" = (
-/turf/open/floor/engine,
-/area/escapepodbay)
 "uay" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -62716,8 +62390,8 @@
 /area/maintenance/starboard/fore)
 "uaC" = (
 /obj/structure/closet/crate,
-/obj/item/twohanded/fishingrod/collapsible,
-/obj/item/twohanded/fishingrod/collapsible,
+/obj/item/twohanded/fishingrod/collapsable,
+/obj/item/twohanded/fishingrod/collapsable,
 /obj/item/twohanded/fishingrod,
 /obj/item/twohanded/fishingrod,
 /obj/item/twohanded/fishingrod,
@@ -62807,16 +62481,15 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "ubP" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "ucc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -62907,7 +62580,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "udN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -63076,6 +62749,9 @@
 	dir = 9
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -63502,7 +63178,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "unf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -63572,7 +63248,7 @@
 "uoP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uoV" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -63639,7 +63315,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "uqF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -64061,7 +63737,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uzw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -64082,7 +63758,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uzx" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -64292,12 +63968,13 @@
 /area/medical/virology)
 "uBA" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8;
+	on = 1;
+	volume_rate = 200
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/atmos_distro)
 "uBJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64319,7 +63996,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "uCb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -64432,7 +64109,7 @@
 "uDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uDr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64872,21 +64549,13 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uKY" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"uLd" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id = "escapepodbay"
-	},
-/obj/structure/spacepoddoor,
-/turf/open/floor/engine,
-/area/escapepodbay)
 "uLk" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -65002,7 +64671,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uNY" = (
 /obj/structure/sign/poster/contraband/rebels_unite,
 /turf/closed/wall/r_wall,
@@ -65070,7 +64739,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uPA" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -65205,14 +64874,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"uRH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "uRP" = (
 /obj/machinery/light,
 /obj/effect/landmark/start/roboticist,
@@ -65272,9 +64933,8 @@
 "uTB" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "uTC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -65301,13 +64961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uUt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uUB" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engine.";
@@ -65375,7 +65028,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "uWo" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -65394,12 +65047,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"uWA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos/hfr)
 "uWT" = (
 /obj/machinery/light{
 	dir = 1
@@ -65623,7 +65270,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "uZu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -65736,11 +65383,12 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "vbM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "vbY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -65942,7 +65590,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vgY" = (
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/structure/rack,
@@ -66127,7 +65775,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vkT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66155,7 +65803,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vla" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -66262,18 +65910,12 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vog" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
 "vot" = (
 /obj/machinery/air_sensor{
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "voE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -66442,7 +66084,7 @@
 "vrS" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "vrT" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 4
@@ -66599,7 +66241,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vtV" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -66655,16 +66297,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/morgue)
-"vuM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/engine,
-/area/escapepodbay)
 "vvc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -66869,14 +66501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vya" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vyc" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -66895,12 +66519,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vyh" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/pumproom";
+	areastring = "/area/engine/atmos_distro";
 	dir = 1;
-	name = "Atmospherics Pumping Room APC";
+	name = "Atmospherics Distribution APC";
 	pixel_y = 23
 	},
 /obj/structure/cable{
@@ -66913,7 +66537,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vyi" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating,
@@ -67089,7 +66713,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "vDy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67294,7 +66918,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vGH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -67403,7 +67027,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos_distro)
 "vJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -67428,7 +67052,7 @@
 	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vJM" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -67519,7 +67143,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vKH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
@@ -67703,7 +67327,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vNt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -67817,6 +67441,21 @@
 "vOX" = (
 /turf/open/floor/engine,
 /area/science/storage)
+"vPe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vPC" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -68015,7 +67654,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vSX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -68032,15 +67671,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"vTj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
 "vTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -68091,7 +67721,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vUv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -68138,7 +67768,7 @@
 	name = "oxygen tank input injector"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vVy" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/engine,
@@ -68269,7 +67899,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vYd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -68387,7 +68017,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "waz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68489,7 +68119,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wbN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
@@ -68500,7 +68130,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wbO" = (
 /obj/machinery/light{
 	dir = 8
@@ -68662,7 +68292,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "wez" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "weB" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/toxins{
@@ -68811,7 +68441,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wgj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68836,9 +68466,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
-"wgX" = (
-/turf/closed/wall,
-/area/escapepodbay)
 "whl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -68973,7 +68600,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wkd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -69312,7 +68939,7 @@
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wpj" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -69393,17 +69020,20 @@
 	},
 /area/maintenance/starboard/fore)
 "wqE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "wqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -69613,7 +69243,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wur" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -69684,7 +69314,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wwD" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -69873,6 +69503,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wAt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos_distro)
 "wAx" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -69906,7 +69543,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wAK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room";
@@ -70242,7 +69879,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wFG" = (
 /obj/machinery/requests_console{
 	department = "Primary Tool Storage";
@@ -70282,7 +69919,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wFY" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -70326,7 +69963,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -70371,7 +70008,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wIf" = (
 /obj/machinery/camera{
 	c_tag = "Brig Equipment Room";
@@ -70403,6 +70040,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wIt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wIy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -70481,7 +70128,7 @@
 	level = 2
 	},
 /turf/closed/wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wJE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -70491,7 +70138,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wJK" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -70603,7 +70250,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "wME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -70873,6 +70520,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
+"wQv" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wQw" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
@@ -71028,7 +70683,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wSY" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -71073,7 +70728,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wTZ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -71202,7 +70857,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wVF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -71323,15 +70978,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wWP" = (
-/obj/structure/rack,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/twentyfive,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "wWV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -71370,7 +71016,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wXN" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
@@ -71757,7 +71403,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "xfD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71766,7 +71412,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xfJ" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/wood{
@@ -71803,9 +71449,8 @@
 /turf/open/floor/grass/snow/safe,
 /area/ruin/space/has_grav/listeningstation)
 "xgb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "xgg" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -71940,7 +71585,7 @@
 /turf/open/floor/plasteel{
 	dir = 4
 	},
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xjc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72014,7 +71659,7 @@
 	node2_concentration = 0.21
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xkR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -72247,7 +71892,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "xom" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -72388,7 +72033,7 @@
 "xri" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xro" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/window/southleft{
@@ -72412,6 +72057,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"xrT" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "xsF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -72625,7 +72276,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xvF" = (
 /obj/item/cigbutt/cigarbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -72697,20 +72348,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xwI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/machinery/button/flasher{
-	id = "cell4";
-	pixel_x = 24;
-	pixel_y = -10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xxg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -72964,7 +72601,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xCh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72972,9 +72609,8 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "xCw" = (
 /obj/structure/window{
 	dir = 1
@@ -73013,7 +72649,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xDm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -73167,6 +72803,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "xGC" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = 32
+	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -73243,7 +72883,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xIn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73273,9 +72913,8 @@
 	c_tag = "Construction Area South";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "xIA" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/white,
@@ -73315,7 +72954,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xJc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73529,7 +73168,20 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
+"xLZ" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xMe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Hallway"
@@ -73650,7 +73302,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xNF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -73846,12 +73498,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xRC" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "xRH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73943,14 +73589,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xTh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+"xTg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/hallway/secondary/exit)
 "xUe" = (
 /obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plating,
@@ -74015,9 +73659,8 @@
 "xUG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/construction)
 "xVq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -74118,7 +73761,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xWi" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -74188,7 +73831,7 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xXv" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -74425,7 +74068,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ycw" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -74443,11 +74086,8 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/construction)
 "ycH" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -74503,7 +74143,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ydp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/firealarm{
@@ -74571,7 +74211,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "yeg" = (
 /obj/machinery/light{
 	dir = 8
@@ -74601,6 +74241,12 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"yeP" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "yff" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2{
@@ -74629,6 +74275,16 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"yfJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/hallway/secondary/exit)
 "yfX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -74704,7 +74360,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yhu" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/burger/plain,
@@ -74728,10 +74384,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"yig" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
 "yim" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -74821,7 +74473,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ykz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -74859,15 +74511,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ylB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/variation/box/sec/brig_cell/perma,
-/obj/machinery/flasher{
-	id = "PCell 3";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ylM" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -102729,7 +102372,7 @@ fdv
 lye
 qBV
 uDg
-qzA
+yeP
 mIc
 djY
 gWF
@@ -103237,7 +102880,7 @@ msb
 msb
 msb
 api
-apA
+njp
 gGp
 wBQ
 tpe
@@ -103245,7 +102888,7 @@ uZS
 sXS
 mAV
 tcG
-iaT
+wIt
 fwF
 bcn
 hsM
@@ -104788,7 +104431,7 @@ nDf
 ssf
 iSG
 mWK
-kOl
+mqE
 rSW
 czo
 aZW
@@ -105816,7 +105459,7 @@ rPF
 aWY
 nfv
 ezN
-oEI
+vms
 rSW
 czo
 aZW
@@ -107355,7 +106998,7 @@ aQv
 dyV
 uSn
 oSQ
-xwI
+tdH
 aGC
 hsQ
 eme
@@ -107854,7 +107497,7 @@ yeg
 iic
 ajQ
 diA
-ylB
+cHT
 ajQ
 mbN
 maF
@@ -109910,7 +109553,7 @@ yfF
 tSh
 ajQ
 heT
-jKm
+cHT
 ajQ
 wNm
 cEb
@@ -115377,7 +115020,7 @@ vyg
 eBe
 txP
 cOH
-mUS
+aXb
 oBq
 oBq
 ahe
@@ -116660,7 +116303,7 @@ mXr
 aOl
 fnU
 fvV
-vTj
+dfp
 rqK
 qHV
 vgW
@@ -116680,10 +116323,10 @@ pJZ
 afp
 tYf
 tYf
-ozg
+xLZ
 wRS
 ozg
-oAU
+hEr
 ruw
 aJj
 dPt
@@ -116940,7 +116583,7 @@ bZf
 oAU
 ozg
 ozg
-ozg
+dLa
 ruw
 aJj
 peF
@@ -117672,7 +117315,7 @@ cva
 cVp
 uaE
 lRU
-qgN
+vPe
 toi
 pDJ
 akh
@@ -117929,7 +117572,7 @@ gyY
 gWT
 cjY
 wUJ
-ren
+aPc
 ajX
 tFs
 anj
@@ -117944,7 +117587,7 @@ kDj
 aXb
 aXb
 ibo
-iKd
+aXb
 ojJ
 aXb
 aXb
@@ -118170,7 +117813,7 @@ aZH
 aZH
 axP
 msM
-wgX
+aNY
 aJn
 aJn
 aJn
@@ -118186,7 +117829,7 @@ wUJ
 wUJ
 wUJ
 nks
-gjQ
+gba
 aRv
 lTa
 anj
@@ -118205,11 +117848,11 @@ tkI
 jvV
 kty
 aXb
-yig
-yig
-yig
-yig
-yig
+aTU
+aTU
+aTU
+aTU
+aTU
 aJj
 vkj
 fQZ
@@ -118427,23 +118070,23 @@ aZH
 axP
 axP
 axP
-wgX
-kiq
-aXI
-sVl
-msW
-iKH
-shY
-shY
-oIL
-rez
-nGH
-joj
-shY
-shY
-ijb
-eTf
-vya
+aNY
+kaH
+feK
+jjq
+iJP
+hFK
+jjq
+jjq
+ewm
+lfG
+piL
+tzO
+jjq
+jjq
+wQv
+fzM
+pJP
 ajX
 uZz
 anj
@@ -118462,11 +118105,11 @@ fZZ
 skT
 rOU
 aXb
-yig
+aTU
 aBu
 aBu
 aBu
-yig
+aTU
 aJj
 rDv
 dbQ
@@ -118684,11 +118327,11 @@ aZH
 axP
 aZH
 aAP
-wgX
-mlN
-pUg
-srH
-eMp
+aNY
+xrT
+xTg
+ajX
+sXP
 aNY
 dRT
 ajX
@@ -118715,15 +118358,15 @@ ppt
 aXb
 wFA
 fOl
-lrf
+aCQ
 jND
 etx
 aXb
-yig
+aTU
 aBu
 aBu
 aBu
-yig
+aTU
 aJj
 rJw
 uAV
@@ -118941,11 +118584,11 @@ aZH
 gzW
 aZH
 wBL
-wgX
-gnD
-pUg
-srH
-arR
+aNY
+tbM
+xTg
+ajX
+eNI
 aNY
 aNY
 imH
@@ -118976,11 +118619,11 @@ qEC
 jND
 iBJ
 aXb
-yig
+aTU
 aox
 aBu
 qui
-yig
+aTU
 aJj
 aJj
 pVi
@@ -119198,11 +118841,11 @@ aZH
 aZH
 aWe
 ppP
-wgX
-wWP
-oWp
-srH
-nJH
+aNY
+nMP
+huV
+ajX
+jOl
 aNY
 eky
 ajX
@@ -119228,16 +118871,16 @@ nyn
 icC
 aXb
 dJx
-gxD
+dyv
 wXG
 jND
 woS
 aXb
-yig
+aTU
 lDF
 aKe
 dvm
-yig
+aTU
 aJj
 bZq
 hSz
@@ -119455,11 +119098,11 @@ axP
 axP
 axP
 axP
-wgX
-vuM
-ozN
-ozN
-kqQ
+aNY
+yfJ
+akk
+akk
+rZx
 aNY
 ajr
 ajX
@@ -119485,7 +119128,7 @@ vRc
 aeV
 aXb
 jLV
-elw
+ceW
 nEQ
 dfp
 fnI
@@ -119712,11 +119355,11 @@ aXS
 aOf
 axP
 msb
-wgX
-aOQ
-uam
-uam
-uam
+aNY
+hoX
+agR
+agR
+agR
 aNY
 ajr
 ajX
@@ -119742,16 +119385,16 @@ nXY
 xBa
 aXb
 wJw
-lsT
+dUD
 wJw
 skY
+ahJ
+ahJ
 hiX
-hiX
-tqi
 kHQ
 wHG
 dAD
-tqi
+hiX
 vpj
 pYp
 wDS
@@ -119969,11 +119612,11 @@ aXS
 aXS
 axP
 msb
-wgX
-jxK
-uam
-uam
-uam
+aNY
+aKw
+agR
+agR
+agR
 aNY
 ajr
 kIA
@@ -119999,7 +119642,7 @@ aUa
 aUa
 ahN
 cfD
-qtN
+qsq
 iuv
 iNj
 wJE
@@ -120226,12 +119869,12 @@ aXS
 aXS
 axP
 msb
-wgX
-uam
-uam
-uam
-uam
-wgX
+aNY
+agR
+agR
+agR
+agR
+aNY
 iwc
 jjp
 wsp
@@ -120256,13 +119899,13 @@ hRt
 aUa
 ahN
 wbN
-ewA
+fbB
 mzk
 iQP
-iTA
-kHx
-iTA
-aNQ
+agi
+sEj
+agi
+nyh
 iMH
 tgX
 kBm
@@ -120483,12 +120126,12 @@ aXS
 aXS
 axP
 msb
-dKd
-mgZ
-mgZ
-mgZ
-uLd
-dKd
+ahn
+agR
+agR
+agR
+arG
+ahn
 iSn
 iSn
 xkg
@@ -120513,14 +120156,14 @@ jmo
 itt
 ahN
 mVg
-puq
-mAp
-fWL
-cNV
-cNV
-uRH
-xTh
-nzV
+jEg
+sou
+rvE
+oLb
+oLb
+nCY
+wAt
+dHK
 jrn
 vUk
 aYa
@@ -120740,12 +120383,12 @@ aXS
 aXS
 axP
 msb
-dKd
-rUZ
-rUZ
-rUZ
-rUZ
-dKd
+ahn
+pAM
+pAM
+pAM
+pAM
+ahn
 acb
 iSn
 iFH
@@ -120775,9 +120418,9 @@ iap
 eZK
 nZm
 nZm
-lOJ
-kUc
-qre
+tAQ
+eaS
+soA
 tgX
 sAW
 aYa
@@ -121034,7 +120677,7 @@ pqo
 pqo
 cNM
 gwE
-ehz
+icR
 kZQ
 thR
 aYa
@@ -121291,7 +120934,7 @@ vKE
 vKE
 npS
 asM
-dte
+rNl
 xXi
 wwm
 aYa
@@ -122068,7 +121711,7 @@ eMS
 hiX
 vDu
 cGf
-lrf
+agi
 vrS
 vrS
 cuH
@@ -122574,7 +122217,7 @@ ahN
 ahN
 vtH
 vtH
-tqi
+hiX
 kgv
 reo
 tzQ
@@ -122583,7 +122226,7 @@ hiX
 gDq
 eye
 mqb
-aZF
+qAG
 dAU
 hEK
 afF
@@ -122830,12 +122473,12 @@ aNg
 aNg
 aNg
 uBA
-vog
+vtH
 cRP
 vGG
 giF
 bVg
-hlS
+sRp
 hiX
 hiX
 iKd
@@ -123091,9 +122734,9 @@ pWQ
 nQn
 xiR
 oxf
-nyh
+mUS
 kOr
-lhu
+lUc
 tiH
 lUc
 jTF
@@ -123114,10 +122757,10 @@ pTx
 lJD
 rnZ
 fwE
-rnZ
+bbC
 oXP
 ycF
-aqD
+xgb
 nAg
 szq
 fcU
@@ -123349,7 +122992,7 @@ niC
 wbF
 kFa
 eaS
-ahJ
+agi
 ltl
 uoP
 hto
@@ -123359,20 +123002,20 @@ gJK
 sht
 afF
 axG
-nTM
+cOK
 nMs
 nBf
 kxr
 fCJ
-tEi
+aNM
 mNo
-tEi
-nFP
+aNM
+aNM
 iMr
-buK
+bJy
 qHo
-rXt
-tBa
+mit
+xgb
 nXU
 xgb
 nAg
@@ -123598,7 +123241,7 @@ aTU
 dSr
 dvR
 gmR
-aay
+aKe
 aNg
 dOL
 txt
@@ -123625,12 +123268,12 @@ kFx
 hiF
 hrE
 xUG
-nyp
+lyR
 lyR
 wqE
-oEH
+xgb
 rXt
-aPI
+xgb
 xIy
 nAg
 kSb
@@ -123878,16 +123521,16 @@ cnQ
 rWz
 afF
 cOs
-tEi
+aNM
 odT
 tEi
 lBg
-cKX
+lBg
 nxO
 hVs
 tnN
 gRf
-aPI
+xgb
 pbU
 nAg
 jGN
@@ -124135,17 +123778,17 @@ lbz
 nuX
 afF
 nuw
-tEi
-odT
-tEi
+aNM
+buK
+aNM
 eBw
-rXt
+bJy
 oEH
 dom
-tNx
-rXt
-aPI
-tAS
+xgb
+aay
+xgb
+xgb
 nAg
 afO
 fZk
@@ -124394,14 +124037,14 @@ afF
 rhk
 aNM
 xLI
-tEi
-xRC
+aNM
 bJy
-rXt
-bYr
-rXt
+bJy
 hqt
-njk
+bYr
+lrf
+xgb
+xgb
 xgb
 nAg
 aMT
@@ -124626,7 +124269,7 @@ aTU
 eaw
 jmp
 vot
-aay
+aKe
 aNg
 dOL
 vJK
@@ -124654,12 +124297,12 @@ eNu
 vbM
 hpE
 fzz
-bbC
+hlS
 eIf
 bbC
 rsq
-rDy
-any
+xgb
+xgb
 nAg
 pkB
 sDL
@@ -124898,7 +124541,7 @@ sZi
 qRp
 agi
 gJK
-oiI
+sBP
 afF
 bgy
 gqX
@@ -124906,12 +124549,12 @@ aTO
 ajR
 afF
 nAg
-uWA
 nAg
 nAg
+nAg
 poB
 poB
-poB
+tqi
 nAg
 nAg
 nAg
@@ -125163,13 +124806,13 @@ hqI
 ajR
 aNg
 aNg
-uUt
-aNg
-dFE
 aNg
 aNg
+aXU
 aNg
-wdn
+aNg
+aqD
+msb
 msb
 msb
 msb
@@ -125410,7 +125053,7 @@ tAQ
 uzv
 nAU
 tAQ
-tYa
+nZm
 ngP
 jsq
 afF
@@ -125426,7 +125069,7 @@ aNg
 aNg
 aNg
 aNg
-wdn
+msb
 msb
 msb
 msb
@@ -125654,7 +125297,7 @@ aTU
 gMM
 qqw
 wAA
-aay
+aKe
 aNg
 dOL
 tHO
@@ -125683,7 +125326,7 @@ aNg
 acb
 aNg
 acb
-wdn
+acb
 msb
 msb
 msb
@@ -126171,7 +125814,7 @@ aTU
 aTU
 aNg
 dOL
-vog
+vtH
 oET
 qAG
 oHj
@@ -126421,11 +126064,11 @@ acb
 adi
 acb
 aNg
-mit
-mit
-mit
-mit
-mit
+ahN
+ahN
+ahN
+ahN
+ahN
 kZM
 vyD
 eZU
@@ -127202,15 +126845,15 @@ acb
 nuh
 aTU
 uNX
-aay
+aKe
 xWh
 aTU
 uNX
-aay
+aKe
 eAh
 aTU
 uNX
-aay
+aKe
 tKd
 aTU
 aNg

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -73169,19 +73169,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/construction)
-"xLZ" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "xMe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Hallway"
@@ -116323,7 +116310,7 @@ pJZ
 afp
 tYf
 tYf
-xLZ
+ozg
 wRS
 ozg
 hEr

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -74,10 +74,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "aay" = (
-/obj/effect/turf_decal/box,
-/obj/structure/frame/machine,
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/plating,
+/area/engine/atmos/distro)
 "aaz" = (
 /obj/structure/sign/poster/contraband/communist_state,
 /turf/closed/wall,
@@ -137,7 +136,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "abe" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -405,7 +404,7 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "acX" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /mob/living/simple_animal/butterfly,
@@ -764,7 +763,7 @@
 /area/security/processing)
 "agi" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "agk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -866,9 +865,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"agR" = (
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "agS" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
@@ -934,10 +930,6 @@
 /obj/item/twohanded/required/pool/pool_noodle,
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
-"ahn" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/hallway/secondary/exit)
 "ahu" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
@@ -975,11 +967,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ahJ" = (
-/turf/closed/wall,
-/area/engine/atmos)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ahN" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ahR" = (
 /obj/structure/window{
 	dir = 8
@@ -1266,12 +1261,6 @@
 "akh" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
-"akk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "akl" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -1301,7 +1290,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "akz" = (
 /obj/structure/rack,
 /obj/item/stock_parts/subspace/transmitter,
@@ -1327,7 +1316,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "akP" = (
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/yellowsiding{
@@ -1633,6 +1622,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"any" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "anC" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/yellowsiding{
@@ -1761,7 +1756,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "aoA" = (
 /obj/structure/window{
 	dir = 8
@@ -1883,6 +1878,23 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"apA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/operating,
+/obj/machinery/flasher{
+	id = "briginfirmary";
+	pixel_x = 8;
+	pixel_y = 28
+	},
+/obj/machinery/button/flasher{
+	id = "briginfirmary";
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/white,
+/area/security/physician)
 "apB" = (
 /turf/closed/wall/r_wall,
 /area/bridge/meeting_room)
@@ -2013,11 +2025,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "aqD" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/construction)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "aqF" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -2190,12 +2202,6 @@
 "arE" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"arG" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id = "escapepodbay"
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "arK" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -2221,6 +2227,11 @@
 "arQ" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
+"arR" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "arS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -2356,7 +2367,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "asO" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -2495,7 +2506,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "atJ" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -2934,6 +2945,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "axH" = (
@@ -3434,7 +3446,7 @@
 /area/crew_quarters/fitness)
 "aBu" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "aBw" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3692,7 +3704,7 @@
 /area/tcommsat/server)
 "aCQ" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aCS" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -4574,7 +4586,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aJG" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -4636,7 +4648,7 @@
 "aKe" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "aKh" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -4672,15 +4684,6 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/library)
-"aKw" = (
-/obj/machinery/button/door{
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "aKE" = (
 /obj/structure/chair{
 	dir = 1
@@ -4934,8 +4937,11 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "aNM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "aNO" = (
 /obj/machinery/door/window/westright{
 	dir = 1;
@@ -4950,6 +4956,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"aNQ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "aNR" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -5072,6 +5084,12 @@
 "aOP" = (
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"aOQ" = (
+/obj/machinery/camera{
+	c_tag = "Escape Podbay"
+	},
+/turf/open/floor/engine,
+/area/escapepodbay)
 "aOR" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteenXnineteen{
@@ -5104,18 +5122,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aPc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aPg" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -5134,7 +5140,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aPq" = (
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -5181,7 +5187,7 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aPy" = (
 /turf/closed/wall,
 /area/medical/patients_rooms/room_a)
@@ -5200,6 +5206,12 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aPI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "aPK" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -5650,7 +5662,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aTS" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window{
@@ -5664,7 +5676,7 @@
 "aTU" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aUa" = (
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -5943,7 +5955,7 @@
 /area/security/brig)
 "aXb" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "aXd" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
@@ -6044,6 +6056,17 @@
 /obj/machinery/electrolyzer,
 /turf/open/floor/engine,
 /area/science/storage)
+"aXI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "aXJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -6266,6 +6289,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aZF" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "aZG" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -6437,11 +6466,14 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "bbC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "bcn" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -7078,7 +7110,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bnm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable/orange{
@@ -7224,7 +7256,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "bqm" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
@@ -7533,12 +7565,11 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "buK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/mob/living/simple_animal/cockroach,
-/turf/open/floor/plasteel,
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "buL" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -7775,7 +7806,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "byL" = (
 /obj/structure/closet/ammunitionlocker,
 /obj/effect/turf_decal/bot_red,
@@ -8327,10 +8358,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bJo" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bJr" = (
@@ -8348,8 +8379,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bJy" = (
-/turf/open/floor/plating,
-/area/construction)
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "bJD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -8411,7 +8445,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bLB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/closet/firecloset,
@@ -8456,7 +8490,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bMl" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -8849,8 +8883,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
 "bTo" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bTF" = (
@@ -8913,8 +8947,9 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bVb" = (
 /obj/machinery/smartfridge/disks,
 /obj/structure/table,
@@ -8932,10 +8967,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bVj" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 1
@@ -9062,14 +9097,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_x = -15
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "bYy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9370,7 +9403,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cdm" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -9515,18 +9548,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"ceW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cfi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -9540,7 +9561,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cfq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -9574,7 +9595,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "cfJ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering South";
@@ -10370,7 +10391,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "cuW" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -10926,8 +10947,8 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "cEa" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "cEb" = (
@@ -11053,7 +11074,7 @@
 "cGf" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "cGi" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11069,11 +11090,15 @@
 /obj/structure/sign/poster/ripped{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Output to Space"
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "cGC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -11288,6 +11313,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cKX" = (
+/obj/effect/turf_decal/arrows/white,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "cLe" = (
 /obj/machinery/light{
 	dir = 8
@@ -11488,7 +11517,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cNA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11507,7 +11536,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "cNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -11527,17 +11556,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"cOs" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"cNV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
+"cOs" = (
+/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Construction Area North";
 	dir = 0
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "cOF" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -11575,7 +11614,7 @@
 	opacity = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cOK" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -11719,8 +11758,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cRU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12481,7 +12523,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "dft" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/line{
@@ -12931,7 +12973,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dof" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12939,14 +12981,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dom" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "dot" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/vending/boozeomat,
@@ -13125,6 +13164,17 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dte" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "dtk" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -13153,7 +13203,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "dtM" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -13185,7 +13235,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "duS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -13207,7 +13257,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "dvu" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -13217,11 +13267,11 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dvR" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dvT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -13292,7 +13342,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dxo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13368,21 +13418,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"dyv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dyD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -13415,7 +13450,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "dzz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
@@ -13520,7 +13555,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "dAN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13532,7 +13567,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "dBf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -13624,7 +13659,7 @@
 /obj/item/clothing/mask/breath,
 /obj/structure/rack,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "dDU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -13724,6 +13759,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"dFE" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = -32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dFN" = (
 /obj/machinery/computer/robotics,
 /obj/machinery/newscaster{
@@ -13839,15 +13882,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dHK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "dIa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -13934,7 +13968,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "dJH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13956,6 +13990,10 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/space/nearstation)
+"dKd" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/escapepodbay)
 "dKg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
@@ -14003,11 +14041,7 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"dLa" = (
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engine/atmos/pumproom)
 "dLg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -14442,7 +14476,7 @@
 /area/maintenance/port/fore)
 "dSr" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dSE" = (
 /obj/structure/statue/snow/snowman,
 /turf/open/floor/grass/snow/safe,
@@ -14581,25 +14615,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"dUD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dUL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14757,7 +14772,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dYI" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -14822,15 +14837,15 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "eab" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "eaw" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eaJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -14859,8 +14874,11 @@
 /area/medical/sleeper)
 "eaS" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eaY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -15113,7 +15131,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eem" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -15272,6 +15290,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ehz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Engine"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "ehV" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -15342,9 +15376,6 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "eiC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
@@ -15471,7 +15502,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ekl" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -15543,6 +15574,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"elw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "elG" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
@@ -15555,7 +15604,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eme" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -15985,7 +16034,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "etS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16139,18 +16188,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"ewm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ews" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ewA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "exb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -16202,7 +16258,7 @@
 	},
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "eyn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16313,7 +16369,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eAk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16365,7 +16421,7 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eBg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16398,14 +16454,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eBw" = (
-/mob/living/simple_animal/cockroach{
-	desc = "Virtually unkillable.";
-	name = "Becquerel";
-	sentience_type = 5;
-	status_flags = 16
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "eBD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -16520,7 +16571,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eEj" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -16784,21 +16835,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eIf" = (
-/obj/machinery/power/apc{
-	areastring = "/area/construction";
-	dir = 4;
-	name = "Construction Area Apc";
-	pixel_x = 24
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/construction)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "eIg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -17056,7 +17102,7 @@
 	name = "N2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eLZ" = (
 /obj/machinery/door/airlock{
 	name = "Gift Shop";
@@ -17098,6 +17144,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eMp" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "eMs" = (
 /obj/machinery/papershredder,
 /obj/machinery/camera{
@@ -17154,26 +17208,23 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eNk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eNu" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction)
-"eNI" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
+/area/engine/atmos/hfr)
 "eNL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel{
@@ -17257,7 +17308,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eQo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -17414,6 +17465,16 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
+"eTf" = (
+/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/start/assistant,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "eTm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -17517,7 +17578,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eVh" = (
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
@@ -17684,7 +17745,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eYe" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -17741,13 +17802,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "eZU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eZW" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -17794,15 +17855,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"fbB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "fbQ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -18050,17 +18102,6 @@
 /obj/item/disk/holodisk/tutorial/AICore,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"feK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "feL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/camera{
@@ -18078,7 +18119,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "feZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -18467,7 +18508,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "fln" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
@@ -18584,7 +18625,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fnN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -18593,7 +18634,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "fnU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18615,7 +18656,7 @@
 	},
 /obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "fod" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -18793,7 +18834,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fsA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -18819,12 +18860,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fta" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "ftc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -18975,7 +19015,7 @@
 "fvV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "fwl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -18994,8 +19034,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/construction)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "fwF" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -19208,11 +19254,14 @@
 	},
 /area/crew_quarters/kitchen)
 "fzz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "fzB" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -19221,13 +19270,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fzM" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fzW" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -19370,7 +19412,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "fCN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19423,7 +19465,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fDR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -19442,12 +19484,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "fEm" = (
-/mob/living/simple_animal/cockroach,
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/core,
+/obj/item/paper/guides/jobs/atmos/hypertorus,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "fEr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -19499,7 +19546,7 @@
 	name = "CO2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fFs" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -19654,7 +19701,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fId" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -19738,7 +19785,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "fKn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -19826,7 +19873,7 @@
 	name = "nitrous oxide input injector"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fMa" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/window/reinforced{
@@ -19936,7 +19983,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fOm" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
@@ -19987,7 +20034,7 @@
 "fPx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "fPC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -20458,7 +20505,7 @@
 	req_one_access_txt = "11;24"
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "fWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -20501,6 +20548,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fWL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Distro"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "fXa" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/white,
@@ -20672,7 +20733,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "gah" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -20705,27 +20766,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"gba" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "gbl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -20805,7 +20845,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gbZ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -20840,7 +20880,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "gdp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
@@ -21160,7 +21200,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "giR" = (
 /obj/structure/table/wood,
 /obj/item/toy/snappop{
@@ -21214,6 +21254,30 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"gjQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "gkb" = (
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
@@ -21266,7 +21330,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "gkG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -21374,7 +21438,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gmW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
@@ -21424,10 +21488,19 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"gnD" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "gnM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gnT" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel{
@@ -21824,11 +21897,12 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "gvI" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gvX" = (
 /obj/structure/chair{
 	dir = 4
@@ -21857,7 +21931,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "gwP" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -21901,6 +21975,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gxD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "gxF" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/security/armory";
@@ -21944,7 +22031,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gyh" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden/layer2{
 	dir = 1
@@ -22091,7 +22178,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gzP" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/toxins{
@@ -22126,7 +22213,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "gAA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -22352,7 +22439,7 @@
 	},
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "gDx" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -22684,7 +22771,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gJN" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -22851,7 +22938,7 @@
 /area/hallway/primary/central)
 "gMM" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gMO" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -22929,8 +23016,9 @@
 "gOc" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "gOt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -23107,10 +23195,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "gRf" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/yellow,
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/arrows/white{
+	color = "#00AAFF";
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "gRp" = (
 /obj/item/stack/marker_beacon{
 	anchored = 1;
@@ -23294,7 +23384,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gUX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23437,7 +23527,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gYH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -23549,7 +23639,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "haC" = (
 /obj/structure/table/wood,
 /obj/item/lipstick/random{
@@ -24024,7 +24114,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hig" = (
 /obj/effect/turf_decal/sand,
 /mob/living/carbon/monkey/punpun,
@@ -24086,9 +24176,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "hiF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -24096,7 +24183,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "hiL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "chemistry_shutters";
@@ -24121,7 +24208,7 @@
 /area/hallway/primary/starboard)
 "hiX" = (
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "hjo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/gloves,
@@ -24149,7 +24236,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hjO" = (
 /obj/structure/bed{
 	pixel_x = 1;
@@ -24290,11 +24377,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hlS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks West";
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/construction)
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hlU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -24512,12 +24606,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"hoX" = (
-/obj/machinery/camera{
-	c_tag = "Escape Podbay"
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "hpr" = (
 /turf/closed/indestructible/riveted,
 /area/ruin/space/has_grav/listeningstation)
@@ -24538,12 +24626,11 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "hpE" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "hpU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -24578,9 +24665,11 @@
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
 "hqt" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/construction)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "hqB" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -24703,13 +24792,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "hrE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "hrR" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/sand,
@@ -24820,7 +24906,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hts" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -24873,7 +24959,7 @@
 /area/security/main)
 "huC" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "huG" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25244,7 +25330,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hAq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -25385,7 +25471,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "hCM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -25530,11 +25616,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hEr" = (
-/obj/effect/decal/cleanable/glass/plasma,
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "hEy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25557,7 +25638,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "hEY" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -25600,18 +25681,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hFK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Escape Podbay"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hFQ" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -25947,7 +26016,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "hMo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -26040,7 +26109,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hNo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -26311,7 +26380,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "hSh" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -26482,17 +26551,9 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "hVs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "hVP" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -26633,7 +26694,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hZf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -26722,7 +26783,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "iaw" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -26754,6 +26815,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iaT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ibk" = (
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -26781,7 +26856,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ibs" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -26852,19 +26927,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"icR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "ida" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26968,7 +27030,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ifs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -27008,7 +27070,7 @@
 "ifU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ifZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -27121,11 +27183,16 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "ihY" = (
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "iic" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -27175,6 +27242,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"ijb" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ijd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -27299,7 +27377,7 @@
 	name = "carbon dioxide tank input injector"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ilt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -27579,7 +27657,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iqQ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27671,7 +27749,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "isM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27833,7 +27911,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "iux" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/carpet/royalblack,
@@ -28218,7 +28296,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "iBN" = (
 /obj/effect/overlay/palmtree_l{
 	pixel_y = 29
@@ -28518,7 +28596,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iJz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28551,11 +28629,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
-"iJP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/stairs,
-/area/hallway/secondary/exit)
 "iJT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light,
@@ -28564,7 +28637,7 @@
 "iKd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "iKj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -28589,6 +28662,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"iKH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Escape Podbay"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "iLj" = (
 /obj/structure/statue/silver/medborg,
 /obj/structure/window/reinforced{
@@ -28638,17 +28726,22 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iMr" = (
-/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "iMH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "iMI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -28686,7 +28779,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "iNz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -28831,7 +28924,7 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iQC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -28865,7 +28958,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "iRg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28990,6 +29083,9 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"iTA" = (
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "iTX" = (
 /obj/item/shard,
 /obj/item/shard,
@@ -29097,7 +29193,7 @@
 	light_color = "#c1caff"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iVi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29511,7 +29607,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "jaz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -30028,7 +30124,7 @@
 "jhF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30060,7 +30156,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jis" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -30169,11 +30265,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"jjq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "jjG" = (
@@ -30386,7 +30477,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jmq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30456,6 +30547,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"joj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Escape North";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "joq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -30487,7 +30595,7 @@
 "joF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "joS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -30564,7 +30672,7 @@
 /area/hallway/primary/central)
 "jqA" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jqF" = (
 /obj/effect/turf_decal/tile/darkblue,
 /obj/effect/turf_decal/tile/darkblue{
@@ -30594,7 +30702,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "jqV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30624,7 +30732,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "jrt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -30685,7 +30793,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jsv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -30853,7 +30961,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jwj" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -30950,6 +31058,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jxK" = (
+/obj/machinery/button/door{
+	id = "escapepodbay";
+	name = "Pod Door Control";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/engine,
+/area/escapepodbay)
 "jxV" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -31118,7 +31235,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jBf" = (
 /obj/item/gun/energy/disabler,
 /obj/item/gun/energy/disabler{
@@ -31318,21 +31435,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"jEg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Distro to filter"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "jEj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/window/reinforced/tinted{
@@ -31640,7 +31742,16 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
+"jKm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/variation/box/sec/brig_cell/perma,
+/obj/machinery/flasher{
+	id = "PCell 1";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "jKr" = (
 /obj/effect/turf_decal/tile/black{
 	dir = 1
@@ -31722,7 +31833,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jMe" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -31811,7 +31922,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jNN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31830,12 +31941,7 @@
 	},
 /obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"jOl" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
+/area/engine/atmos/foyer)
 "jOn" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -31893,7 +31999,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "jPv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -32150,7 +32256,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jTI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -32503,10 +32609,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kaH" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "kbb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32580,8 +32682,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kcm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -32589,7 +32694,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kcI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -32673,7 +32778,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kfl" = (
 /obj/item/reagent_containers/glass/bottle/drugs,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -32822,7 +32927,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kgy" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -32910,6 +33015,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"kiq" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "kit" = (
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/port/fore)
@@ -33382,6 +33491,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"kqQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/escapepodbay)
 "kqT" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -33517,7 +33635,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ksJ" = (
 /obj/effect/mine/stun{
 	icon = 'icons/obj/assemblies.dmi';
@@ -33616,7 +33734,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ktA" = (
 /obj/structure/window{
 	dir = 1
@@ -33772,7 +33890,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kxk" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -33998,7 +34116,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kBW" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -34044,7 +34162,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "kDf" = (
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
@@ -34223,8 +34341,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kFb" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1"
@@ -34263,13 +34384,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kFx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "kFT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -34318,7 +34436,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kGE" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -34328,7 +34446,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kHg" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -34346,6 +34464,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"kHx" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "kHy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
@@ -34359,7 +34481,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kHO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/chapel/main";
@@ -34379,7 +34501,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kHT" = (
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
@@ -34652,19 +34774,38 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"kOl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = 2;
+	prison_radio = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -27;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kOr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks West";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kOw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -34962,6 +35103,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kUc" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "kUk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -35039,7 +35184,7 @@
 "kVH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -35225,7 +35370,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kZM" = (
 /obj/structure/lattice,
 /obj/machinery/door/poddoor/preopen{
@@ -35240,7 +35385,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "lad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -35308,7 +35453,7 @@
 	name = "nitrogen tank input injector"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lbP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -35336,7 +35481,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "lcg" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -35381,7 +35526,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lcG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -35393,7 +35538,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lcL" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -35459,7 +35604,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ldt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35538,14 +35683,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
-"lfG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lfU" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
@@ -35595,8 +35732,8 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "lhk" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lhs" = (
@@ -35605,6 +35742,24 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"lhu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 8;
+	name = "Atmospherics Distribution APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "lhK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -35672,7 +35827,7 @@
 /area/crew_quarters/locker)
 "ljF" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ljH" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -35945,11 +36100,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lrf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/construction)
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "lrg" = (
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced{
@@ -35959,7 +36111,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "lri" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35967,8 +36119,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "lrr" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
@@ -36040,10 +36193,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lsT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ltl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ltn" = (
 /obj/machinery/door/airlock/external{
 	name = "MiniSat External Access";
@@ -36388,10 +36569,9 @@
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/construction)
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "lzi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36540,11 +36720,11 @@
 	},
 /area/maintenance/port/aft)
 "lBg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "lBs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -36623,7 +36803,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "lDV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36735,7 +36915,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lHj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
@@ -36839,11 +37019,18 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = -32
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/hfr";
+	dir = 8;
+	name = "Atmospherics HFR Room APC";
+	pixel_x = -25
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "lJE" = (
 /obj/structure/cable/white{
 	icon_state = "1-8"
@@ -37092,7 +37279,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lMQ" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage"
@@ -37112,7 +37299,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lNd" = (
 /obj/machinery/telecomms/server/presets/service,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -37197,6 +37384,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lOJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "lOL" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Disposal Exit";
@@ -37394,7 +37585,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lRU" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -37551,7 +37742,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lUe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
@@ -37593,7 +37784,7 @@
 "lUG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lVv" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -37762,9 +37953,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -37969,7 +38157,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mbl" = (
 /obj/machinery/light_switch{
 	pixel_y = 27
@@ -38080,7 +38268,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mdk" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -38244,7 +38432,7 @@
 "mfZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mgd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -38313,6 +38501,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/bridge)
+"mgZ" = (
+/obj/structure/spacepoddoor,
+/turf/open/floor/engine,
+/area/escapepodbay)
 "mhj" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -38351,7 +38543,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mhN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38397,11 +38589,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "mit" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/construction)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "miz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38577,6 +38766,12 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mlN" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "mmc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -38859,7 +39054,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "mqk" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -38905,7 +39100,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mqC" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -38919,29 +39114,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"mqE" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -27;
-	pixel_y = -7
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = 2;
-	prison_radio = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mqS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -39041,6 +39213,17 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"msW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs,
+/area/escapepodbay)
 "mtn" = (
 /obj/machinery/light{
 	dir = 8
@@ -39346,7 +39529,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mzm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39403,7 +39586,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mAn" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -39411,6 +39594,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"mAp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "mAs" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -40235,7 +40426,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "mNt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -40307,7 +40498,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -40427,7 +40618,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mQy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -40659,14 +40850,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "mUS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/foyer)
 "mUV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40707,7 +40892,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mVk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41036,7 +41221,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mYt" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -41176,7 +41361,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mZO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -41580,7 +41765,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ngX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41643,7 +41828,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "niG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -41685,6 +41870,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"njk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "njm" = (
 /obj/machinery/light{
 	dir = 1
@@ -41695,13 +41886,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"njp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/white,
-/area/security/physician)
 "njw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -41936,7 +42120,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "nmW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42065,7 +42249,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "npT" = (
 /obj/machinery/photocopier,
 /turf/open/floor/plasteel/bluespace,
@@ -42329,11 +42513,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nuw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "nuz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42544,13 +42729,11 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "nxO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "nxX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -42559,7 +42742,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "nya" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42580,13 +42763,18 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nyn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nyp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "nys" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42646,6 +42834,18 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/powered)
+"nzV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "nzW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -42659,7 +42859,7 @@
 /area/science/research)
 "nAg" = (
 /turf/closed/wall/r_wall,
-/area/construction)
+/area/engine/atmos/hfr)
 "nAi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42727,7 +42927,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nAX" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -42855,13 +43055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"nCY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "nDf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42961,7 +43154,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nFe" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
@@ -43002,6 +43195,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"nFP" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "nFT" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
@@ -43037,6 +43234,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"nGH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nHc" = (
 /obj/structure/sign/poster/contraband/cc64k_ad,
 /turf/closed/wall/r_wall,
@@ -43180,6 +43389,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"nJH" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "nJL" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
@@ -43269,7 +43483,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nMf" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -43304,15 +43518,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"nMP" = (
-/obj/structure/rack,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/twentyfive,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "nNs" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine,
@@ -43399,7 +43604,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nOQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -43473,7 +43678,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nQE" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -43574,7 +43779,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "nRV" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/window/reinforced,
@@ -43710,6 +43915,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"nTM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/cockroach{
+	desc = "Virtually unkillable.";
+	name = "Becquerel";
+	sentience_type = 5;
+	status_flags = 16
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "nUc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
@@ -43786,7 +44006,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nVd" = (
 /obj/machinery/vending/sovietsoda,
 /obj/effect/decal/cleanable/dirt,
@@ -43935,9 +44155,11 @@
 /turf/open/floor/wood,
 /area/vacant_room)
 "nXU" = (
-/obj/item/stack/cable_coil/red,
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "nXY" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
@@ -44011,7 +44233,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "nZw" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -44047,7 +44269,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oao" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -44190,7 +44412,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "obR" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -44315,7 +44537,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "oeo" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/glowshroom,
@@ -44373,7 +44595,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ofC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -44550,6 +44772,13 @@
 /obj/structure/frame/machine,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"oiI" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ojt" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Research Division";
@@ -44594,7 +44823,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ojR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -44880,7 +45109,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "opf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44936,12 +45165,12 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "oqQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "oqX" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
@@ -45132,7 +45361,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oua" = (
 /obj/machinery/light{
 	dir = 8
@@ -45249,7 +45478,7 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ovH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -45309,7 +45538,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oxt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45404,6 +45633,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/listeningstation)
+"ozN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/escapepodbay)
 "ozT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -45497,7 +45732,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "oBF" = (
 /obj/structure/closet/secure_closet/hos,
 /obj/structure/disposalpipe/segment{
@@ -45530,7 +45765,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "oBQ" = (
 /obj/structure/chair{
 	dir = 4
@@ -45693,10 +45928,32 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oEH" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
+"oEI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/construction)
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = 2;
+	prison_radio = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -27;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45725,7 +45982,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oFo" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
@@ -45832,7 +46089,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oHB" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45937,6 +46194,17 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
+"oIL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "oJe" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -46021,15 +46289,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"oLb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "oLd" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plasteel/showroomfloor,
@@ -46137,7 +46396,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oNd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/landmark/event_spawn,
@@ -46702,6 +46961,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"oWp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "oWB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -46756,11 +47021,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oXP" = (
-/obj/machinery/light/broken{
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "oYb" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -46782,10 +47053,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oYF" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oYY" = (
@@ -47049,16 +47320,16 @@
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "pbT" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
-	dir = 1;
-	name = "toxins space injector"
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
 	},
 /turf/open/space/basic,
-/area/science/mixing/chamber)
+/area/space/nearstation)
 "pbU" = (
 /obj/machinery/light/small,
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "pbV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
@@ -47068,7 +47339,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pce" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/psych";
@@ -47392,7 +47663,7 @@
 	name = "plasma tank input injector"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "phV" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
@@ -47430,15 +47701,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"piL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "piV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47615,7 +47877,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pmj" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -47813,7 +48075,7 @@
 "poB" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/construction)
+/area/engine/atmos/hfr)
 "poD" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -47988,7 +48250,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "pqt" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Incinerator";
@@ -48237,6 +48499,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"puq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to filter"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "puW" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/dark,
@@ -48338,7 +48618,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pwr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -48630,12 +48910,6 @@
 /obj/machinery/computer/ai_server_console,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"pAM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
-/area/hallway/secondary/exit)
 "pAX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -48916,7 +49190,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pGu" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49135,11 +49409,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"pJP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pJZ" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -49170,7 +49439,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -49181,16 +49450,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pKp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "pKr" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -49205,7 +49471,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "pLe" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/grown/poppy,
@@ -49607,7 +49873,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "pQu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49808,6 +50074,16 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
 "pTx" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/rglass{
+	amount = 5
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 5
+	},
+/obj/item/pipe_dispenser,
+/obj/item/wrench,
+/obj/item/multitool,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -49816,7 +50092,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "pTT" = (
 /obj/machinery/computer/telecomms/traffic{
 	network = "tcommsat"
@@ -49843,6 +50119,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"pUg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "pUj" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
@@ -49865,7 +50147,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pUv" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -50106,7 +50388,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pXg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -50253,8 +50535,9 @@
 "pYC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "pYJ" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -50334,7 +50617,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qac" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
@@ -50676,7 +50959,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "qfA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -50748,6 +51031,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"qgN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qhb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51101,8 +51402,9 @@
 "qmU" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "qnl" = (
 /obj/machinery/light{
 	dir = 8
@@ -51288,11 +51590,23 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qqO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qre" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "qri" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -51354,18 +51668,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"qsq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "qsu" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -51425,6 +51727,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"qtN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "qtP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/power/apc/highcap/five_k{
@@ -51456,7 +51776,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "qum" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -51547,7 +51867,7 @@
 	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qvy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -51627,7 +51947,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qxT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51651,7 +51971,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qxY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -51737,6 +52057,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qzA" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 10
+	},
+/obj/machinery/button/flasher{
+	id = "brigentry";
+	pixel_x = -28;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qzO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -51760,7 +52091,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qAN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52055,7 +52386,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qEH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -52234,9 +52565,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qHo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -52244,10 +52572,13 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "qHp" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -52322,7 +52653,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "qHX" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
@@ -52789,7 +53120,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qRr" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
@@ -52998,7 +53329,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "qWF" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -53385,7 +53716,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "rcz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53403,7 +53734,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "rcD" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
@@ -53555,6 +53886,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ren" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "reo" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -53576,7 +53922,18 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
+"rez" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "reA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53755,11 +54112,12 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "rhk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "rhT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53821,7 +54179,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "riS" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53829,8 +54187,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "riV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -54140,7 +54499,7 @@
 	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rng" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -54177,10 +54536,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "rnZ" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/area/construction)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "rog" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -54335,7 +54698,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rqO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -54427,11 +54790,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "rsq" = (
-/obj/machinery/light/built{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "rsR" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth{
@@ -54677,19 +55046,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"rvE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Distro"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "rvH" = (
 /obj/effect/spawner/lootdrop/techstorage/rnd,
 /obj/structure/rack,
@@ -55089,6 +55445,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"rDy" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "rDJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -55317,7 +55682,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rFu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -55584,7 +55949,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "rLN" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -55675,19 +56040,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rNl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "rNE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -55778,7 +56130,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "rPd" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -56162,6 +56514,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
+"rUZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine/airless,
+/area/escapepodbay)
 "rVb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -56177,7 +56535,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "rVl" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/bait/worm/leech,
@@ -56365,9 +56723,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "rXt" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/engine,
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "rXC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56530,15 +56887,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rZx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	light_color = "#c1caff"
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "rZz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/start/station_engineer,
@@ -56669,7 +57017,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sbR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -56804,7 +57152,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "scG" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -56986,7 +57334,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sgi" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/light/small{
@@ -57012,7 +57360,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "shu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57024,6 +57372,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"shY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sia" = (
 /obj/machinery/button/door{
 	id = "Dorm1";
@@ -57123,7 +57479,7 @@
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "skV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -57138,7 +57494,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -57286,14 +57642,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
-"sou" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sov" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -57322,15 +57671,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"soA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "soS" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -57387,8 +57727,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "sqh" = (
 /obj/structure/table/glass,
 /obj/item/stack/packageWrap,
@@ -57462,6 +57803,9 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"srH" = (
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "srI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -57532,7 +57876,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ssK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -57689,7 +58033,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "swd" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/turf_decal/bot_white,
@@ -57924,7 +58268,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sAd" = (
 /obj/structure/chair{
 	dir = 4
@@ -57939,7 +58283,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sAZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57976,7 +58320,7 @@
 "sBP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sBX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -58069,7 +58413,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sCR" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Break Room";
@@ -58175,7 +58519,7 @@
 "sEj" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sEL" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
@@ -58297,7 +58641,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sGf" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mine/stun{
@@ -58375,7 +58719,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sHS" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -58493,7 +58837,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sJB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -58748,7 +59092,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sMq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -58787,9 +59131,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos";
+	areastring = "/area/engine/atmos/foyer";
 	dir = 1;
-	name = "Atmospherics Wing APC";
+	name = "Atmospherics Foyer APC";
 	pixel_y = 23
 	},
 /obj/structure/cable{
@@ -58822,7 +59166,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sMU" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -59090,7 +59434,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sRv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59133,7 +59477,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sSc" = (
 /obj/machinery/ai/server_cabinet/prefilled,
 /turf/open/floor/circuit,
@@ -59282,7 +59626,7 @@
 	sensors = list("tox_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sTC" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -59393,6 +59737,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sVl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/escapepodbay";
+	dir = 8;
+	name = "Podbay APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "sVB" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -59458,10 +59816,10 @@
 /turf/open/floor/carpet/exoticgreen,
 /area/hallway/secondary/entry)
 "sXl" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sXo" = (
@@ -59489,14 +59847,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sXP" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "sXS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59555,7 +59905,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sYY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -59588,7 +59938,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sZm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59741,15 +60091,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tbM" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "tbS" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -59856,15 +60197,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"tdH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tdI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -59920,9 +60252,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "teA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -60042,7 +60371,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "tgE" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -60061,7 +60390,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "thu" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "ai_core_airlock_interior"
@@ -60136,7 +60465,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "tic" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -60191,7 +60520,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tiX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/orange{
@@ -60228,14 +60557,11 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "tkI" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "tld" = (
 /obj/structure/rack,
 /obj/item/multitool{
@@ -60396,16 +60722,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "tnN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "toa" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "tob" = (
@@ -60463,7 +60787,7 @@
 	name = "Pure to Mix"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "tpe" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60528,12 +60852,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tqi" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/construction)
+/turf/closed/wall,
+/area/engine/atmos/pumproom)
 "tqO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -60634,13 +60954,13 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ttb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "O2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ttk" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
@@ -60685,7 +61005,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ttL" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel,
@@ -60756,7 +61076,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tvh" = (
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
@@ -60923,7 +61243,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "txw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -60953,7 +61273,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "tyi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61019,27 +61339,13 @@
 /obj/item/pen,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"tzO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Escape North";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "tzQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "tAc" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -61094,7 +61400,17 @@
 "tAQ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
+"tAS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
+"tBa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "tBi" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -61224,11 +61540,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "tEi" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "tEI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -61440,7 +61753,7 @@
 	sensors = list("o2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tHP" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
@@ -61614,13 +61927,13 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tKo" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tKx" = (
 /obj/item/soap/syndie,
 /turf/open/floor/plasteel/freezer,
@@ -61704,6 +62017,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tNx" = (
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "tOe" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -62019,7 +62336,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tUl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -62286,6 +62603,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"tYa" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tYf" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plasteel/dark,
@@ -62382,6 +62705,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
+"uam" = (
+/turf/open/floor/engine,
+/area/escapepodbay)
 "uay" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -62390,8 +62716,8 @@
 /area/maintenance/starboard/fore)
 "uaC" = (
 /obj/structure/closet/crate,
-/obj/item/twohanded/fishingrod/collapsable,
-/obj/item/twohanded/fishingrod/collapsable,
+/obj/item/twohanded/fishingrod/collapsible,
+/obj/item/twohanded/fishingrod/collapsible,
 /obj/item/twohanded/fishingrod,
 /obj/item/twohanded/fishingrod,
 /obj/item/twohanded/fishingrod,
@@ -62481,15 +62807,16 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "ubP" = (
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
-	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "ucc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -62580,7 +62907,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "udN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -62749,9 +63076,6 @@
 	dir = 9
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -63178,7 +63502,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "unf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -63248,7 +63572,7 @@
 "uoP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uoV" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -63315,7 +63639,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "uqF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -63737,7 +64061,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uzw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63758,7 +64082,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uzx" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -63968,13 +64292,12 @@
 /area/medical/virology)
 "uBA" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 8;
-	on = 1;
-	volume_rate = 200
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos_distro)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uBJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63996,7 +64319,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "uCb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -64109,7 +64432,7 @@
 "uDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uDr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64549,13 +64872,21 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uKY" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uLd" = (
+/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
+	id = "escapepodbay"
+	},
+/obj/structure/spacepoddoor,
+/turf/open/floor/engine,
+/area/escapepodbay)
 "uLk" = (
 /obj/machinery/telecomms/hub/preset,
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
@@ -64671,7 +65002,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uNY" = (
 /obj/structure/sign/poster/contraband/rebels_unite,
 /turf/closed/wall/r_wall,
@@ -64739,7 +65070,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uPA" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -64874,6 +65205,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"uRH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "uRP" = (
 /obj/machinery/light,
 /obj/effect/landmark/start/roboticist,
@@ -64933,8 +65272,9 @@
 "uTB" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "uTC" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -64961,6 +65301,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uUt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uUB" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engine.";
@@ -65028,7 +65375,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "uWo" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -65047,6 +65394,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"uWA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos/hfr)
 "uWT" = (
 /obj/machinery/light{
 	dir = 1
@@ -65270,7 +65623,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "uZu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -65383,12 +65736,11 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "vbM" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "vbY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -65590,7 +65942,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vgY" = (
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/structure/rack,
@@ -65775,7 +66127,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vkT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65803,7 +66155,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vla" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -65910,12 +66262,18 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vog" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "vot" = (
 /obj/machinery/air_sensor{
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "voE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -66084,7 +66442,7 @@
 "vrS" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "vrT" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 4
@@ -66241,7 +66599,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vtV" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -66297,6 +66655,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/morgue)
+"vuM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/escapepodbay)
 "vvc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -66501,6 +66869,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vya" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vyc" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -66519,12 +66895,12 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vyh" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos_distro";
+	areastring = "/area/engine/atmos/pumproom";
 	dir = 1;
-	name = "Atmospherics Distribution APC";
+	name = "Atmospherics Pumping Room APC";
 	pixel_y = 23
 	},
 /obj/structure/cable{
@@ -66537,7 +66913,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vyi" = (
 /mob/living/simple_animal/cockroach,
 /turf/open/floor/plating,
@@ -66713,7 +67089,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "vDy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66918,7 +67294,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vGH" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -67027,7 +67403,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/storage)
 "vJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -67052,7 +67428,7 @@
 	sensors = list("n2_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vJM" = (
 /obj/effect/turf_decal/tile/darkgreen{
 	dir = 1
@@ -67143,7 +67519,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vKH" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
@@ -67327,7 +67703,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vNt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -67441,21 +67817,6 @@
 "vOX" = (
 /turf/open/floor/engine,
 /area/science/storage)
-"vPe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vPC" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -67654,7 +68015,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vSX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -67671,6 +68032,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"vTj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/foyer)
 "vTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -67721,7 +68091,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vUv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -67768,7 +68138,7 @@
 	name = "oxygen tank input injector"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vVy" = (
 /obj/item/stack/rods/ten,
 /turf/open/floor/engine,
@@ -67899,7 +68269,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vYd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -68017,7 +68387,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "waz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -68119,7 +68489,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wbN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
@@ -68130,7 +68500,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wbO" = (
 /obj/machinery/light{
 	dir = 8
@@ -68292,7 +68662,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "wez" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "weB" = (
 /obj/structure/table,
 /obj/item/cartridge/signal/toxins{
@@ -68441,7 +68811,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wgj" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68466,6 +68836,9 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"wgX" = (
+/turf/closed/wall,
+/area/escapepodbay)
 "whl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -68600,7 +68973,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wkd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -68939,7 +69312,7 @@
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wpj" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -69020,20 +69393,17 @@
 	},
 /area/maintenance/starboard/fore)
 "wqE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
-/turf/open/floor/engine,
-/area/construction)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "wqX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -69243,7 +69613,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wur" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -69314,7 +69684,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wwD" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -69503,13 +69873,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wAt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos_distro)
 "wAx" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/aft";
@@ -69543,7 +69906,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wAK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room";
@@ -69879,7 +70242,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wFG" = (
 /obj/machinery/requests_console{
 	department = "Primary Tool Storage";
@@ -69919,7 +70282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wFY" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
@@ -69963,7 +70326,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -70008,7 +70371,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wIf" = (
 /obj/machinery/camera{
 	c_tag = "Brig Equipment Room";
@@ -70040,16 +70403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wIt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wIy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -70128,7 +70481,7 @@
 	level = 2
 	},
 /turf/closed/wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wJE" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -70138,7 +70491,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wJK" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -70250,7 +70603,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "wME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -70520,14 +70873,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/maintenance/department/tcoms)
-"wQv" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wQw" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
@@ -70683,7 +71028,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wSY" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -70728,7 +71073,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wTZ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red{
@@ -70857,7 +71202,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wVF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -70978,6 +71323,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wWP" = (
+/obj/structure/rack,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/twentyfive,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "wWV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -71016,7 +71370,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wXN" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/icecreamsandwich,
@@ -71403,7 +71757,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "xfD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71412,7 +71766,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xfJ" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /turf/open/floor/wood{
@@ -71449,8 +71803,9 @@
 /turf/open/floor/grass/snow/safe,
 /area/ruin/space/has_grav/listeningstation)
 "xgb" = (
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xgg" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -71585,7 +71940,7 @@
 /turf/open/floor/plasteel{
 	dir = 4
 	},
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xjc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -71659,7 +72014,7 @@
 	node2_concentration = 0.21
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xkR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -71892,7 +72247,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "xom" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -72033,7 +72388,7 @@
 "xri" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xro" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/machinery/door/window/southleft{
@@ -72057,12 +72412,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"xrT" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "xsF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -72276,7 +72625,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xvF" = (
 /obj/item/cigbutt/cigarbutt,
 /obj/effect/decal/cleanable/dirt,
@@ -72348,6 +72697,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xwI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/button/flasher{
+	id = "cell4";
+	pixel_x = 24;
+	pixel_y = -10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xxg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -72601,7 +72964,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xCh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72609,8 +72972,9 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "xCw" = (
 /obj/structure/window{
 	dir = 1
@@ -72649,7 +73013,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xDm" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -72803,10 +73167,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "xGC" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = 32
-	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -72883,7 +73243,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xIn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -72913,8 +73273,9 @@
 	c_tag = "Construction Area South";
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xIA" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/white,
@@ -72954,7 +73315,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xJc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -73168,20 +73529,7 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
-/area/construction)
-"xLZ" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/area/engine/atmos/hfr)
 "xMe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Hallway"
@@ -73302,7 +73650,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xNF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -73498,6 +73846,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xRC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xRH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73589,12 +73943,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xTg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+"xTh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/pumproom)
 "xUe" = (
 /obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plating,
@@ -73659,8 +74015,9 @@
 "xUG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/construction)
+/area/engine/atmos/hfr)
 "xVq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -73761,7 +74118,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xWi" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -73831,7 +74188,7 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xXv" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -74068,7 +74425,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ycw" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -74086,8 +74443,11 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/turf/open/floor/engine,
-/area/construction)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "ycH" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -74143,7 +74503,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ydp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/firealarm{
@@ -74211,7 +74571,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "yeg" = (
 /obj/machinery/light{
 	dir = 8
@@ -74241,12 +74601,6 @@
 /obj/effect/landmark/start/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"yeP" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "yff" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2{
@@ -74275,16 +74629,6 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"yfJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/engine,
-/area/hallway/secondary/exit)
 "yfX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -74360,7 +74704,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yhu" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/burger/plain,
@@ -74384,6 +74728,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"yig" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/engine/atmos/pumproom)
 "yim" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -74473,7 +74821,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ykz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -74511,6 +74859,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ylB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/variation/box/sec/brig_cell/perma,
+/obj/machinery/flasher{
+	id = "PCell 3";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ylM" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -102372,7 +102729,7 @@ fdv
 lye
 qBV
 uDg
-yeP
+qzA
 mIc
 djY
 gWF
@@ -102880,7 +103237,7 @@ msb
 msb
 msb
 api
-njp
+apA
 gGp
 wBQ
 tpe
@@ -102888,7 +103245,7 @@ uZS
 sXS
 mAV
 tcG
-wIt
+iaT
 fwF
 bcn
 hsM
@@ -104431,7 +104788,7 @@ nDf
 ssf
 iSG
 mWK
-mqE
+kOl
 rSW
 czo
 aZW
@@ -105459,7 +105816,7 @@ rPF
 aWY
 nfv
 ezN
-vms
+oEI
 rSW
 czo
 aZW
@@ -106998,7 +107355,7 @@ aQv
 dyV
 uSn
 oSQ
-tdH
+xwI
 aGC
 hsQ
 eme
@@ -107497,7 +107854,7 @@ yeg
 iic
 ajQ
 diA
-cHT
+ylB
 ajQ
 mbN
 maF
@@ -109553,7 +109910,7 @@ yfF
 tSh
 ajQ
 heT
-cHT
+jKm
 ajQ
 wNm
 cEb
@@ -115020,7 +115377,7 @@ vyg
 eBe
 txP
 cOH
-aXb
+mUS
 oBq
 oBq
 ahe
@@ -116303,7 +116660,7 @@ mXr
 aOl
 fnU
 fvV
-dfp
+vTj
 rqK
 qHV
 vgW
@@ -116323,10 +116680,10 @@ pJZ
 afp
 tYf
 tYf
-xLZ
+ozg
 wRS
 ozg
-hEr
+oAU
 ruw
 aJj
 dPt
@@ -116583,7 +116940,7 @@ bZf
 oAU
 ozg
 ozg
-dLa
+ozg
 ruw
 aJj
 peF
@@ -117315,7 +117672,7 @@ cva
 cVp
 uaE
 lRU
-vPe
+qgN
 toi
 pDJ
 akh
@@ -117572,7 +117929,7 @@ gyY
 gWT
 cjY
 wUJ
-aPc
+ren
 ajX
 tFs
 anj
@@ -117587,7 +117944,7 @@ kDj
 aXb
 aXb
 ibo
-aXb
+iKd
 ojJ
 aXb
 aXb
@@ -117813,7 +118170,7 @@ aZH
 aZH
 axP
 msM
-aNY
+wgX
 aJn
 aJn
 aJn
@@ -117829,7 +118186,7 @@ wUJ
 wUJ
 wUJ
 nks
-gba
+gjQ
 aRv
 lTa
 anj
@@ -117848,11 +118205,11 @@ tkI
 jvV
 kty
 aXb
-aTU
-aTU
-aTU
-aTU
-aTU
+yig
+yig
+yig
+yig
+yig
 aJj
 vkj
 fQZ
@@ -118070,23 +118427,23 @@ aZH
 axP
 axP
 axP
-aNY
-kaH
-feK
-jjq
-iJP
-hFK
-jjq
-jjq
-ewm
-lfG
-piL
-tzO
-jjq
-jjq
-wQv
-fzM
-pJP
+wgX
+kiq
+aXI
+sVl
+msW
+iKH
+shY
+shY
+oIL
+rez
+nGH
+joj
+shY
+shY
+ijb
+eTf
+vya
 ajX
 uZz
 anj
@@ -118105,11 +118462,11 @@ fZZ
 skT
 rOU
 aXb
-aTU
+yig
 aBu
 aBu
 aBu
-aTU
+yig
 aJj
 rDv
 dbQ
@@ -118327,11 +118684,11 @@ aZH
 axP
 aZH
 aAP
-aNY
-xrT
-xTg
-ajX
-sXP
+wgX
+mlN
+pUg
+srH
+eMp
 aNY
 dRT
 ajX
@@ -118358,15 +118715,15 @@ ppt
 aXb
 wFA
 fOl
-aCQ
+lrf
 jND
 etx
 aXb
-aTU
+yig
 aBu
 aBu
 aBu
-aTU
+yig
 aJj
 rJw
 uAV
@@ -118584,11 +118941,11 @@ aZH
 gzW
 aZH
 wBL
-aNY
-tbM
-xTg
-ajX
-eNI
+wgX
+gnD
+pUg
+srH
+arR
 aNY
 aNY
 imH
@@ -118619,11 +118976,11 @@ qEC
 jND
 iBJ
 aXb
-aTU
+yig
 aox
 aBu
 qui
-aTU
+yig
 aJj
 aJj
 pVi
@@ -118841,11 +119198,11 @@ aZH
 aZH
 aWe
 ppP
-aNY
-nMP
-huV
-ajX
-jOl
+wgX
+wWP
+oWp
+srH
+nJH
 aNY
 eky
 ajX
@@ -118871,16 +119228,16 @@ nyn
 icC
 aXb
 dJx
-dyv
+gxD
 wXG
 jND
 woS
 aXb
-aTU
+yig
 lDF
 aKe
 dvm
-aTU
+yig
 aJj
 bZq
 hSz
@@ -119098,11 +119455,11 @@ axP
 axP
 axP
 axP
-aNY
-yfJ
-akk
-akk
-rZx
+wgX
+vuM
+ozN
+ozN
+kqQ
 aNY
 ajr
 ajX
@@ -119128,7 +119485,7 @@ vRc
 aeV
 aXb
 jLV
-ceW
+elw
 nEQ
 dfp
 fnI
@@ -119355,11 +119712,11 @@ aXS
 aOf
 axP
 msb
-aNY
-hoX
-agR
-agR
-agR
+wgX
+aOQ
+uam
+uam
+uam
 aNY
 ajr
 ajX
@@ -119385,16 +119742,16 @@ nXY
 xBa
 aXb
 wJw
-dUD
+lsT
 wJw
 skY
-ahJ
-ahJ
 hiX
+hiX
+tqi
 kHQ
 wHG
 dAD
-hiX
+tqi
 vpj
 pYp
 wDS
@@ -119612,11 +119969,11 @@ aXS
 aXS
 axP
 msb
-aNY
-aKw
-agR
-agR
-agR
+wgX
+jxK
+uam
+uam
+uam
 aNY
 ajr
 kIA
@@ -119642,7 +119999,7 @@ aUa
 aUa
 ahN
 cfD
-qsq
+qtN
 iuv
 iNj
 wJE
@@ -119869,12 +120226,12 @@ aXS
 aXS
 axP
 msb
-aNY
-agR
-agR
-agR
-agR
-aNY
+wgX
+uam
+uam
+uam
+uam
+wgX
 iwc
 jjp
 wsp
@@ -119899,13 +120256,13 @@ hRt
 aUa
 ahN
 wbN
-fbB
+ewA
 mzk
 iQP
-agi
-sEj
-agi
-nyh
+iTA
+kHx
+iTA
+aNQ
 iMH
 tgX
 kBm
@@ -120126,12 +120483,12 @@ aXS
 aXS
 axP
 msb
-ahn
-agR
-agR
-agR
-arG
-ahn
+dKd
+mgZ
+mgZ
+mgZ
+uLd
+dKd
 iSn
 iSn
 xkg
@@ -120156,14 +120513,14 @@ jmo
 itt
 ahN
 mVg
-jEg
-sou
-rvE
-oLb
-oLb
-nCY
-wAt
-dHK
+puq
+mAp
+fWL
+cNV
+cNV
+uRH
+xTh
+nzV
 jrn
 vUk
 aYa
@@ -120383,12 +120740,12 @@ aXS
 aXS
 axP
 msb
-ahn
-pAM
-pAM
-pAM
-pAM
-ahn
+dKd
+rUZ
+rUZ
+rUZ
+rUZ
+dKd
 acb
 iSn
 iFH
@@ -120418,9 +120775,9 @@ iap
 eZK
 nZm
 nZm
-tAQ
-eaS
-soA
+lOJ
+kUc
+qre
 tgX
 sAW
 aYa
@@ -120677,7 +121034,7 @@ pqo
 pqo
 cNM
 gwE
-icR
+ehz
 kZQ
 thR
 aYa
@@ -120934,7 +121291,7 @@ vKE
 vKE
 npS
 asM
-rNl
+dte
 xXi
 wwm
 aYa
@@ -121711,7 +122068,7 @@ eMS
 hiX
 vDu
 cGf
-agi
+lrf
 vrS
 vrS
 cuH
@@ -122217,7 +122574,7 @@ ahN
 ahN
 vtH
 vtH
-hiX
+tqi
 kgv
 reo
 tzQ
@@ -122226,7 +122583,7 @@ hiX
 gDq
 eye
 mqb
-qAG
+aZF
 dAU
 hEK
 afF
@@ -122473,12 +122830,12 @@ aNg
 aNg
 aNg
 uBA
-vtH
+vog
 cRP
 vGG
 giF
 bVg
-sRp
+hlS
 hiX
 hiX
 iKd
@@ -122734,9 +123091,9 @@ pWQ
 nQn
 xiR
 oxf
-mUS
+nyh
 kOr
-lUc
+lhu
 tiH
 lUc
 jTF
@@ -122757,10 +123114,10 @@ pTx
 lJD
 rnZ
 fwE
-bbC
+rnZ
 oXP
 ycF
-xgb
+aqD
 nAg
 szq
 fcU
@@ -122992,7 +123349,7 @@ niC
 wbF
 kFa
 eaS
-agi
+ahJ
 ltl
 uoP
 hto
@@ -123002,20 +123359,20 @@ gJK
 sht
 afF
 axG
-cOK
+nTM
 nMs
 nBf
 kxr
 fCJ
-aNM
+tEi
 mNo
-aNM
-aNM
+tEi
+nFP
 iMr
-bJy
+buK
 qHo
-mit
-xgb
+rXt
+tBa
 nXU
 xgb
 nAg
@@ -123241,7 +123598,7 @@ aTU
 dSr
 dvR
 gmR
-aKe
+aay
 aNg
 dOL
 txt
@@ -123268,12 +123625,12 @@ kFx
 hiF
 hrE
 xUG
-lyR
+nyp
 lyR
 wqE
-xgb
+oEH
 rXt
-xgb
+aPI
 xIy
 nAg
 kSb
@@ -123521,16 +123878,16 @@ cnQ
 rWz
 afF
 cOs
-aNM
+tEi
 odT
 tEi
 lBg
-lBg
+cKX
 nxO
 hVs
 tnN
 gRf
-xgb
+aPI
 pbU
 nAg
 jGN
@@ -123778,17 +124135,17 @@ lbz
 nuX
 afF
 nuw
-aNM
-buK
-aNM
+tEi
+odT
+tEi
 eBw
-bJy
+rXt
 oEH
 dom
-xgb
-aay
-xgb
-xgb
+tNx
+rXt
+aPI
+tAS
 nAg
 afO
 fZk
@@ -124037,14 +124394,14 @@ afF
 rhk
 aNM
 xLI
-aNM
+tEi
+xRC
 bJy
-bJy
-hqt
+rXt
 bYr
-lrf
-xgb
-xgb
+rXt
+hqt
+njk
 xgb
 nAg
 aMT
@@ -124269,7 +124626,7 @@ aTU
 eaw
 jmp
 vot
-aKe
+aay
 aNg
 dOL
 vJK
@@ -124297,12 +124654,12 @@ eNu
 vbM
 hpE
 fzz
-hlS
+bbC
 eIf
 bbC
 rsq
-xgb
-xgb
+rDy
+any
 nAg
 pkB
 sDL
@@ -124541,7 +124898,7 @@ sZi
 qRp
 agi
 gJK
-sBP
+oiI
 afF
 bgy
 gqX
@@ -124549,12 +124906,12 @@ aTO
 ajR
 afF
 nAg
-nAg
+uWA
 nAg
 nAg
 poB
 poB
-tqi
+poB
 nAg
 nAg
 nAg
@@ -124806,13 +125163,13 @@ hqI
 ajR
 aNg
 aNg
+uUt
+aNg
+dFE
 aNg
 aNg
-aXU
 aNg
-aNg
-aqD
-msb
+wdn
 msb
 msb
 msb
@@ -125053,7 +125410,7 @@ tAQ
 uzv
 nAU
 tAQ
-nZm
+tYa
 ngP
 jsq
 afF
@@ -125069,7 +125426,7 @@ aNg
 aNg
 aNg
 aNg
-msb
+wdn
 msb
 msb
 msb
@@ -125297,7 +125654,7 @@ aTU
 gMM
 qqw
 wAA
-aKe
+aay
 aNg
 dOL
 tHO
@@ -125326,7 +125683,7 @@ aNg
 acb
 aNg
 acb
-acb
+wdn
 msb
 msb
 msb
@@ -125814,7 +126171,7 @@ aTU
 aTU
 aNg
 dOL
-vtH
+vog
 oET
 qAG
 oHj
@@ -126064,11 +126421,11 @@ acb
 adi
 acb
 aNg
-ahN
-ahN
-ahN
-ahN
-ahN
+mit
+mit
+mit
+mit
+mit
 kZM
 vyD
 eZU
@@ -126845,15 +127202,15 @@ acb
 nuh
 aTU
 uNX
-aKe
+aay
 xWh
 aTU
 uNX
-aKe
+aay
 eAh
 aTU
 uNX
-aKe
+aay
 tKd
 aTU
 aNg

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -21492,8 +21492,17 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
 "kKN" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
 /obj/effect/turf_decal/bot,
-/obj/machinery/shieldgen,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kLw" = (

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -46820,6 +46820,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"xse" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "xsi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -70644,7 +70649,7 @@ mwk
 sSU
 dBO
 kPJ
-kKN
+xse
 xTt
 iwh
 rcq

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -12,7 +12,17 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"aax" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "aaP" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -32,12 +42,13 @@
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
 "aaQ" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8;
+	on = 1;
+	volume_rate = 200
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "abw" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -102,7 +113,7 @@
 "acO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "acW" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/delivery,
@@ -303,6 +314,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"age" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/item/hand_labeler,
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "agf" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -319,7 +343,7 @@
 "agx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "agy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -409,7 +433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ail" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -497,7 +521,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "all" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -537,6 +561,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"ams" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 8;
+	name = "CE Office APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/paper/monitorkey,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "amw" = (
 /obj/machinery/light{
 	dir = 8
@@ -633,6 +674,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"anE" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/security/processing)
 "anH" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -736,7 +786,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "arc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1004,6 +1054,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ayE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_exterior";
+	name = "Physical Core Access";
+	req_access_txt = "30"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "ayK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -1065,7 +1132,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aAR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1129,21 +1196,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aCs" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "aCD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"aCE" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "aCJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -1175,15 +1238,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"aCU" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aDO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1365,7 +1419,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "aJN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -1670,7 +1724,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aQF" = (
 /obj/machinery/light{
 	dir = 1
@@ -1738,6 +1792,18 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"aSz" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/item/folder/blue,
+/obj/item/stamp/hop,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "aSA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -1816,25 +1882,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aUj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "aUB" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1923,18 +1970,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"aWF" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aWK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -2192,19 +2227,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bcT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/heads/chief)
 "bcW" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -2334,7 +2356,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "bfP" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -2350,7 +2372,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "bgo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2530,7 +2552,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2630,7 +2652,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "box" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -2823,16 +2845,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "btg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/storage/eva";
@@ -2898,7 +2920,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3002,7 +3024,7 @@
 "bxz" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bxI" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -3101,7 +3123,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bBB" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -3241,7 +3263,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3302,18 +3324,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"bGF" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "bGP" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -3363,19 +3373,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"bHK" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "bHY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3513,7 +3510,7 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3556,19 +3553,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"bOF" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "bOI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3584,7 +3568,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bPi" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -3604,7 +3588,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bPw" = (
 /obj/machinery/light{
 	dir = 8
@@ -3667,17 +3651,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bQp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bQv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3718,7 +3691,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bQU" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -3728,6 +3701,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"bQZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "bRd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3774,6 +3757,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"bSd" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/security/processing)
 "bSD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3937,30 +3930,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bVm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "bVq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bVC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bVZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "bWu" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -4091,13 +4070,13 @@
 /area/hydroponics/garden)
 "cbm" = (
 /obj/structure/window/reinforced,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "cbr" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -4123,9 +4102,8 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ccU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos/storage)
+/turf/closed/wall,
+/area/engine/atmos)
 "cds" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -4321,7 +4299,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "chD" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses{
@@ -4390,7 +4368,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "cjy" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/glass/bucket,
@@ -4474,7 +4452,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "clE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -4553,7 +4531,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "coh" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -4684,7 +4662,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cry" = (
 /obj/machinery/light{
 	dir = 4
@@ -4789,7 +4767,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "cur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -4897,7 +4875,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "cxh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4997,6 +4975,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"cyz" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "cyB" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -5192,7 +5181,7 @@
 "cBX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cCb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5219,7 +5208,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cCj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5227,7 +5216,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cCv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5290,7 +5279,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cEv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -5348,7 +5337,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/primary/central)
 "cFy" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5389,7 +5378,7 @@
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cGi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5412,7 +5401,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -5518,7 +5507,19 @@
 	dir = 1
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"cJz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "cKj" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
@@ -5634,16 +5635,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"cMQ" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cNs" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -5762,7 +5753,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cPL" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
@@ -5852,7 +5843,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cTk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 8
@@ -6046,20 +6037,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"cWD" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "cXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6223,18 +6200,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"daP" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "dbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6337,7 +6302,7 @@
 /area/maintenance/department/bridge)
 "ddA" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dea" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -6741,15 +6706,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dng" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "dnl" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleshutter";
@@ -6767,12 +6732,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"doI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "dpf" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
@@ -6847,6 +6806,23 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"dqQ" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "dru" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -6878,7 +6854,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dsF" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6957,7 +6933,7 @@
 "dve" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dvp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -7035,7 +7011,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dxA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
@@ -7118,7 +7094,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dAf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/firealarm{
@@ -7144,7 +7120,24 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"dAK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "dAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7318,7 +7311,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dFX" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -7356,11 +7349,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -7391,6 +7381,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
+"dGF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "dGO" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -7422,14 +7420,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dHF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7516,23 +7506,6 @@
 "dLk" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
-"dLz" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 8;
-	name = "CE Office APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "dLC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7773,7 +7746,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "dTU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -7792,7 +7765,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dUo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -7830,27 +7803,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"dUw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "dUG" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7923,7 +7875,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dVZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7992,7 +7944,7 @@
 "dWX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dXK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -8179,6 +8131,10 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
+"ecI" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "ecL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -8248,7 +8204,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "edn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -8292,6 +8248,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"eet" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "eew" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
@@ -8568,7 +8532,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "emd" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -8706,7 +8670,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eoN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -8741,7 +8705,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eph" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -9269,46 +9233,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ezB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/pen/red{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/cartridge/quartermaster{
-	pixel_x = 8;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
-"eAe" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/security/processing)
 "eAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -9395,7 +9322,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eBY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -9486,7 +9413,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eDB" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -9585,7 +9512,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eEB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -9598,7 +9525,7 @@
 /area/crew_quarters/heads/hor)
 "eEF" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "eEI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9891,15 +9818,15 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"eLS" = (
+"eLR" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/auxiliary)
 "eMf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10027,7 +9954,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eNT" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -10091,7 +10018,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ePa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -10150,6 +10077,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"eRj" = (
+/mob/living/simple_animal/pet/dog/corgi/borgi,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "eRu" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -10194,7 +10128,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eRU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10218,7 +10152,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "eSb" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -10258,7 +10192,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eUq" = (
 /obj/structure/chair{
 	dir = 4
@@ -10285,7 +10219,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "eVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/sign/departments/minsky/medical/medical1{
@@ -10398,7 +10332,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "eYP" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -10686,6 +10620,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ffC" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hos";
+	dir = 4;
+	name = "Head of Security's Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "ffF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10872,7 +10821,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fkk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -11231,6 +11180,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ftd" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "ftr" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -11277,7 +11238,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fvA" = (
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -11293,6 +11254,19 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"fvK" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "fvV" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -11302,7 +11276,7 @@
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -11416,15 +11390,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "fzk" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "fzx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -12003,7 +11977,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fJH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -12104,7 +12078,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "fNm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/departments/minsky/command/bridge{
@@ -12153,7 +12127,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fNK" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -12256,7 +12230,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fRH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -12406,12 +12380,15 @@
 /area/security/checkpoint/supply)
 "fVB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/machinery/electrolyzer,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12426,7 +12403,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fVR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12444,11 +12421,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fWw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/cryopods";
@@ -12486,10 +12460,6 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"fXM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "fXQ" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -12725,7 +12695,7 @@
 	name = "Station Alert Console"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "gda" = (
 /obj/machinery/light{
 	dir = 8
@@ -12934,7 +12904,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "giF" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -12948,7 +12918,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gjL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -13054,7 +13024,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "glR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -13124,7 +13094,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "goh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -13142,7 +13112,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "gpn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -13272,7 +13242,7 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gsZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13366,7 +13336,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -13376,7 +13346,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -13418,7 +13388,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"gvL" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13525,7 +13504,7 @@
 	name = "O2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gzB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -13555,7 +13534,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gAq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -13585,7 +13564,7 @@
 /area/security/processing)
 "gAG" = (
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gAI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -13812,7 +13791,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gHe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13969,7 +13948,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gJE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -14150,7 +14129,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gRH" = (
 /obj/machinery/light{
 	dir = 4
@@ -14176,7 +14155,7 @@
 	level = 2
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gSf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -14509,6 +14488,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hbH" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "hbL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -14606,6 +14593,10 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"heE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "heG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14728,24 +14719,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"hif" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "secondary_aicore_exterior";
-	name = "Physical Core Access";
-	req_access_txt = "0";
-	req_one_access_txt = "30, 70"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "hiw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -14765,6 +14738,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/teleporter)
+"hiY" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "hjd" = (
 /obj/machinery/light{
 	dir = 1
@@ -14906,9 +14891,6 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/starboard)
-"hll" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
 "hlo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15022,7 +15004,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hmZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15073,7 +15055,7 @@
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hoO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15119,7 +15101,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hpl" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -15188,7 +15170,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hpP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -15526,7 +15508,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hzF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15813,6 +15795,13 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"hFy" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hFP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
@@ -15885,16 +15874,6 @@
 	dir = 4
 	},
 /area/chapel/main)
-"hIC" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hII" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -15906,6 +15885,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/processing)
+"hJq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "hJB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -16057,21 +16051,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"hOw" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hOz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -16209,19 +16188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"hSC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hSV" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -16317,7 +16283,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "hUI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -16370,7 +16336,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16380,7 +16346,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hVC" = (
 /obj/structure/window/reinforced,
 /obj/structure/rack,
@@ -16533,13 +16499,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"ibe" = (
-/obj/machinery/computer/security/qm{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "ibA" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -16656,7 +16615,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -16666,7 +16625,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ifK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16787,34 +16746,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"iid" = (
-/obj/machinery/camera{
-	c_tag = "Chief Medical Office";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/glass,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Medical Officer";
-	name = "Chief Medical Officer's Fax Machine"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "iiq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16954,20 +16885,6 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
-"inC" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Personnel";
-	name = "Head of Personnel's Fax Machine"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "inD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -17197,7 +17114,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17207,7 +17124,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iuV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -17254,6 +17171,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ivM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -17270,7 +17196,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "iwi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -17524,21 +17450,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"iAS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "iBa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -17597,7 +17508,7 @@
 	dir = 6
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iCY" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
@@ -17837,15 +17748,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "iMk" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "iMK" = (
 /obj/structure/railing{
 	dir = 1
@@ -17899,13 +17810,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iNL" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "iNQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18156,7 +18067,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -18310,7 +18221,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iZk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -18327,7 +18238,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iZl" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -18392,12 +18303,8 @@
 	},
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/shoes/magboots,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jbW" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -18674,7 +18581,7 @@
 /area/engine/gravity_generator)
 "jjX" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18733,6 +18640,14 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"jmf" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "jmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -18941,12 +18856,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jsn" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/maintenance/disposal/incinerator)
 "jsq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -18967,7 +18881,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jtL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -18989,7 +18903,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jut" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -19078,23 +18992,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jxz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -24
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jxA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -19495,12 +19392,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jEZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19711,7 +19608,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jMO" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 1
@@ -20224,7 +20121,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jZd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -20309,9 +20206,9 @@
 "kbj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	name = "Atmospherics Storage Room APC";
-	pixel_y = -25
+	areastring = "/area/engine/atmos";
+	name = "Atmospherics Wing APC";
+	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20324,7 +20221,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "kbt" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
@@ -20353,7 +20250,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "kcC" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable,
@@ -20362,7 +20259,7 @@
 "kcE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kcF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20393,27 +20290,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kdQ" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/stamp/cmo,
-/turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/heads/cmo)
 "kdW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "keq" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -20499,7 +20381,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/primary/central)
 "kia" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -20641,7 +20523,7 @@
 "klv" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "klA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -20675,20 +20557,6 @@
 "kma" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"kmd" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "kmh" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -20741,7 +20609,19 @@
 /area/medical/chemistry)
 "knf" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"knl" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "knp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20847,16 +20727,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"krf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "krm" = (
 /obj/machinery/vending/games,
 /obj/machinery/light{
@@ -20964,7 +20834,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21018,7 +20888,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kwy" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -21160,18 +21030,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"kzY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "kAf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21335,6 +21193,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kGm" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "kGp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21623,17 +21492,19 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
 "kKN" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
 /obj/effect/turf_decal/bot,
-/obj/machinery/shieldgen,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"kKS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "kLw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21754,6 +21625,41 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"kOy" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Quartermaster";
+	req_access_txt = "41"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "kOA" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -22058,7 +21964,7 @@
 /area/hallway/primary/central)
 "kYf" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kYl" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -22168,6 +22074,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"kZT" = (
+/obj/machinery/door/airlock/command{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/secondarydatacore)
 "kZW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22179,6 +22101,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kZX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "laa" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -22217,14 +22149,6 @@
 "laH" = (
 /turf/closed/wall,
 /area/quartermaster/office)
-"laK" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "laL" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/cable{
@@ -22389,7 +22313,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ldQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -22431,13 +22355,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
-"ley" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/quartermaster,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "leG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -22702,7 +22619,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "llu" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/radio/intercom{
@@ -23060,7 +22977,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -23070,7 +22987,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lwt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/storage";
@@ -23121,7 +23038,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "lxh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -23172,6 +23089,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"lxF" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "lxG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23248,15 +23177,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "lyH" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "lzf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -23352,7 +23281,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lBk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -23571,13 +23500,13 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lGy" = (
 /obj/structure/flora/tree/jungle{
 	desc = "A tree? In space?"
@@ -23591,7 +23520,7 @@
 	name = "Atmospheric Alert Console"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "lGK" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -23614,6 +23543,25 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"lGX" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -23685,7 +23633,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lKJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23831,20 +23779,6 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lOg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/captain";
-	name = "Captain's Office APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
-	department = "Captain";
-	name = "Captain's Fax Machine"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "lOQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -24012,6 +23946,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"lRA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "lRK" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -24062,7 +24009,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lSl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24077,7 +24024,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lSp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -24339,13 +24286,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "lYd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lYq" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 5
@@ -24626,7 +24573,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mgL" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -24828,7 +24775,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "mko" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24953,7 +24900,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mnG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -25141,7 +25088,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "mrq" = (
 /turf/closed/wall,
 /area/library)
@@ -25259,6 +25206,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mtt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "mtW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Nanite Laboratory Maintenance";
@@ -25289,7 +25245,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/primary/central)
 "muA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -25471,7 +25427,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "myw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -25776,6 +25732,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"mKS" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "mKW" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -25814,7 +25779,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "mLP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -25845,7 +25810,7 @@
 /obj/item/assembly/igniter,
 /obj/item/book/manual/wiki/atmospherics,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "mMi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/science/central";
@@ -25997,7 +25962,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mQt" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -26306,7 +26271,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mXu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26441,7 +26406,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "ndg" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -26477,7 +26442,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26535,7 +26500,7 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nfz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -26675,7 +26640,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nkd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -26940,7 +26905,7 @@
 /area/hallway/secondary/entry)
 "nrB" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nsu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -26956,12 +26921,28 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"nsF" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/computer/security/qm{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -37
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "nsK" = (
 /obj/machinery/air_sensor{
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nsR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27042,8 +27023,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -30
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nuz" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -27272,7 +27257,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nzG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27319,7 +27304,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nAg" = (
 /obj/machinery/computer/prisoner,
 /obj/structure/cable{
@@ -27611,11 +27596,11 @@
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nHm" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nHr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27737,22 +27722,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"nKd" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28048,18 +28017,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"nQr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "nQW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -28407,7 +28364,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "obf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -28561,19 +28518,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
-"oha" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "ohb" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
@@ -28581,11 +28529,8 @@
 	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ohg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28693,7 +28638,7 @@
 "ojo" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -28767,15 +28712,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "onu" = (
+/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "onz" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -28800,7 +28745,7 @@
 	},
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "onQ" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -28895,7 +28840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "opt" = (
 /obj/structure/bed,
 /obj/machinery/button/door{
@@ -29070,7 +29015,7 @@
 "otk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "ots" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -29213,7 +29158,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "oyB" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
@@ -29372,6 +29317,24 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"oCo" = (
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "oCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -29408,13 +29371,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oEb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "oEt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -29425,7 +29388,7 @@
 "oEG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oFa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29709,7 +29672,7 @@
 /obj/machinery/atmospherics/miner/toxins,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oPq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd2";
@@ -29829,6 +29792,15 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"oTZ" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oUD" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -30102,27 +30074,6 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"pcW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -2;
-	pixel_y = -29
-	},
-/obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = -23
-	},
-/obj/structure/table,
-/obj/machinery/photocopier/faxmachine{
-	density = 0;
-	department = "Quartermaster";
-	name = "Quartermaster's Fax Machine"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "pdq" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -30203,7 +30154,7 @@
 	name = "CO2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "peP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -30472,7 +30423,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "pke" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -30509,7 +30460,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30687,18 +30638,9 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
+/obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "pph" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -30857,7 +30799,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pts" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -30985,26 +30927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pye" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 4;
-	name = "Head of Security's Office APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/table/wood,
-/obj/machinery/photocopier/faxmachine{
-	department = "Head of Security";
-	name = "Head of Securities Fax Machine"
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "pyf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -31018,7 +30940,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pyH" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
@@ -31106,6 +31028,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pBy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "pBD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -31205,7 +31137,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pCt" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -31512,7 +31444,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pLY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31660,7 +31592,7 @@
 /area/security/main)
 "pPd" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pPw" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -31763,7 +31695,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pSg" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -32000,7 +31932,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pXc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -32018,7 +31950,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pXi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -32040,21 +31972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"pXP" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "pXU" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -32075,6 +31992,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"pYq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "pYt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -32114,20 +32037,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"pYB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/machinery/photocopier/faxmachine{
-	department = "Warden";
-	name = "Warden's Fax Machine"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "pYV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32534,7 +32443,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "qja" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -32787,7 +32696,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plating,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qnX" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -32854,7 +32763,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qpx" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -32924,6 +32833,14 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"qrX" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qsy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -33109,29 +33026,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"qxH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qxJ" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen{
@@ -33231,11 +33125,11 @@
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "qCJ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qCO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -33365,7 +33259,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "qGQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -33582,7 +33476,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qNI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -33628,7 +33522,7 @@
 /obj/structure/rack,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qPn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -33767,7 +33661,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qSj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -34043,7 +33937,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qZz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -34125,7 +34019,7 @@
 "rbs" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rbJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -34193,7 +34087,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "rcD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -34336,19 +34230,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"rfi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rfm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -34534,6 +34415,29 @@
 "rjs" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"rjy" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "rjC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -34567,7 +34471,7 @@
 /area/security/checkpoint/customs)
 "rjX" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
+	areastring = "/area/engine/atmos_distro";
 	dir = 1;
 	name = "Atmospherics Distribution APC";
 	pixel_y = 23
@@ -34579,7 +34483,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rkj" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -34712,7 +34616,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rpr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -34875,17 +34779,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"rrE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/machinery/photocopier/faxmachine{
-	department = "Research Director";
-	name = "Research Director's Fax Machine"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "rrG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -34972,18 +34865,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rtq" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/yellow,
-/obj/item/paper/monitorkey,
-/obj/item/stamp/ce,
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/heads/chief)
 "rtB" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -35277,7 +35158,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -35489,7 +35370,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rGj" = (
 /obj/structure/sign/departments/minsky/supply/mining{
 	pixel_y = -32
@@ -35682,7 +35563,7 @@
 /area/science/mixing/chamber)
 "rKl" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rKr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -35794,7 +35675,7 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rOC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35810,7 +35691,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rOD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Service";
@@ -36144,7 +36025,7 @@
 /area/medical/sleeper)
 "rXM" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rXN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -36566,21 +36447,6 @@
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"skY" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
-/obj/item/folder/blue,
-/obj/item/stamp/hop,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "slm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -36595,11 +36461,8 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste to Space"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "slG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -36651,7 +36514,7 @@
 	name = "Tank Monitor"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "snf" = (
 /obj/machinery/light{
 	dir = 8
@@ -37035,41 +36898,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"sup" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster";
-	req_access_txt = "41"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "sus" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
@@ -37093,6 +36921,26 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"svp" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_interior";
+	name = "Physical Core Access";
+	req_access_txt = "30"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "svr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -37128,7 +36976,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "swg" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -37176,7 +37024,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "sxt" = (
 /obj/machinery/turnstile/brig{
 	dir = 1
@@ -37194,7 +37042,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "sxC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -37283,7 +37131,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "szj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -37370,14 +37218,13 @@
 /area/hallway/primary/fore)
 "sAf" = (
 /obj/structure/window/reinforced,
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "sAk" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/cable{
@@ -37437,7 +37284,7 @@
 	sortType = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "sBE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -37609,7 +37456,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sHi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37621,6 +37468,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sHR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "sIj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -37645,7 +37502,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37791,7 +37648,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sMM" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -38251,7 +38108,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "sXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38385,17 +38242,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"tal" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tar" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable,
@@ -38633,7 +38479,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "tia" = (
 /turf/closed/wall,
 /area/clerk)
@@ -38714,7 +38560,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tjr" = (
 /turf/closed/wall,
 /area/engine/engineering)
@@ -39086,7 +38932,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "twz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -39236,7 +39082,7 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "tAk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -39482,19 +39328,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tHe" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "tHh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39643,7 +39476,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tLc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39746,7 +39579,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "tNs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39988,6 +39821,29 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
 /area/medical/chemistry)
+"tUv" = (
+/obj/machinery/camera{
+	c_tag = "Chief Medical Office";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "tUy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Conference Room Maintenance";
@@ -40172,6 +40028,17 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"tYk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "tYq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40753,7 +40620,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "unn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40819,7 +40686,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uqi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40855,13 +40722,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"usS" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/power/apc{
+	areastring = "/area/quartermaster/qm";
+	dir = 8;
+	name = "Quartermaster APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "utx" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "utN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40954,7 +40837,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "uxf" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -41014,7 +40897,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -41024,7 +40907,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uyk" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -41179,7 +41062,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uCW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -41315,7 +41198,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uGJ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -41404,7 +41287,7 @@
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "uIF" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41449,7 +41332,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -41738,7 +41621,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uON" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -41749,23 +41632,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uPj" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uPN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -41829,23 +41695,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"uRs" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/research/glass{
-	name = "Secondary AI Core";
-	normalspeed = 0;
-	req_access_txt = "47"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/secondarydatacore)
 "uRz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
@@ -42158,42 +42007,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uZz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
-	dir = 8;
-	name = "Quartermaster APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/item/clipboard{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stamp/qm{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/coin/silver{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "uZR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42256,7 +42069,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vcc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -42276,7 +42089,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vcA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -42464,15 +42277,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"vha" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "vhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -42525,7 +42329,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42746,16 +42550,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"vnq" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "vnv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -42850,7 +42644,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vps" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43135,6 +42929,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vxA" = (
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/item/folder/white,
+/obj/item/stamp/cmo,
+/turf/open/floor/carpet/exoticblue,
+/area/crew_quarters/heads/cmo)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/door/poddoor/shutters{
@@ -43228,12 +43037,12 @@
 	id = "atmos";
 	name = "atmos blast door"
 	},
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "vAc" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -43344,7 +43153,7 @@
 	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vEi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43699,7 +43508,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vME" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43755,7 +43564,7 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vNC" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -43850,7 +43659,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/primary/central)
 "vQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -43898,7 +43707,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "vTf" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -43941,7 +43750,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vTU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -44211,7 +44020,7 @@
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vZe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -44340,7 +44149,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wda" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -44380,7 +44189,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "weB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44650,7 +44459,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wlE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -44838,6 +44647,22 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"wpp" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Holding Area";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "wpP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -44848,7 +44673,7 @@
 "wqk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wqp" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -45005,7 +44830,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wtT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -45105,7 +44930,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wwI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -45165,7 +44990,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wye" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45286,7 +45111,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wDL" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -45564,7 +45389,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45576,7 +45401,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wIS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -45638,7 +45463,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "wKH" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -45765,7 +45590,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wOL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45874,7 +45699,7 @@
 "wQK" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wQM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -46021,7 +45846,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -46141,27 +45966,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"wYJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "secondary_aicore_interior";
-	name = "Physical Core Access";
-	req_access_txt = "0";
-	req_one_access_txt = "30, 70"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "wYP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
@@ -46211,7 +46015,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xau" = (
 /mob/living/simple_animal/hostile/retaliate/bat{
 	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
@@ -46302,7 +46106,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xbn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -46698,7 +46502,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/maintenance/port/aft)
 "xkJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -46781,6 +46585,17 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"xmw" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "xmW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46862,7 +46677,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xoB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -47014,6 +46829,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"xse" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "xsi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47366,7 +47186,16 @@
 /area/hydroponics/garden)
 "xBE" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
+"xBL" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/captain";
+	name = "Captain's Office APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "xBM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/carbon/monkey,
@@ -47522,7 +47351,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xGG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -47558,6 +47387,27 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"xHx" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "xHB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
@@ -47636,6 +47486,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xKO" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "xKZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -47674,7 +47531,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xLC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -48032,7 +47889,7 @@
 /area/maintenance/aft)
 "xTt" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xTx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -48154,25 +48011,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"xVC" = (
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "xWa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -48182,7 +48020,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -48573,7 +48411,7 @@
 "ydx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ydG" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
@@ -48588,7 +48426,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yeK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48619,7 +48457,7 @@
 /area/science/mixing)
 "yfF" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "yfX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -48698,7 +48536,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yhm" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -48725,7 +48563,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yiu" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -48752,7 +48590,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos)
 "yjk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -68767,9 +68605,9 @@ twv
 oxM
 jjX
 jjX
-otk
+jjX
 cPG
-otk
+jjX
 jjX
 jjX
 jjX
@@ -69037,9 +68875,9 @@ ctL
 jPk
 lah
 ewm
-tHe
+knl
 uIF
-cWD
+cyz
 wKL
 wKL
 wKL
@@ -69284,7 +69122,7 @@ xTt
 fMN
 sIn
 qCF
-jjX
+xTt
 wIS
 tzj
 aMM
@@ -69538,9 +69376,9 @@ wKh
 xFT
 fRC
 xTt
-ccU
+xTt
 xbm
-ccU
+xTt
 xTt
 aJe
 vdN
@@ -70275,7 +70113,7 @@ kHq
 xGP
 twc
 jpZ
-pye
+ffC
 xau
 qPP
 xGP
@@ -70523,8 +70361,8 @@ hlo
 vNC
 xMn
 wFZ
-pYB
-bVZ
+pBy
+pYq
 czC
 pjL
 dpv
@@ -70820,7 +70658,7 @@ mwk
 sSU
 dBO
 kPJ
-kKN
+xse
 xTt
 iwh
 rcq
@@ -72056,9 +71894,9 @@ vRP
 vRP
 vRP
 seS
-eAe
+anE
 lUn
-bOF
+bSd
 qfO
 eNb
 rUN
@@ -73084,9 +72922,9 @@ vRP
 vRP
 vRP
 vRP
-eAe
+anE
 hII
-bOF
+bSd
 qfO
 hRF
 tdd
@@ -73134,9 +72972,9 @@ qRW
 adT
 qRW
 qRW
-ccU
+otk
 qnR
-ccU
+otk
 xTt
 cNu
 uBb
@@ -73386,15 +73224,15 @@ xEm
 dwr
 nDJ
 xMB
-dLz
-rtq
+ams
+aax
 ybK
 bEd
 qRW
 khz
 xnG
 mup
-aMM
+kgb
 bQv
 uBb
 vro
@@ -73644,7 +73482,7 @@ igr
 jZB
 rTz
 cZc
-bcT
+kZX
 cXc
 iAE
 cRS
@@ -74106,7 +73944,7 @@ vRP
 vRP
 vRP
 eRC
-daP
+gvL
 eRC
 gOA
 gOA
@@ -74389,7 +74227,7 @@ mfS
 fmz
 eEI
 rfL
-jxz
+dqQ
 sTv
 lPr
 xKc
@@ -74425,7 +74263,7 @@ hOJ
 pQR
 xZY
 bUS
-uZz
+usS
 lQU
 pQR
 gTy
@@ -74620,7 +74458,7 @@ vRP
 vRP
 eRC
 eRC
-pXP
+ftd
 eRC
 jYQ
 kVu
@@ -74937,11 +74775,11 @@ fhh
 xFu
 maX
 pQR
-vnq
-iAS
-doI
-ibe
-bVm
+bQZ
+lGX
+mtt
+nsF
+pQR
 hqm
 bco
 xYw
@@ -75194,10 +75032,10 @@ kmr
 ewA
 maX
 pQR
-ley
-aUj
-ezB
-pcW
+hMf
+kOy
+dGF
+iNn
 pQR
 bDB
 svs
@@ -75450,13 +75288,13 @@ bYF
 ljA
 ewA
 vAA
-pQR
-hMf
-sup
-dHF
-iNn
-pQR
-bco
+oyO
+gbT
+xHx
+jvU
+jvU
+jvU
+dNz
 bco
 sNz
 bco
@@ -75708,12 +75546,12 @@ oRt
 ewA
 maX
 kzS
-gbT
-dUw
-nQr
-nQr
-nQr
-kzY
+xKO
+hJq
+aNy
+aNy
+aNy
+aNy
 aNy
 cur
 oqX
@@ -75967,7 +75805,7 @@ xzj
 oyO
 nZD
 rlg
-kKS
+amE
 amE
 xkF
 kiS
@@ -78036,9 +77874,9 @@ pun
 pun
 lAn
 lHR
-cMQ
+oTZ
 uDe
-tal
+eet
 tkl
 iUq
 aCD
@@ -79027,7 +78865,7 @@ fYS
 jGi
 uWs
 dog
-iid
+tUv
 jiG
 sbI
 dog
@@ -79541,7 +79379,7 @@ oWT
 oWT
 dog
 dog
-kdQ
+vxA
 aBM
 xvb
 riA
@@ -81380,7 +81218,7 @@ dpf
 vFH
 ydu
 dpf
-hif
+ayE
 dpf
 dpf
 aCD
@@ -81894,7 +81732,7 @@ ylC
 fvC
 cvx
 dpf
-wYJ
+svp
 dpf
 aCD
 aCD
@@ -82919,7 +82757,7 @@ vwU
 eCM
 cyI
 xId
-uRs
+kZT
 lKJ
 lAt
 nui
@@ -86006,9 +85844,9 @@ hQr
 glR
 mhe
 tpB
-bHK
+hiY
 ipc
-kmd
+xmw
 crc
 crc
 qPn
@@ -88047,7 +87885,7 @@ gqK
 hso
 bdB
 rIB
-rrE
+eRj
 iPv
 tAW
 lID
@@ -88305,7 +88143,7 @@ eHi
 rHi
 xny
 xbl
-xVC
+oCo
 tAW
 gEB
 tKb
@@ -89797,11 +89635,11 @@ vRP
 vRP
 vRP
 vRP
-eqc
-hll
-hll
-hll
-hll
+ecI
+rsW
+rsW
+rsW
+rsW
 rsW
 pHK
 rsW
@@ -90052,13 +89890,13 @@ vRP
 vRP
 vRP
 vRP
-eqc
-pQh
-eqc
-aCU
-nKd
-uPj
-aWF
+ecI
+dLk
+ecI
+mKS
+wpp
+dAK
+cJz
 dLk
 slG
 hxY
@@ -90309,13 +90147,13 @@ vRP
 vRP
 vRP
 vRP
-eLS
-pqy
-bGF
-bQp
-krf
-hSC
-rfi
+hbH
+kGm
+eLR
+tYk
+sHR
+fvK
+lRA
 pqf
 rui
 vhc
@@ -90566,13 +90404,13 @@ vRP
 vRP
 vRP
 vRP
-eqc
-eqc
-eqc
-pQh
-fXM
-qxH
-fXM
+ecI
+ecI
+ecI
+dLk
+niO
+rjy
+niO
 dLk
 ckp
 pnA
@@ -90823,9 +90661,9 @@ vRP
 vRP
 vRP
 jzc
-laK
+aCE
 hCF
-aCs
+jmf
 ddt
 tYq
 vps
@@ -91338,7 +91176,7 @@ vRP
 vRP
 vRP
 vRP
-aCD
+heE
 eqc
 adM
 amf
@@ -91594,8 +91432,8 @@ vRP
 vRP
 vRP
 vRP
-aCD
-aCD
+heE
+vRP
 eqc
 wGz
 kxF
@@ -91852,7 +91690,7 @@ vRP
 vRP
 vRP
 vRP
-aCD
+heE
 eqc
 adM
 kxF
@@ -92365,9 +92203,9 @@ vRP
 vRP
 vRP
 vRP
-laK
+aCE
 pqy
-aCs
+jmf
 wqQ
 ibW
 qJT
@@ -92685,9 +92523,9 @@ tkl
 tkl
 tkl
 sqz
-oha
+ivM
 sqz
-oha
+ivM
 sqz
 tkl
 tkl
@@ -92879,9 +92717,9 @@ vRP
 vRP
 vRP
 vRP
-laK
+aCE
 hCF
-aCs
+jmf
 bbe
 dkW
 lOQ
@@ -93199,9 +93037,9 @@ sqz
 sqz
 sqz
 sqz
-hOw
+lxF
 rKC
-hOw
+lxF
 rrx
 lMA
 lMA
@@ -93718,9 +93556,9 @@ aAR
 giq
 nOX
 wUk
-vha
+qrX
 aJn
-hIC
+hFy
 hAq
 vRP
 vRP
@@ -94201,7 +94039,7 @@ hVM
 pgQ
 tpP
 mXu
-lOg
+xBL
 hVM
 hVM
 eGu
@@ -94448,8 +94286,8 @@ tDe
 xdL
 nzI
 izV
-inC
-skY
+aSz
+age
 omw
 vjf
 vTy

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -21492,17 +21492,8 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
 "kKN" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
 /obj/effect/turf_decal/bot,
+/obj/machinery/shieldgen,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kLw" = (

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -12,17 +12,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"aax" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/heads/chief)
+/area/engine/atmos/distro)
 "aaP" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -42,13 +32,12 @@
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
 "aaQ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 8;
-	on = 1;
-	volume_rate = 200
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "abw" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -113,7 +102,7 @@
 "acO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "acW" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /obj/effect/turf_decal/delivery,
@@ -314,19 +303,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"age" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "agf" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -343,7 +319,7 @@
 "agx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "agy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -433,7 +409,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ail" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -521,7 +497,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "all" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -561,23 +537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ams" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 8;
-	name = "CE Office APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/paper/monitorkey,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "amw" = (
 /obj/machinery/light{
 	dir = 8
@@ -674,15 +633,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"anE" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/security/processing)
 "anH" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -786,7 +736,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "arc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1054,23 +1004,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ayE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "secondary_aicore_exterior";
-	name = "Physical Core Access";
-	req_access_txt = "30"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "ayK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -1132,7 +1065,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aAR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1196,17 +1129,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aCs" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "aCD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aCE" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "aCJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -1238,6 +1175,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"aCU" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "aDO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1419,7 +1365,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "aJN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -1724,7 +1670,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aQF" = (
 /obj/machinery/light{
 	dir = 1
@@ -1792,18 +1738,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"aSz" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/item/folder/blue,
-/obj/item/stamp/hop,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "aSA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -1882,6 +1816,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aUj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "aUB" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1970,6 +1923,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"aWF" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "aWK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -2227,6 +2192,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bcT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "bcW" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -2356,7 +2334,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "bfP" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -2372,7 +2350,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "bgo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2552,7 +2530,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2652,7 +2630,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "box" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -2845,16 +2823,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "btg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/storage/eva";
@@ -2920,7 +2898,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3024,7 +3002,7 @@
 "bxz" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bxI" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -3123,7 +3101,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bBB" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -3263,7 +3241,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bEM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3324,6 +3302,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"bGF" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "bGP" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -3373,6 +3363,19 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"bHK" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "bHY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3510,7 +3513,7 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3553,6 +3556,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"bOF" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "bOI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3568,7 +3584,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bPi" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -3588,7 +3604,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bPw" = (
 /obj/machinery/light{
 	dir = 8
@@ -3651,6 +3667,17 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"bQp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bQv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3691,7 +3718,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bQU" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -3701,16 +3728,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"bQZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "bRd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3757,16 +3774,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bSd" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/processing)
 "bSD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3930,16 +3937,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"bVm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "bVq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bVC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bVZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "bWu" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -4070,13 +4091,13 @@
 /area/hydroponics/garden)
 "cbm" = (
 /obj/structure/window/reinforced,
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "cbr" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -4102,8 +4123,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "ccU" = (
-/turf/closed/wall,
-/area/engine/atmos)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos/storage)
 "cds" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -4299,7 +4321,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "chD" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses{
@@ -4368,7 +4390,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "cjy" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/glass/bucket,
@@ -4452,7 +4474,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "clE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -4531,7 +4553,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "coh" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -4662,7 +4684,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cry" = (
 /obj/machinery/light{
 	dir = 4
@@ -4767,7 +4789,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "cur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -4875,7 +4897,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "cxh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4975,17 +4997,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"cyz" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "cyB" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -5181,7 +5192,7 @@
 "cBX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cCb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5208,7 +5219,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cCj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5216,7 +5227,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cCv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5279,7 +5290,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cEv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -5337,7 +5348,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/storage)
 "cFy" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5378,7 +5389,7 @@
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cGi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5401,7 +5412,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -5507,19 +5518,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
-"cJz" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/area/engine/atmos/distro)
 "cKj" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
@@ -5635,6 +5634,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"cMQ" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cNs" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -5753,7 +5762,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cPL" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
@@ -5843,7 +5852,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cTk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 8
@@ -6037,6 +6046,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cWD" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "cXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6200,6 +6223,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"daP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "dbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6302,7 +6337,7 @@
 /area/maintenance/department/bridge)
 "ddA" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dea" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -6706,15 +6741,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dng" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "dnl" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleshutter";
@@ -6732,6 +6767,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"doI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "dpf" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
@@ -6806,23 +6847,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"dqQ" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dru" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -6854,7 +6878,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dsF" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6933,7 +6957,7 @@
 "dve" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dvp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -7011,7 +7035,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dxA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/dark,
@@ -7094,7 +7118,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dAf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/firealarm{
@@ -7120,24 +7144,7 @@
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
-"dAK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/area/engine/atmos/distro)
 "dAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7311,7 +7318,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dFX" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -7349,8 +7356,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -7381,14 +7391,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
-"dGF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/qm)
 "dGO" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -7420,6 +7422,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dHF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/quartermaster/qm)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7506,6 +7516,23 @@
 "dLk" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
+"dLz" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 8;
+	name = "CE Office APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "dLC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7746,7 +7773,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "dTU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -7765,7 +7792,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dUo" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -7803,6 +7830,27 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"dUw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "dUG" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -7875,7 +7923,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dVZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7944,7 +7992,7 @@
 "dWX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dXK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -8131,10 +8179,6 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
-"ecI" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "ecL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -8204,7 +8248,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "edn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -8248,14 +8292,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"eet" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "eew" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
@@ -8532,7 +8568,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "emd" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -8670,7 +8706,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eoN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -8705,7 +8741,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eph" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -9233,9 +9269,46 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ezB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/pen/red{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/cartridge/quartermaster{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
+"eAe" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/security/processing)
 "eAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -9322,7 +9395,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eBY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -9413,7 +9486,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eDB" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -9512,7 +9585,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eEB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -9525,7 +9598,7 @@
 /area/crew_quarters/heads/hor)
 "eEF" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "eEI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9818,15 +9891,15 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"eLR" = (
+"eLS" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
+/area/hallway/secondary/exit)
 "eMf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9954,7 +10027,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eNT" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -10018,7 +10091,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ePa" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -10077,13 +10150,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"eRj" = (
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "eRu" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -10128,7 +10194,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eRU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10152,7 +10218,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "eSb" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -10192,7 +10258,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eUq" = (
 /obj/structure/chair{
 	dir = 4
@@ -10219,7 +10285,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "eVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/sign/departments/minsky/medical/medical1{
@@ -10332,7 +10398,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "eYP" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -10620,21 +10686,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ffC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 4;
-	name = "Head of Security's Office APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "ffF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10821,7 +10872,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fkk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -11180,18 +11231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ftd" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "ftr" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -11238,7 +11277,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fvA" = (
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -11254,19 +11293,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"fvK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "fvV" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -11276,7 +11302,7 @@
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -11390,15 +11416,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "fzk" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "fzx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -11977,7 +12003,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fJH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -12078,7 +12104,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "fNm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/structure/sign/departments/minsky/command/bridge{
@@ -12127,7 +12153,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fNK" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -12230,7 +12256,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fRH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -12380,15 +12406,12 @@
 /area/security/checkpoint/supply)
 "fVB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/machinery/electrolyzer,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12403,7 +12426,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fVR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12421,8 +12444,11 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fWw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/cryopods";
@@ -12460,6 +12486,10 @@
 /obj/structure/closet/secure_closet/detective,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"fXM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "fXQ" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
@@ -12695,7 +12725,7 @@
 	name = "Station Alert Console"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "gda" = (
 /obj/machinery/light{
 	dir = 8
@@ -12904,7 +12934,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "giF" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -12918,7 +12948,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gjL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -13024,7 +13054,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "glR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -13094,7 +13124,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "goh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -13112,7 +13142,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "gpn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -13242,7 +13272,7 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gsZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13336,7 +13366,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -13346,7 +13376,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -13388,16 +13418,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
-"gvL" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
+/area/engine/atmos/distro)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13504,7 +13525,7 @@
 	name = "O2 to Pure"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gzB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -13534,7 +13555,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gAq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chips,
@@ -13564,7 +13585,7 @@
 /area/security/processing)
 "gAG" = (
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gAI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -13791,7 +13812,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gHe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13948,7 +13969,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gJE" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -14129,7 +14150,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gRH" = (
 /obj/machinery/light{
 	dir = 4
@@ -14155,7 +14176,7 @@
 	level = 2
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gSf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -14488,14 +14509,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hbH" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "hbL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -14593,10 +14606,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"heE" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "heG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14719,6 +14728,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"hif" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_exterior";
+	name = "Physical Core Access";
+	req_access_txt = "0";
+	req_one_access_txt = "30, 70"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "hiw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -14738,18 +14765,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"hiY" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "hjd" = (
 /obj/machinery/light{
 	dir = 1
@@ -14891,6 +14906,9 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/starboard)
+"hll" = (
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/exit)
 "hlo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15004,7 +15022,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hmZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15055,7 +15073,7 @@
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hoO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15101,7 +15119,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hpl" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -15170,7 +15188,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hpP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -15508,7 +15526,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hzF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15795,13 +15813,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"hFy" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hFP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
@@ -15874,6 +15885,16 @@
 	dir = 4
 	},
 /area/chapel/main)
+"hIC" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hII" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -15885,21 +15906,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/processing)
-"hJq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "hJB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -16051,6 +16057,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"hOw" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hOz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -16188,6 +16209,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"hSC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hSV" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -16283,7 +16317,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "hUI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -16336,7 +16370,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16346,7 +16380,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hVC" = (
 /obj/structure/window/reinforced,
 /obj/structure/rack,
@@ -16499,6 +16533,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"ibe" = (
+/obj/machinery/computer/security/qm{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "ibA" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -16615,7 +16656,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -16625,7 +16666,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ifK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16746,6 +16787,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"iid" = (
+/obj/machinery/camera{
+	c_tag = "Chief Medical Office";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer RC";
+	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/glass,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Medical Officer";
+	name = "Chief Medical Officer's Fax Machine"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "iiq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16885,6 +16954,20 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
+"inC" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Personnel";
+	name = "Head of Personnel's Fax Machine"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "inD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -17114,7 +17197,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17124,7 +17207,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iuV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -17171,15 +17254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ivM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -17196,7 +17270,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "iwi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -17450,6 +17524,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"iAS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "iBa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -17508,7 +17597,7 @@
 	dir = 6
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iCY" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/plasteel/white,
@@ -17748,15 +17837,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "iMk" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "iMK" = (
 /obj/structure/railing{
 	dir = 1
@@ -17810,13 +17899,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iNL" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "iNQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18067,7 +18156,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -18221,7 +18310,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iZk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -18238,7 +18327,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iZl" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -18303,8 +18392,12 @@
 	},
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/shoes/magboots,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jbW" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -18581,7 +18674,7 @@
 /area/engine/gravity_generator)
 "jjX" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18640,14 +18733,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"jmf" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "jmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -18856,11 +18941,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jsn" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jsq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -18881,7 +18967,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jtL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -18903,7 +18989,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jut" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -18992,6 +19078,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"jxz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -24
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jxA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -19392,12 +19495,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jEZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jFl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19608,7 +19711,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jMO" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 1
@@ -20121,7 +20224,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jZd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -20206,9 +20309,9 @@
 "kbj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos";
-	name = "Atmospherics Wing APC";
-	pixel_y = -23
+	areastring = "/area/engine/atmos/storage";
+	name = "Atmospherics Storage Room APC";
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20221,7 +20324,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "kbt" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
@@ -20250,7 +20353,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "kcC" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable,
@@ -20259,7 +20362,7 @@
 "kcE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kcF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20290,12 +20393,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"kdQ" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/stamp/cmo,
+/turf/open/floor/carpet/exoticblue,
+/area/crew_quarters/heads/cmo)
 "kdW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "keq" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -20381,7 +20499,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/storage)
 "kia" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -20523,7 +20641,7 @@
 "klv" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "klA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -20557,6 +20675,20 @@
 "kma" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"kmd" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "kmh" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -20609,19 +20741,7 @@
 /area/medical/chemistry)
 "knf" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
-"knl" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/engine/atmos/distro)
 "knp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20727,6 +20847,16 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"krf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "krm" = (
 /obj/machinery/vending/games,
 /obj/machinery/light{
@@ -20834,7 +20964,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20888,7 +21018,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kwy" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -21030,6 +21160,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"kzY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "kAf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21193,17 +21335,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kGm" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "kGp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21492,19 +21623,17 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
 "kKN" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
 /obj/effect/turf_decal/bot,
+/obj/machinery/shieldgen,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"kKS" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "kLw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21625,41 +21754,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"kOy" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster";
-	req_access_txt = "41"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "kOA" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -21964,7 +22058,7 @@
 /area/hallway/primary/central)
 "kYf" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kYl" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -22074,22 +22168,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"kZT" = (
-/obj/machinery/door/airlock/command{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/secondarydatacore)
 "kZW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22101,16 +22179,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kZX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/heads/chief)
 "laa" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -22149,6 +22217,14 @@
 "laH" = (
 /turf/closed/wall,
 /area/quartermaster/office)
+"laK" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "laL" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/cable{
@@ -22313,7 +22389,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ldQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -22355,6 +22431,13 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"ley" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/quartermaster,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "leG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -22619,7 +22702,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "llu" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/radio/intercom{
@@ -22977,7 +23060,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -22987,7 +23070,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lwt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/storage";
@@ -23038,7 +23121,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "lxh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -23089,18 +23172,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lxF" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "lxG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23177,15 +23248,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "lyH" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "lzf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -23281,7 +23352,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lBk" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -23500,13 +23571,13 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lGy" = (
 /obj/structure/flora/tree/jungle{
 	desc = "A tree? In space?"
@@ -23520,7 +23591,7 @@
 	name = "Atmospheric Alert Console"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "lGK" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -23543,25 +23614,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"lGX" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -23633,7 +23685,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lKJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23779,6 +23831,20 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lOg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/captain";
+	name = "Captain's Office APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine{
+	department = "Captain";
+	name = "Captain's Fax Machine"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "lOQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -23946,19 +24012,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"lRA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "lRK" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -24009,7 +24062,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lSl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24024,7 +24077,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lSp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -24286,13 +24339,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "lYd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lYq" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 5
@@ -24573,7 +24626,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mgL" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -24775,7 +24828,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "mko" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24900,7 +24953,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mnG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -25088,7 +25141,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "mrq" = (
 /turf/closed/wall,
 /area/library)
@@ -25206,15 +25259,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"mtt" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "mtW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Nanite Laboratory Maintenance";
@@ -25245,7 +25289,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/storage)
 "muA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -25427,7 +25471,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "myw" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -25732,15 +25776,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"mKS" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "mKW" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -25779,7 +25814,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "mLP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -25810,7 +25845,7 @@
 /obj/item/assembly/igniter,
 /obj/item/book/manual/wiki/atmospherics,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "mMi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/science/central";
@@ -25962,7 +25997,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mQt" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -26271,7 +26306,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mXu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26406,7 +26441,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "ndg" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -26442,7 +26477,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26500,7 +26535,7 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nfz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -26640,7 +26675,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nkd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -26905,7 +26940,7 @@
 /area/hallway/secondary/entry)
 "nrB" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nsu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -26921,28 +26956,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"nsF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/computer/security/qm{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -37
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "nsK" = (
 /obj/machinery/air_sensor{
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nsR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27023,12 +27042,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nuz" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -27257,7 +27272,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nzG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27304,7 +27319,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nAg" = (
 /obj/machinery/computer/prisoner,
 /obj/structure/cable{
@@ -27596,11 +27611,11 @@
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nHm" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nHr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27722,6 +27737,22 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"nKd" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Holding Area";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28017,6 +28048,18 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"nQr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nQW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -28364,7 +28407,7 @@
 	dir = 2
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "obf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -28518,10 +28561,19 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
-"ohb" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
+"oha" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"ohb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
@@ -28529,8 +28581,11 @@
 	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ohg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28638,7 +28693,7 @@
 "ojo" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -28712,15 +28767,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "onu" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "onz" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -28745,7 +28800,7 @@
 	},
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "onQ" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -28840,7 +28895,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "opt" = (
 /obj/structure/bed,
 /obj/machinery/button/door{
@@ -29015,7 +29070,7 @@
 "otk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "ots" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -29158,7 +29213,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "oyB" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
@@ -29317,24 +29372,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oCo" = (
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "oCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -29371,13 +29408,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oEb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "oEt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -29388,7 +29425,7 @@
 "oEG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oFa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29672,7 +29709,7 @@
 /obj/machinery/atmospherics/miner/toxins,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oPq" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd2";
@@ -29792,15 +29829,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"oTZ" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "oUD" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -30074,6 +30102,27 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"pcW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -2;
+	pixel_y = -29
+	},
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = -23
+	},
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine{
+	density = 0;
+	department = "Quartermaster";
+	name = "Quartermaster's Fax Machine"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "pdq" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -30154,7 +30203,7 @@
 	name = "CO2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "peP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -30423,7 +30472,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "pke" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -30460,7 +30509,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pmd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30638,9 +30687,18 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/machinery/pipedispenser,
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "pph" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -30799,7 +30857,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pts" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -30927,6 +30985,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pye" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hos";
+	dir = 4;
+	name = "Head of Security's Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security";
+	name = "Head of Securities Fax Machine"
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "pyf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -30940,7 +31018,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pyH" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
@@ -31028,16 +31106,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pBy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "pBD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -31137,7 +31205,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pCt" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -31444,7 +31512,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pLY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31592,7 +31660,7 @@
 /area/security/main)
 "pPd" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pPw" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -31695,7 +31763,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pSg" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -31932,7 +32000,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pXc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -31950,7 +32018,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pXi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -31972,6 +32040,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pXP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "pXU" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -31992,12 +32075,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"pYq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "pYt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -32037,6 +32114,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"pYB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine{
+	department = "Warden";
+	name = "Warden's Fax Machine"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "pYV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32443,7 +32534,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "qja" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -32696,7 +32787,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qnX" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -32763,7 +32854,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qpx" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -32833,14 +32924,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"qrX" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "qsy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -33026,6 +33109,29 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"qxH" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qxJ" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen{
@@ -33125,11 +33231,11 @@
 /obj/machinery/light/small,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "qCJ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qCO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -33259,7 +33365,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "qGQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
@@ -33476,7 +33582,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qNI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -33522,7 +33628,7 @@
 /obj/structure/rack,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qPn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -33661,7 +33767,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qSj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -33937,7 +34043,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qZz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -34019,7 +34125,7 @@
 "rbs" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rbJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -34087,7 +34193,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "rcD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -34230,6 +34336,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rfi" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rfm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -34415,29 +34534,6 @@
 "rjs" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rjy" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "rjC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -34471,7 +34567,7 @@
 /area/security/checkpoint/customs)
 "rjX" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos_distro";
+	areastring = "/area/engine/atmos/distro";
 	dir = 1;
 	name = "Atmospherics Distribution APC";
 	pixel_y = 23
@@ -34483,7 +34579,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rkj" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -34616,7 +34712,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rpr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -34779,6 +34875,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rrE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/machinery/photocopier/faxmachine{
+	department = "Research Director";
+	name = "Research Director's Fax Machine"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "rrG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -34865,6 +34972,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rtq" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/yellow,
+/obj/item/paper/monitorkey,
+/obj/item/stamp/ce,
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
 "rtB" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -35158,7 +35277,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -35370,7 +35489,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rGj" = (
 /obj/structure/sign/departments/minsky/supply/mining{
 	pixel_y = -32
@@ -35563,7 +35682,7 @@
 /area/science/mixing/chamber)
 "rKl" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rKr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -35675,7 +35794,7 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rOC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -35691,7 +35810,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rOD" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Service";
@@ -36025,7 +36144,7 @@
 /area/medical/sleeper)
 "rXM" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rXN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/door/firedoor/border_only{
@@ -36447,6 +36566,21 @@
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"skY" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/item/hand_labeler,
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = -24
+	},
+/obj/item/folder/blue,
+/obj/item/stamp/hop,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "slm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -36461,8 +36595,11 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste to Space"
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "slG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/auxiliary";
@@ -36514,7 +36651,7 @@
 	name = "Tank Monitor"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "snf" = (
 /obj/machinery/light{
 	dir = 8
@@ -36898,6 +37035,41 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"sup" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Quartermaster";
+	req_access_txt = "41"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "sus" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
@@ -36921,26 +37093,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"svp" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/command/glass{
-	id_tag = "secondary_aicore_interior";
-	name = "Physical Core Access";
-	req_access_txt = "30"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "svr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -36976,7 +37128,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "swg" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -37024,7 +37176,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "sxt" = (
 /obj/machinery/turnstile/brig{
 	dir = 1
@@ -37042,7 +37194,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "sxC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -37131,7 +37283,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "szj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -37218,13 +37370,14 @@
 /area/hallway/primary/fore)
 "sAf" = (
 /obj/structure/window/reinforced,
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "sAk" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/cable{
@@ -37284,7 +37437,7 @@
 	sortType = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "sBE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -37456,7 +37609,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sHi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37468,16 +37621,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sHR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "sIj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -37502,7 +37645,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37648,7 +37791,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sMM" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -38108,7 +38251,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "sXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38242,6 +38385,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"tal" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tar" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable,
@@ -38479,7 +38633,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "tia" = (
 /turf/closed/wall,
 /area/clerk)
@@ -38560,7 +38714,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tjr" = (
 /turf/closed/wall,
 /area/engine/engineering)
@@ -38932,7 +39086,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "twz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -39082,7 +39236,7 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "tAk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -39328,6 +39482,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tHe" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "tHh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39476,7 +39643,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tLc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39579,7 +39746,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "tNs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39821,29 +39988,6 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
 /area/medical/chemistry)
-"tUv" = (
-/obj/machinery/camera{
-	c_tag = "Chief Medical Office";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "tUy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Conference Room Maintenance";
@@ -40028,17 +40172,6 @@
 /obj/machinery/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"tYk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "tYq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40620,7 +40753,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "unn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40686,7 +40819,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uqi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40722,29 +40855,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"usS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
-	dir = 8;
-	name = "Quartermaster APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/qm)
 "utx" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "utN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40837,7 +40954,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "uxf" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -40897,7 +41014,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -40907,7 +41024,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uyk" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -41062,7 +41179,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uCW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -41198,7 +41315,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uGJ" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -41287,7 +41404,7 @@
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "uIF" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41332,7 +41449,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -41621,7 +41738,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uON" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -41632,6 +41749,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uPj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uPN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -41695,6 +41829,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"uRs" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/research/glass{
+	name = "Secondary AI Core";
+	normalspeed = 0;
+	req_access_txt = "47"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/secondarydatacore)
 "uRz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
@@ -42007,6 +42158,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uZz" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/power/apc{
+	areastring = "/area/quartermaster/qm";
+	dir = 8;
+	name = "Quartermaster APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/clipboard{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stamp/qm{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/coin/silver{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "uZR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42069,7 +42256,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vcc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -42089,7 +42276,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vcA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -42277,6 +42464,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vha" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -42329,7 +42525,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vib" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42550,6 +42746,16 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vnq" = (
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel,
+/area/quartermaster/qm)
 "vnv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -42644,7 +42850,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vps" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -42929,21 +43135,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vxA" = (
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/item/folder/white,
-/obj/item/stamp/cmo,
-/turf/open/floor/carpet/exoticblue,
-/area/crew_quarters/heads/cmo)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/door/poddoor/shutters{
@@ -43037,12 +43228,12 @@
 	id = "atmos";
 	name = "atmos blast door"
 	},
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "vAc" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -43153,7 +43344,7 @@
 	name = "N2O Outlet Pump"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vEi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43508,7 +43699,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vME" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43564,7 +43755,7 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vNC" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -43659,7 +43850,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/storage)
 "vQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -43707,7 +43898,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "vTf" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -43750,7 +43941,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vTU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -44020,7 +44211,7 @@
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vZe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -44149,7 +44340,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wda" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -44189,7 +44380,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "weB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44459,7 +44650,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wlE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -44647,22 +44838,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"wpp" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "wpP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -44673,7 +44848,7 @@
 "wqk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wqp" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -44830,7 +45005,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wtT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -44930,7 +45105,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wwI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -44990,7 +45165,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wye" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45111,7 +45286,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wDL" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -45389,7 +45564,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45401,7 +45576,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wIS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -45463,7 +45638,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "wKH" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -45590,7 +45765,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wOL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45699,7 +45874,7 @@
 "wQK" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wQM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -45846,7 +46021,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -45966,6 +46141,27 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"wYJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command/glass{
+	id_tag = "secondary_aicore_interior";
+	name = "Physical Core Access";
+	req_access_txt = "0";
+	req_one_access_txt = "30, 70"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "wYP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
@@ -46015,7 +46211,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xau" = (
 /mob/living/simple_animal/hostile/retaliate/bat{
 	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
@@ -46106,7 +46302,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xbn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -46502,7 +46698,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/department/engine)
 "xkJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -46585,17 +46781,6 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"xmw" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "xmW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46677,7 +46862,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xoB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -46829,11 +47014,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"xse" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "xsi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47186,16 +47366,7 @@
 /area/hydroponics/garden)
 "xBE" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
-"xBL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/captain";
-	name = "Captain's Office APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/area/engine/atmos/distro)
 "xBM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/carbon/monkey,
@@ -47351,7 +47522,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xGG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -47387,27 +47558,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"xHx" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "xHB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
@@ -47486,13 +47636,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xKO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "xKZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -47531,7 +47674,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xLC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -47889,7 +48032,7 @@
 /area/maintenance/aft)
 "xTt" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xTx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -48011,6 +48154,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"xVC" = (
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/mob/living/simple_animal/pet/dog/corgi/borgi,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "xWa" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -48020,7 +48182,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -48411,7 +48573,7 @@
 "ydx" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ydG" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
@@ -48426,7 +48588,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yeK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48457,7 +48619,7 @@
 /area/science/mixing)
 "yfF" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "yfX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -48536,7 +48698,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yhm" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -48563,7 +48725,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yiu" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -48590,7 +48752,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/distro)
 "yjk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -68605,9 +68767,9 @@ twv
 oxM
 jjX
 jjX
-jjX
+otk
 cPG
-jjX
+otk
 jjX
 jjX
 jjX
@@ -68875,9 +69037,9 @@ ctL
 jPk
 lah
 ewm
-knl
+tHe
 uIF
-cyz
+cWD
 wKL
 wKL
 wKL
@@ -69122,7 +69284,7 @@ xTt
 fMN
 sIn
 qCF
-xTt
+jjX
 wIS
 tzj
 aMM
@@ -69376,9 +69538,9 @@ wKh
 xFT
 fRC
 xTt
-xTt
+ccU
 xbm
-xTt
+ccU
 xTt
 aJe
 vdN
@@ -70113,7 +70275,7 @@ kHq
 xGP
 twc
 jpZ
-ffC
+pye
 xau
 qPP
 xGP
@@ -70361,8 +70523,8 @@ hlo
 vNC
 xMn
 wFZ
-pBy
-pYq
+pYB
+bVZ
 czC
 pjL
 dpv
@@ -70658,7 +70820,7 @@ mwk
 sSU
 dBO
 kPJ
-xse
+kKN
 xTt
 iwh
 rcq
@@ -71894,9 +72056,9 @@ vRP
 vRP
 vRP
 seS
-anE
+eAe
 lUn
-bSd
+bOF
 qfO
 eNb
 rUN
@@ -72922,9 +73084,9 @@ vRP
 vRP
 vRP
 vRP
-anE
+eAe
 hII
-bSd
+bOF
 qfO
 hRF
 tdd
@@ -72972,9 +73134,9 @@ qRW
 adT
 qRW
 qRW
-otk
+ccU
 qnR
-otk
+ccU
 xTt
 cNu
 uBb
@@ -73224,15 +73386,15 @@ xEm
 dwr
 nDJ
 xMB
-ams
-aax
+dLz
+rtq
 ybK
 bEd
 qRW
 khz
 xnG
 mup
-kgb
+aMM
 bQv
 uBb
 vro
@@ -73482,7 +73644,7 @@ igr
 jZB
 rTz
 cZc
-kZX
+bcT
 cXc
 iAE
 cRS
@@ -73944,7 +74106,7 @@ vRP
 vRP
 vRP
 eRC
-gvL
+daP
 eRC
 gOA
 gOA
@@ -74227,7 +74389,7 @@ mfS
 fmz
 eEI
 rfL
-dqQ
+jxz
 sTv
 lPr
 xKc
@@ -74263,7 +74425,7 @@ hOJ
 pQR
 xZY
 bUS
-usS
+uZz
 lQU
 pQR
 gTy
@@ -74458,7 +74620,7 @@ vRP
 vRP
 eRC
 eRC
-ftd
+pXP
 eRC
 jYQ
 kVu
@@ -74775,11 +74937,11 @@ fhh
 xFu
 maX
 pQR
-bQZ
-lGX
-mtt
-nsF
-pQR
+vnq
+iAS
+doI
+ibe
+bVm
 hqm
 bco
 xYw
@@ -75032,10 +75194,10 @@ kmr
 ewA
 maX
 pQR
-hMf
-kOy
-dGF
-iNn
+ley
+aUj
+ezB
+pcW
 pQR
 bDB
 svs
@@ -75288,13 +75450,13 @@ bYF
 ljA
 ewA
 vAA
-oyO
-gbT
-xHx
-jvU
-jvU
-jvU
-dNz
+pQR
+hMf
+sup
+dHF
+iNn
+pQR
+bco
 bco
 sNz
 bco
@@ -75546,12 +75708,12 @@ oRt
 ewA
 maX
 kzS
-xKO
-hJq
-aNy
-aNy
-aNy
-aNy
+gbT
+dUw
+nQr
+nQr
+nQr
+kzY
 aNy
 cur
 oqX
@@ -75805,7 +75967,7 @@ xzj
 oyO
 nZD
 rlg
-amE
+kKS
 amE
 xkF
 kiS
@@ -77874,9 +78036,9 @@ pun
 pun
 lAn
 lHR
-oTZ
+cMQ
 uDe
-eet
+tal
 tkl
 iUq
 aCD
@@ -78865,7 +79027,7 @@ fYS
 jGi
 uWs
 dog
-tUv
+iid
 jiG
 sbI
 dog
@@ -79379,7 +79541,7 @@ oWT
 oWT
 dog
 dog
-vxA
+kdQ
 aBM
 xvb
 riA
@@ -81218,7 +81380,7 @@ dpf
 vFH
 ydu
 dpf
-ayE
+hif
 dpf
 dpf
 aCD
@@ -81732,7 +81894,7 @@ ylC
 fvC
 cvx
 dpf
-svp
+wYJ
 dpf
 aCD
 aCD
@@ -82757,7 +82919,7 @@ vwU
 eCM
 cyI
 xId
-kZT
+uRs
 lKJ
 lAt
 nui
@@ -85844,9 +86006,9 @@ hQr
 glR
 mhe
 tpB
-hiY
+bHK
 ipc
-xmw
+kmd
 crc
 crc
 qPn
@@ -87885,7 +88047,7 @@ gqK
 hso
 bdB
 rIB
-eRj
+rrE
 iPv
 tAW
 lID
@@ -88143,7 +88305,7 @@ eHi
 rHi
 xny
 xbl
-oCo
+xVC
 tAW
 gEB
 tKb
@@ -89635,11 +89797,11 @@ vRP
 vRP
 vRP
 vRP
-ecI
-rsW
-rsW
-rsW
-rsW
+eqc
+hll
+hll
+hll
+hll
 rsW
 pHK
 rsW
@@ -89890,13 +90052,13 @@ vRP
 vRP
 vRP
 vRP
-ecI
-dLk
-ecI
-mKS
-wpp
-dAK
-cJz
+eqc
+pQh
+eqc
+aCU
+nKd
+uPj
+aWF
 dLk
 slG
 hxY
@@ -90147,13 +90309,13 @@ vRP
 vRP
 vRP
 vRP
-hbH
-kGm
-eLR
-tYk
-sHR
-fvK
-lRA
+eLS
+pqy
+bGF
+bQp
+krf
+hSC
+rfi
 pqf
 rui
 vhc
@@ -90404,13 +90566,13 @@ vRP
 vRP
 vRP
 vRP
-ecI
-ecI
-ecI
-dLk
-niO
-rjy
-niO
+eqc
+eqc
+eqc
+pQh
+fXM
+qxH
+fXM
 dLk
 ckp
 pnA
@@ -90661,9 +90823,9 @@ vRP
 vRP
 vRP
 jzc
-aCE
+laK
 hCF
-jmf
+aCs
 ddt
 tYq
 vps
@@ -91176,7 +91338,7 @@ vRP
 vRP
 vRP
 vRP
-heE
+aCD
 eqc
 adM
 amf
@@ -91432,8 +91594,8 @@ vRP
 vRP
 vRP
 vRP
-heE
-vRP
+aCD
+aCD
 eqc
 wGz
 kxF
@@ -91690,7 +91852,7 @@ vRP
 vRP
 vRP
 vRP
-heE
+aCD
 eqc
 adM
 kxF
@@ -92203,9 +92365,9 @@ vRP
 vRP
 vRP
 vRP
-aCE
+laK
 pqy
-jmf
+aCs
 wqQ
 ibW
 qJT
@@ -92523,9 +92685,9 @@ tkl
 tkl
 tkl
 sqz
-ivM
+oha
 sqz
-ivM
+oha
 sqz
 tkl
 tkl
@@ -92717,9 +92879,9 @@ vRP
 vRP
 vRP
 vRP
-aCE
+laK
 hCF
-jmf
+aCs
 bbe
 dkW
 lOQ
@@ -93037,9 +93199,9 @@ sqz
 sqz
 sqz
 sqz
-lxF
+hOw
 rKC
-lxF
+hOw
 rrx
 lMA
 lMA
@@ -93556,9 +93718,9 @@ aAR
 giq
 nOX
 wUk
-qrX
+vha
 aJn
-hFy
+hIC
 hAq
 vRP
 vRP
@@ -94039,7 +94201,7 @@ hVM
 pgQ
 tpP
 mXu
-xBL
+lOg
 hVM
 hVM
 eGu
@@ -94286,8 +94448,8 @@ tDe
 xdL
 nzI
 izV
-aSz
-age
+inC
+skY
 omw
 vjf
 vTy

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -15810,6 +15810,10 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"crt" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cru" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/door/firedoor/border_only,
@@ -96329,7 +96333,7 @@ bCq
 uzc
 ccw
 ppM
-efb
+crt
 soW
 cmD
 cmD
@@ -96586,7 +96590,7 @@ bCq
 uzc
 ccw
 ppM
-wil
+efb
 bQa
 cmD
 cmD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -53924,6 +53924,19 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"rJX" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -96591,7 +96604,7 @@ uzc
 ccw
 ppM
 efb
-bQa
+rJX
 cmD
 cmD
 cfe
@@ -96848,7 +96861,7 @@ uzc
 ccw
 lTT
 wil
-wil
+bQa
 cfe
 cfe
 cfe

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -53924,19 +53924,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rJX" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -96604,7 +96591,7 @@ uzc
 ccw
 ppM
 efb
-rJX
+bQa
 cmD
 cmD
 cfe
@@ -96861,7 +96848,7 @@ uzc
 ccw
 lTT
 wil
-bQa
+wil
 cfe
 cfe
 cfe

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2,6 +2,16 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/mob/living/simple_animal/mouse/brown/Tom,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "aac" = (
 /obj/machinery/modular_computer/console/preset/curator{
 	dir = 1
@@ -9,6 +19,24 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/library)
+"aad" = (
+/obj/structure/bed/dogbed{
+	desc = "Jacob's bed! Looks comfy";
+	name = "Jacob's bed"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "Much better at protecting the armory than your average warden.";
+	name = "Warden Jacob";
+	real_name = "Warden Jacob"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -21,6 +49,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
+"aah" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
+/mob/living/simple_animal/moonrat{
+	name = "Joe"
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "aai" = (
 /obj/machinery/camera{
 	c_tag = "Prison Common Room South";
@@ -30,6 +67,47 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aaj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/mob/living/simple_animal/spiffles,
+/turf/open/floor/plasteel,
+/area/clerk)
+"aak" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
+"aal" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
+/mob/living/simple_animal/crab/kreb{
+	desc = "Here to lay down the hard claws of the law!";
+	health = 50;
+	name = "Officer Kreb";
+	real_name = "Officer Kreb"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "aam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -43,10 +121,84 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aan" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/mob/living/simple_animal/pet/fox/fennec/Autumn,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "aao" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"aap" = (
+/obj/structure/bed/dogbed/ian,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/toy/figure/hop{
+	layer = 2.89;
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"aaq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/mob/living/simple_animal/pet/dog/corgi/borgi,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
+"aar" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/bot/cleanbot/medical{
+	on = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
+"aas" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail";
+	real_name = "Wags-His-Tail"
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "aat" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -56,10 +208,58 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aav" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/small,
+/mob/living/carbon/monkey{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/medical/genetics)
 "aaw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"aax" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 5
+	},
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"aay" = (
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 10
+	},
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"aaz" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/ce,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"aaA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/mob/living/simple_animal/cockroach{
+	desc = "Virtually unkillable.";
+	name = "Becquerel";
+	sentience_type = 5;
+	status_flags = 16
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "aaH" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -466,7 +666,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "acJ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -556,16 +756,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"adh" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/Tom,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "adi" = (
 /obj/structure/closet/toolcloset,
 /obj/item/toy/figure/assistant,
@@ -2140,12 +2330,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "anE" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "anM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2262,7 +2452,7 @@
 /area/maintenance/port/fore)
 "aol" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aoq" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -2428,7 +2618,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aqc" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/rainbow{
@@ -2802,7 +2992,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "asU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -3217,7 +3407,7 @@
 /area/maintenance/fore)
 "avy" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "avC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -3504,7 +3694,7 @@
 	level = 2
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "axL" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -4092,7 +4282,7 @@
 	name = "Tank Monitor"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4291,7 +4481,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aCX" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -6179,7 +6369,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aMH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "permacell1";
@@ -6212,7 +6402,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North"
@@ -6372,7 +6562,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aNN" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -7303,7 +7493,7 @@
 /area/maintenance/aft)
 "aSJ" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -7459,7 +7649,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aTB" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -7511,7 +7701,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aTP" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -8199,7 +8389,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aYF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -8397,7 +8587,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bal" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -8410,7 +8600,7 @@
 "bao" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bay" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -9070,7 +9260,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "beH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/corner{
@@ -9483,7 +9673,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bhn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9611,7 +9801,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bik" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool{
@@ -10181,7 +10371,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "bnE" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -10511,7 +10701,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bqD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -11041,7 +11231,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "buZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11088,7 +11278,7 @@
 "bvA" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bvB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11248,7 +11438,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -11351,7 +11541,7 @@
 "bxI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bxJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -11518,7 +11708,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11613,15 +11803,15 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "bzK" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bzL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11702,7 +11892,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bAs" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1
@@ -11715,7 +11905,7 @@
 "bAx" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bAy" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -11911,7 +12101,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bBo" = (
 /obj/structure/table,
 /obj/structure/mirror{
@@ -11948,7 +12138,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bBx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11966,7 +12156,7 @@
 /area/hallway/primary/central)
 "bBC" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bBE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12146,6 +12336,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bCv" = (
@@ -12179,7 +12370,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bCR" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12279,7 +12470,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "bDG" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -12323,7 +12514,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bEh" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -12466,7 +12657,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bFY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
@@ -12505,7 +12696,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bGi" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -12543,18 +12734,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"bGO" = (
-/mob/living/simple_animal/cockroach{
-	desc = "Virtually unkillable.";
-	name = "Becquerel";
-	sentience_type = 5;
-	status_flags = 16
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "bGP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -12586,7 +12765,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bHd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12616,7 +12795,7 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bHk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12786,7 +12965,6 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJq" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -12794,8 +12972,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bJv" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12808,12 +12987,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bJy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bJA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -12869,7 +13048,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bKB" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/electricshock{
@@ -12912,7 +13091,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bKQ" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
@@ -12924,7 +13103,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bKS" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -12959,7 +13138,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bLe" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -13041,15 +13220,21 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 4;
+	name = "Atmospherics Distribution APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bLG" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -13060,14 +13245,20 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bLK" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "bLM" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "bLO" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -13099,8 +13290,11 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bLX" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -13110,7 +13304,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bLZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -13127,7 +13321,6 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bMf" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -13135,8 +13328,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bMj" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -13147,7 +13341,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bMk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -13205,7 +13399,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bNd" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -13308,7 +13502,7 @@
 /area/storage/primary)
 "bOd" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bOi" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -13324,7 +13518,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -13469,7 +13663,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bPo" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -13536,14 +13730,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bPH" = (
-/obj/structure/lattice,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "atmos blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "bPN" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -13769,7 +13963,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/atmos/foyer)
 "bRQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13816,7 +14010,7 @@
 /obj/effect/turf_decal/trimline/white,
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -13911,12 +14105,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bTC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
-	dir = 1;
-	name = "toxins space injector"
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/science/mixing)
+/area/space/nearstation)
 "bTD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -14009,8 +14203,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bVC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -14082,7 +14279,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "bWC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -14179,7 +14376,7 @@
 "bXJ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bXP" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -14195,7 +14392,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "bYj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -14468,7 +14665,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "caY" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -14688,7 +14885,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cek" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14720,7 +14917,7 @@
 /area/crew_quarters/cryopods)
 "cet" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ceA" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
@@ -15032,7 +15229,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cif" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -15151,6 +15348,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjQ" = (
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "cjX" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -15330,7 +15530,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "clD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -15546,7 +15746,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cnC" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -15609,24 +15809,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cow" = (
-/obj/structure/bed/dogbed{
-	desc = "Jacob's bed! Looks comfy";
-	name = "Jacob's bed"
-	},
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "Much better at protecting the armory than your average warden.";
-	name = "Warden Jacob";
-	real_name = "Warden Jacob"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "coz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -15648,7 +15830,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "coR" = (
 /obj/machinery/light{
 	dir = 1
@@ -15809,10 +15991,6 @@
 "crp" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
-"crt" = (
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "cru" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -16069,7 +16247,7 @@
 /area/medical/storage)
 "ctR" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cum" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16513,7 +16691,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cAY" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel{
@@ -16556,15 +16734,15 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cBI" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "cBK" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16608,7 +16786,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cCd" = (
 /turf/open/floor/plasteel,
 /area/construction)
@@ -16630,7 +16808,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cCl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/atmos_sim{
@@ -16667,7 +16845,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cCG" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -16716,7 +16894,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "cDS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -16849,7 +17027,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cGH" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -17034,7 +17212,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cJy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -17178,7 +17356,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cLS" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/bounty_board{
@@ -17242,7 +17420,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/atmos/foyer)
 "cME" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -17268,7 +17446,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cMR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17292,7 +17470,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cNd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -17316,7 +17494,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cNI" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -17380,7 +17558,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cOj" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
@@ -17388,7 +17566,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cOw" = (
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
@@ -17409,7 +17587,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cOE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17437,7 +17615,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cOQ" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -17599,7 +17777,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cRY" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
@@ -17711,7 +17889,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cTK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -17759,7 +17937,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cUm" = (
 /obj/structure/sign/departments/minsky/security/security,
 /turf/closed/wall,
@@ -17822,13 +18000,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
 "cVC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 8;
-	on = 1;
-	volume_rate = 200
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos_distro)
+/turf/open/space/basic,
+/area/space/nearstation)
 "cVZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -17860,8 +18037,11 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "cWT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -17906,7 +18086,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cYj" = (
 /obj/structure/lattice,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -17924,7 +18104,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -18333,7 +18513,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dls" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -18384,7 +18564,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "dlZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -18540,7 +18720,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "doZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -18550,6 +18730,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dpF" = (
@@ -18990,7 +19171,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dzP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -19080,6 +19261,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"dBe" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "dBg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19389,6 +19579,18 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
+"dHL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dHZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -19408,7 +19610,7 @@
 /obj/machinery/light,
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "dIf" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
@@ -19495,7 +19697,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "dJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposaloutlet{
@@ -19622,7 +19824,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dMQ" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -19637,7 +19839,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/red,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "dNo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -19835,6 +20037,15 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dQH" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/foyer)
 "dQI" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore{
@@ -20340,7 +20551,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "edl" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -20513,7 +20724,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "egd" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway East";
@@ -20657,7 +20868,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eil" = (
 /obj/machinery/paystand/register{
 	dir = 1
@@ -20676,8 +20887,10 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "eiw" = (
-/obj/item/stack/cable_coil/red,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "eiN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20903,6 +21116,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"emJ" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
+/area/engine/atmos/mix)
 "enf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -21146,7 +21363,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "esT" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -21172,7 +21389,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "etJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -21266,7 +21483,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "euJ" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only,
@@ -21489,7 +21706,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eyp" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -21554,16 +21771,16 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eAN" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "eAP" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos_distro";
+	areastring = "/area/engine/atmos/mix";
 	dir = 8;
-	name = "Atmospherics Distribution APC";
+	name = "Atmospherics Mixing Room APC";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -21581,7 +21798,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eAQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -21727,10 +21944,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "eDN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "eDW" = (
 /obj/machinery/airalarm{
@@ -21756,8 +21973,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "eEd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21808,7 +22028,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eEB" = (
 /obj/machinery/camera{
 	c_tag = "Service Hall Exterior";
@@ -21926,7 +22146,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eGj" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -21988,7 +22208,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eGN" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -22523,6 +22743,14 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"eSk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "eSM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -22776,7 +23004,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eXA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22850,7 +23078,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eYB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -22990,8 +23218,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fbZ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -23003,10 +23234,10 @@
 /turf/open/floor/plating,
 /area/construction)
 "fca" = (
-/obj/machinery/light/broken{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "fcB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -23014,7 +23245,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fde" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -23131,6 +23362,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"feM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "feV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -23215,10 +23452,8 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "fgV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/arrows/white,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "fhN" = (
 /obj/docking_port/stationary/random{
@@ -23334,7 +23569,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "fjN" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
@@ -23464,7 +23699,7 @@
 "fme" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fmo" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -23669,8 +23904,12 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "frg" = (
-/obj/item/stack/sheet/metal/five,
-/turf/open/floor/engine,
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "frB" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -23803,7 +24042,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ftB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -23940,6 +24179,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"fwa" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -24119,7 +24365,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fAa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24207,7 +24453,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "fCb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -24486,7 +24732,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fGX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/sleeper";
@@ -24632,7 +24878,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fJb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -24803,7 +25049,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fKY" = (
 /obj/machinery/light{
 	dir = 4;
@@ -25203,7 +25449,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fUW" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/machinery/power/apc{
@@ -25469,7 +25715,7 @@
 "gaB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gaH" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25984,7 +26230,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gnD" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -26023,7 +26269,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "goW" = (
 /obj/machinery/light{
 	dir = 4
@@ -26038,10 +26284,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "goZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "gpb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26309,7 +26553,7 @@
 "gtZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gus" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -26675,7 +26919,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gBO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
@@ -26723,8 +26967,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "gDG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26893,7 +27140,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gHO" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
@@ -26914,10 +27161,10 @@
 /area/hallway/secondary/entry)
 "gIq" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos";
+	areastring = "/area/engine/atmos/foyer";
 	dir = 1;
-	name = "Atmospherics Wing APC";
-	pixel_y = 23
+	name = "Atmospherics Foyer APC";
+	pixel_y = 25
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -26929,7 +27176,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "gIv" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
@@ -27109,8 +27356,11 @@
 /area/security/prison)
 "gOU" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "gPb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses{
@@ -27196,17 +27446,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gQo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos/distro)
 "gQB" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/orange{
@@ -27370,7 +27611,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "gTa" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/photocopier,
@@ -27704,7 +27945,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "gZD" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
@@ -27827,7 +28068,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "hbe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28088,7 +28329,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hgu" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice,
@@ -28230,6 +28471,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hiw" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "hiE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -28322,7 +28567,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hjC" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -28475,7 +28720,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hlY" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -28499,7 +28744,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hmj" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -28921,7 +29166,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -28956,18 +29201,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"huH" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/event_spawn,
-/mob/living/simple_animal/crab/kreb{
-	desc = "Here to lay down the hard claws of the law!";
-	health = 50;
-	name = "Officer Kreb";
-	real_name = "Officer Kreb"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "huO" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine{
@@ -29119,15 +29352,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hyV" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "hzm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29187,8 +29420,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "hAO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29324,7 +29560,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hCn" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -29599,7 +29835,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hIO" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -29621,7 +29857,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hJu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -29782,6 +30018,12 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/starboard/aft)
+"hNw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "hNI" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29924,7 +30166,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hPx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -30023,7 +30265,7 @@
 	},
 /obj/effect/turf_decal/trimline/red,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hQy" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -30095,7 +30337,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hRy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -30377,8 +30619,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hWw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -30402,7 +30647,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hXu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -30518,6 +30763,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iak" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "ias" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30560,7 +30812,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ibi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -30804,7 +31056,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ifh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -30814,7 +31066,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ifk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -31003,7 +31255,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ikV" = (
 /obj/machinery/ai/server_cabinet/prefilled,
 /turf/open/floor/circuit/green/telecomms,
@@ -31312,7 +31564,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ipy" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -31419,7 +31671,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iqX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -31488,7 +31740,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "irQ" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -31569,7 +31821,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "itu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -31614,7 +31866,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ivp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -31831,7 +32083,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iAF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -31866,6 +32118,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iBI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Tinker"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "iCk" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -31906,7 +32165,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "iDj" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
@@ -31968,7 +32227,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iEc" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -32099,9 +32358,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "iGK" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_x = -15
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "iHi" = (
 /obj/machinery/light_switch{
@@ -32261,7 +32522,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iJY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32314,7 +32575,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iKq" = (
 /turf/template_noop,
 /area/maintenance/starboard/aft)
@@ -32346,7 +32607,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iLO" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -32484,7 +32745,7 @@
 	pixel_x = 23
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iNt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -32650,13 +32911,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iRt" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "iRA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -32779,7 +33040,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
+"iTT" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos/foyer)
 "iUb" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -32834,8 +33099,11 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/rods/ten,
 /obj/item/toy/figure/atmos,
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "iVs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -32951,7 +33219,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iXv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -32984,7 +33252,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "iZh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33165,11 +33433,11 @@
 /area/medical/virology)
 "jcf" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/maintenance/disposal/incinerator)
+/area/space/nearstation)
 "jcq" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -33262,7 +33530,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jeO" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -33340,7 +33608,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jhc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -33385,7 +33653,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jhV" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -33415,13 +33683,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jjC" = (
-/obj/machinery/light/built{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "jjR" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins,
@@ -33526,7 +33794,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jlI" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
@@ -33762,7 +34030,7 @@
 /obj/item/multitool,
 /obj/item/electronics/firelock,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "jqk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -34002,7 +34270,7 @@
 	dir = 9
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "juN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -34087,8 +34355,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jxk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34129,10 +34400,11 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "jzg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/arrows/white{
+	color = "#00AAFF";
+	pixel_y = 15
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "jzm" = (
 /obj/structure/cable/yellow{
@@ -34168,7 +34440,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jAv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34301,7 +34573,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jDM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -34320,7 +34592,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jDY" = (
 /obj/structure/displaycase/cmo,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -34626,19 +34898,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"jKn" = (
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
 "jKG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -34704,7 +34963,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jLW" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -35281,8 +35540,14 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 9
 	},
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jZi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
@@ -35300,15 +35565,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"jZC" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/toy/figure/ce,
-/mob/living/simple_animal/parrot/Poly,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "kad" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35512,7 +35768,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kgG" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/janitor,
@@ -35643,7 +35899,7 @@
 "kim" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kiq" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -35775,7 +36031,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kjQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/aft";
@@ -36187,7 +36443,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kvG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -36610,7 +36866,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kDz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36711,7 +36967,7 @@
 "kEN" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37042,7 +37298,7 @@
 /area/bridge)
 "kNz" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kNE" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -37103,6 +37359,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"kOp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "kOq" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -37189,7 +37451,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kQg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -37236,14 +37498,8 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "kRa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "kRb" = (
 /obj/machinery/flasher{
@@ -37353,7 +37609,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kTp" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -37384,7 +37640,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kTR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37478,7 +37734,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kWL" = (
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
@@ -38377,7 +38633,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lnv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38555,7 +38811,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lrt" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -38662,13 +38918,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ltj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/disposal/incinerator)
+/turf/open/space/basic,
+/area/space)
 "ltp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
@@ -38693,7 +38947,7 @@
 /obj/machinery/electrolyzer,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ltQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -39171,7 +39425,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lFZ" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 8
@@ -39237,6 +39491,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lIC" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "lIL" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -39294,7 +39552,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lKH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera{
@@ -39393,8 +39651,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lMg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39553,7 +39814,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lOS" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -39591,6 +39852,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"lQl" = (
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "lQm" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -39700,7 +39969,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lSB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/closet/emcloset,
@@ -39880,7 +40149,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lXT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -40019,7 +40288,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lZn" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -40199,7 +40468,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mdj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40282,7 +40551,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "meA" = (
 /obj/machinery/flasher{
 	id = "briginfirmary";
@@ -40650,7 +40919,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mkZ" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -41033,7 +41302,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "msz" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
@@ -41089,12 +41358,10 @@
 /turf/open/floor/carpet/purple,
 /area/hallway/secondary/exit)
 "mtm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "mtD" = (
 /obj/machinery/door/airlock/maintenance{
@@ -41309,8 +41576,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "mxv" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "mxL" = (
 /obj/docking_port/stationary{
@@ -41413,7 +41680,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mzr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -41560,7 +41827,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mAV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -41601,7 +41868,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mBu" = (
 /obj/structure/sign/departments/minsky/supply/janitorial{
 	pixel_y = -32
@@ -41768,7 +42035,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mDN" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -41803,7 +42070,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mEI" = (
 /obj/structure/rack,
 /obj/item/pickaxe{
@@ -41956,7 +42223,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mIB" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -42085,8 +42352,11 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mMn" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -42138,7 +42408,7 @@
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "mNn" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -42483,6 +42753,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mVw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mVF" = (
 /obj/machinery/camera{
 	c_tag = "Research and Development";
@@ -42685,7 +42961,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nam" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -42835,7 +43111,7 @@
 "ncf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nck" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -43066,7 +43342,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ngy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -43185,9 +43461,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "nka" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable/yellow,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "nkd" = (
 /obj/structure/cable{
@@ -43228,7 +43506,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "nkL" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nkZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -43386,7 +43664,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "noF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -43545,7 +43823,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nsc" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/cable/yellow{
@@ -43939,15 +44217,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"nBg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "nBp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/storage)
 "nBq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44046,7 +44324,7 @@
 "nDb" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nDj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -44249,7 +44527,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nHR" = (
 /obj/machinery/light{
 	dir = 8
@@ -44361,13 +44639,13 @@
 "nJW" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nKh" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
@@ -44481,7 +44759,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nNR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -44675,7 +44953,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nSQ" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -44708,17 +44986,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"nTv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/mob/living/carbon/monkey,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nTF" = (
 /obj/machinery/shower{
 	dir = 8
@@ -44743,7 +45010,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nUh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -44841,7 +45108,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nVq" = (
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -44869,6 +45136,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"nWn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "nWs" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -44902,15 +45179,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "nWB" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "nWH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -45042,7 +45319,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "oaG" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -45172,7 +45449,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oeb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45636,7 +45913,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oos" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer2{
 	dir = 8
@@ -45726,7 +46003,7 @@
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "orC" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -45787,7 +46064,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ota" = (
 /obj/structure/toilet{
 	dir = 1
@@ -46000,7 +46277,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ovG" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46008,8 +46284,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "ovY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46076,7 +46353,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oxg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -46162,12 +46439,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oyx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46273,8 +46550,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ozQ" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -46300,7 +46580,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oAa" = (
 /obj/effect/turf_decal/box/corners,
 /obj/structure/window/reinforced,
@@ -46381,7 +46661,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oBt" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -46533,7 +46813,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oGo" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
@@ -46764,7 +47044,7 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oLE" = (
 /obj/machinery/meter,
 /obj/machinery/button/door{
@@ -47065,17 +47345,23 @@
 /turf/open/floor/plating,
 /area/bridge)
 "oSN" = (
-/obj/item/radio/intercom{
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/storage";
+	dir = 4;
+	name = "Atmospherics Storage APC";
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "oSP" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -47203,15 +47489,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"oVL" = (
-/mob/living/simple_animal/moonrat{
-	name = "Joe"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "oVO" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -47263,7 +47540,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oXp" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -47434,7 +47711,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pat" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -47462,7 +47739,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pck" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47505,7 +47782,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pdx" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -47686,8 +47963,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "phL" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office/dark{
@@ -47799,8 +48079,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "piz" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "piL" = (
 /obj/machinery/door/firedoor/border_only,
@@ -48020,7 +48300,17 @@
 "pnh" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
+"pnp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pny" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -48146,6 +48436,12 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"pqo" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "pqr" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -48216,7 +48512,14 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
+"prq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "prw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -48749,7 +49052,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pAl" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel,
@@ -48959,7 +49262,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pEm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49026,10 +49329,11 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "pFA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8;
+	name = "Output to Space"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "pFB" = (
 /obj/docking_port/stationary/random{
@@ -49134,10 +49438,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pIA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "pIL" = (
 /obj/structure/window/reinforced{
@@ -49212,14 +49514,14 @@
 "pLs" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pLQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pMs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49264,7 +49566,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -49320,6 +49622,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"pPt" = (
+/obj/structure/grille,
+/obj/machinery/meter{
+	layer = 3.4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "pPI" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
@@ -49329,7 +49641,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pPW" = (
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "pPX" = (
 /obj/structure/lattice/catwalk,
@@ -49481,7 +49793,7 @@
 /obj/item/pipe_dispenser,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pSe" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor/border_only{
@@ -49721,7 +50033,7 @@
 "pXS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pXV" = (
 /obj/machinery/light{
 	dir = 1
@@ -49813,12 +50125,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pZl" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pZF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -49849,6 +50161,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "qai" = (
@@ -49874,7 +50189,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qaO" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -50449,7 +50764,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "qmr" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -50702,7 +51017,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qsH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -50718,6 +51033,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qsI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qtd" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -50784,7 +51104,6 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "qut" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -50792,8 +51111,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "quG" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
@@ -50850,7 +51170,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "qvj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50912,7 +51232,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qxl" = (
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
@@ -51722,7 +52042,7 @@
 "qMD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qMH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -51735,8 +52055,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qNt" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad"
@@ -51943,6 +52266,9 @@
 "qQF" = (
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -52155,7 +52481,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qVe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52256,18 +52582,24 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qXS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/rglass{
+	amount = 5
 	},
-/obj/item/stack/sheet/metal/five,
-/turf/open/floor/engine,
+/obj/item/stack/sheet/plasteel{
+	amount = 5
+	},
+/obj/item/pipe_dispenser,
+/obj/item/wrench,
+/obj/item/multitool,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "qYw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/white,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "qYx" = (
 /obj/machinery/camera{
 	c_tag = "Virology Monkey Pen";
@@ -52332,7 +52664,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ray" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -52361,7 +52693,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rbD" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 8
@@ -52559,7 +52891,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rgx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52568,7 +52900,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rgM" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -52631,8 +52963,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rip" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/camera{
@@ -52912,13 +53247,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"rnx" = (
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "rnO" = (
 /obj/item/seeds/potato,
 /obj/machinery/hydroponics/soil,
@@ -52989,7 +53317,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "roZ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -53034,7 +53362,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rqF" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -53237,7 +53565,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rwm" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
@@ -53308,7 +53636,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rxM" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -53335,6 +53663,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/library)
+"ryJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rzx" = (
 /obj/machinery/light{
 	dir = 1
@@ -53436,7 +53770,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rBz" = (
 /obj/item/radio/intercom{
 	pixel_y = -27
@@ -53488,7 +53822,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rCG" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/aft)
@@ -53502,11 +53836,11 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rCT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rDa" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -53560,22 +53894,15 @@
 /turf/open/floor/wood,
 /area/library)
 "rEA" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/engine/atmos_distro)
-"rER" = (
-/mob/living/simple_animal/pet/fox/fennec/Autumn,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/space/nearstation)
 "rFc" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53693,7 +54020,7 @@
 /area/teleporter)
 "rHf" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rHh" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -53811,7 +54138,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rIL" = (
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/chair/office/dark,
@@ -53910,7 +54237,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rJJ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -53924,19 +54251,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"rJX" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -53996,7 +54310,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rLC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -54008,7 +54322,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "rLG" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -54016,8 +54329,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "rLL" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
@@ -54086,6 +54400,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rOf" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal/incinerator)
 "rOh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -54130,8 +54450,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rPa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -54140,7 +54463,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rPd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -54311,11 +54634,15 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rSl" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"rST" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/plating,
+/area/engine/atmos/distro)
 "rTb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -54621,7 +54948,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rYz" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -54668,7 +54995,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "rZU" = (
 /obj/machinery/light{
 	dir = 8;
@@ -54827,15 +55154,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"sdv" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/carbon/monkey{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/grass,
-/area/medical/genetics)
 "sdJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -54871,7 +55189,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "sew" = (
 /obj/structure/table/optable{
 	dir = 8
@@ -54897,11 +55215,11 @@
 /area/maintenance/starboard/fore)
 "seW" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/maintenance/disposal/incinerator)
+/area/space/nearstation)
 "seX" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -54924,7 +55242,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sfl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55034,7 +55352,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/atmos/foyer)
 "sgY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -55334,7 +55652,7 @@
 /area/ai_monitored/turret_protected/ai)
 "soo" = (
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "soz" = (
 /obj/structure/table/optable,
 /obj/item/storage/backpack/duffelbag/sec/surgery,
@@ -55460,8 +55778,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ssx" = (
-/turf/open/floor/plating,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "ssK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -55529,7 +55850,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "stz" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -55761,7 +56082,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sAu" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
@@ -55776,7 +56097,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "sAJ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -55989,7 +56310,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sEx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -56117,7 +56438,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sGY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/carbon/monkey{
@@ -56244,7 +56565,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sJk" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/window/reinforced{
@@ -56254,7 +56575,7 @@
 /obj/effect/turf_decal/trimline/green,
 /obj/effect/turf_decal/trimline/neutral,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -56485,7 +56806,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sQs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -56549,7 +56870,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sSb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -56659,7 +56980,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sTG" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -56720,7 +57041,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "sUD" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
@@ -56758,7 +57079,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sVM" = (
 /obj/structure/chair{
 	dir = 4
@@ -56826,6 +57147,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"sWR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "sWS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -56896,7 +57223,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "sXz" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -56912,7 +57239,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sXB" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner,
@@ -56951,6 +57278,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"sXH" = (
+/turf/closed/wall/r_wall,
+/area/engine/atmos/foyer)
 "sXS" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -57082,7 +57412,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sZR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -57152,7 +57482,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "taW" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -57178,7 +57508,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "taZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -57273,30 +57603,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tdw" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tdV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/mob/living/simple_animal/bot/cleanbot/medical{
-	on = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "tdY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -57360,20 +57672,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"tfC" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "tfF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -57381,12 +57679,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tfH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "tge" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -57532,7 +57828,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tin" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -57735,7 +58031,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "tmz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -57882,7 +58178,7 @@
 "tpE" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tpJ" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only,
@@ -57926,7 +58222,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "trn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57980,8 +58276,11 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tsu" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -58056,7 +58355,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "tvb" = (
 /obj/structure/alien/weeds,
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
@@ -58278,7 +58577,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tyC" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -58322,7 +58621,7 @@
 	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tzJ" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -58346,7 +58645,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tAh" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -58482,7 +58781,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tDe" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -58630,7 +58929,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tHk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -58740,7 +59039,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tJW" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -58855,6 +59154,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/core,
+/obj/item/paper/guides/jobs/atmos/hypertorus,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "tMG" = (
@@ -59016,7 +59318,7 @@
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -59133,17 +59435,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"tQs" = (
-/mob/living/simple_animal/spiffles,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/clerk)
 "tQv" = (
 /obj/machinery/light{
 	dir = 4
@@ -59256,6 +59547,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tSS" = (
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tSX" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -59409,7 +59703,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "tVZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -59972,7 +60266,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uhU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -60236,7 +60530,7 @@
 "unK" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uoh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -60271,9 +60565,8 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "upb" = (
-/obj/effect/turf_decal/box,
-/obj/structure/frame/machine,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "upk" = (
 /turf/closed/wall/r_wall,
@@ -60664,7 +60957,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uye" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60686,7 +60979,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uyV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -60705,6 +60998,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uzn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "uzs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -60928,7 +61227,7 @@
 "uDV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uEc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -61173,7 +61472,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -61293,7 +61592,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uLE" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -61489,7 +61788,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uOF" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -61619,7 +61918,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/space,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "uQA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -61838,7 +62137,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uWK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -62016,11 +62315,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "uYk" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "uYr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62255,7 +62552,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vcN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62713,7 +63010,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/atmos/foyer)
 "vnv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -63425,9 +63722,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vCE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -63435,7 +63729,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "vCK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -63697,8 +63991,11 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vHO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -64431,7 +64728,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vUZ" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -64537,24 +64834,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"vXF" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "vYi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -64576,7 +64855,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vYC" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -64739,7 +65018,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wag" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -64840,7 +65119,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wcl" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -64854,7 +65133,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wcD" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -65009,7 +65288,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wga" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -65023,6 +65302,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"whu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "whv" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -65086,7 +65371,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wiV" = (
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
@@ -65120,7 +65405,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wjO" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -65243,7 +65528,7 @@
 "wma" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wmr" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -65335,12 +65620,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"wnV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "wnZ" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -65597,8 +65876,11 @@
 "wtu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wtN" = (
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32;
@@ -65780,7 +66062,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wxs" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
@@ -66036,7 +66318,7 @@
 /area/security/interrogation)
 "wEo" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wEr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66104,6 +66386,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"wFh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wFr" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -66365,7 +66656,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wMj" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -66402,6 +66693,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"wML" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8;
+	name = "Output Gas Connector Port"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "wMP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66445,7 +66743,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wOC" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -66478,7 +66776,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wPt" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -66608,14 +66906,17 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wTe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wTn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -67176,7 +67477,7 @@
 "xgn" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xgu" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -67294,10 +67595,15 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "xiL" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
-/area/maintenance/disposal/incinerator)
+/obj/machinery/meter{
+	layer = 3.4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "xjd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67315,7 +67621,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xjo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -67360,7 +67666,7 @@
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xjK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -67373,7 +67679,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xjV" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -67564,7 +67870,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xpf" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -67628,11 +67934,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "xqu" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -67789,7 +68095,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67810,7 +68116,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xtT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67928,7 +68234,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xwW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -68012,11 +68318,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xxO" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xxQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -68024,7 +68330,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xyb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -68056,7 +68362,7 @@
 /area/medical/medbay/lobby)
 "xyU" = (
 /turf/closed/wall,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "xzh" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -68087,8 +68393,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "xAA" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xAC" = (
@@ -68148,9 +68454,9 @@
 /area/maintenance/aft)
 "xBp" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "xBG" = (
 /obj/structure/rack,
@@ -68189,7 +68495,7 @@
 "xBO" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xBP" = (
 /obj/structure/rack,
 /obj/item/storage/box,
@@ -68200,7 +68506,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "xBU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -68417,6 +68723,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"xHK" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xIf" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -68643,7 +68953,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xOv" = (
 /obj/machinery/light{
 	dir = 4
@@ -68737,8 +69047,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xQR" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -68961,7 +69274,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xUp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69581,7 +69894,7 @@
 /obj/item/analyzer,
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "ygg" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/warning/nosmoking{
@@ -69657,7 +69970,7 @@
 /obj/item/flashlight,
 /obj/item/assembly/igniter,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/storage)
 "yhr" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -69848,28 +70161,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"yjC" = (
-/obj/structure/bed/dogbed/ian,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/item/toy/figure/hop{
-	layer = 2.89;
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "yjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -84714,7 +85005,7 @@ vZz
 aBI
 iqm
 pAL
-huH
+aal
 cfI
 sJV
 hmO
@@ -84967,9 +85258,9 @@ lFj
 lFj
 lFj
 alU
-vZz
+nWn
 aBI
-vXF
+aak
 pAL
 lBX
 aHu
@@ -87024,7 +87315,7 @@ alU
 amC
 azF
 pYO
-oVL
+aah
 kAz
 kAz
 fLl
@@ -92447,7 +92738,7 @@ gjl
 gjl
 bhW
 sES
-rER
+aan
 ivQ
 yhe
 gzl
@@ -95210,7 +95501,7 @@ eKy
 adp
 adp
 wcS
-adh
+aab
 eNX
 eNX
 eNX
@@ -96346,7 +96637,7 @@ bCq
 uzc
 ccw
 ppM
-crt
+efb
 soW
 cmD
 cmD
@@ -96603,8 +96894,8 @@ bCq
 uzc
 ccw
 ppM
-efb
-rJX
+wil
+bQa
 cmD
 cmD
 cfe
@@ -96861,7 +97152,7 @@ uzc
 ccw
 lTT
 wil
-bQa
+wil
 cfe
 cfe
 cfe
@@ -97589,7 +97880,7 @@ mqz
 bjA
 xul
 dEb
-yjC
+aap
 boZ
 nfX
 iHr
@@ -99077,7 +99368,7 @@ aeq
 aiB
 eCy
 aqd
-cow
+aad
 xit
 xng
 ewO
@@ -100435,13 +100726,13 @@ nDu
 bCv
 mdG
 bzs
-bLK
-bLK
+sXH
+sXH
 taW
 byS
 oaA
 rZO
-bLK
+sXH
 iYj
 qmg
 nNC
@@ -100687,12 +100978,12 @@ qyo
 bCv
 ehG
 veb
-tfC
+aas
 tmB
 bCv
 eEO
 rkM
-bLK
+sXH
 mzo
 cej
 cMO
@@ -100702,7 +100993,7 @@ rLz
 fBT
 chM
 gSW
-bLK
+sXH
 utd
 aXz
 aiv
@@ -100949,9 +101240,9 @@ vUs
 bCv
 eEO
 vYi
-bLK
+sXH
 jZf
-iCQ
+dQH
 sEr
 acF
 bOd
@@ -100969,7 +101260,7 @@ aiv
 lRK
 imH
 vhL
-jZC
+aaz
 lMD
 oqf
 wMq
@@ -101206,7 +101497,7 @@ sCi
 bCv
 eEO
 bAw
-bLK
+sXH
 tmy
 bOd
 wRZ
@@ -101463,9 +101754,9 @@ qCG
 bCv
 yey
 bAw
-bLK
+sXH
 hjA
-bOd
+iTT
 kDr
 caT
 bSC
@@ -101720,7 +102011,7 @@ weY
 vZn
 moC
 wUc
-bLK
+sXH
 gIq
 vYt
 jxg
@@ -101977,7 +102268,7 @@ uEm
 bCv
 wTn
 wUw
-bLK
+sXH
 hIN
 uDV
 wTe
@@ -102234,7 +102525,7 @@ bCv
 bCv
 eEO
 wUw
-bLK
+sXH
 rIA
 eie
 lMa
@@ -102490,16 +102781,16 @@ bAw
 bHX
 xgI
 eEO
-bLK
-bLK
+nBp
+nBp
 uIH
 uIH
 bLT
 cYB
-bLK
-bLK
-bLK
-bLK
+sXH
+sXH
+sXH
+sXH
 bWQ
 bWQ
 bWQ
@@ -102747,14 +103038,14 @@ bAw
 bAw
 vzs
 liS
-bLK
+nBp
 xsA
 dlN
 iCQ
 cWJ
 nHM
 aBE
-bLK
+nBp
 bvA
 bvA
 bvA
@@ -103004,14 +103295,14 @@ hUr
 hUr
 sYd
 tpg
-bLK
+nBp
 xwU
 bDF
-bOd
+tSS
 fbJ
 fjz
 trj
-bLK
+nBp
 bvA
 rHf
 mkP
@@ -103019,19 +103310,19 @@ rHf
 bvA
 avy
 gXs
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
 gXs
 aaa
 sjo
@@ -103261,14 +103552,14 @@ bAw
 bHX
 vZH
 liS
-bLK
+nBp
 xxO
 bDF
 yfZ
 eEc
 fjz
 tut
-bLK
+nBp
 bvA
 rHf
 rHf
@@ -103276,19 +103567,19 @@ rHf
 bvA
 avy
 aaa
-bvA
+uYk
 aol
 aol
 aol
-bvA
+uYk
 ctR
 ctR
 ctR
-bvA
+uYk
 cet
 cet
 cet
-bvA
+uYk
 aaa
 aaa
 sjo
@@ -103518,14 +103809,14 @@ bAw
 iAN
 wag
 eMZ
-bLK
+nBp
 xyU
 qve
 yhk
 hAJ
 fjz
 xyU
-bLK
+nBp
 bvA
 lKf
 fme
@@ -103533,19 +103824,19 @@ etv
 bvA
 avy
 gXs
-bvA
+uYk
 aol
 anE
 aol
-bvA
+uYk
 ctR
 fzJ
 ctR
-bvA
+uYk
 cet
 aqb
 cet
-bvA
+uYk
 aaa
 aaa
 jlM
@@ -103775,14 +104066,14 @@ bAw
 bHX
 bAw
 liS
-bLK
+nBp
 bLM
 bDF
 jpZ
 hAJ
 fjz
 mNg
-bLK
+nBp
 bvA
 mDE
 nDb
@@ -103790,19 +104081,19 @@ nrq
 bvA
 avy
 aaa
-bvA
+uYk
 xOa
 cAT
 iJO
-bvA
+uYk
 oxe
 mBi
 dkS
-bvA
+uYk
 sTw
 lSz
 beC
-bvA
+uYk
 aaa
 aaa
 jlM
@@ -104032,14 +104323,14 @@ dze
 bHX
 bAw
 liS
-bLK
+nBp
 esK
 bDF
 gOU
 gDD
 fjz
 dId
-bLK
+nBp
 avy
 bzK
 bBw
@@ -104047,19 +104338,19 @@ nWB
 avy
 avy
 gXs
-bvA
-mDE
-nDb
-nrq
-bvA
-mDE
-nDb
+uYk
+xiL
+rST
+pPt
+uYk
+xiL
+rST
 dML
-bvA
-mDE
+uYk
+xiL
 coC
 cnq
-bvA
+uYk
 gXs
 aaa
 jlM
@@ -104243,7 +104534,7 @@ lpv
 nHm
 ayG
 sko
-tQs
+aaj
 fnk
 ayG
 wva
@@ -104289,14 +104580,14 @@ rZt
 bzs
 bzs
 liS
-bLK
+nBp
 nJW
 haI
 oSN
 xjE
 bnD
 iVn
-bLK
+nBp
 avy
 xUn
 ijY
@@ -104560,7 +104851,7 @@ bBC
 iDY
 pZg
 tyA
-avy
+cjQ
 lOu
 rYt
 bKJ
@@ -104573,9 +104864,9 @@ gaB
 pdq
 bJv
 iKp
-avy
-avy
-avy
+cjQ
+cjQ
+cjQ
 aaa
 aaa
 aaa
@@ -105068,7 +105359,7 @@ ngq
 ngq
 rCQ
 kim
-kgs
+ssx
 uWH
 wfZ
 wiS
@@ -105077,18 +105368,18 @@ jlB
 jut
 rwb
 eYt
-aSJ
+gQo
 lrl
-wma
+xHK
 sRm
-aSJ
-aSJ
-aSJ
+gQo
+gQo
+gQo
 xji
-aSJ
+gQo
 ezB
 kgs
-aSJ
+gQo
 wxr
 gXs
 gXs
@@ -105333,21 +105624,21 @@ ncf
 uyr
 oyj
 ifh
-kim
-aSJ
+lIC
+gQo
 pal
-wma
+xHK
 gnb
-wma
-wma
-wma
+xHK
+xHK
+xHK
 sRm
-aSJ
+gQo
 cUi
 xjN
-avy
-avy
-avy
+cjQ
+cjQ
+cjQ
 xBO
 tiH
 pEf
@@ -105591,15 +105882,15 @@ hWv
 tss
 vHH
 rig
-wtu
-cCi
-wtu
+eSk
+pnp
+wFh
 cLM
-wtu
+qsI
 cCi
-wtu
+qsI
 iew
-wtu
+qsI
 iLK
 qaz
 stn
@@ -105832,25 +106123,25 @@ rqd
 jdO
 liS
 wXV
-xBO
+emJ
 wcf
 aSJ
 aTO
 aYy
 baj
 qwX
-pLs
+hiw
 unK
 nSI
 qsy
-pLs
+hiw
 sdX
 onT
 sQq
 rCT
 pLs
 fcB
-pLs
+fwa
 bOo
 bhl
 fcB
@@ -105859,11 +106150,11 @@ rCT
 qVb
 bYa
 sGW
-avy
-avy
-avy
-avy
-avy
+cjQ
+cjQ
+cjQ
+cjQ
+cjQ
 kEN
 pEf
 pEf
@@ -106104,16 +106395,16 @@ bao
 oGn
 rSe
 oWJ
-uWH
-aSJ
+ryJ
+gQo
 kPL
-aSJ
-uWH
-aSJ
+sWR
+ryJ
+gQo
 kPL
-aSJ
-uWH
-aSJ
+gQo
+ryJ
+gQo
 cUi
 tax
 kjM
@@ -106616,7 +106907,7 @@ hIX
 uLo
 pri
 bHa
-avy
+cjQ
 kvn
 oyd
 eye
@@ -106629,9 +106920,9 @@ gaB
 oyd
 kTM
 fKX
-avy
-avy
-avy
+cjQ
+cjQ
+cjQ
 cOL
 aCV
 uOs
@@ -106869,7 +107160,7 @@ iuY
 aSJ
 fIS
 aSJ
-kPL
+nBg
 hlN
 avy
 bHa
@@ -107122,7 +107413,7 @@ xCv
 aHM
 avy
 ltM
-rwb
+dBe
 buY
 bxI
 bAx
@@ -107131,19 +107422,19 @@ eFW
 bFX
 bHa
 aaf
-bvA
-mDE
-nDb
+uYk
+xiL
+rST
 dML
-bvA
-mDE
-nDb
+uYk
+xiL
+rST
 dML
-bvA
-mDE
+uYk
+xiL
 eEv
 jgK
-bvA
+uYk
 aaf
 pXS
 sZP
@@ -107388,19 +107679,19 @@ rqi
 bFX
 bHa
 aoV
-bvA
+uYk
 jec
 cNy
 tzN
-bvA
+uYk
 rbs
 cCF
 hfW
-bvA
+uYk
 sAs
 gHM
 mZO
-bvA
+uYk
 aaa
 cmd
 cmd
@@ -107410,8 +107701,8 @@ cmd
 cmd
 cDS
 cmd
-aaa
-aaa
+cmd
+cmd
 aaa
 aaa
 aaa
@@ -107636,7 +107927,7 @@ bAw
 hbO
 avy
 pZl
-rwb
+dBe
 buY
 rCr
 bBn
@@ -107645,19 +107936,19 @@ lZm
 bFX
 bHa
 aaf
-bvA
+uYk
 wEo
 wLC
 wEo
-bvA
+uYk
 nkL
 eWN
 nkL
-bvA
+uYk
 kNz
 gon
 kNz
-bvA
+uYk
 aaf
 cmd
 edX
@@ -107665,11 +107956,11 @@ fKW
 ctE
 aHd
 qQF
-mtm
-ufD
-aaa
-aaa
-aaa
+pFA
+iak
+fKW
+cmd
+cmd
 aaa
 aaa
 aaa
@@ -107882,7 +108173,7 @@ eFE
 rTb
 xAI
 riv
-tdV
+aar
 mzH
 gBy
 jhe
@@ -107902,33 +108193,33 @@ rxG
 avy
 bHa
 aoV
-bvA
+uYk
 wEo
 wEo
 wEo
-bvA
+uYk
 nkL
 nkL
 nkL
-bvA
+uYk
 kNz
 kNz
 kNz
-bvA
+uYk
 aoV
 cmd
-fKW
+frg
 fKW
 ctE
-iGK
 fKW
-pFA
-ufD
-aaa
-aaa
-aaa
-aaa
-aaa
+fKW
+wML
+fKW
+fKW
+mVw
+cmd
+cmd
+ltj
 aaa
 aaa
 aaa
@@ -108159,32 +108450,32 @@ avy
 avy
 cVC
 aaf
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
-bvA
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
 aaf
 cmd
 tLS
 fKW
 ctE
 fKW
-ssx
-mxv
-cmd
-cmd
-cmd
-cmd
-aaa
+kRa
+fca
+fca
+fca
+tfH
+fKW
+ufD
 aaa
 aaa
 aaa
@@ -108413,8 +108704,8 @@ pYm
 ijr
 vOo
 hEv
-avy
-avy
+xDQ
+xDQ
 aaf
 aaf
 aaf
@@ -108431,17 +108722,17 @@ aaf
 aaf
 aaf
 cmd
-fKW
+lQl
 vsW
 ctE
-fKW
-ssx
-xiL
 kRa
-fca
+hNw
 pPW
+eiw
+pPW
+kOp
+tfH
 ufD
-aaa
 aaa
 aaa
 aaa
@@ -108688,17 +108979,17 @@ wAc
 cmd
 cmd
 cmd
-fKW
+qXS
 mSL
 ctE
-ssx
-qXS
-wnV
-uYk
-eiw
+pIA
 pPW
+piz
+mtm
+upb
+pPW
+whu
 ufD
-aaa
 aaa
 aaa
 aaa
@@ -108948,14 +109239,14 @@ fwi
 dAA
 csz
 xqu
-ssx
-xBp
-pPW
-piz
-pPW
-pPW
+iBI
+fgV
+nka
+goZ
+mxv
+jzg
+whu
 ufD
-aaa
 aaa
 aaa
 aaa
@@ -109176,7 +109467,7 @@ fju
 dSq
 jxu
 qYx
-rnx
+aay
 bNd
 bNd
 bNd
@@ -109204,15 +109495,15 @@ jkh
 kBc
 mFW
 ilQ
-gQo
-ltj
-nBp
-fgV
-nka
+dzz
+pIA
 pPW
+upb
+rOf
+piz
 pPW
+whu
 ufD
-aaa
 aaa
 aaa
 aaa
@@ -109432,7 +109723,7 @@ eNx
 smo
 tEx
 jxu
-nTv
+aax
 cpO
 qbG
 uOh
@@ -109462,14 +109753,14 @@ cmd
 fKW
 svh
 dzz
-fKW
+eDN
 xBp
 pPW
-upb
+iGK
 pPW
-pPW
+feM
+uzn
 ufD
-aaa
 aaa
 aaa
 bPq
@@ -109719,14 +110010,14 @@ cmd
 hko
 sDi
 dzz
-ssx
+fKW
 eDN
-goZ
 bJy
-pPW
-frg
+bJy
+bJy
+uzn
+fKW
 ufD
-aaa
 aaa
 aaa
 nzG
@@ -109977,13 +110268,13 @@ lic
 bVC
 dfL
 tEp
-jzg
-tfH
+tEp
+tEp
 vCE
 jjC
-pIA
+bLK
+tEp
 sSk
-vUc
 vUc
 vUc
 iwZ
@@ -110240,8 +110531,8 @@ cmd
 cmd
 cmd
 cmd
-aaa
-pEf
+cmd
+prq
 eKu
 hag
 khH
@@ -110748,7 +111039,7 @@ jjR
 hwq
 oHg
 bLf
-bGO
+aaA
 uFy
 ufD
 aaa
@@ -111225,7 +111516,7 @@ sTG
 cNd
 nKh
 nHr
-sdv
+aav
 vGx
 vYi
 ufj
@@ -111772,7 +112063,7 @@ ldW
 ldW
 ldW
 cmd
-fKW
+pqo
 huB
 cmd
 vIf
@@ -118929,7 +119220,7 @@ bvJ
 bxj
 emB
 bwR
-jKn
+aaq
 rss
 bvK
 bEv
@@ -120458,7 +120749,7 @@ bdz
 hPW
 ptr
 bhH
-biY
+dHL
 biY
 biY
 bjS

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2,16 +2,6 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
-"aab" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/mob/living/simple_animal/mouse/brown/Tom,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aac" = (
 /obj/machinery/modular_computer/console/preset/curator{
 	dir = 1
@@ -19,24 +9,6 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/library)
-"aad" = (
-/obj/structure/bed/dogbed{
-	desc = "Jacob's bed! Looks comfy";
-	name = "Jacob's bed"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "Much better at protecting the armory than your average warden.";
-	name = "Warden Jacob";
-	real_name = "Warden Jacob"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -49,15 +21,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"aah" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/mob/living/simple_animal/moonrat{
-	name = "Joe"
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "aai" = (
 /obj/machinery/camera{
 	c_tag = "Prison Common Room South";
@@ -67,47 +30,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/green/opposingcorners{
-	dir = 1
-	},
-/mob/living/simple_animal/spiffles,
-/turf/open/floor/plasteel,
-/area/clerk)
-"aak" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
-"aal" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
-/mob/living/simple_animal/crab/kreb{
-	desc = "Here to lay down the hard claws of the law!";
-	health = 50;
-	name = "Officer Kreb";
-	real_name = "Officer Kreb"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "aam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -121,84 +43,10 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aan" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/mob/living/simple_animal/pet/fox/fennec/Autumn,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aao" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"aap" = (
-/obj/structure/bed/dogbed/ian,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = 32
-	},
-/obj/item/toy/figure/hop{
-	layer = 2.89;
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"aaq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/hor)
-"aar" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/bot/cleanbot/medical{
-	on = 0
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"aas" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/lizard{
-	name = "Wags-His-Tail";
-	real_name = "Wags-His-Tail"
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "aat" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -208,58 +56,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aav" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small,
-/mob/living/carbon/monkey{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/medical/genetics)
 "aaw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"aax" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 5
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"aay" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 10
-	},
-/mob/living/carbon/monkey,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"aaz" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/toy/figure/ce,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"aaA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/mob/living/simple_animal/cockroach{
-	desc = "Virtually unkillable.";
-	name = "Becquerel";
-	sentience_type = 5;
-	status_flags = 16
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "aaH" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -666,7 +466,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "acJ" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -756,6 +556,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"adh" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/brown/Tom,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "adi" = (
 /obj/structure/closet/toolcloset,
 /obj/item/toy/figure/assistant,
@@ -2330,12 +2140,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "anE" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "anM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2452,7 +2262,7 @@
 /area/maintenance/port/fore)
 "aol" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aoq" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -2618,7 +2428,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aqc" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/rainbow{
@@ -2992,7 +2802,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "asU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -3407,7 +3217,7 @@
 /area/maintenance/fore)
 "avy" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "avC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -3694,7 +3504,7 @@
 	level = 2
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "axL" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -4282,7 +4092,7 @@
 	name = "Tank Monitor"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -4481,7 +4291,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aCX" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -6369,7 +6179,7 @@
 	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aMH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "permacell1";
@@ -6402,7 +6212,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North"
@@ -6562,7 +6372,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aNN" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -7493,7 +7303,7 @@
 /area/maintenance/aft)
 "aSJ" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aSM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -7649,7 +7459,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aTB" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -7701,7 +7511,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aTP" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -8389,7 +8199,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aYF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -8587,7 +8397,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bal" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -8600,7 +8410,7 @@
 "bao" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bay" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -9260,7 +9070,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "beH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/corner{
@@ -9673,7 +9483,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bhn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9801,7 +9611,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bik" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool{
@@ -10371,7 +10181,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "bnE" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -10701,7 +10511,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bqD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -11231,7 +11041,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "buZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11278,7 +11088,7 @@
 "bvA" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bvB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11438,7 +11248,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bwY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -11541,7 +11351,7 @@
 "bxI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bxJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -11708,7 +11518,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11803,15 +11613,15 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "bzK" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bzL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11892,7 +11702,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bAs" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 1
@@ -11905,7 +11715,7 @@
 "bAx" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bAy" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -12101,7 +11911,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bBo" = (
 /obj/structure/table,
 /obj/structure/mirror{
@@ -12138,7 +11948,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bBx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -12156,7 +11966,7 @@
 /area/hallway/primary/central)
 "bBC" = (
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bBE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12336,7 +12146,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bCv" = (
@@ -12370,7 +12179,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bCR" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12470,7 +12279,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "bDG" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -12514,7 +12323,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bEh" = (
 /obj/machinery/door/airlock/maintenance{
 	id_tag = "commissarydoor";
@@ -12657,7 +12466,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bFY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "8;12"
@@ -12696,7 +12505,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bGi" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -12734,6 +12543,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"bGO" = (
+/mob/living/simple_animal/cockroach{
+	desc = "Virtually unkillable.";
+	name = "Becquerel";
+	sentience_type = 5;
+	status_flags = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "bGP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -12765,7 +12586,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bHd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12795,7 +12616,7 @@
 	dir = 10
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bHk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12965,6 +12786,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bJq" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -12972,9 +12794,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bJv" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12987,12 +12808,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bJy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "bJA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -13048,7 +12869,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bKB" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/warning/electricshock{
@@ -13091,7 +12912,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bKQ" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
@@ -13103,7 +12924,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bKS" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -13138,7 +12959,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bLe" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -13220,21 +13041,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	pixel_x = 27
+	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 4;
-	name = "Atmospherics Distribution APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bLG" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -13245,20 +13060,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bLK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "bLM" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "bLO" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -13290,11 +13099,8 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bLX" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -13304,7 +13110,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bLZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -13321,6 +13127,7 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bMf" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
@@ -13328,9 +13135,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bMj" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -13341,7 +13147,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bMk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -13399,7 +13205,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bNd" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -13502,7 +13308,7 @@
 /area/storage/primary)
 "bOd" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bOi" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -13518,7 +13324,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -13663,7 +13469,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bPo" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -13730,14 +13536,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bPH" = (
+/obj/structure/lattice,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "atmos blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "bPN" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -13963,7 +13769,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/hallway/primary/aft)
 "bRQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14010,7 +13816,7 @@
 /obj/effect/turf_decal/trimline/white,
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area{
@@ -14105,12 +13911,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bTC" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 1;
+	name = "toxins space injector"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/science/mixing)
 "bTD" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -14203,11 +14009,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bVC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -14279,7 +14082,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "bWC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -14376,7 +14179,7 @@
 "bXJ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bXP" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -14392,7 +14195,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "bYj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -14665,7 +14468,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "caY" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -14885,7 +14688,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cek" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14917,7 +14720,7 @@
 /area/crew_quarters/cryopods)
 "cet" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ceA" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
@@ -15229,7 +15032,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cif" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -15348,9 +15151,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cjQ" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
 "cjX" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -15530,7 +15330,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "clD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -15746,7 +15546,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cnC" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -15809,6 +15609,24 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cow" = (
+/obj/structure/bed/dogbed{
+	desc = "Jacob's bed! Looks comfy";
+	name = "Jacob's bed"
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "Much better at protecting the armory than your average warden.";
+	name = "Warden Jacob";
+	real_name = "Warden Jacob"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "coz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -15830,7 +15648,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "coR" = (
 /obj/machinery/light{
 	dir = 1
@@ -15991,6 +15809,10 @@
 "crp" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
+/area/engine/engineering)
+"crt" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cru" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -16247,7 +16069,7 @@
 /area/medical/storage)
 "ctR" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cum" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16691,7 +16513,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cAY" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/chapel{
@@ -16734,15 +16556,15 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cBI" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "cBK" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16786,7 +16608,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cCd" = (
 /turf/open/floor/plasteel,
 /area/construction)
@@ -16808,7 +16630,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cCl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/atmos_sim{
@@ -16845,7 +16667,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cCG" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -16894,7 +16716,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "cDS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -17027,7 +16849,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cGH" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -17212,7 +17034,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cJy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -17356,7 +17178,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cLS" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/bounty_board{
@@ -17420,7 +17242,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/hallway/primary/aft)
 "cME" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -17446,7 +17268,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cMR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17470,7 +17292,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cNd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -17494,7 +17316,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cNI" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -17558,7 +17380,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cOj" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
@@ -17566,7 +17388,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cOw" = (
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plasteel,
@@ -17587,7 +17409,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cOE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17615,7 +17437,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cOQ" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
@@ -17777,7 +17599,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cRY" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
@@ -17889,7 +17711,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cTK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -17937,7 +17759,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cUm" = (
 /obj/structure/sign/departments/minsky/security/security,
 /turf/closed/wall,
@@ -18000,12 +17822,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
 "cVC" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8;
+	on = 1;
+	volume_rate = 200
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/atmos_distro)
 "cVZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -18037,11 +17860,8 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "cWT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -18086,7 +17906,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cYj" = (
 /obj/structure/lattice,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -18104,7 +17924,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -18513,7 +18333,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dls" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -18564,7 +18384,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "dlZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -18720,7 +18540,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "doZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -18730,7 +18550,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dpF" = (
@@ -19171,7 +18990,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dzP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -19261,15 +19080,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"dBe" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "dBg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19579,18 +19389,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
-"dHL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "dHZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
@@ -19610,7 +19408,7 @@
 /obj/machinery/light,
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "dIf" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
@@ -19697,7 +19495,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "dJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposaloutlet{
@@ -19824,7 +19622,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dMQ" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -19839,7 +19637,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/red,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "dNo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20037,15 +19835,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"dQH" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
 "dQI" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore{
@@ -20551,7 +20340,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "edl" = (
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -20724,7 +20513,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "egd" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway East";
@@ -20868,7 +20657,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eil" = (
 /obj/machinery/paystand/register{
 	dir = 1
@@ -20887,10 +20676,8 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "eiw" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/stack/cable_coil/red,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "eiN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21116,10 +20903,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"emJ" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
 "enf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -21363,7 +21146,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "esT" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -21389,7 +21172,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "etJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -21483,7 +21266,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "euJ" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only,
@@ -21706,7 +21489,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eyp" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
@@ -21771,16 +21554,16 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eAN" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "eAP" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/mix";
+	areastring = "/area/engine/atmos_distro";
 	dir = 8;
-	name = "Atmospherics Mixing Room APC";
+	name = "Atmospherics Distribution APC";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -21798,7 +21581,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eAQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -21944,10 +21727,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "eDN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "eDW" = (
 /obj/machinery/airalarm{
@@ -21973,11 +21756,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "eEd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -22028,7 +21808,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eEB" = (
 /obj/machinery/camera{
 	c_tag = "Service Hall Exterior";
@@ -22146,7 +21926,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eGj" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -22208,7 +21988,7 @@
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eGN" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -22743,14 +22523,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"eSk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "eSM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -23004,7 +22776,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eXA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23078,7 +22850,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eYB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -23218,11 +22990,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fbZ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -23234,10 +23003,10 @@
 /turf/open/floor/plating,
 /area/construction)
 "fca" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/light/broken{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "fcB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -23245,7 +23014,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fde" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -23362,12 +23131,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"feM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "feV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -23452,8 +23215,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "fgV" = (
-/obj/effect/turf_decal/arrows/white,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "fhN" = (
 /obj/docking_port/stationary/random{
@@ -23569,7 +23334,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "fjN" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
@@ -23699,7 +23464,7 @@
 "fme" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fmo" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -23904,12 +23669,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "frg" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/turf/open/floor/plasteel,
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "frB" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -24042,7 +23803,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ftB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -24179,13 +23940,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"fwa" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -24365,7 +24119,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fAa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -24453,7 +24207,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "fCb" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -24732,7 +24486,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fGX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/sleeper";
@@ -24878,7 +24632,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fJb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -25049,7 +24803,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fKY" = (
 /obj/machinery/light{
 	dir = 4;
@@ -25449,7 +25203,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fUW" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/machinery/power/apc{
@@ -25715,7 +25469,7 @@
 "gaB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gaH" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26230,7 +25984,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gnD" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -26269,7 +26023,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "goW" = (
 /obj/machinery/light{
 	dir = 4
@@ -26284,8 +26038,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "goZ" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "gpb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26553,7 +26309,7 @@
 "gtZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gus" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -26919,7 +26675,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gBO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
@@ -26967,11 +26723,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "gDG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27140,7 +26893,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gHO" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
@@ -27161,10 +26914,10 @@
 /area/hallway/secondary/entry)
 "gIq" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/foyer";
+	areastring = "/area/engine/atmos";
 	dir = 1;
-	name = "Atmospherics Foyer APC";
-	pixel_y = 25
+	name = "Atmospherics Wing APC";
+	pixel_y = 23
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -27176,7 +26929,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "gIv" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
@@ -27356,11 +27109,8 @@
 /area/security/prison)
 "gOU" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "gPb" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/rxglasses{
@@ -27446,8 +27196,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gQo" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/maintenance/disposal/incinerator)
 "gQB" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable/orange{
@@ -27611,7 +27370,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "gTa" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/photocopier,
@@ -27945,7 +27704,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "gZD" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
@@ -28068,7 +27827,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "hbe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28329,7 +28088,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hgu" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice,
@@ -28471,10 +28230,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hiw" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "hiE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -28567,7 +28322,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hjC" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -28720,7 +28475,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hlY" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -28744,7 +28499,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hmj" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -29166,7 +28921,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "htO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/exit";
@@ -29201,6 +28956,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"huH" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/crab/kreb{
+	desc = "Here to lay down the hard claws of the law!";
+	health = 50;
+	name = "Officer Kreb";
+	real_name = "Officer Kreb"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "huO" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine{
@@ -29352,15 +29119,15 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "hyV" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "hzm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29420,11 +29187,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "hAO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29560,7 +29324,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hCn" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -29835,7 +29599,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hIO" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -29857,7 +29621,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hJu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -30018,12 +29782,6 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/starboard/aft)
-"hNw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "hNI" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -30166,7 +29924,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hPx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -30265,7 +30023,7 @@
 	},
 /obj/effect/turf_decal/trimline/red,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hQy" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -30337,7 +30095,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hRy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -30619,11 +30377,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hWw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -30647,7 +30402,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hXu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
@@ -30763,13 +30518,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"iak" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "ias" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30812,7 +30560,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ibi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -31056,7 +30804,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ifh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -31066,7 +30814,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ifk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -31255,7 +31003,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ikV" = (
 /obj/machinery/ai/server_cabinet/prefilled,
 /turf/open/floor/circuit/green/telecomms,
@@ -31564,7 +31312,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ipy" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -31671,7 +31419,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iqX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -31740,7 +31488,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "irQ" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -31821,7 +31569,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "itu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -31866,7 +31614,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ivp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -32083,7 +31831,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iAF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -32118,13 +31866,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"iBI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Tinker"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "iCk" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -32165,7 +31906,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "iDj" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
@@ -32227,7 +31968,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iEc" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -32358,11 +32099,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "iGK" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_x = -15
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "iHi" = (
 /obj/machinery/light_switch{
@@ -32522,7 +32261,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iJY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32575,7 +32314,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iKq" = (
 /turf/template_noop,
 /area/maintenance/starboard/aft)
@@ -32607,7 +32346,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iLO" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing";
@@ -32745,7 +32484,7 @@
 	pixel_x = 23
 	},
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iNt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -32911,13 +32650,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iRt" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "iRA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33040,11 +32779,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"iTT" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos_distro)
 "iUb" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -33099,11 +32834,8 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/rods/ten,
 /obj/item/toy/figure/atmos,
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "iVs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -33219,7 +32951,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iXv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -33252,7 +32984,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "iZh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33433,11 +33165,11 @@
 /area/medical/virology)
 "jcf" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/maintenance/disposal/incinerator)
 "jcq" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -33530,7 +33262,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jeO" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -33608,7 +33340,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jhc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -33653,7 +33385,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jhV" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -33683,13 +33415,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jjC" = (
+/obj/machinery/light/built{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "jjR" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins,
@@ -33794,7 +33526,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jlI" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
@@ -34030,7 +33762,7 @@
 /obj/item/multitool,
 /obj/item/electronics/firelock,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "jqk" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -34270,7 +34002,7 @@
 	dir = 9
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "juN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -34355,11 +34087,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jxk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34400,11 +34129,10 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "jzg" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#00AAFF";
-	pixel_y = 15
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "jzm" = (
 /obj/structure/cable/yellow{
@@ -34440,7 +34168,7 @@
 	name = "Pure to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jAv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34573,7 +34301,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jDM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -34592,7 +34320,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jDY" = (
 /obj/structure/displaycase/cmo,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -34898,6 +34626,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"jKn" = (
+/mob/living/simple_animal/pet/dog/corgi/borgi,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/hor)
 "jKG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -34963,7 +34704,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jLW" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -35540,14 +35281,8 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 9
 	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = 30
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jZi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
@@ -35565,6 +35300,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jZC" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/ce,
+/mob/living/simple_animal/parrot/Poly,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "kad" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35768,7 +35512,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kgG" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/janitor,
@@ -35899,7 +35643,7 @@
 "kim" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kiq" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -36031,7 +35775,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kjQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/aft";
@@ -36443,7 +36187,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kvG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -36866,7 +36610,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kDz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36967,7 +36711,7 @@
 "kEN" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37298,7 +37042,7 @@
 /area/bridge)
 "kNz" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kNE" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -37359,12 +37103,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kOp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "kOq" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -37451,7 +37189,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kQg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -37498,8 +37236,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "kRa" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "kRb" = (
 /obj/machinery/flasher{
@@ -37609,7 +37353,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kTp" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -37640,7 +37384,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kTR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37734,7 +37478,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kWL" = (
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
@@ -38633,7 +38377,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lnv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38811,7 +38555,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lrt" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -38918,11 +38662,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ltj" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/disposal/incinerator)
 "ltp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
@@ -38947,7 +38693,7 @@
 /obj/machinery/electrolyzer,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ltQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -39425,7 +39171,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lFZ" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 8
@@ -39491,10 +39237,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lIC" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "lIL" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -39552,7 +39294,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lKH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera{
@@ -39651,11 +39393,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lMg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39814,7 +39553,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lOS" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -39852,14 +39591,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"lQl" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "lQm" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -39969,7 +39700,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lSB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/closet/emcloset,
@@ -40149,7 +39880,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lXT" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -40288,7 +40019,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lZn" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -40468,7 +40199,7 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mdj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40551,7 +40282,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "meA" = (
 /obj/machinery/flasher{
 	id = "briginfirmary";
@@ -40919,7 +40650,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mkZ" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -41302,7 +41033,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "msz" = (
 /obj/structure/table/wood,
 /obj/item/melee/chainofcommand,
@@ -41358,10 +41089,12 @@
 /turf/open/floor/carpet/purple,
 /area/hallway/secondary/exit)
 "mtm" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/disposal/incinerator)
 "mtD" = (
 /obj/machinery/door/airlock/maintenance{
@@ -41576,8 +41309,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "mxv" = (
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel/dark,
+/obj/item/wrench,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "mxL" = (
 /obj/docking_port/stationary{
@@ -41680,7 +41413,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mzr" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -41827,7 +41560,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mAV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -41868,7 +41601,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mBu" = (
 /obj/structure/sign/departments/minsky/supply/janitorial{
 	pixel_y = -32
@@ -42035,7 +41768,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mDN" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -42070,7 +41803,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mEI" = (
 /obj/structure/rack,
 /obj/item/pickaxe{
@@ -42223,7 +41956,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mIB" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -42352,11 +42085,8 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mMn" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -42408,7 +42138,7 @@
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "mNn" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -42753,12 +42483,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mVw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "mVF" = (
 /obj/machinery/camera{
 	c_tag = "Research and Development";
@@ -42961,7 +42685,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nam" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -43111,7 +42835,7 @@
 "ncf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nck" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -43342,7 +43066,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ngy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -43461,11 +43185,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "nka" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "nkd" = (
 /obj/structure/cable{
@@ -43506,7 +43228,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "nkL" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nkZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -43664,7 +43386,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "noF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -43823,7 +43545,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nsc" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/cable/yellow{
@@ -44217,15 +43939,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"nBg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "nBp" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "nBq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44324,7 +44046,7 @@
 "nDb" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nDj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -44527,7 +44249,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nHR" = (
 /obj/machinery/light{
 	dir = 8
@@ -44639,13 +44361,13 @@
 "nJW" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "nJX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nKh" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
@@ -44759,7 +44481,7 @@
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nNR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -44953,7 +44675,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nSQ" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -44986,6 +44708,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"nTv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/mob/living/carbon/monkey,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nTF" = (
 /obj/machinery/shower{
 	dir = 8
@@ -45010,7 +44743,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nUh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -45108,7 +44841,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nVq" = (
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -45136,16 +44869,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"nWn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "nWs" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45179,15 +44902,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "nWB" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "nWH" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -45319,7 +45042,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "oaG" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -45449,7 +45172,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oeb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45913,7 +45636,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oos" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer2{
 	dir = 8
@@ -46003,7 +45726,7 @@
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "orC" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -46064,7 +45787,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ota" = (
 /obj/structure/toilet{
 	dir = 1
@@ -46277,6 +46000,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ovG" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46284,9 +46008,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "ovY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46353,7 +46076,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oxg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -46439,12 +46162,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oyx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46550,11 +46273,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ozQ" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -46580,7 +46300,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oAa" = (
 /obj/effect/turf_decal/box/corners,
 /obj/structure/window/reinforced,
@@ -46661,7 +46381,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oBt" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -46813,7 +46533,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oGo" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
@@ -47044,7 +46764,7 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oLE" = (
 /obj/machinery/meter,
 /obj/machinery/button/door{
@@ -47345,23 +47065,17 @@
 /turf/open/floor/plating,
 /area/bridge)
 "oSN" = (
+/obj/item/radio/intercom{
+	pixel_x = 30
+	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	dir = 4;
-	name = "Atmospherics Storage APC";
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "oSP" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -47489,6 +47203,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"oVL" = (
+/mob/living/simple_animal/moonrat{
+	name = "Joe"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "oVO" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -47540,7 +47263,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oXp" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -47711,7 +47434,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pat" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -47739,7 +47462,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pck" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47782,7 +47505,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pdx" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -47963,11 +47686,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "phL" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office/dark{
@@ -48079,8 +47799,8 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "piz" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "piL" = (
 /obj/machinery/door/firedoor/border_only,
@@ -48300,17 +48020,7 @@
 "pnh" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"pnp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pny" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -48436,12 +48146,6 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"pqo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "pqr" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -48512,14 +48216,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
-"prq" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "prw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -49052,7 +48749,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pAl" = (
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel,
@@ -49262,7 +48959,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pEm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49329,11 +49026,10 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "pFA" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8;
-	name = "Output to Space"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "pFB" = (
 /obj/docking_port/stationary/random{
@@ -49438,8 +49134,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pIA" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "pIL" = (
 /obj/structure/window/reinforced{
@@ -49514,14 +49212,14 @@
 "pLs" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pLQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pMs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49566,7 +49264,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -49622,16 +49320,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"pPt" = (
-/obj/structure/grille,
-/obj/machinery/meter{
-	layer = 3.4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
 "pPI" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/bot,
@@ -49641,7 +49329,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pPW" = (
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "pPX" = (
 /obj/structure/lattice/catwalk,
@@ -49793,7 +49481,7 @@
 /obj/item/pipe_dispenser,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pSe" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor/border_only{
@@ -50033,7 +49721,7 @@
 "pXS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pXV" = (
 /obj/machinery/light{
 	dir = 1
@@ -50125,12 +49813,12 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pZl" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pZF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -50161,9 +49849,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "qai" = (
@@ -50189,7 +49874,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qaO" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -50764,7 +50449,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "qmr" = (
 /obj/structure/table,
 /obj/item/screwdriver{
@@ -51017,7 +50702,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qsH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -51033,11 +50718,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qsI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qtd" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -51104,6 +50784,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "qut" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -51111,9 +50792,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "quG" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
@@ -51170,7 +50850,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "qvj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51232,7 +50912,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qxl" = (
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
@@ -52042,7 +51722,7 @@
 "qMD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qMH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -52055,11 +51735,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qNt" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad"
@@ -52266,9 +51943,6 @@
 "qQF" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -52481,7 +52155,7 @@
 	name = "Pure to Incinerator"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qVe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52582,24 +52256,18 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qXS" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/rglass{
-	amount = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/item/stack/sheet/plasteel{
-	amount = 5
-	},
-/obj/item/pipe_dispenser,
-/obj/item/wrench,
-/obj/item/multitool,
-/turf/open/floor/plasteel,
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "qYw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/white,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "qYx" = (
 /obj/machinery/camera{
 	c_tag = "Virology Monkey Pen";
@@ -52664,7 +52332,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ray" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -52693,7 +52361,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rbD" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 8
@@ -52891,7 +52559,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rgx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52900,7 +52568,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rgM" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
@@ -52963,11 +52631,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rip" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/camera{
@@ -53247,6 +52912,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rnx" = (
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "rnO" = (
 /obj/item/seeds/potato,
 /obj/machinery/hydroponics/soil,
@@ -53317,7 +52989,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "roZ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2
@@ -53362,7 +53034,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rqF" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -53565,7 +53237,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rwm" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
@@ -53636,7 +53308,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rxM" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -53663,12 +53335,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/library)
-"ryJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rzx" = (
 /obj/machinery/light{
 	dir = 1
@@ -53770,7 +53436,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rBz" = (
 /obj/item/radio/intercom{
 	pixel_y = -27
@@ -53822,7 +53488,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rCG" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/aft)
@@ -53836,11 +53502,11 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rCT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rDa" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -53894,15 +53560,22 @@
 /turf/open/floor/wood,
 /area/library)
 "rEA" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos_distro)
+"rER" = (
+/mob/living/simple_animal/pet/fox/fennec/Autumn,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "rFc" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -54020,7 +53693,7 @@
 /area/teleporter)
 "rHf" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rHh" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -54138,7 +53811,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rIL" = (
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/chair/office/dark,
@@ -54237,7 +53910,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rJJ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -54251,6 +53924,19 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"rJX" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -54310,7 +53996,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rLC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -54322,6 +54008,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "rLG" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
@@ -54329,9 +54016,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "rLL" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
@@ -54400,12 +54086,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rOf" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/disposal/incinerator)
 "rOh" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -54450,11 +54130,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rPa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -54463,7 +54140,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rPd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -54634,15 +54311,11 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rSl" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"rST" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/atmos/distro)
 "rTb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -54948,7 +54621,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rYz" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -54995,7 +54668,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "rZU" = (
 /obj/machinery/light{
 	dir = 8;
@@ -55154,6 +54827,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"sdv" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/sparsegrass,
+/mob/living/carbon/monkey{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/grass,
+/area/medical/genetics)
 "sdJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -55189,7 +54871,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "sew" = (
 /obj/structure/table/optable{
 	dir = 8
@@ -55215,11 +54897,11 @@
 /area/maintenance/starboard/fore)
 "seW" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/maintenance/disposal/incinerator)
 "seX" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -55242,7 +54924,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sfl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55352,7 +55034,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/hallway/primary/aft)
 "sgY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -55652,7 +55334,7 @@
 /area/ai_monitored/turret_protected/ai)
 "soo" = (
 /turf/closed/wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "soz" = (
 /obj/structure/table/optable,
 /obj/item/storage/backpack/duffelbag/sec/surgery,
@@ -55778,11 +55460,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ssx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "ssK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -55850,7 +55529,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "stz" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -56082,7 +55761,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sAu" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
@@ -56097,7 +55776,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "sAJ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -56310,7 +55989,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sEx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -56438,7 +56117,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sGY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/carbon/monkey{
@@ -56565,7 +56244,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sJk" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/window/reinforced{
@@ -56575,7 +56254,7 @@
 /obj/effect/turf_decal/trimline/green,
 /obj/effect/turf_decal/trimline/neutral,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sJG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -56806,7 +56485,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sQs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -56870,7 +56549,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sSb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -56980,7 +56659,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sTG" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
@@ -57041,7 +56720,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "sUD" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
@@ -57079,7 +56758,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sVM" = (
 /obj/structure/chair{
 	dir = 4
@@ -57147,12 +56826,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sWR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "sWS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57223,7 +56896,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "sXz" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -57239,7 +56912,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sXB" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner,
@@ -57278,9 +56951,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"sXH" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
 "sXS" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -57412,7 +57082,7 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sZR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -57482,7 +57152,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "taW" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -57508,7 +57178,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "taZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -57603,12 +57273,30 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tdw" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tdV" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/mob/living/simple_animal/bot/cleanbot/medical{
+	on = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "tdY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -57672,6 +57360,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"tfC" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/lizard{
+	name = "Wags-His-Tail";
+	real_name = "Wags-His-Tail"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "tfF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -57679,10 +57381,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tfH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/disposal/incinerator)
 "tge" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -57828,7 +57532,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tin" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -58031,7 +57735,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "tmz" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -58178,7 +57882,7 @@
 "tpE" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tpJ" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only,
@@ -58222,7 +57926,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "trn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58276,11 +57980,8 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tsu" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -58355,7 +58056,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "tvb" = (
 /obj/structure/alien/weeds,
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
@@ -58577,7 +58278,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tyC" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -58621,7 +58322,7 @@
 	name = "Mix Outlet Pump"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tzJ" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -58645,7 +58346,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tAh" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -58781,7 +58482,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tDe" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -58929,7 +58630,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tHk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -59039,7 +58740,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tJW" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -59154,9 +58855,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/core,
-/obj/item/paper/guides/jobs/atmos/hypertorus,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "tMG" = (
@@ -59318,7 +59016,7 @@
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tOM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -59435,6 +59133,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"tQs" = (
+/mob/living/simple_animal/spiffles,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/green/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/clerk)
 "tQv" = (
 /obj/machinery/light{
 	dir = 4
@@ -59547,9 +59256,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"tSS" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tSX" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -59703,7 +59409,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "tVZ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics";
@@ -60266,7 +59972,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uhU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -60530,7 +60236,7 @@
 "unK" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uoh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -60565,8 +60271,9 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "upb" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/box,
+/obj/structure/frame/machine,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "upk" = (
 /turf/closed/wall/r_wall,
@@ -60957,7 +60664,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uye" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -60979,7 +60686,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uyV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -60998,12 +60705,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uzn" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "uzs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -61227,7 +60928,7 @@
 "uDV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uEc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -61472,7 +61173,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -61592,7 +61293,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uLE" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -61788,7 +61489,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uOF" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -61918,7 +61619,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "uQA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -62137,7 +61838,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uWK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -62315,9 +62016,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "uYk" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "uYr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62552,7 +62255,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vcN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -63010,7 +62713,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/hallway/primary/aft)
 "vnv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -63722,6 +63425,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vCE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -63729,7 +63435,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "vCK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -63991,11 +63697,8 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vHO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -64728,7 +64431,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vUZ" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -64834,6 +64537,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"vXF" = (
+/obj/machinery/computer/secure_data,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "vYi" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -64855,7 +64576,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vYC" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -65018,7 +64739,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wag" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -65119,7 +64840,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wcl" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -65133,7 +64854,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wcD" = (
 /obj/structure/rack,
 /obj/item/electronics/apc,
@@ -65288,7 +65009,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wga" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -65302,12 +65023,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"whu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "whv" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -65371,7 +65086,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wiV" = (
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
@@ -65405,7 +65120,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wjO" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -65528,7 +65243,7 @@
 "wma" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wmr" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -65620,6 +65335,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"wnV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "wnZ" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -65876,11 +65597,8 @@
 "wtu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wtN" = (
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32;
@@ -66062,7 +65780,7 @@
 	name = "atmos blast door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wxs" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
@@ -66318,7 +66036,7 @@
 /area/security/interrogation)
 "wEo" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wEr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66386,15 +66104,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"wFh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wFr" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -66656,7 +66365,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wMj" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -66693,13 +66402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"wML" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8;
-	name = "Output Gas Connector Port"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "wMP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66743,7 +66445,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wOC" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -66776,7 +66478,7 @@
 	name = "Port to Filter"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wPt" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -66906,17 +66608,14 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wTe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wTn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -67477,7 +67176,7 @@
 "xgn" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xgu" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -67595,15 +67294,10 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "xiL" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/meter{
-	layer = 3.4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/maintenance/disposal/incinerator)
 "xjd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67621,7 +67315,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xjo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -67666,7 +67360,7 @@
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xjK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -67679,7 +67373,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xjV" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -67870,7 +67564,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xpf" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -67934,11 +67628,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "xqu" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -68095,7 +67789,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68116,7 +67810,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xtT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68234,7 +67928,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xwW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -68318,11 +68012,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xxO" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xxQ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -68330,7 +68024,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xyb" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -68362,7 +68056,7 @@
 /area/medical/medbay/lobby)
 "xyU" = (
 /turf/closed/wall,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "xzh" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -68393,8 +68087,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "xAA" = (
+/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "xAC" = (
@@ -68454,9 +68148,9 @@
 /area/maintenance/aft)
 "xBp" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xBG" = (
 /obj/structure/rack,
@@ -68495,7 +68189,7 @@
 "xBO" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xBP" = (
 /obj/structure/rack,
 /obj/item/storage/box,
@@ -68506,7 +68200,7 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "xBU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -68723,10 +68417,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"xHK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xIf" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -68953,7 +68643,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xOv" = (
 /obj/machinery/light{
 	dir = 4
@@ -69047,11 +68737,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xQR" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -69274,7 +68961,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xUp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69894,7 +69581,7 @@
 /obj/item/analyzer,
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "ygg" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/warning/nosmoking{
@@ -69970,7 +69657,7 @@
 /obj/item/flashlight,
 /obj/item/assembly/igniter,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos)
 "yhr" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -70161,6 +69848,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"yjC" = (
+/obj/structure/bed/dogbed/ian,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = 32
+	},
+/obj/item/toy/figure/hop{
+	layer = 2.89;
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "yjF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -85005,7 +84714,7 @@ vZz
 aBI
 iqm
 pAL
-aal
+huH
 cfI
 sJV
 hmO
@@ -85258,9 +84967,9 @@ lFj
 lFj
 lFj
 alU
-nWn
+vZz
 aBI
-aak
+vXF
 pAL
 lBX
 aHu
@@ -87315,7 +87024,7 @@ alU
 amC
 azF
 pYO
-aah
+oVL
 kAz
 kAz
 fLl
@@ -92738,7 +92447,7 @@ gjl
 gjl
 bhW
 sES
-aan
+rER
 ivQ
 yhe
 gzl
@@ -95501,7 +95210,7 @@ eKy
 adp
 adp
 wcS
-aab
+adh
 eNX
 eNX
 eNX
@@ -96637,7 +96346,7 @@ bCq
 uzc
 ccw
 ppM
-efb
+crt
 soW
 cmD
 cmD
@@ -96894,8 +96603,8 @@ bCq
 uzc
 ccw
 ppM
-wil
-bQa
+efb
+rJX
 cmD
 cmD
 cfe
@@ -97152,7 +96861,7 @@ uzc
 ccw
 lTT
 wil
-wil
+bQa
 cfe
 cfe
 cfe
@@ -97880,7 +97589,7 @@ mqz
 bjA
 xul
 dEb
-aap
+yjC
 boZ
 nfX
 iHr
@@ -99368,7 +99077,7 @@ aeq
 aiB
 eCy
 aqd
-aad
+cow
 xit
 xng
 ewO
@@ -100726,13 +100435,13 @@ nDu
 bCv
 mdG
 bzs
-sXH
-sXH
+bLK
+bLK
 taW
 byS
 oaA
 rZO
-sXH
+bLK
 iYj
 qmg
 nNC
@@ -100978,12 +100687,12 @@ qyo
 bCv
 ehG
 veb
-aas
+tfC
 tmB
 bCv
 eEO
 rkM
-sXH
+bLK
 mzo
 cej
 cMO
@@ -100993,7 +100702,7 @@ rLz
 fBT
 chM
 gSW
-sXH
+bLK
 utd
 aXz
 aiv
@@ -101240,9 +100949,9 @@ vUs
 bCv
 eEO
 vYi
-sXH
+bLK
 jZf
-dQH
+iCQ
 sEr
 acF
 bOd
@@ -101260,7 +100969,7 @@ aiv
 lRK
 imH
 vhL
-aaz
+jZC
 lMD
 oqf
 wMq
@@ -101497,7 +101206,7 @@ sCi
 bCv
 eEO
 bAw
-sXH
+bLK
 tmy
 bOd
 wRZ
@@ -101754,9 +101463,9 @@ qCG
 bCv
 yey
 bAw
-sXH
+bLK
 hjA
-iTT
+bOd
 kDr
 caT
 bSC
@@ -102011,7 +101720,7 @@ weY
 vZn
 moC
 wUc
-sXH
+bLK
 gIq
 vYt
 jxg
@@ -102268,7 +101977,7 @@ uEm
 bCv
 wTn
 wUw
-sXH
+bLK
 hIN
 uDV
 wTe
@@ -102525,7 +102234,7 @@ bCv
 bCv
 eEO
 wUw
-sXH
+bLK
 rIA
 eie
 lMa
@@ -102781,16 +102490,16 @@ bAw
 bHX
 xgI
 eEO
-nBp
-nBp
+bLK
+bLK
 uIH
 uIH
 bLT
 cYB
-sXH
-sXH
-sXH
-sXH
+bLK
+bLK
+bLK
+bLK
 bWQ
 bWQ
 bWQ
@@ -103038,14 +102747,14 @@ bAw
 bAw
 vzs
 liS
-nBp
+bLK
 xsA
 dlN
 iCQ
 cWJ
 nHM
 aBE
-nBp
+bLK
 bvA
 bvA
 bvA
@@ -103295,14 +103004,14 @@ hUr
 hUr
 sYd
 tpg
-nBp
+bLK
 xwU
 bDF
-tSS
+bOd
 fbJ
 fjz
 trj
-nBp
+bLK
 bvA
 rHf
 mkP
@@ -103310,19 +103019,19 @@ rHf
 bvA
 avy
 gXs
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
 gXs
 aaa
 sjo
@@ -103552,14 +103261,14 @@ bAw
 bHX
 vZH
 liS
-nBp
+bLK
 xxO
 bDF
 yfZ
 eEc
 fjz
 tut
-nBp
+bLK
 bvA
 rHf
 rHf
@@ -103567,19 +103276,19 @@ rHf
 bvA
 avy
 aaa
-uYk
+bvA
 aol
 aol
 aol
-uYk
+bvA
 ctR
 ctR
 ctR
-uYk
+bvA
 cet
 cet
 cet
-uYk
+bvA
 aaa
 aaa
 sjo
@@ -103809,14 +103518,14 @@ bAw
 iAN
 wag
 eMZ
-nBp
+bLK
 xyU
 qve
 yhk
 hAJ
 fjz
 xyU
-nBp
+bLK
 bvA
 lKf
 fme
@@ -103824,19 +103533,19 @@ etv
 bvA
 avy
 gXs
-uYk
+bvA
 aol
 anE
 aol
-uYk
+bvA
 ctR
 fzJ
 ctR
-uYk
+bvA
 cet
 aqb
 cet
-uYk
+bvA
 aaa
 aaa
 jlM
@@ -104066,14 +103775,14 @@ bAw
 bHX
 bAw
 liS
-nBp
+bLK
 bLM
 bDF
 jpZ
 hAJ
 fjz
 mNg
-nBp
+bLK
 bvA
 mDE
 nDb
@@ -104081,19 +103790,19 @@ nrq
 bvA
 avy
 aaa
-uYk
+bvA
 xOa
 cAT
 iJO
-uYk
+bvA
 oxe
 mBi
 dkS
-uYk
+bvA
 sTw
 lSz
 beC
-uYk
+bvA
 aaa
 aaa
 jlM
@@ -104323,14 +104032,14 @@ dze
 bHX
 bAw
 liS
-nBp
+bLK
 esK
 bDF
 gOU
 gDD
 fjz
 dId
-nBp
+bLK
 avy
 bzK
 bBw
@@ -104338,19 +104047,19 @@ nWB
 avy
 avy
 gXs
-uYk
-xiL
-rST
-pPt
-uYk
-xiL
-rST
+bvA
+mDE
+nDb
+nrq
+bvA
+mDE
+nDb
 dML
-uYk
-xiL
+bvA
+mDE
 coC
 cnq
-uYk
+bvA
 gXs
 aaa
 jlM
@@ -104534,7 +104243,7 @@ lpv
 nHm
 ayG
 sko
-aaj
+tQs
 fnk
 ayG
 wva
@@ -104580,14 +104289,14 @@ rZt
 bzs
 bzs
 liS
-nBp
+bLK
 nJW
 haI
 oSN
 xjE
 bnD
 iVn
-nBp
+bLK
 avy
 xUn
 ijY
@@ -104851,7 +104560,7 @@ bBC
 iDY
 pZg
 tyA
-cjQ
+avy
 lOu
 rYt
 bKJ
@@ -104864,9 +104573,9 @@ gaB
 pdq
 bJv
 iKp
-cjQ
-cjQ
-cjQ
+avy
+avy
+avy
 aaa
 aaa
 aaa
@@ -105359,7 +105068,7 @@ ngq
 ngq
 rCQ
 kim
-ssx
+kgs
 uWH
 wfZ
 wiS
@@ -105368,18 +105077,18 @@ jlB
 jut
 rwb
 eYt
-gQo
+aSJ
 lrl
-xHK
+wma
 sRm
-gQo
-gQo
-gQo
+aSJ
+aSJ
+aSJ
 xji
-gQo
+aSJ
 ezB
 kgs
-gQo
+aSJ
 wxr
 gXs
 gXs
@@ -105624,21 +105333,21 @@ ncf
 uyr
 oyj
 ifh
-lIC
-gQo
+kim
+aSJ
 pal
-xHK
+wma
 gnb
-xHK
-xHK
-xHK
+wma
+wma
+wma
 sRm
-gQo
+aSJ
 cUi
 xjN
-cjQ
-cjQ
-cjQ
+avy
+avy
+avy
 xBO
 tiH
 pEf
@@ -105882,15 +105591,15 @@ hWv
 tss
 vHH
 rig
-eSk
-pnp
-wFh
-cLM
-qsI
+wtu
 cCi
-qsI
+wtu
+cLM
+wtu
+cCi
+wtu
 iew
-qsI
+wtu
 iLK
 qaz
 stn
@@ -106123,25 +105832,25 @@ rqd
 jdO
 liS
 wXV
-emJ
+xBO
 wcf
 aSJ
 aTO
 aYy
 baj
 qwX
-hiw
+pLs
 unK
 nSI
 qsy
-hiw
+pLs
 sdX
 onT
 sQq
 rCT
 pLs
 fcB
-fwa
+pLs
 bOo
 bhl
 fcB
@@ -106150,11 +105859,11 @@ rCT
 qVb
 bYa
 sGW
-cjQ
-cjQ
-cjQ
-cjQ
-cjQ
+avy
+avy
+avy
+avy
+avy
 kEN
 pEf
 pEf
@@ -106395,16 +106104,16 @@ bao
 oGn
 rSe
 oWJ
-ryJ
-gQo
+uWH
+aSJ
 kPL
-sWR
-ryJ
-gQo
+aSJ
+uWH
+aSJ
 kPL
-gQo
-ryJ
-gQo
+aSJ
+uWH
+aSJ
 cUi
 tax
 kjM
@@ -106907,7 +106616,7 @@ hIX
 uLo
 pri
 bHa
-cjQ
+avy
 kvn
 oyd
 eye
@@ -106920,9 +106629,9 @@ gaB
 oyd
 kTM
 fKX
-cjQ
-cjQ
-cjQ
+avy
+avy
+avy
 cOL
 aCV
 uOs
@@ -107160,7 +106869,7 @@ iuY
 aSJ
 fIS
 aSJ
-nBg
+kPL
 hlN
 avy
 bHa
@@ -107413,7 +107122,7 @@ xCv
 aHM
 avy
 ltM
-dBe
+rwb
 buY
 bxI
 bAx
@@ -107422,19 +107131,19 @@ eFW
 bFX
 bHa
 aaf
-uYk
-xiL
-rST
+bvA
+mDE
+nDb
 dML
-uYk
-xiL
-rST
+bvA
+mDE
+nDb
 dML
-uYk
-xiL
+bvA
+mDE
 eEv
 jgK
-uYk
+bvA
 aaf
 pXS
 sZP
@@ -107679,19 +107388,19 @@ rqi
 bFX
 bHa
 aoV
-uYk
+bvA
 jec
 cNy
 tzN
-uYk
+bvA
 rbs
 cCF
 hfW
-uYk
+bvA
 sAs
 gHM
 mZO
-uYk
+bvA
 aaa
 cmd
 cmd
@@ -107701,8 +107410,8 @@ cmd
 cmd
 cDS
 cmd
-cmd
-cmd
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107927,7 +107636,7 @@ bAw
 hbO
 avy
 pZl
-dBe
+rwb
 buY
 rCr
 bBn
@@ -107936,19 +107645,19 @@ lZm
 bFX
 bHa
 aaf
-uYk
+bvA
 wEo
 wLC
 wEo
-uYk
+bvA
 nkL
 eWN
 nkL
-uYk
+bvA
 kNz
 gon
 kNz
-uYk
+bvA
 aaf
 cmd
 edX
@@ -107956,11 +107665,11 @@ fKW
 ctE
 aHd
 qQF
-pFA
-iak
-fKW
-cmd
-cmd
+mtm
+ufD
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108173,7 +107882,7 @@ eFE
 rTb
 xAI
 riv
-aar
+tdV
 mzH
 gBy
 jhe
@@ -108193,33 +107902,33 @@ rxG
 avy
 bHa
 aoV
-uYk
+bvA
 wEo
 wEo
 wEo
-uYk
+bvA
 nkL
 nkL
 nkL
-uYk
+bvA
 kNz
 kNz
 kNz
-uYk
+bvA
 aoV
 cmd
-frg
+fKW
 fKW
 ctE
+iGK
 fKW
-fKW
-wML
-fKW
-fKW
-mVw
-cmd
-cmd
-ltj
+pFA
+ufD
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108450,32 +108159,32 @@ avy
 avy
 cVC
 aaf
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
-uYk
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
+bvA
 aaf
 cmd
 tLS
 fKW
 ctE
 fKW
-kRa
-fca
-fca
-fca
-tfH
-fKW
-ufD
+ssx
+mxv
+cmd
+cmd
+cmd
+cmd
+aaa
 aaa
 aaa
 aaa
@@ -108704,8 +108413,8 @@ pYm
 ijr
 vOo
 hEv
-xDQ
-xDQ
+avy
+avy
 aaf
 aaf
 aaf
@@ -108722,17 +108431,17 @@ aaf
 aaf
 aaf
 cmd
-lQl
+fKW
 vsW
 ctE
+fKW
+ssx
+xiL
 kRa
-hNw
+fca
 pPW
-eiw
-pPW
-kOp
-tfH
 ufD
+aaa
 aaa
 aaa
 aaa
@@ -108979,17 +108688,17 @@ wAc
 cmd
 cmd
 cmd
-qXS
+fKW
 mSL
 ctE
-pIA
+ssx
+qXS
+wnV
+uYk
+eiw
 pPW
-piz
-mtm
-upb
-pPW
-whu
 ufD
+aaa
 aaa
 aaa
 aaa
@@ -109239,14 +108948,14 @@ fwi
 dAA
 csz
 xqu
-iBI
-fgV
-nka
-goZ
-mxv
-jzg
-whu
+ssx
+xBp
+pPW
+piz
+pPW
+pPW
 ufD
+aaa
 aaa
 aaa
 aaa
@@ -109467,7 +109176,7 @@ fju
 dSq
 jxu
 qYx
-aay
+rnx
 bNd
 bNd
 bNd
@@ -109495,15 +109204,15 @@ jkh
 kBc
 mFW
 ilQ
-dzz
-pIA
+gQo
+ltj
+nBp
+fgV
+nka
 pPW
-upb
-rOf
-piz
 pPW
-whu
 ufD
+aaa
 aaa
 aaa
 aaa
@@ -109723,7 +109432,7 @@ eNx
 smo
 tEx
 jxu
-aax
+nTv
 cpO
 qbG
 uOh
@@ -109753,14 +109462,14 @@ cmd
 fKW
 svh
 dzz
-eDN
+fKW
 xBp
 pPW
-iGK
+upb
 pPW
-feM
-uzn
+pPW
 ufD
+aaa
 aaa
 aaa
 bPq
@@ -110010,14 +109719,14 @@ cmd
 hko
 sDi
 dzz
-fKW
+ssx
 eDN
+goZ
 bJy
-bJy
-bJy
-uzn
-fKW
+pPW
+frg
 ufD
+aaa
 aaa
 aaa
 nzG
@@ -110268,13 +109977,13 @@ lic
 bVC
 dfL
 tEp
-tEp
-tEp
+jzg
+tfH
 vCE
 jjC
-bLK
-tEp
+pIA
 sSk
+vUc
 vUc
 vUc
 iwZ
@@ -110531,8 +110240,8 @@ cmd
 cmd
 cmd
 cmd
-cmd
-prq
+aaa
+pEf
 eKu
 hag
 khH
@@ -111039,7 +110748,7 @@ jjR
 hwq
 oHg
 bLf
-aaA
+bGO
 uFy
 ufD
 aaa
@@ -111516,7 +111225,7 @@ sTG
 cNd
 nKh
 nHr
-aav
+sdv
 vGx
 vYi
 ufj
@@ -112063,7 +111772,7 @@ ldW
 ldW
 ldW
 cmd
-pqo
+fKW
 huB
 cmd
 vIf
@@ -119220,7 +118929,7 @@ bvJ
 bxj
 emB
 bwR
-aaq
+jKn
 rss
 bvK
 bEv
@@ -120749,7 +120458,7 @@ bdz
 hPW
 ptr
 bhH
-dHL
+biY
 biY
 biY
 bjS

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -52255,7 +52255,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
 "fdr" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/the_singularitygen,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "fdz" = (

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -14001,6 +14001,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aJu" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJw" = (

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -233,7 +233,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aaP" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/cultivator,
@@ -1523,7 +1523,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "aeE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock";
@@ -2513,7 +2513,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ahn" = (
 /obj/structure/chair{
 	dir = 4
@@ -2876,9 +2876,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aic" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -3210,7 +3209,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "aiW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -4288,7 +4287,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "alK" = (
 /turf/closed/wall,
 /area/maintenance/port)
@@ -5105,7 +5104,7 @@
 "anM" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "anO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -6052,7 +6051,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aqD" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -7209,7 +7208,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "att" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9158,11 +9157,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aza" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9938,6 +9934,22 @@
 "aAC" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"aAD" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "aAE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -10531,6 +10543,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"aBS" = (
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "aBT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
@@ -13981,6 +14001,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aJu" = (
+/obj/structure/closet/crate/engineering{
+	name = "particle accelerator crate"
+	},
+/obj/structure/particle_accelerator/fuel_chamber,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/obj/structure/particle_accelerator/particle_emitter/left,
+/obj/structure/particle_accelerator/particle_emitter/right,
+/obj/structure/particle_accelerator/power_box,
+/obj/structure/particle_accelerator/end_cap,
+/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJw" = (
@@ -17818,7 +17848,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "aRK" = (
 /obj/machinery/computer/security/qm{
 	dir = 4
@@ -24204,7 +24234,7 @@
 "bhD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bhE" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -24323,7 +24353,7 @@
 "bhU" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bif" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -26016,7 +26046,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "blQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -27037,7 +27067,7 @@
 "boM" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "boQ" = (
 /obj/item/trash/candy,
 /turf/open/floor/plating,
@@ -27173,7 +27203,7 @@
 "bps" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -27751,7 +27781,7 @@
 "bqR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bqS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28974,7 +29004,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "bvj" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -29376,6 +29406,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bwB" = (
+/obj/structure/sign/warning/fire{
+	pixel_x = 32
+	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Fuel Pipe to Incinerator"
 	},
@@ -29464,7 +29497,7 @@
 /area/crew_quarters/bar)
 "bxc" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bxf" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -30494,7 +30527,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "bBu" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
@@ -30835,7 +30868,7 @@
 /area/hallway/secondary/command)
 "bCi" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos)
 "bCl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33216,7 +33249,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bKa" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/dark,
@@ -33779,15 +33812,15 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bLY" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bLZ" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bMe" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -34587,11 +34620,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bPn" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bPt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -34976,7 +35009,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bQU" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -35315,7 +35348,7 @@
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bSe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35327,7 +35360,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "bSk" = (
 /obj/structure/table/wood,
 /obj/item/deskbell/preset/library{
@@ -37509,7 +37542,7 @@
 "cbi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cbm" = (
 /obj/structure/closet/crate,
 /obj/item/storage/belt/utility,
@@ -37828,7 +37861,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cdc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38924,7 +38957,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "ciB" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/airalarm{
@@ -39250,7 +39283,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cjX" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -40028,7 +40061,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "coU" = (
 /obj/machinery/light{
 	dir = 1
@@ -40313,11 +40346,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "cpN" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/disposal/incinerator)
 "cpP" = (
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
@@ -43554,6 +43587,10 @@
 	},
 /area/science/mixing)
 "czH" = (
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -44255,11 +44292,9 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEq" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/structure/lattice,
+/turf/open/space,
+/area/science/mixing/chamber)
 "cEr" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -44311,7 +44346,7 @@
 "cEA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "cED" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44522,7 +44557,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cHk" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -44831,8 +44866,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cJG" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "cJJ" = (
 /obj/machinery/computer/operating{
 	dir = 1;
@@ -45474,7 +45515,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "cNN" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -46858,7 +46899,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "cTz" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -46997,14 +47038,8 @@
 	layer = 2.4;
 	name = "Mix to Port"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cVx" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -47020,7 +47055,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "cVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47043,11 +47078,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "cWA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -48986,7 +49018,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "dou" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -49016,11 +49048,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "doJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49127,7 +49156,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dqT" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
@@ -49156,7 +49185,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "dsh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49403,9 +49432,8 @@
 	c_tag = "Incinerator";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "dzP" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=10-Aft-To-Central";
@@ -49779,7 +49807,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "dFY" = (
 /obj/item/cigbutt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
@@ -49851,7 +49879,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dKb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50000,12 +50028,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "dOi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = -32
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "dOp" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
@@ -50032,7 +50057,7 @@
 "dOs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dOB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -50065,13 +50090,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "dQj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dQn" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -50150,11 +50175,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "dRA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -50179,7 +50201,7 @@
 /area/ai_monitored/turret_protected/ai)
 "dSh" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dSA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50249,8 +50271,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "dUo" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "dUz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -50268,7 +50293,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "dUK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50334,13 +50359,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "dWv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "dWE" = (
 /obj/item/reagent_containers/food/snacks/sosjerky,
 /obj/structure/table/glass,
@@ -50479,10 +50504,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"eap" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "eau" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -50531,7 +50552,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ebG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/chair/office/light{
@@ -50552,8 +50573,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "ebO" = (
-/turf/closed/wall,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "ebZ" = (
 /obj/machinery/button/door{
 	id = "chemistry_shutters";
@@ -50668,11 +50692,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eeq" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line,
@@ -50708,7 +50729,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "efl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51037,7 +51058,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "enT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51080,13 +51101,13 @@
 "eoS" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "epf" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eqK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51122,7 +51143,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "erl" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -51136,7 +51157,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ery" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -51155,12 +51176,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"esg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "ess" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -51341,7 +51356,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ezk" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -51362,12 +51377,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
-"ezP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "eAd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -51475,7 +51484,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/meter,
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eEI" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -51520,7 +51529,7 @@
 "eFk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eFo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51615,16 +51624,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"eGV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "eHu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -51729,12 +51729,12 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eKb" = (
 /obj/machinery/pipedispenser,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eKo" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
@@ -51839,9 +51839,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
 "eNb" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "eNy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -51866,7 +51868,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "eOb" = (
 /obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plasteel/dark,
@@ -51943,11 +51945,8 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "eRU" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 1
@@ -51978,7 +51977,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "eSm" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only{
@@ -52182,10 +52181,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/physician)
-"eXW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos/pumproom)
 "eYy" = (
 /obj/effect/spawner/lootdrop/tanks/fuelonly/midchance,
 /turf/open/floor/plating{
@@ -52232,7 +52227,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "faR" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52241,10 +52236,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"fbx" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "fcd" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/wirecutters,
@@ -52274,7 +52265,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
 "fdr" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/the_singularitygen,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "fdz" = (
@@ -52321,7 +52312,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -52548,7 +52539,7 @@
 "foV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "foX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -52672,12 +52663,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"fsy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "fsO" = (
 /obj/structure/table/wood,
 /obj/item/bikehorn,
@@ -52970,7 +52955,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fAj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53059,11 +53044,11 @@
 	},
 /area/maintenance/port/aft)
 "fDc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "fDL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -53188,31 +53173,9 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "fIG" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
-"fIT" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/obj/effect/turf_decal/box,
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "fJm" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
@@ -53220,7 +53183,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fKf" = (
 /obj/structure/table/wood,
 /obj/item/folder/white{
@@ -53258,7 +53221,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fMg" = (
 /obj/machinery/light{
 	dir = 1
@@ -53305,9 +53268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"fND" = (
-/turf/closed/wall,
-/area/maintenance/department/engine/atmos)
 "fNE" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -53354,7 +53314,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fOz" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -53387,7 +53347,7 @@
 "fPs" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "fPH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -53470,7 +53430,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "fTc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53487,7 +53447,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "fTC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -53518,7 +53478,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "fTZ" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -53641,13 +53601,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fXM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/atmospherics,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/item/analyzer,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "fXP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53755,7 +53711,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/maintenance/starboard)
 "gbR" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -53927,7 +53883,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gfC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -53941,7 +53897,7 @@
 "gfJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "gfL" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -53986,7 +53942,7 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ggI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -54108,9 +54064,9 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "glw" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "glP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/smartfridge/drying_rack,
@@ -54190,12 +54146,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"gnD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "gou" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -54229,18 +54179,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gpa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gpo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -54271,7 +54215,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "gqO" = (
 /obj/item/crowbar/red,
 /obj/item/wrench,
@@ -54350,11 +54294,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gut" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -54409,10 +54350,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"gwn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "gxv" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -54434,14 +54371,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"gxD" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "gxY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -54508,16 +54437,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"gAC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "gAI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -54605,7 +54524,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gGV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -54626,13 +54545,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = -32
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
+/obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gHw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -54737,7 +54655,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "gIT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54948,12 +54866,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"gPe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "gPo" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -55026,7 +54938,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "gUh" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -55085,14 +54997,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "gVB" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -55183,7 +55089,7 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "gZz" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics - Foyer"
@@ -55264,8 +55170,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "hdi" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "hdx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 Outlet Pump";
@@ -55275,7 +55184,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "her" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55285,6 +55194,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"heF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/stack/ore/iron,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "heW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -55328,7 +55244,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hhn" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -55480,7 +55396,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hlX" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -55677,7 +55593,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hqE" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 2;
@@ -55724,12 +55640,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopods)
-"hsp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "hsP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -55840,8 +55750,8 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "hyX" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -55933,7 +55843,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "hEi" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -56013,7 +55923,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hGb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56183,7 +56093,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "hLU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -56222,7 +56132,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "hMB" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hMP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -56253,7 +56163,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hON" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -56451,7 +56361,7 @@
 "hVH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
@@ -56506,7 +56416,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "hYv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -56515,7 +56425,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "hYx" = (
 /obj/machinery/chem_master,
 /obj/item/book/manual/wiki/chemistry,
@@ -56578,12 +56488,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "hZS" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
+	dir = 1;
+	name = "toxins space injector"
 	},
-/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space/nearstation)
+/area/science/mixing/chamber)
 "ibb" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -56726,7 +56637,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "igS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56857,11 +56768,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ike" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -57034,7 +56942,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "irq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57045,14 +56953,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iru" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "isj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 1
@@ -57066,7 +56971,7 @@
 "isn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "isF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -57092,7 +56997,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "itl" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -57117,15 +57022,8 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Incinerator Access";
-	req_access_txt = "24"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "iua" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/cafeteria{
@@ -57245,7 +57143,7 @@
 /area/maintenance/starboard/fore)
 "izR" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "izW" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -57325,20 +57223,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iCr" = (
-/obj/machinery/light{
+/obj/machinery/light/built{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
-"iCR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "iDk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -57444,7 +57333,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iGI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57486,19 +57375,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"iHM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"iIc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "iIw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -57536,7 +57412,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "iKc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -57716,11 +57592,8 @@
 	dir = 1;
 	name = "Pure to Port"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iRa" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -57808,7 +57681,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "iSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57856,13 +57729,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/hallway)
-"iTq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "iTV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -57874,7 +57740,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iUo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -57888,12 +57754,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"iUu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "iUJ" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -57954,13 +57814,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "iWF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iWR" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -57989,11 +57849,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "iYN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "iYP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -58006,7 +57866,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "iYQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -58112,11 +57972,8 @@
 	dir = 8;
 	name = "Port to Incinerator"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jbq" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58237,10 +58094,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"jfv" = (
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "jfL" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -58303,7 +58156,7 @@
 "jhQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jhU" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -58386,7 +58239,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "jjs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -58445,7 +58298,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "jkG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -58586,7 +58439,7 @@
 "jou" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "joF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58654,10 +58507,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "jpK" = (
@@ -58697,7 +58546,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jqX" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -58795,7 +58644,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jtu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -58894,7 +58743,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jwt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58932,7 +58781,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -59016,7 +58865,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "jAO" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -59031,7 +58880,7 @@
 "jBH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jCV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -59049,11 +58898,11 @@
 	name = "atmos blast door"
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "jDF" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jDR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
@@ -59224,7 +59073,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jIE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -59318,10 +59167,10 @@
 /area/hallway/primary/port)
 "jKu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "jKJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -59345,13 +59194,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"jKR" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "jLc" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -59389,7 +59231,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jLN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59417,7 +59259,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "jMd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59446,7 +59288,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "jNW" = (
 /obj/structure/closet,
 /obj/item/flashlight,
@@ -59527,7 +59369,7 @@
 "jPG" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jPM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -59563,7 +59405,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "jQt" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -59597,13 +59439,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"jSK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "jTe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -59643,11 +59478,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jTH" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -59657,13 +59489,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jTL" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "jUq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -59675,11 +59507,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jWm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59731,7 +59560,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "jWP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59937,11 +59766,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kcB" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "kdi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60184,7 +60010,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kkF" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -60210,7 +60036,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "klj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -60218,7 +60044,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kmH" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -60245,7 +60071,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "koH" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Central";
@@ -60273,13 +60099,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kpZ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "kqF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -60292,7 +60118,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kro" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -60328,7 +60154,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "krM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -60447,7 +60273,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kuQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -60511,12 +60337,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"kwN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "kwP" = (
 /turf/template_noop,
 /area/maintenance/fore)
@@ -60736,7 +60556,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kFP" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/small{
@@ -60826,7 +60646,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kIE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -60899,7 +60719,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kMj" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/machinery/airalarm{
@@ -60994,12 +60814,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "kOv" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "kPz" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 4
@@ -61159,8 +60979,9 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "kRB" = (
-/turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "kRO" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -61174,30 +60995,27 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kRS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kRT" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kRV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kSY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -61232,7 +61050,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kTA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -61416,7 +61234,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "kWW" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral,
@@ -61461,7 +61279,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "kYu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61490,11 +61308,11 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "kYO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "kYS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair,
@@ -61516,12 +61334,6 @@
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/medical/sleeper)
-"kZx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "laa" = (
 /obj/machinery/button/door{
 	id = "telelab";
@@ -61539,12 +61351,6 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lbn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "lbs" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -61619,7 +61425,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ldr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61679,11 +61485,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lfy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced,
@@ -61850,11 +61653,11 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "lij" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "liM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61888,17 +61691,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"ljH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/item/stack/ore/iron,
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "ljZ" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck{
@@ -61921,12 +61713,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"lko" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "lkt" = (
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
@@ -62085,7 +61871,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "loO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -62101,7 +61887,7 @@
 "lpw" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lpP" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/cable{
@@ -62253,11 +62039,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "luw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -62271,7 +62054,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lvh" = (
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/grimy,
@@ -62286,7 +62069,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "lwe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -62389,7 +62172,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lzJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -62465,7 +62248,7 @@
 "lBi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lBm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -62478,10 +62261,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lBI" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/atmos/distro)
 "lBJ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -62549,7 +62328,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lEy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -62560,7 +62339,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lED" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -62572,7 +62351,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -62634,7 +62413,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lKC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -62696,11 +62475,11 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "lLE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "lLU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.3-Escape-3";
@@ -62767,7 +62546,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "lOJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62890,7 +62669,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lSs" = (
 /obj/structure/rack,
 /obj/item/lightreplacer{
@@ -62925,7 +62704,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "lTy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -62975,7 +62754,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lVB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -62988,7 +62767,7 @@
 /obj/item/t_scanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "lVC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -63003,7 +62782,7 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "lVN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -63145,10 +62924,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"lYF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "lYX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -63170,7 +62945,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "lZV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63190,7 +62965,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "maC" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -63434,7 +63209,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "mjF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -63463,7 +63238,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mkz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63484,7 +63259,7 @@
 /obj/machinery/electrolyzer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mmB" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -63587,13 +63362,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "moI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "moY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -63658,7 +63430,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "msm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -63762,9 +63534,8 @@
 /area/medical/storage)
 "mxx" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "mxF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor/border_only{
@@ -63847,7 +63618,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "mAJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -63864,11 +63635,8 @@
 /area/maintenance/port/fore)
 "mAP" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mBa" = (
 /obj/structure/sink{
 	dir = 4;
@@ -63946,15 +63714,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"mCI" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/core,
-/obj/item/paper/guides/jobs/atmos/hypertorus,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "mCW" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -64109,17 +63868,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/pumproom";
-	dir = 1;
-	name = "Atmospherics Pumping Room APC";
-	pixel_y = 23
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "mGM" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -64129,10 +63879,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "mGX" = (
-/obj/machinery/atmospherics/components/unary/passive_vent,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	on = 1;
+	volume_rate = 200
+	},
+/turf/open/floor/plating/airless,
+/area/engine/atmos_distro)
 "mHl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -64141,7 +63893,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mHL" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -64241,7 +63993,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mKO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -64360,14 +64112,14 @@
 "mQO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mQT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mRu" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -64415,10 +64167,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mSj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "mSs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -64436,7 +64184,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mTb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64478,7 +64226,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mTV" = (
 /obj/machinery/button/door{
 	id = "transittube";
@@ -64521,11 +64269,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "mUb" = (
 /obj/machinery/door/airlock{
 	name = "Recreation Area"
@@ -64733,7 +64478,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "naH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64770,11 +64515,8 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Tinker"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ncC" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/treatment,
@@ -64847,12 +64589,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"neH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "neP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -64964,7 +64700,7 @@
 	c_tag = "Incinerator Access"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "niZ" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -65075,7 +64811,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nlw" = (
 /obj/machinery/shower{
 	dir = 4
@@ -65196,7 +64932,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nqi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -65227,7 +64963,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nqB" = (
 /obj/item/trash/semki,
 /obj/structure/disposalpipe/segment{
@@ -65242,7 +64978,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nsn" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Cargo Bay Bridge Access"
@@ -65407,7 +65143,7 @@
 "nwR" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nxg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/flasher{
@@ -65624,7 +65360,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nBL" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 4
@@ -65644,7 +65380,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nDD" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -65675,7 +65411,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nEa" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -65790,11 +65526,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "nGH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -65811,7 +65544,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nHk" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/robotics/lab";
@@ -65907,13 +65640,16 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nIY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "nJv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65983,7 +65719,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nNr" = (
 /obj/machinery/light{
 	dir = 4
@@ -65995,7 +65731,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nNv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -66098,7 +65834,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "nQQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -66142,8 +65878,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "nSS" = (
-/turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/obj/effect/turf_decal/box,
+/obj/structure/frame/machine,
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "nSY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -66231,7 +65969,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nWQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -66242,7 +65980,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "nXc" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
@@ -66344,8 +66082,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oap" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -66479,7 +66218,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oeb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -66546,7 +66285,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "ohf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -66562,9 +66301,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"ohr" = (
-/turf/closed/wall,
-/area/engine/atmos/mix)
 "oiG" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -66572,7 +66308,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oiM" = (
 /obj/machinery/oven,
 /turf/open/floor/plasteel/cafeteria{
@@ -66755,14 +66491,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "omG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66857,7 +66587,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "opl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -66868,11 +66598,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "opv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66941,7 +66668,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oqZ" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -67251,7 +66978,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oIk" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -67442,7 +67169,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "oQv" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -67681,18 +67408,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"oVu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "oVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -67776,7 +67491,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oXx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67830,7 +67545,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "oZD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -67859,12 +67574,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
-"pbD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "pbQ" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -67882,9 +67591,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "pbV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "pce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -68100,7 +67809,7 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "piW" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -68155,7 +67864,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "plb" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -68259,7 +67968,7 @@
 "pqx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pqy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
@@ -68378,7 +68087,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "pvg" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -68416,7 +68125,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pwn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -68459,7 +68168,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pxL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4;
@@ -68480,7 +68189,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pyC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68532,7 +68241,7 @@
 "pzL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pzZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -68545,7 +68254,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pAy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -68582,7 +68291,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pBa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -68780,7 +68489,7 @@
 /obj/item/analyzer,
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pGm" = (
 /obj/item/caution,
 /obj/effect/landmark/blobstart,
@@ -68807,7 +68516,7 @@
 "pHk" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pHm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -68816,7 +68525,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pHt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -68846,9 +68555,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "pIr" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "pIO" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -68865,7 +68576,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "pJf" = (
 /obj/machinery/door/window{
 	name = "MiniSat Walkway Access"
@@ -68904,7 +68615,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pJR" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -68944,7 +68655,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pKe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -69015,16 +68726,16 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/mix";
+	areastring = "/area/engine/atmos_distro";
 	dir = 1;
-	name = "Atmospherics Mixing Room APC";
+	name = "Atmospherics Distribution APC";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pML" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -69062,7 +68773,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "pPV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69111,7 +68822,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "pSL" = (
 /obj/machinery/plate_press,
 /turf/open/floor/plasteel/dark,
@@ -69129,7 +68840,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pSY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -69160,11 +68871,8 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "pUF" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -69264,12 +68972,6 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"pYx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "pYF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -69546,7 +69248,7 @@
 /obj/item/pipe_dispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "qji" = (
 /obj/structure/chair{
 	dir = 1
@@ -69640,7 +69342,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qle" = (
 /obj/machinery/bookbinder,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -69673,9 +69375,12 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "qlP" = (
-/obj/effect/turf_decal/arrows/white,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "qmf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -69813,7 +69518,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qpG" = (
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = -32
@@ -69927,7 +69632,7 @@
 "qsh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "qsj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -69963,18 +69668,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/physician)
-"qsR" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "qtD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "qtN" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -70047,11 +69746,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qwL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70076,28 +69772,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qzR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"qAg" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/rglass{
-	amount = 5
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 5
-	},
-/obj/item/pipe_dispenser,
-/obj/item/wrench,
-/obj/item/multitool,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "qAD" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -70160,7 +69840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qCo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -70340,12 +70020,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"qHH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "qHJ" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/airalarm{
@@ -70404,7 +70078,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "qJm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -70426,9 +70100,9 @@
 "qJq" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/foyer";
+	areastring = "/area/engine/atmos";
 	dir = 1;
-	name = "Atmospherics Foyer APC";
+	name = "Atmospherics Wing APC";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -70438,7 +70112,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "qJB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -70478,7 +70152,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -70491,7 +70165,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "qLW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -70581,12 +70255,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qOB" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/light/built{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "qOT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -70806,7 +70479,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qTr" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -70958,7 +70631,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "qZG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70968,7 +70641,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qZJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -70979,7 +70652,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "qZQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -71096,7 +70769,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rdX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "Connector Port (Air Supply)"
@@ -71282,11 +70955,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "rjN" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "rka" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -71348,7 +71021,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rlE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -71610,7 +71283,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rsb" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
@@ -71682,11 +71355,8 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "ruC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -71768,7 +71438,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rxa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71804,12 +71474,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rxC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "ryt" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
@@ -72007,11 +71671,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rGz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -72019,16 +71680,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"rHk" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "rHp" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -72092,7 +71743,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rIu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -72158,7 +71809,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rMp" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories - Fore";
@@ -72203,7 +71854,7 @@
 	name = "Port to Incinerator/Tinker"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rOP" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -72238,7 +71889,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rPP" = (
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 8
@@ -72256,7 +71907,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "rRZ" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -72278,7 +71929,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "rSv" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -72595,12 +72246,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"scX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "sdD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72622,7 +72267,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "sew" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -72732,17 +72377,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "sjs" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "sjw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"slm" = (
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "slu" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -72760,7 +72403,7 @@
 /area/hallway/secondary/entry)
 "smB" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "snd" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
@@ -72892,7 +72535,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "sqn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -73036,31 +72679,11 @@
 "suR" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/interrogation)
-"suW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "svg" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"svp" = (
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "svF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -73195,7 +72818,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "sAJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -73465,10 +73088,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sGj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "sGl" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
@@ -73501,17 +73120,12 @@
 "sHe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/hfr";
-	dir = 8;
-	name = "Atmospherics HFR Room APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "sHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -73620,7 +73234,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "sLT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -73645,24 +73259,15 @@
 	c_tag = "Atmospherics Tanks West";
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 8;
-	name = "Atmospherics Distribution APC";
-	pixel_x = -25
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sMm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "sMs" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -73702,7 +73307,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "sNT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -74028,15 +73633,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"sYf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
 "sYp" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -74184,7 +73780,7 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "tbh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -74410,11 +74006,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tig" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -74446,12 +74039,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "tit" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "tjd" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Starboard";
@@ -74520,12 +74112,12 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tlT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tlW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -74714,11 +74306,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "tso" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -74846,7 +74435,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tvE" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -74854,7 +74443,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "twH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -74977,25 +74566,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tCd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "tCy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
-"tDa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "tDj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/reagent_containers/food/snacks/grown/banana,
@@ -75021,13 +74597,6 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"tDD" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "tDL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75166,7 +74735,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tJP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -75192,13 +74761,10 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "tKo" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "tKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
@@ -75452,7 +75018,7 @@
 /area/quartermaster/office)
 "tQz" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tQJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -75533,7 +75099,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "tTD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -75577,11 +75143,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tUo" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/cafeteria{
@@ -75641,13 +75204,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/storage/locker)
 "tWB" = (
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/atmos_distro)
 "tWL" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "tWY" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -75676,19 +75239,13 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "tYl" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "tYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -75738,7 +75295,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uaC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75780,7 +75337,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ucx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75919,23 +75476,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
-"ugt" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ugL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ugU" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 8
@@ -76085,7 +75633,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uia" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14-Starboard-Central";
@@ -76156,7 +75704,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "ujF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76232,7 +75780,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ula" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -76267,7 +75815,7 @@
 /area/security/checkpoint/medical)
 "ulM" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ulT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -76292,7 +75840,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "unI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Toxins Lab Maintenance";
@@ -76487,7 +76035,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "utn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -76547,7 +76095,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "uxv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -76596,13 +76144,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"uAo" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "uAw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -76626,7 +76167,7 @@
 /area/maintenance/port/aft)
 "uBz" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "uBE" = (
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/wood,
@@ -76743,12 +76284,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "uDX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "uEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -76835,11 +76373,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uHr" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Telecomms Camera Monitor";
@@ -77008,7 +76543,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "uNl" = (
 /obj/machinery/power/apc/unlocked{
 	areastring = "/area/medical/genetics/cloning";
@@ -77268,7 +76803,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uUn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -77289,7 +76824,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "uUQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -77322,7 +76857,7 @@
 /area/maintenance/port/fore)
 "uUY" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uVc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -77360,14 +76895,14 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uVk" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#00AAFF";
-	pixel_y = 15
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "uVu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -77385,7 +76920,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "uVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/hydroponics/constructable,
@@ -77496,7 +77031,7 @@
 "uYo" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "uYs" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -77507,10 +77042,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"uYM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos/mix)
 "uYW" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -77542,7 +77073,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vay" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -77590,7 +77121,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vdK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -77639,14 +77170,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "veu" = (
 /obj/machinery/light{
 	dir = 1
@@ -77776,7 +77301,7 @@
 	name = "Port to Engine"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "viG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -77968,14 +77493,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vqG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "vqY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -78235,14 +77757,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
-"vAr" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_x = -15
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "vAK" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -78283,9 +77798,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vDz" = (
 /obj/machinery/light{
 	dir = 4
@@ -78311,7 +77825,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vFr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -78339,7 +77853,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vGz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78348,7 +77862,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vHB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -78501,7 +78015,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vLg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78559,7 +78073,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "vMZ" = (
 /obj/machinery/door/window/westleft{
 	dir = 4;
@@ -78585,7 +78099,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vOi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -78593,7 +78107,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vOI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78625,7 +78139,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vPe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78635,7 +78149,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vPs" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -78649,7 +78163,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vQl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78773,7 +78287,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "vUe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78846,17 +78360,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vVH" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/turf/closed/wall,
+/area/engine/atmos_distro)
 "vVV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vWd" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -78884,7 +78395,7 @@
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "vWF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -78976,7 +78487,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "vYF" = (
 /obj/machinery/button{
 	id = "maintshut";
@@ -79051,7 +78562,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "waT" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -79243,19 +78754,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"wjv" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Incinerator Access";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "wjC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79615,11 +79113,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wxY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79711,7 +79206,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wAR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -79735,7 +79230,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "wBH" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -79788,7 +79283,7 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wDw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79821,7 +79316,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wEE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -79829,7 +79324,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos_distro)
 "wFr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -79838,7 +79333,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wFH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79916,10 +79411,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wHu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "wHM" = (
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
@@ -79968,11 +79459,8 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wJi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -79981,11 +79469,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wJq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -80035,7 +79520,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wKk" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -80216,11 +79701,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wRO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -80272,7 +79754,7 @@
 /area/tcommsat/server)
 "wSR" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "wTc" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bodycontainer/morgue{
@@ -80291,7 +79773,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "wTy" = (
 /obj/structure/closet/crate/sphere,
 /turf/open/floor/plating,
@@ -80392,12 +79874,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/area/engine/atmos_distro)
 "wZp" = (
 /obj/structure/chair/stool,
 /obj/machinery/firealarm{
@@ -80444,7 +79922,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xbm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -80593,7 +80071,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xgk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80668,7 +80146,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xiA" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -80763,7 +80241,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xmC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -80947,11 +80425,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "xrY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
+/turf/open/floor/plating,
+/area/engine/atmos_distro)
 "xsR" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -81037,18 +80512,15 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xuK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xuL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -81156,11 +80628,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
-/area/engine/atmos/mix)
-"xxh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xyf" = (
 /obj/structure/table/optable,
 /obj/item/radio/intercom{
@@ -81182,10 +80650,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xyD" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "xyP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -81271,12 +80735,12 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xBs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xCh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -81477,7 +80941,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xHk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -81487,7 +80951,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xHY" = (
 /obj/structure/chair,
 /obj/machinery/computer/security/telescreen/interrogation{
@@ -81529,10 +80993,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"xJA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "xJC" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -81554,7 +81014,7 @@
 "xKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xKG" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -81568,15 +81028,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"xLv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "xLz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -81621,7 +81072,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/mix)
+/area/engine/atmos_distro)
 "xLN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -81652,12 +81103,6 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/closed/wall,
 /area/maintenance/port/fore)
-"xNv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/hfr)
 "xOc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -81709,7 +81154,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xPY" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -81729,11 +81174,11 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos/foyer)
+/area/engine/atmos)
 "xQD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xQR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -81798,7 +81243,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "xTb" = (
 /obj/structure/chair/comfy/beige,
 /obj/effect/landmark/start/chief_engineer,
@@ -81880,7 +81325,7 @@
 	on = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "xWt" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -81958,13 +81403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"xXl" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/engine/atmos/mix)
 "xXP" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Staging Area";
@@ -82087,7 +81525,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yab" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -82152,9 +81590,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"ybT" = (
-/turf/closed/wall,
-/area/engine/atmos/distro)
 "ybZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -82299,7 +81734,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "ygf" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -82367,11 +81802,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos_distro)
 "yhJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -82401,7 +81833,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos/pumproom)
+/area/engine/atmos_distro)
 "yiC" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 2;
@@ -98538,10 +97970,10 @@ dne
 aaf
 aaa
 aaf
-ayj
-ljH
-suW
-svp
+aFO
+heF
+aAC
+aBS
 aFO
 aaf
 aaa
@@ -98797,7 +98229,7 @@ aaa
 aaf
 aFO
 azk
-xLv
+aAC
 aBT
 aFO
 aaf
@@ -99054,7 +98486,7 @@ aaf
 aaf
 ayj
 ayj
-fIT
+aAD
 aBU
 ayj
 aFO
@@ -114038,8 +113470,8 @@ kTi
 ike
 ahf
 hZS
-aaf
-aaf
+cEq
+cEq
 cIg
 cIa
 cIU
@@ -121202,11 +120634,11 @@ joF
 alq
 bcs
 apc
-ohr
-ohr
-ohr
+vVH
+vVH
+vVH
 qCN
-ohr
+vVH
 bZE
 aaV
 acd
@@ -121459,7 +120891,7 @@ xAq
 alq
 bVC
 jmm
-ohr
+vVH
 kRS
 faw
 iWl
@@ -121716,7 +121148,7 @@ apc
 alq
 rpR
 aad
-ohr
+vVH
 jPG
 jTl
 ruc
@@ -121973,10 +121405,10 @@ apc
 alq
 wnv
 apc
-ohr
+vVH
 niQ
 dRc
-kwN
+cNG
 bZE
 bZE
 veu
@@ -122225,15 +121657,15 @@ bxc
 bxc
 bxc
 bxc
-fND
-fND
-fND
-fND
+alq
+alq
+alq
+alq
 dFJ
-ohr
-ohr
+vVH
+vVH
 cVV
-bCi
+uUY
 bZE
 tYt
 uEk
@@ -122483,9 +121915,9 @@ aaO
 mAo
 bxc
 bLX
-slm
+apc
 bps
-xyD
+bpU
 bqR
 cit
 gbB
@@ -122734,18 +122166,18 @@ lVM
 piK
 bhD
 lRH
-kRB
+bCi
 aiN
 aiN
 mAo
 bxc
 bLY
 boM
-slm
-jfv
-slm
+apc
+aqq
+apc
 bJX
-ohr
+vVH
 rEH
 hla
 bZE
@@ -122989,7 +122421,7 @@ hmH
 aTq
 bxc
 lUF
-kRB
+bCi
 nQJ
 bhU
 pJo
@@ -122998,19 +122430,19 @@ jAt
 bxc
 bLZ
 bPm
-slm
+apc
 bSf
-slm
-dUo
-dUo
+apc
+uBz
+uBz
 veo
-dUo
+uBz
+cgz
 cgz
 cgz
 cgz
 lQC
-wjv
-lQC
+cgz
 cgz
 cgz
 cgz
@@ -123258,18 +122690,18 @@ bPn
 bQR
 bSd
 anM
-dUo
+uBz
 eKb
 mSs
-scX
-ebO
-fXM
-hsp
-iru
-vqG
-omr
-hsp
 wYT
+vVH
+xrY
+xrY
+xrY
+xrY
+omr
+xrY
+xrY
 uBz
 lMJ
 aaa
@@ -123506,27 +122938,27 @@ bxc
 pvP
 ahm
 nrs
-dUo
-dUo
-dUo
-dUo
-dUo
-dUo
-dUo
-dUo
-dUo
-dUo
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
 eKb
 gtz
-sGj
-qsh
-iIc
-fsy
-xJA
-jKu
-hdi
-fbx
 cEA
+qsh
+xrY
+xrY
+xrY
+xrY
+jKu
+sjs
+xrY
 uBz
 lMJ
 lMJ
@@ -123763,31 +123195,31 @@ nqm
 ogH
 mkc
 lEx
-dUo
+uBz
 pxO
-dUo
+uBz
 sAp
 jTH
 hKT
 aqC
-dUo
+uBz
 fPs
 kuG
 fJm
 uHq
-lYF
-qsh
-jSK
-pbD
-hdi
-hdi
-hdi
-hdi
-wHu
-uBz
-uBz
-uBz
+dOs
+xrY
+xrY
+xrY
 tit
+xrY
+iYN
+xrY
+xrY
+uBz
+uBz
+uBz
+lMJ
 aaa
 aaa
 aaa
@@ -124034,15 +123466,15 @@ fOy
 wIM
 krL
 qsh
-moI
-pbD
+xrY
+xrY
 eNb
+glw
 fDc
-fDc
-fDc
-eGV
-tCd
-qHH
+moI
+xrY
+xrY
+xrY
 tWL
 lMJ
 lMJ
@@ -124275,31 +123707,31 @@ fkB
 bxc
 qJq
 uVu
-kRB
+bCi
 kYO
-uYM
+qsh
 xfO
 rrX
-bCi
+uUY
 sql
 iqG
-bCi
-bCi
+uUY
+uUY
 aRJ
-bCi
-bCi
+uUY
+uUY
 jaZ
 gHq
-ebO
-ebO
-rHk
+vVH
+vVH
+qOB
 iYN
-sjs
+ebO
 rjN
-sjs
-ezP
+rjN
+rjN
 qtD
-wHu
+xrY
 tWL
 lMJ
 lMJ
@@ -124538,25 +123970,25 @@ jsY
 rlC
 odX
 eoS
-ohr
+vVH
 rwX
 oXw
 rwX
-ohr
-xXl
-bCi
+vVH
+gVA
+uUY
 wxL
 knN
 nIY
 sHe
-gAC
-sjs
-fIG
-kcB
+tKo
+cJG
 pIr
-sjs
-gPe
-cEA
+kcB
+nSS
+kcB
+kRB
+xrY
 tWL
 lMJ
 aaa
@@ -124791,28 +124223,28 @@ fTK
 hhg
 iJJ
 erl
-uYM
+qsh
 xfO
 pJS
 erj
-ohr
-ohr
+vVH
+vVH
 jou
-ohr
-ohr
+vVH
+vVH
 vCE
-bCi
+uUY
 tYl
 nch
 ity
-uAo
-uDX
+pbV
+pbV
 qlP
 kOv
-glw
+kcB
 tWB
-uVk
-gPe
+kcB
+kRB
 mxx
 uBz
 lMJ
@@ -125043,34 +124475,34 @@ roy
 qCo
 eyz
 cXA
-cJG
+uBz
 yiB
-eXW
+qsh
 yiB
-cJG
-dUo
+uBz
+uBz
 jHL
 vPe
 iTV
-ohr
+vVH
 kYM
 kYM
 gYP
-ohr
+vVH
 ahZ
-bCi
+uUY
 iiP
-bCi
-qsh
+uUY
+uVk
 hxX
-uDX
-sjs
+xrY
+iru
 pIr
-cEq
+kcB
 fIG
-sjs
-gPe
-cEA
+kcB
+kRB
+xrY
 tWL
 lMJ
 aaa
@@ -125305,10 +124737,10 @@ qZA
 kjx
 lwd
 uvk
-ohr
+vVH
 mHl
 xLG
-bCi
+uUY
 wTl
 gGM
 gGM
@@ -125318,16 +124750,16 @@ vTV
 rOx
 xuB
 dOi
-ebO
-ebO
-gVA
-lbn
-sjs
-vAr
-sjs
+vVH
+vVH
+vqG
+iru
+dUo
+jTL
+jTL
 jTL
 dWv
-wHu
+xrY
 tWL
 lMJ
 lMJ
@@ -125562,29 +124994,29 @@ pSk
 buT
 jku
 xSW
-ohr
+vVH
 pMu
 goS
-rxC
+uUY
 pUi
-rxC
-rxC
+uUY
+uUY
 mAP
-rxC
+uUY
 eRS
 cVm
-iTq
+uDX
 tlO
 qsh
-gxD
-gnD
+xrY
+xrY
 lij
 lLE
-lLE
-lLE
-qOB
-iCR
-xNv
+xrY
+xrY
+xrY
+xrY
+xrY
 tWL
 lMJ
 lMJ
@@ -125815,8 +125247,8 @@ bvo
 lpT
 aTq
 mGy
-sYf
-ugt
+jLQ
+tJN
 vzX
 gpR
 pAP
@@ -125824,26 +125256,26 @@ dUE
 mTW
 tvn
 nwR
-bCi
-bCi
-bCi
-bCi
-vVH
+uUY
+uUY
+uUY
+uUY
+eRS
 iQX
 mKz
 wEo
 qsh
-mCI
-gnD
+xrY
+moI
+xrY
 hdi
-hdi
-hdi
-hdi
+xrY
+fXM
 dzJ
 uBz
 uBz
 uBz
-tit
+lMJ
 aaa
 aaa
 aaa
@@ -126073,10 +125505,10 @@ kui
 aTq
 vGz
 jLQ
-jKR
-pYx
+lpw
+vVV
 kRV
-ohr
+vVH
 uUE
 nGc
 fOy
@@ -126087,16 +125519,16 @@ vOi
 vOi
 qLB
 leZ
-qsR
+qpv
 mQT
 qsh
-tKo
-tDD
-mSj
-lko
-hdi
-hdi
-cEA
+xrY
+sjs
+xrY
+xrY
+moI
+xrY
+xrY
 uBz
 lMJ
 lMJ
@@ -126330,30 +125762,30 @@ iqf
 aTq
 ujk
 jLQ
-kZx
-pYx
+uUY
+vVV
 xPM
-uYM
+qsh
 xfO
-oVu
-bCi
+pkQ
+uUY
 viE
 rcV
 klj
 lOy
 ggy
-eap
+lpw
 ayY
 vGq
 wEo
-ebO
-qAg
+vVH
+xrY
 xrY
 tse
 xrY
 iCr
 xrY
-esg
+xrY
 uBz
 lMJ
 aaa
@@ -126587,7 +126019,7 @@ uyP
 aTq
 taN
 jLQ
-tDa
+cbi
 ltp
 opl
 tTT
@@ -126603,7 +126035,7 @@ npZ
 jUq
 opk
 hFO
-ebO
+vVH
 uBz
 uBz
 uBz
@@ -126860,8 +126292,8 @@ xuK
 doD
 aeD
 tCy
-ybT
-nSS
+vVH
+uBz
 lMJ
 lMJ
 aaa
@@ -127098,19 +126530,19 @@ aZj
 aaf
 aaf
 ack
-aTq
-cJG
-cJG
-cJG
-cJG
-cJG
-dUo
-dUo
-dUo
-dUo
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
+uBz
 dop
-dUo
-nSS
+uBz
+uBz
 xHk
 sMj
 eGE
@@ -127118,7 +126550,7 @@ yhB
 xZR
 wFr
 gIP
-nSS
+uBz
 jDy
 pHk
 pHk
@@ -127367,7 +126799,7 @@ wuF
 wuF
 lVC
 lMJ
-lBI
+tWL
 vOg
 wRN
 qwz
@@ -127881,13 +127313,13 @@ lMJ
 lMJ
 lMJ
 lMJ
-lBI
+tWL
 mrN
-neH
+jLQ
 vVV
 pkQ
 dqD
-xxh
+uDX
 lZR
 oQt
 wEE
@@ -128397,11 +127829,11 @@ rPj
 jiG
 nWQ
 xGK
-gwn
+jBH
 ukR
 dWm
 xQD
-xxh
+uDX
 unb
 ebF
 puB
@@ -128653,13 +128085,13 @@ tTl
 lBi
 fTh
 kTm
-iUu
+xfO
 uUY
 uUY
 pkQ
 qpv
 lpw
-pbV
+cEA
 kRO
 seq
 lBi
@@ -128916,7 +128348,7 @@ epf
 pkQ
 qpv
 uUY
-pbV
+cEA
 kpD
 uMs
 uZI
@@ -129429,7 +128861,7 @@ kRT
 rMg
 igM
 xQD
-xxh
+uDX
 lzo
 ebF
 puB
@@ -130457,7 +129889,7 @@ hVH
 kRT
 vdv
 usm
-xxh
+uDX
 efd
 ebF
 puB
@@ -130709,13 +130141,13 @@ fzM
 lBi
 fTh
 wKe
-iUu
+xfO
 uUY
 uUY
 pkQ
 uUY
 uUY
-pbV
+cEA
 luw
 seq
 lBi
@@ -130966,13 +130398,13 @@ eFk
 uZI
 kpZ
 pIW
-iUu
+xfO
 cbi
 ats
 hYv
 xKj
-iHM
-pbV
+mTM
+cEA
 fLu
 uMs
 uZI
@@ -131479,7 +130911,7 @@ lMJ
 aaa
 lMJ
 lMJ
-nSS
+uBz
 pxC
 uUY
 eno
@@ -131487,7 +130919,7 @@ nNr
 uUY
 uUY
 jhQ
-nSS
+uBz
 aaa
 lMJ
 lMJ
@@ -131736,15 +131168,15 @@ fwb
 fwb
 nYJ
 lMJ
-nSS
-lBI
-lBI
-nSS
+uBz
+tWL
+tWL
+uBz
 sNo
-nSS
-lBI
-lBI
-nSS
+uBz
+tWL
+tWL
+uBz
 lMJ
 lMJ
 fwb
@@ -131996,9 +131428,9 @@ lMJ
 lMJ
 lMJ
 lMJ
-nSS
+uBz
 nBL
-nSS
+uBz
 lMJ
 lMJ
 lMJ
@@ -132253,9 +131685,9 @@ nYJ
 lMJ
 lMJ
 lMJ
-nSS
+uBz
 miQ
-nSS
+uBz
 lMJ
 lMJ
 lMJ

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -233,7 +233,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aaP" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/cultivator,
@@ -1523,7 +1523,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "aeE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Airlock";
@@ -2513,7 +2513,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ahn" = (
 /obj/structure/chair{
 	dir = 4
@@ -2876,8 +2876,9 @@
 /obj/item/radio/intercom{
 	pixel_y = 28
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aic" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Prison Gate";
@@ -3209,7 +3210,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "aiW" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -4287,7 +4288,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "alK" = (
 /turf/closed/wall,
 /area/maintenance/port)
@@ -5104,7 +5105,7 @@
 "anM" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "anO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -6051,7 +6052,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aqD" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating{
@@ -7208,7 +7209,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "att" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9157,8 +9158,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aza" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9934,22 +9938,6 @@
 "aAC" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"aAD" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "aAE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -10543,14 +10531,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"aBS" = (
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "aBT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
@@ -14001,16 +13981,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aJu" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJw" = (
@@ -17848,7 +17818,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "aRK" = (
 /obj/machinery/computer/security/qm{
 	dir = 4
@@ -24234,7 +24204,7 @@
 "bhD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bhE" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -24353,7 +24323,7 @@
 "bhU" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bif" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -26046,7 +26016,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "blQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -27067,7 +27037,7 @@
 "boM" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "boQ" = (
 /obj/item/trash/candy,
 /turf/open/floor/plating,
@@ -27203,7 +27173,7 @@
 "bps" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -27781,7 +27751,7 @@
 "bqR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bqS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29004,7 +28974,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "bvj" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -29406,9 +29376,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bwB" = (
-/obj/structure/sign/warning/fire{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Fuel Pipe to Incinerator"
 	},
@@ -29497,7 +29464,7 @@
 /area/crew_quarters/bar)
 "bxc" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bxf" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/stripes/line{
@@ -30527,7 +30494,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "bBu" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
@@ -30868,7 +30835,7 @@
 /area/hallway/secondary/command)
 "bCi" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/mix)
 "bCl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33249,7 +33216,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bKa" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/dark,
@@ -33812,15 +33779,15 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bLY" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bLZ" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bMe" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -34620,11 +34587,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bPn" = (
 /obj/machinery/atmospherics/components/trinary/filter,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bPt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -35009,7 +34976,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bQU" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -35348,7 +35315,7 @@
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bSe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35360,7 +35327,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "bSk" = (
 /obj/structure/table/wood,
 /obj/item/deskbell/preset/library{
@@ -37542,7 +37509,7 @@
 "cbi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cbm" = (
 /obj/structure/closet/crate,
 /obj/item/storage/belt/utility,
@@ -37861,7 +37828,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cdc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38957,7 +38924,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "ciB" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/airalarm{
@@ -39283,7 +39250,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cjX" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -40061,7 +40028,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "coU" = (
 /obj/machinery/light{
 	dir = 1
@@ -40346,11 +40313,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "cpN" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+/obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
+/area/space/nearstation)
 "cpP" = (
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
@@ -43587,10 +43554,6 @@
 	},
 /area/science/mixing)
 "czH" = (
-/obj/machinery/airalarm/all_access{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -44292,9 +44255,11 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEq" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/science/mixing/chamber)
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "cEr" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -44346,7 +44311,7 @@
 "cEA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "cED" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44557,7 +44522,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cHk" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
@@ -44866,14 +44831,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cJG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/pumproom)
 "cJJ" = (
 /obj/machinery/computer/operating{
 	dir = 1;
@@ -45515,7 +45474,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "cNN" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -46899,7 +46858,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "cTz" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -47038,8 +46997,14 @@
 	layer = 2.4;
 	name = "Mix to Port"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cVx" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -47055,7 +47020,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "cVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47078,8 +47043,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "cWA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -49018,7 +48986,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "dou" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -49048,8 +49016,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "doJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49156,7 +49127,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dqT" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
@@ -49185,7 +49156,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "dsh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -49432,8 +49403,9 @@
 	c_tag = "Incinerator";
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "dzP" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=10-Aft-To-Central";
@@ -49807,7 +49779,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "dFY" = (
 /obj/item/cigbutt,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
@@ -49879,7 +49851,7 @@
 	id_tag = "n2_sensor"
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dKb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50028,9 +50000,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "dOi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "dOp" = (
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
@@ -50057,7 +50032,7 @@
 "dOs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dOB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -50090,13 +50065,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "dQj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dQn" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -50175,8 +50150,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "dRA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -50201,7 +50179,7 @@
 /area/ai_monitored/turret_protected/ai)
 "dSh" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dSA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50271,11 +50249,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "dUo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/mix)
 "dUz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -50293,7 +50268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "dUK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -50359,13 +50334,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "dWv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "dWE" = (
 /obj/item/reagent_containers/food/snacks/sosjerky,
 /obj/structure/table/glass,
@@ -50504,6 +50479,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"eap" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "eau" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -50552,7 +50531,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ebG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/chair/office/light{
@@ -50573,11 +50552,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "ebO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/closed/wall,
+/area/engine/atmos/hfr)
 "ebZ" = (
 /obj/machinery/button/door{
 	id = "chemistry_shutters";
@@ -50692,8 +50668,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eeq" = (
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line,
@@ -50729,7 +50708,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "efl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51058,7 +51037,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "enT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51101,13 +51080,13 @@
 "eoS" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "epf" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eqK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51143,7 +51122,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "erl" = (
 /obj/machinery/light_switch{
 	pixel_x = 26
@@ -51157,7 +51136,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ery" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -51176,6 +51155,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"esg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "ess" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -51356,7 +51341,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ezk" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -51377,6 +51362,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
+"ezP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "eAd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -51484,7 +51475,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/meter,
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eEI" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -51529,7 +51520,7 @@
 "eFk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eFo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51624,7 +51615,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
+"eGV" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "eHu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
@@ -51729,12 +51729,12 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eKb" = (
 /obj/machinery/pipedispenser,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eKo" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
@@ -51839,11 +51839,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
 "eNb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "eNy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -51868,7 +51866,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "eOb" = (
 /obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plasteel/dark,
@@ -51945,8 +51943,11 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "eRU" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 1
@@ -51977,7 +51978,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "eSm" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only{
@@ -52181,6 +52182,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/physician)
+"eXW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos/pumproom)
 "eYy" = (
 /obj/effect/spawner/lootdrop/tanks/fuelonly/midchance,
 /turf/open/floor/plating{
@@ -52227,7 +52232,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "faR" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52236,6 +52241,10 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"fbx" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "fcd" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/wirecutters,
@@ -52265,7 +52274,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
 "fdr" = (
-/obj/machinery/the_singularitygen,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "fdz" = (
@@ -52312,7 +52321,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -52539,7 +52548,7 @@
 "foV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "foX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -52663,6 +52672,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"fsy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "fsO" = (
 /obj/structure/table/wood,
 /obj/item/bikehorn,
@@ -52955,7 +52970,7 @@
 	id_tag = "o2_sensor"
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fAj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53044,11 +53059,11 @@
 	},
 /area/maintenance/port/aft)
 "fDc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "fDL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -53173,9 +53188,31 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "fIG" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
+"fIT" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Dock";
+	req_access_txt = "48"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "fJm" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
@@ -53183,7 +53220,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fKf" = (
 /obj/structure/table/wood,
 /obj/item/folder/white{
@@ -53221,7 +53258,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fMg" = (
 /obj/machinery/light{
 	dir = 1
@@ -53268,6 +53305,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"fND" = (
+/turf/closed/wall,
+/area/maintenance/department/engine/atmos)
 "fNE" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -53314,7 +53354,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fOz" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/blue{
@@ -53347,7 +53387,7 @@
 "fPs" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "fPH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -53430,7 +53470,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "fTc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53447,7 +53487,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "fTC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -53478,7 +53518,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "fTZ" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -53601,9 +53641,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fXM" = (
-/obj/item/analyzer,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "fXP" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53711,7 +53755,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/engine/atmos)
 "gbR" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -53883,7 +53927,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gfC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -53897,7 +53941,7 @@
 "gfJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "gfL" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -53942,7 +53986,7 @@
 	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ggI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -54064,9 +54108,9 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "glw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "glP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/smartfridge/drying_rack,
@@ -54146,6 +54190,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"gnD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "gou" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -54179,12 +54229,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gpa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gpo" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -54215,7 +54271,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "gqO" = (
 /obj/item/crowbar/red,
 /obj/item/wrench,
@@ -54294,8 +54350,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gut" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -54350,6 +54409,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"gwn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "gxv" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -54371,6 +54434,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"gxD" = (
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "gxY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -54437,6 +54508,16 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"gAC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "gAI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -54524,7 +54605,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gGV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -54545,12 +54626,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gHw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -54655,7 +54737,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "gIT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54866,6 +54948,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"gPe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "gPo" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -54938,7 +55026,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "gUh" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -54997,8 +55085,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "gVB" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -55089,7 +55183,7 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "gZz" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics - Foyer"
@@ -55170,11 +55264,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "hdi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "hdx" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 Outlet Pump";
@@ -55184,7 +55275,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "her" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55194,13 +55285,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"heF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/item/stack/ore/iron,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
 "heW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -55244,7 +55328,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hhn" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -55396,7 +55480,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hlX" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -55593,7 +55677,7 @@
 	id_tag = "co2_sensor"
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hqE" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 2;
@@ -55640,6 +55724,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopods)
+"hsp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "hsP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -55750,8 +55840,8 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "hyX" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -55843,7 +55933,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "hEi" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -55923,7 +56013,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hGb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56093,7 +56183,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "hLU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -56132,7 +56222,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "hMB" = (
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hMP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -56163,7 +56253,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hON" = (
 /obj/machinery/cryopod,
 /obj/machinery/light{
@@ -56361,7 +56451,7 @@
 "hVH" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hVM" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel/white,
@@ -56416,7 +56506,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "hYv" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -56425,7 +56515,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "hYx" = (
 /obj/machinery/chem_master,
 /obj/item/book/manual/wiki/chemistry,
@@ -56488,13 +56578,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "hZS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
-	dir = 1;
-	name = "toxins space injector"
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/science/mixing/chamber)
+/area/space/nearstation)
 "ibb" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
@@ -56637,7 +56726,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "igS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56768,8 +56857,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ike" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -56942,7 +57034,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "irq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -56953,11 +57045,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iru" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "isj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 1
@@ -56971,7 +57066,7 @@
 "isn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "isF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -56997,7 +57092,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "itl" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -57022,8 +57117,15 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Incinerator Access";
+	req_access_txt = "24"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "iua" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/cafeteria{
@@ -57143,7 +57245,7 @@
 /area/maintenance/starboard/fore)
 "izR" = (
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "izW" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -57223,11 +57325,20 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iCr" = (
-/obj/machinery/light/built{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
+"iCR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "iDk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -57333,7 +57444,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iGI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57375,6 +57486,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"iHM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
+"iIc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "iIw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -57412,7 +57536,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "iKc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -57592,8 +57716,11 @@
 	dir = 1;
 	name = "Pure to Port"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iRa" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -57681,7 +57808,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "iSC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57729,6 +57856,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/hallway)
+"iTq" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "iTV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -57740,7 +57874,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iUo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -57754,6 +57888,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"iUu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "iUJ" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -57814,13 +57954,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "iWF" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iWR" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -57849,11 +57989,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "iYN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "iYP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	external_pressure_bound = 0;
@@ -57866,7 +58006,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "iYQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -57972,8 +58112,11 @@
 	dir = 8;
 	name = "Port to Incinerator"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jbq" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -58094,6 +58237,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jfv" = (
+/obj/item/cigbutt,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "jfL" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -58156,7 +58303,7 @@
 "jhQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jhU" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -58239,7 +58386,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "jjs" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -58298,7 +58445,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "jkG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -58439,7 +58586,7 @@
 "jou" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "joF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58507,6 +58654,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
 	},
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "jpK" = (
@@ -58546,7 +58697,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jqX" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -58644,7 +58795,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jtu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -58743,7 +58894,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jwt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58781,7 +58932,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -58865,7 +59016,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "jAO" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -58880,7 +59031,7 @@
 "jBH" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jCV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -58898,11 +59049,11 @@
 	name = "atmos blast door"
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "jDF" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jDR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
@@ -59073,7 +59224,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jIE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -59167,10 +59318,10 @@
 /area/hallway/primary/port)
 "jKu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "jKJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -59194,6 +59345,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"jKR" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "jLc" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
@@ -59231,7 +59389,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jLN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59259,7 +59417,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "jMd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -59288,7 +59446,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "jNW" = (
 /obj/structure/closet,
 /obj/item/flashlight,
@@ -59369,7 +59527,7 @@
 "jPG" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jPM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -59405,7 +59563,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "jQt" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -59439,6 +59597,13 @@
 	},
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"jSK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "jTe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -59478,8 +59643,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jTH" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -59489,13 +59657,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jTL" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "jUq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -59507,8 +59675,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jWm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59560,7 +59731,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "jWP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59766,8 +59937,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kcB" = (
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "kdi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60010,7 +60184,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kkF" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -60036,7 +60210,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "klj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -60044,7 +60218,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kmH" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -60071,7 +60245,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "koH" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Central";
@@ -60099,13 +60273,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kpZ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "kqF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -60118,7 +60292,7 @@
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kro" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -60154,7 +60328,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "krM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -60273,7 +60447,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kuQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -60337,6 +60511,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"kwN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "kwP" = (
 /turf/template_noop,
 /area/maintenance/fore)
@@ -60556,7 +60736,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kFP" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/small{
@@ -60646,7 +60826,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kIE" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -60719,7 +60899,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kMj" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/machinery/airalarm{
@@ -60814,12 +60994,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "kOv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "kPz" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 4
@@ -60979,9 +61159,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "kRB" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/foyer)
 "kRO" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -60995,27 +61174,30 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kRS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kRT" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kRV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kSY" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -61050,7 +61232,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kTA" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -61234,7 +61416,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "kWW" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral,
@@ -61279,7 +61461,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "kYu" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -61308,11 +61490,11 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "kYO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "kYS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/chair,
@@ -61334,6 +61516,12 @@
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/medical/sleeper)
+"kZx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "laa" = (
 /obj/machinery/button/door{
 	id = "telelab";
@@ -61351,6 +61539,12 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lbn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "lbs" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -61425,7 +61619,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ldr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -61485,8 +61679,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lfy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced,
@@ -61653,11 +61850,11 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "lij" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "liM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61691,6 +61888,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"ljH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/stack/ore/iron,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/layer4,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "ljZ" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck{
@@ -61713,6 +61921,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"lko" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "lkt" = (
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
@@ -61871,7 +62085,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "loO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -61887,7 +62101,7 @@
 "lpw" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lpP" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/cable{
@@ -62039,8 +62253,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "luw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -62054,7 +62271,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lvh" = (
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/grimy,
@@ -62069,7 +62286,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "lwe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -62172,7 +62389,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lzJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -62248,7 +62465,7 @@
 "lBi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lBm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -62261,6 +62478,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lBI" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/engine/atmos/distro)
 "lBJ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -62328,7 +62549,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lEy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -62339,7 +62560,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lED" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -62351,7 +62572,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -62413,7 +62634,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lKC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -62475,11 +62696,11 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "lLE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "lLU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.3-Escape-3";
@@ -62546,7 +62767,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "lOJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62669,7 +62890,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lSs" = (
 /obj/structure/rack,
 /obj/item/lightreplacer{
@@ -62704,7 +62925,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "lTy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -62754,7 +62975,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lVB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -62767,7 +62988,7 @@
 /obj/item/t_scanner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "lVC" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -62782,7 +63003,7 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "lVN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -62924,6 +63145,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"lYF" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "lYX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -62945,7 +63170,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "lZV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -62965,7 +63190,7 @@
 	id_tag = "tox_sensor"
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "maC" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -63209,7 +63434,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "mjF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -63238,7 +63463,7 @@
 	},
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mkz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63259,7 +63484,7 @@
 /obj/machinery/electrolyzer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mmB" = (
 /obj/machinery/light_switch{
 	pixel_x = 1;
@@ -63362,10 +63587,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "moI" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/area/engine/atmos_distro)
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "moY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -63430,7 +63658,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "msm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -63534,8 +63762,9 @@
 /area/medical/storage)
 "mxx" = (
 /obj/machinery/light,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "mxF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor/border_only{
@@ -63618,7 +63847,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "mAJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -63635,8 +63864,11 @@
 /area/maintenance/port/fore)
 "mAP" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mBa" = (
 /obj/structure/sink{
 	dir = 4;
@@ -63714,6 +63946,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"mCI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/core,
+/obj/item/paper/guides/jobs/atmos/hypertorus,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "mCW" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -63868,8 +64109,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/pumproom";
+	dir = 1;
+	name = "Atmospherics Pumping Room APC";
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "mGM" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -63879,12 +64129,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "mGX" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	on = 1;
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/engine/atmos_distro)
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mHl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -63893,7 +64141,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mHL" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -63993,7 +64241,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mKO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -64112,14 +64360,14 @@
 "mQO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mQT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mRu" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -64167,6 +64415,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mSj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "mSs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -64184,7 +64436,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mTb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64226,7 +64478,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mTV" = (
 /obj/machinery/button/door{
 	id = "transittube";
@@ -64269,8 +64521,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "mUb" = (
 /obj/machinery/door/airlock{
 	name = "Recreation Area"
@@ -64478,7 +64733,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "naH" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64515,8 +64770,11 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Tinker"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ncC" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/treatment,
@@ -64589,6 +64847,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"neH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "neP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -64700,7 +64964,7 @@
 	c_tag = "Incinerator Access"
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "niZ" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -64811,7 +65075,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nlw" = (
 /obj/machinery/shower{
 	dir = 4
@@ -64932,7 +65196,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nqi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -64963,7 +65227,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nqB" = (
 /obj/item/trash/semki,
 /obj/structure/disposalpipe/segment{
@@ -64978,7 +65242,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nsn" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Cargo Bay Bridge Access"
@@ -65143,7 +65407,7 @@
 "nwR" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nxg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/flasher{
@@ -65360,7 +65624,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nBL" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 4
@@ -65380,7 +65644,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nDD" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -65411,7 +65675,7 @@
 	sensors = list("mix_sensor" = "Tank")
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nEa" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -65526,8 +65790,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "nGH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -65544,7 +65811,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nHk" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/robotics/lab";
@@ -65640,16 +65907,13 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nIY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "nJv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65719,7 +65983,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nNr" = (
 /obj/machinery/light{
 	dir = 4
@@ -65731,7 +65995,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nNv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/window/reinforced{
@@ -65834,7 +66098,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "nQQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -65878,10 +66142,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "nSS" = (
-/obj/effect/turf_decal/box,
-/obj/structure/frame/machine,
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/closed/wall/r_wall,
+/area/engine/atmos/distro)
 "nSY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -65969,7 +66231,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nWQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -65980,7 +66242,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "nXc" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
@@ -66082,9 +66344,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oap" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -66218,7 +66479,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oeb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -66285,7 +66546,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "ohf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -66301,6 +66562,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ohr" = (
+/turf/closed/wall,
+/area/engine/atmos/mix)
 "oiG" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -66308,7 +66572,7 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oiM" = (
 /obj/machinery/oven,
 /turf/open/floor/plasteel/cafeteria{
@@ -66491,8 +66755,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "omG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66587,7 +66857,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "opl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -66598,8 +66868,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "opv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66668,7 +66941,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oqZ" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -66978,7 +67251,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oIk" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -67169,7 +67442,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "oQv" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -67408,6 +67681,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oVu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "oVx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -67491,7 +67776,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oXx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67545,7 +67830,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "oZD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -67574,6 +67859,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/locker)
+"pbD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "pbQ" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -67591,9 +67882,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "pbV" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -67809,7 +68100,7 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "piW" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -67864,7 +68155,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "plb" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -67968,7 +68259,7 @@
 "pqx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pqy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cigarette,
@@ -68087,7 +68378,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "pvg" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
@@ -68125,7 +68416,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pwn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -68168,7 +68459,7 @@
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pxL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4;
@@ -68189,7 +68480,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pyC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68241,7 +68532,7 @@
 "pzL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pzZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -68254,7 +68545,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pAy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -68291,7 +68582,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pBa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -68489,7 +68780,7 @@
 /obj/item/analyzer,
 /obj/item/t_scanner,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pGm" = (
 /obj/item/caution,
 /obj/effect/landmark/blobstart,
@@ -68516,7 +68807,7 @@
 "pHk" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pHm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -68525,7 +68816,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pHt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -68555,11 +68846,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "pIr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "pIO" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -68576,7 +68865,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "pJf" = (
 /obj/machinery/door/window{
 	name = "MiniSat Walkway Access"
@@ -68615,7 +68904,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pJR" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -68655,7 +68944,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pKe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -68726,16 +69015,16 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos_distro";
+	areastring = "/area/engine/atmos/mix";
 	dir = 1;
-	name = "Atmospherics Distribution APC";
+	name = "Atmospherics Mixing Room APC";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pML" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -68773,7 +69062,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "pPV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68822,7 +69111,7 @@
 	on = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "pSL" = (
 /obj/machinery/plate_press,
 /turf/open/floor/plasteel/dark,
@@ -68840,7 +69129,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pSY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68871,8 +69160,11 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "pUF" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -68972,6 +69264,12 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"pYx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "pYF" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -69248,7 +69546,7 @@
 /obj/item/pipe_dispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "qji" = (
 /obj/structure/chair{
 	dir = 1
@@ -69342,7 +69640,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qle" = (
 /obj/machinery/bookbinder,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -69375,12 +69673,9 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "qlP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/arrows/white,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "qmf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -69518,7 +69813,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qpG" = (
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = -32
@@ -69632,7 +69927,7 @@
 "qsh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "qsj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -69668,12 +69963,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/physician)
-"qtD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+"qsR" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
+"qtD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "qtN" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -69746,8 +70047,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qwL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69772,12 +70076,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qzR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"qAg" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/rglass{
+	amount = 5
+	},
+/obj/item/stack/sheet/plasteel{
+	amount = 5
+	},
+/obj/item/pipe_dispenser,
+/obj/item/wrench,
+/obj/item/multitool,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "qAD" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -69840,7 +70160,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qCo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -70020,6 +70340,12 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"qHH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "qHJ" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/airalarm{
@@ -70078,7 +70404,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "qJm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -70100,9 +70426,9 @@
 "qJq" = (
 /obj/machinery/space_heater,
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmos";
+	areastring = "/area/engine/atmos/foyer";
 	dir = 1;
-	name = "Atmospherics Wing APC";
+	name = "Atmospherics Foyer APC";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -70112,7 +70438,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "qJB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -70152,7 +70478,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -70165,7 +70491,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "qLW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -70255,11 +70581,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qOB" = (
-/obj/machinery/light/built{
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "qOT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -70479,7 +70806,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qTr" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -70631,7 +70958,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "qZG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70641,7 +70968,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qZJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -70652,7 +70979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "qZQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -70769,7 +71096,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rdX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	name = "Connector Port (Air Supply)"
@@ -70955,11 +71282,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "rjN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "rka" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -71021,7 +71348,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rlE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -71283,7 +71610,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rsb" = (
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
@@ -71355,8 +71682,11 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "ruC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -71438,7 +71768,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rxa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71474,6 +71804,12 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rxC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "ryt" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
@@ -71671,8 +72007,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rGz" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -71680,6 +72019,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"rHk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "rHp" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -71743,7 +72092,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rIu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -71809,7 +72158,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rMp" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories - Fore";
@@ -71854,7 +72203,7 @@
 	name = "Port to Incinerator/Tinker"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rOP" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -71889,7 +72238,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rPP" = (
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 8
@@ -71907,7 +72256,7 @@
 	id_tag = "n2o_sensor"
 	},
 /turf/open/floor/engine/n2o,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "rRZ" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -71929,7 +72278,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "rSv" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -72246,6 +72595,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"scX" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "sdD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72267,7 +72622,7 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "sew" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -72377,15 +72732,17 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "sjs" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "sjw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"slm" = (
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "slu" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -72403,7 +72760,7 @@
 /area/hallway/secondary/entry)
 "smB" = (
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "snd" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
@@ -72535,7 +72892,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "sqn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -72679,11 +73036,31 @@
 "suR" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/interrogation)
+"suW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "svg" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"svp" = (
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "svF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72818,7 +73195,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "sAJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -73088,6 +73465,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sGj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "sGl" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
@@ -73120,12 +73501,17 @@
 "sHe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/hfr";
+	dir = 8;
+	name = "Atmospherics HFR Room APC";
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "sHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -73234,7 +73620,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "sLT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -73259,15 +73645,24 @@
 	c_tag = "Atmospherics Tanks West";
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 8;
+	name = "Atmospherics Distribution APC";
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sMm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "sMs" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -73307,7 +73702,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "sNT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -73633,6 +74028,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"sYf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "sYp" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp{
@@ -73780,7 +74184,7 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "tbh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -74006,8 +74410,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tig" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -74039,11 +74446,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "tit" = (
-/obj/item/pipe_dispenser,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/lattice,
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
-/area/engine/atmos_distro)
+/turf/open/space/basic,
+/area/space/nearstation)
 "tjd" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Starboard";
@@ -74112,12 +74520,12 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tlT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tlW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -74306,8 +74714,11 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "tso" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -74435,7 +74846,7 @@
 	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tvE" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -74443,7 +74854,7 @@
 	layer = 3.4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "twH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -74566,12 +74977,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tCd" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "tCy" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
+"tDa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "tDj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/item/reagent_containers/food/snacks/grown/banana,
@@ -74597,6 +75021,13 @@
 /obj/item/clothing/mask/breath,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"tDD" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "tDL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74735,7 +75166,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tJP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -74761,10 +75192,13 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "tKo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "tKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
@@ -75018,7 +75452,7 @@
 /area/quartermaster/office)
 "tQz" = (
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tQJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -75099,7 +75533,7 @@
 	id_tag = "air_sensor"
 	},
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "tTD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
@@ -75143,8 +75577,11 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tUo" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/cafeteria{
@@ -75204,13 +75641,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/storage/locker)
 "tWB" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "tWL" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "tWY" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -75239,13 +75676,19 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "tYl" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "tYt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
@@ -75295,7 +75738,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uaC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75337,7 +75780,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ucx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75476,14 +75919,23 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
+"ugt" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/pumproom)
 "ugL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ugU" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line{
 	dir = 8
@@ -75633,7 +76085,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uia" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14-Starboard-Central";
@@ -75704,7 +76156,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "ujF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -75780,7 +76232,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ula" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -75815,7 +76267,7 @@
 /area/security/checkpoint/medical)
 "ulM" = (
 /turf/open/floor/engine/vacuum,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ulT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -75840,7 +76292,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "unI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Toxins Lab Maintenance";
@@ -76035,7 +76487,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "utn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -76095,7 +76547,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "uxv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -76144,6 +76596,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"uAo" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "uAw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -76167,7 +76626,7 @@
 /area/maintenance/port/aft)
 "uBz" = (
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "uBE" = (
 /obj/structure/closet/crate/wooden/toy,
 /turf/open/floor/wood,
@@ -76284,9 +76743,12 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "uDX" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "uEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -76373,8 +76835,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uHr" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Telecomms Camera Monitor";
@@ -76543,7 +77008,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "uNl" = (
 /obj/machinery/power/apc/unlocked{
 	areastring = "/area/medical/genetics/cloning";
@@ -76803,7 +77268,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uUn" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -76824,7 +77289,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "uUQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -76857,7 +77322,7 @@
 /area/maintenance/port/fore)
 "uUY" = (
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uVc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -76895,14 +77360,14 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uVk" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/arrows/white{
+	color = "#00AAFF";
+	pixel_y = 15
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "uVu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -76920,7 +77385,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "uVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/hydroponics/constructable,
@@ -77031,7 +77496,7 @@
 "uYo" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "uYs" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -77042,6 +77507,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uYM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos/mix)
 "uYW" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -77073,7 +77542,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vay" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -77121,7 +77590,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vdK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -77170,8 +77639,14 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "veu" = (
 /obj/machinery/light{
 	dir = 1
@@ -77301,7 +77776,7 @@
 	name = "Port to Engine"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "viG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -77493,11 +77968,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vqG" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "vqY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -77757,7 +78235,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
+"vAr" = (
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_x = -15
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/hfr)
 "vAK" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -77798,8 +78283,9 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vDz" = (
 /obj/machinery/light{
 	dir = 4
@@ -77825,7 +78311,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vFr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -77853,7 +78339,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vGz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -77862,7 +78348,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vHB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -78015,7 +78501,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vLg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78073,7 +78559,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "vMZ" = (
 /obj/machinery/door/window/westleft{
 	dir = 4;
@@ -78099,7 +78585,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vOi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -78107,7 +78593,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vOI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78139,7 +78625,7 @@
 	target_pressure = 4500
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vPe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78149,7 +78635,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vPs" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -78163,7 +78649,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vQl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78287,7 +78773,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "vUe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78360,14 +78846,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vVH" = (
-/turf/closed/wall,
-/area/engine/atmos_distro)
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "vVV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vWd" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -78395,7 +78884,7 @@
 /obj/item/wrench,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "vWF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -78487,7 +78976,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "vYF" = (
 /obj/machinery/button{
 	id = "maintshut";
@@ -78562,7 +79051,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "waT" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -78754,6 +79243,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"wjv" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Incinerator Access";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "wjC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79113,8 +79615,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wxY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79206,7 +79711,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wAR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -79230,7 +79735,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "wBH" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -79283,7 +79788,7 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wDw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79316,7 +79821,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wEE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -79324,7 +79829,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/space/basic,
-/area/engine/atmos_distro)
+/area/space/nearstation)
 "wFr" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -79333,7 +79838,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wFH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79411,6 +79916,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wHu" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "wHM" = (
 /obj/item/phone{
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
@@ -79459,8 +79968,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wJi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -79469,8 +79981,11 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wJq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79520,7 +80035,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wKk" = (
 /obj/machinery/door/airlock/external{
 	name = "Transport Airlock"
@@ -79701,8 +80216,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wRO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -79754,7 +80272,7 @@
 /area/tcommsat/server)
 "wSR" = (
 /turf/open/floor/engine/air,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "wTc" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/bodycontainer/morgue{
@@ -79773,7 +80291,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "wTy" = (
 /obj/structure/closet/crate/sphere,
 /turf/open/floor/plating,
@@ -79874,8 +80392,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/hfr)
 "wZp" = (
 /obj/structure/chair/stool,
 /obj/machinery/firealarm{
@@ -79922,7 +80444,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xbm" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 8
@@ -80071,7 +80593,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xgk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80146,7 +80668,7 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xiA" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -80241,7 +80763,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xmC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -80425,8 +80947,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "xrY" = (
-/turf/open/floor/plating,
-/area/engine/atmos_distro)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xsR" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -80512,15 +81037,18 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xuK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xuL" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -80628,7 +81156,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plating,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
+"xxh" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xyf" = (
 /obj/structure/table/optable,
 /obj/item/radio/intercom{
@@ -80650,6 +81182,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xyD" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/engine/atmos)
 "xyP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -80735,12 +81271,12 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/plasma,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xBs" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xCh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -80941,7 +81477,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xHk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -80951,7 +81487,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xHY" = (
 /obj/structure/chair,
 /obj/machinery/computer/security/telescreen/interrogation{
@@ -80993,6 +81529,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"xJA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xJC" = (
 /obj/structure/cable/yellow,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -81014,7 +81554,7 @@
 "xKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xKG" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -81028,6 +81568,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"xLv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "xLz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -81072,7 +81621,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/mix)
 "xLN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -81103,6 +81652,12 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/closed/wall,
 /area/maintenance/port/fore)
+"xNv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/hfr)
 "xOc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -81154,7 +81709,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xPY" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -81174,11 +81729,11 @@
 	name = "Atmospherics Blast Door"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmos/foyer)
 "xQD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xQR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -81243,7 +81798,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "xTb" = (
 /obj/structure/chair/comfy/beige,
 /obj/effect/landmark/start/chief_engineer,
@@ -81325,7 +81880,7 @@
 	on = 1
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "xWt" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -81403,6 +81958,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"xXl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
+/area/engine/atmos/mix)
 "xXP" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Staging Area";
@@ -81525,7 +82087,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yab" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -81590,6 +82152,9 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"ybT" = (
+/turf/closed/wall,
+/area/engine/atmos/distro)
 "ybZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -81734,7 +82299,7 @@
 	pump_direction = 0
 	},
 /turf/open/floor/engine/co2,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "ygf" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -81802,8 +82367,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/engine/atmos_distro)
+/area/engine/atmos/distro)
 "yhJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -81833,7 +82401,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos_distro)
+/area/engine/atmos/pumproom)
 "yiC" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 2;
@@ -97970,10 +98538,10 @@ dne
 aaf
 aaa
 aaf
-aFO
-heF
-aAC
-aBS
+ayj
+ljH
+suW
+svp
 aFO
 aaf
 aaa
@@ -98229,7 +98797,7 @@ aaa
 aaf
 aFO
 azk
-aAC
+xLv
 aBT
 aFO
 aaf
@@ -98486,7 +99054,7 @@ aaf
 aaf
 ayj
 ayj
-aAD
+fIT
 aBU
 ayj
 aFO
@@ -113470,8 +114038,8 @@ kTi
 ike
 ahf
 hZS
-cEq
-cEq
+aaf
+aaf
 cIg
 cIa
 cIU
@@ -120634,11 +121202,11 @@ joF
 alq
 bcs
 apc
-vVH
-vVH
-vVH
+ohr
+ohr
+ohr
 qCN
-vVH
+ohr
 bZE
 aaV
 acd
@@ -120891,7 +121459,7 @@ xAq
 alq
 bVC
 jmm
-vVH
+ohr
 kRS
 faw
 iWl
@@ -121148,7 +121716,7 @@ apc
 alq
 rpR
 aad
-vVH
+ohr
 jPG
 jTl
 ruc
@@ -121405,10 +121973,10 @@ apc
 alq
 wnv
 apc
-vVH
+ohr
 niQ
 dRc
-cNG
+kwN
 bZE
 bZE
 veu
@@ -121657,15 +122225,15 @@ bxc
 bxc
 bxc
 bxc
-alq
-alq
-alq
-alq
+fND
+fND
+fND
+fND
 dFJ
-vVH
-vVH
+ohr
+ohr
 cVV
-uUY
+bCi
 bZE
 tYt
 uEk
@@ -121915,9 +122483,9 @@ aaO
 mAo
 bxc
 bLX
-apc
+slm
 bps
-bpU
+xyD
 bqR
 cit
 gbB
@@ -122166,18 +122734,18 @@ lVM
 piK
 bhD
 lRH
-bCi
+kRB
 aiN
 aiN
 mAo
 bxc
 bLY
 boM
-apc
-aqq
-apc
+slm
+jfv
+slm
 bJX
-vVH
+ohr
 rEH
 hla
 bZE
@@ -122421,7 +122989,7 @@ hmH
 aTq
 bxc
 lUF
-bCi
+kRB
 nQJ
 bhU
 pJo
@@ -122430,19 +122998,19 @@ jAt
 bxc
 bLZ
 bPm
-apc
+slm
 bSf
-apc
-uBz
-uBz
+slm
+dUo
+dUo
 veo
-uBz
-cgz
+dUo
 cgz
 cgz
 cgz
 lQC
-cgz
+wjv
+lQC
 cgz
 cgz
 cgz
@@ -122690,18 +123258,18 @@ bPn
 bQR
 bSd
 anM
-uBz
+dUo
 eKb
 mSs
-wYT
-vVH
-xrY
-xrY
-xrY
-xrY
+scX
+ebO
+fXM
+hsp
+iru
+vqG
 omr
-xrY
-xrY
+hsp
+wYT
 uBz
 lMJ
 aaa
@@ -122938,27 +123506,27 @@ bxc
 pvP
 ahm
 nrs
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
+dUo
+dUo
+dUo
+dUo
+dUo
+dUo
+dUo
+dUo
+dUo
+dUo
 eKb
 gtz
-cEA
+sGj
 qsh
-xrY
-xrY
-xrY
-xrY
+iIc
+fsy
+xJA
 jKu
-sjs
-xrY
+hdi
+fbx
+cEA
 uBz
 lMJ
 lMJ
@@ -123195,31 +123763,31 @@ nqm
 ogH
 mkc
 lEx
-uBz
+dUo
 pxO
-uBz
+dUo
 sAp
 jTH
 hKT
 aqC
-uBz
+dUo
 fPs
 kuG
 fJm
 uHq
-dOs
-xrY
-xrY
-xrY
+lYF
+qsh
+jSK
+pbD
+hdi
+hdi
+hdi
+hdi
+wHu
+uBz
+uBz
+uBz
 tit
-xrY
-iYN
-xrY
-xrY
-uBz
-uBz
-uBz
-lMJ
 aaa
 aaa
 aaa
@@ -123466,15 +124034,15 @@ fOy
 wIM
 krL
 qsh
-xrY
-xrY
-eNb
-glw
-fDc
 moI
-xrY
-xrY
-xrY
+pbD
+eNb
+fDc
+fDc
+fDc
+eGV
+tCd
+qHH
 tWL
 lMJ
 lMJ
@@ -123707,31 +124275,31 @@ fkB
 bxc
 qJq
 uVu
-bCi
+kRB
 kYO
-qsh
+uYM
 xfO
 rrX
-uUY
+bCi
 sql
 iqG
-uUY
-uUY
+bCi
+bCi
 aRJ
-uUY
-uUY
+bCi
+bCi
 jaZ
 gHq
-vVH
-vVH
-qOB
-iYN
 ebO
+ebO
+rHk
+iYN
+sjs
 rjN
-rjN
-rjN
+sjs
+ezP
 qtD
-xrY
+wHu
 tWL
 lMJ
 lMJ
@@ -123970,25 +124538,25 @@ jsY
 rlC
 odX
 eoS
-vVH
+ohr
 rwX
 oXw
 rwX
-vVH
-gVA
-uUY
+ohr
+xXl
+bCi
 wxL
 knN
 nIY
 sHe
-tKo
-cJG
+gAC
+sjs
+fIG
+kcB
 pIr
-kcB
-nSS
-kcB
-kRB
-xrY
+sjs
+gPe
+cEA
 tWL
 lMJ
 aaa
@@ -124223,28 +124791,28 @@ fTK
 hhg
 iJJ
 erl
-qsh
+uYM
 xfO
 pJS
 erj
-vVH
-vVH
+ohr
+ohr
 jou
-vVH
-vVH
+ohr
+ohr
 vCE
-uUY
+bCi
 tYl
 nch
 ity
-pbV
-pbV
+uAo
+uDX
 qlP
 kOv
-kcB
+glw
 tWB
-kcB
-kRB
+uVk
+gPe
 mxx
 uBz
 lMJ
@@ -124475,34 +125043,34 @@ roy
 qCo
 eyz
 cXA
-uBz
+cJG
 yiB
-qsh
+eXW
 yiB
-uBz
-uBz
+cJG
+dUo
 jHL
 vPe
 iTV
-vVH
+ohr
 kYM
 kYM
 gYP
-vVH
+ohr
 ahZ
-uUY
+bCi
 iiP
-uUY
-uVk
+bCi
+qsh
 hxX
-xrY
-iru
+uDX
+sjs
 pIr
-kcB
+cEq
 fIG
-kcB
-kRB
-xrY
+sjs
+gPe
+cEA
 tWL
 lMJ
 aaa
@@ -124737,10 +125305,10 @@ qZA
 kjx
 lwd
 uvk
-vVH
+ohr
 mHl
 xLG
-uUY
+bCi
 wTl
 gGM
 gGM
@@ -124750,16 +125318,16 @@ vTV
 rOx
 xuB
 dOi
-vVH
-vVH
-vqG
-iru
-dUo
-jTL
-jTL
+ebO
+ebO
+gVA
+lbn
+sjs
+vAr
+sjs
 jTL
 dWv
-xrY
+wHu
 tWL
 lMJ
 lMJ
@@ -124994,29 +125562,29 @@ pSk
 buT
 jku
 xSW
-vVH
+ohr
 pMu
 goS
-uUY
+rxC
 pUi
-uUY
-uUY
+rxC
+rxC
 mAP
-uUY
+rxC
 eRS
 cVm
-uDX
+iTq
 tlO
 qsh
-xrY
-xrY
+gxD
+gnD
 lij
 lLE
-xrY
-xrY
-xrY
-xrY
-xrY
+lLE
+lLE
+qOB
+iCR
+xNv
 tWL
 lMJ
 lMJ
@@ -125247,8 +125815,8 @@ bvo
 lpT
 aTq
 mGy
-jLQ
-tJN
+sYf
+ugt
 vzX
 gpR
 pAP
@@ -125256,26 +125824,26 @@ dUE
 mTW
 tvn
 nwR
-uUY
-uUY
-uUY
-uUY
-eRS
+bCi
+bCi
+bCi
+bCi
+vVH
 iQX
 mKz
 wEo
 qsh
-xrY
-moI
-xrY
+mCI
+gnD
 hdi
-xrY
-fXM
+hdi
+hdi
+hdi
 dzJ
 uBz
 uBz
 uBz
-lMJ
+tit
 aaa
 aaa
 aaa
@@ -125505,10 +126073,10 @@ kui
 aTq
 vGz
 jLQ
-lpw
-vVV
+jKR
+pYx
 kRV
-vVH
+ohr
 uUE
 nGc
 fOy
@@ -125519,16 +126087,16 @@ vOi
 vOi
 qLB
 leZ
-qpv
+qsR
 mQT
 qsh
-xrY
-sjs
-xrY
-xrY
-moI
-xrY
-xrY
+tKo
+tDD
+mSj
+lko
+hdi
+hdi
+cEA
 uBz
 lMJ
 lMJ
@@ -125762,30 +126330,30 @@ iqf
 aTq
 ujk
 jLQ
-uUY
-vVV
+kZx
+pYx
 xPM
-qsh
+uYM
 xfO
-pkQ
-uUY
+oVu
+bCi
 viE
 rcV
 klj
 lOy
 ggy
-lpw
+eap
 ayY
 vGq
 wEo
-vVH
-xrY
+ebO
+qAg
 xrY
 tse
 xrY
 iCr
 xrY
-xrY
+esg
 uBz
 lMJ
 aaa
@@ -126019,7 +126587,7 @@ uyP
 aTq
 taN
 jLQ
-cbi
+tDa
 ltp
 opl
 tTT
@@ -126035,7 +126603,7 @@ npZ
 jUq
 opk
 hFO
-vVH
+ebO
 uBz
 uBz
 uBz
@@ -126292,8 +126860,8 @@ xuK
 doD
 aeD
 tCy
-vVH
-uBz
+ybT
+nSS
 lMJ
 lMJ
 aaa
@@ -126530,19 +127098,19 @@ aZj
 aaf
 aaf
 ack
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
-uBz
+aTq
+cJG
+cJG
+cJG
+cJG
+cJG
+dUo
+dUo
+dUo
+dUo
 dop
-uBz
-uBz
+dUo
+nSS
 xHk
 sMj
 eGE
@@ -126550,7 +127118,7 @@ yhB
 xZR
 wFr
 gIP
-uBz
+nSS
 jDy
 pHk
 pHk
@@ -126799,7 +127367,7 @@ wuF
 wuF
 lVC
 lMJ
-tWL
+lBI
 vOg
 wRN
 qwz
@@ -127313,13 +127881,13 @@ lMJ
 lMJ
 lMJ
 lMJ
-tWL
+lBI
 mrN
-jLQ
+neH
 vVV
 pkQ
 dqD
-uDX
+xxh
 lZR
 oQt
 wEE
@@ -127829,11 +128397,11 @@ rPj
 jiG
 nWQ
 xGK
-jBH
+gwn
 ukR
 dWm
 xQD
-uDX
+xxh
 unb
 ebF
 puB
@@ -128085,13 +128653,13 @@ tTl
 lBi
 fTh
 kTm
-xfO
+iUu
 uUY
 uUY
 pkQ
 qpv
 lpw
-cEA
+pbV
 kRO
 seq
 lBi
@@ -128348,7 +128916,7 @@ epf
 pkQ
 qpv
 uUY
-cEA
+pbV
 kpD
 uMs
 uZI
@@ -128861,7 +129429,7 @@ kRT
 rMg
 igM
 xQD
-uDX
+xxh
 lzo
 ebF
 puB
@@ -129889,7 +130457,7 @@ hVH
 kRT
 vdv
 usm
-uDX
+xxh
 efd
 ebF
 puB
@@ -130141,13 +130709,13 @@ fzM
 lBi
 fTh
 wKe
-xfO
+iUu
 uUY
 uUY
 pkQ
 uUY
 uUY
-cEA
+pbV
 luw
 seq
 lBi
@@ -130398,13 +130966,13 @@ eFk
 uZI
 kpZ
 pIW
-xfO
+iUu
 cbi
 ats
 hYv
 xKj
-mTM
-cEA
+iHM
+pbV
 fLu
 uMs
 uZI
@@ -130911,7 +131479,7 @@ lMJ
 aaa
 lMJ
 lMJ
-uBz
+nSS
 pxC
 uUY
 eno
@@ -130919,7 +131487,7 @@ nNr
 uUY
 uUY
 jhQ
-uBz
+nSS
 aaa
 lMJ
 lMJ
@@ -131168,15 +131736,15 @@ fwb
 fwb
 nYJ
 lMJ
-uBz
-tWL
-tWL
-uBz
+nSS
+lBI
+lBI
+nSS
 sNo
-uBz
-tWL
-tWL
-uBz
+nSS
+lBI
+lBI
+nSS
 lMJ
 lMJ
 fwb
@@ -131428,9 +131996,9 @@ lMJ
 lMJ
 lMJ
 lMJ
-uBz
+nSS
 nBL
-uBz
+nSS
 lMJ
 lMJ
 lMJ
@@ -131685,9 +132253,9 @@ nYJ
 lMJ
 lMJ
 lMJ
-uBz
+nSS
 miQ
-uBz
+nSS
 lMJ
 lMJ
 lMJ

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -14001,16 +14001,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aJu" = (
-/obj/structure/closet/crate/engineering{
-	name = "particle accelerator crate"
-	},
-/obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/particle_accelerator/particle_emitter/center,
-/obj/structure/particle_accelerator/particle_emitter/left,
-/obj/structure/particle_accelerator/particle_emitter/right,
-/obj/structure/particle_accelerator/power_box,
-/obj/structure/particle_accelerator/end_cap,
-/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aJw" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7114,7 +7114,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "apT" = (
-/obj/machinery/portable_atmospherics/canister/stimulum,
+/obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "apU" = (
@@ -21630,7 +21630,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/stimulum,
+/obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
 "aRQ" = (
@@ -21648,7 +21648,7 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/item/nullrod/claymore/glowing{
+/obj/item/nullrod/glowing{
 	damtype = "stamina";
 	force = 30
 	},
@@ -22013,7 +22013,7 @@
 	},
 /area/holodeck/rec_center/lounge)
 "aSL" = (
-/obj/machinery/portable_atmospherics/canister/nitryl,
+/obj/machinery/portable_atmospherics/canister/nitrium,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "aSM" = (
@@ -23426,7 +23426,7 @@
 /area/centcom/testchamber)
 "aVF" = (
 /obj/structure/rack,
-/obj/item/nullrod/scythe/vibro{
+/obj/item/nullrod/vibro{
 	damtype = "stamina";
 	force = 30
 	},
@@ -24442,7 +24442,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitryl,
+/obj/machinery/portable_atmospherics/canister/nitrium,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "aXF" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7114,7 +7114,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "apT" = (
-/obj/machinery/portable_atmospherics/canister/freon,
+/obj/machinery/portable_atmospherics/canister/stimulum,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "apU" = (
@@ -21630,7 +21630,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/freon,
+/obj/machinery/portable_atmospherics/canister/stimulum,
 /turf/open/floor/plasteel/dark,
 /area/centcom/testchamber)
 "aRQ" = (
@@ -21648,7 +21648,7 @@
 	dir = 8
 	},
 /obj/structure/rack,
-/obj/item/nullrod/glowing{
+/obj/item/nullrod/claymore/glowing{
 	damtype = "stamina";
 	force = 30
 	},
@@ -22013,7 +22013,7 @@
 	},
 /area/holodeck/rec_center/lounge)
 "aSL" = (
-/obj/machinery/portable_atmospherics/canister/nitrium,
+/obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "aSM" = (
@@ -23426,7 +23426,7 @@
 /area/centcom/testchamber)
 "aVF" = (
 /obj/structure/rack,
-/obj/item/nullrod/vibro{
+/obj/item/nullrod/scythe/vibro{
 	damtype = "stamina";
 	force = 30
 	},
@@ -24442,7 +24442,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitrium,
+/obj/machinery/portable_atmospherics/canister/nitryl,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "aXF" = (

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 50, "Engine TEG" = 0)
+	template_names = list("Engine SM" = 100, "Engine Singulo And Tesla" = 0, "Engine TEG" = 0)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -137,7 +137,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Transfer 1", "Transfer 2", "Transfer 3", "Transfer 4", "Transfer 5", "Transfer 6", "Transfer 7", "Transfer 8", "Transfer 9", "Transfer 10")
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta Singulo And Tesla" = 50, "Meta SM" = 50, "Meta TEG" = 0)
+	template_names = list("Meta SM" = 100, "Meta Singulo And Tesla" = 0, , "Meta TEG" = 0)
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
This will make the SM engine spawn at roundstart every time. I added tesla & singulo generators in the secure storage for each map (as well as 4 field generators and emitters) so engineers can still build them if they feel like it.

# Why this is a good change
The SM engine is the superior engine out of the 3 remaining ones (rip TEG), admit it. The singulo and tesla are boring and bland engines with little to no depth or interaction. The most meaningful thing you do is wrench a few things, turn on the PA and close the shutters. After the initial setup, there is almost nothing interesting you can do with the engine. This is in stark contrast with the SM engine. It is equally easy to set up, however provides numerous interesting interactions with different gas combinations. For example, you can intentionally delaminate the SM to farm anomalies or create large amounts of interesting gases such as pluoxium. This allows players to go wild with various SM setups to experiment with. It additionally creates an additional reason for engineering and atmos to cooperate, as some of the more interesting gases are regularly produced by atmos.

The singulo and tesla are too easy and boring to sabotage, while having a ridiculous binary fail state. The engine is often sabotaged by simply messing with an emitter or field generator, which is easy to overlook if you're not actively looking for it as an engineer. Not to mention that once the tesla/singulo escape, it is next to impossible to re-contain and as a result, the shuttle is called immediately in 99% of cases. Meanwhile, the SM engine is more difficult and interesting to sabotage, and doesn't instantly doom the station. Rather it will create a huge crater in engineering and leave the station without power. However, determined players can fix it and recover from this. Additionally, sabotage isn't instant and gives players some time to find and fix the issue. This allowed players to feel more invested in trying to fix the engine rather than "singuloose, call the shuttle".

"but muh i liked the singulo/tesla". You'll be happy to know that this does **NOT** completely remove them from the game. Instead, I simply the tesla and singulary generators to the secure storage on each map. Granted, it takes some more effort to set up than before, but it's still possible to do. This will allow for engineers to potentially have all 3 engines running on boring rounds if they want to, while still having the ability to experiment with the SM.

# Wiki Documentation
The supermatter engine will now spawn every round, with the tesla/singulo generators getting move to secure storage.

# Changelog

:cl:  
rscadd: Tesla and Singularity generators added to secure storage of each map
tweak: The Supermatter engine will now spawn every round
/:cl:
