### PR TITLE
Classic/tele batons now self-apply stamina damage

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -222,7 +222,8 @@
 
 	var/obj/item/bodypart/affecting = target.get_bodypart(user.zone_selected)
 	var/armor_block = target.run_armor_check(affecting, MELEE)
-	target.apply_damage(stamina_damage, STAMINA, user.zone_selected, armor_block)
+	if(target.apply_damage(stamina_damage, STAMINA, user.zone_selected, armor_block))
+		user.apply_damage(5, STAMINA, BODY_ZONE_CHEST) // boy this is tiring
 	var/current_stamina_damage = target.getStaminaLoss()
 
 	if(stun_animation)


### PR DESCRIPTION
# Document the changes in your pull request

Classic batons are in a very strong state right now, having a shorter cooldown than stun batons, stunning in 2 hits and being able to get a guaranteed 1.5 second knockdown on the first hit by targetting legs

Prevents endless baton spam by slowing the user after 8 swings and stunning the user after 20 swings

Applies 5 stamina damage per swing

# Changelog

:cl:  
tweak: Detective, telescopic, contractor, and donksoft bat batons now self-apply stamina damage
/:cl:
