### PR TITLE
Injecting a vaccine doesn't require 5u

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -102,13 +102,12 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(reac_volume >= 5) //needs at least a certain amount for it to take effect
-		if(islist(data) && (method == INGEST || method == INJECT))
-			for(var/thing in L.diseases)
-				var/datum/disease/D = thing
-				if(D.GetDiseaseID() in data)
-					D.cure()
-			L.disease_resistances |= data
+	if(islist(data) && ((method == INGEST && reac_volume >= 5) || method == INJECT))//drinking it requires at least 5u, injection doesn't
+		for(var/thing in L.diseases)
+			var/datum/disease/D = thing
+			if(D.GetDiseaseID() in data)
+				D.cure()
+		L.disease_resistances |= data
 
 /datum/reagent/vaccine/on_merge(list/data)
 	if(istype(data))


### PR DESCRIPTION
requiring 5u of vaccine to cure a disease just makes curing large numbers of people tedious and boring, needing to press the "generate a vaccine bottle" every 5 seconds(?) or so
This gives an alternative, assuming someone's willing to dilute the vaccine with other chemicals, injecting it via syringe lets it work regardless as to the amount of vaccine.
This way, it'll either take 5u pills, a swig of the vaccine bottle, or carefully set-up injections to cure a disease, allowing for more thought as to how the disease will be tackled

:cl:  
tweak: Injecting a vaccine doesn't require 5u
/:cl:
