### PR TITLE
Revenant EMP cannot affect air alarms because I died to it once as AI.

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -304,7 +304,7 @@
 		new /obj/effect/temp_visual/revenant(human.loc)
 		human.emp_act(EMP_HEAVY)
 	for(var/obj/thing in T)
-		if(istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes) || istype(thing, /obj/machinery/particle_accelerator/control_box)) //Doesn't work on SMES and APCs or the PA control box, to prevent kekkery
+		if(istype(thing,/obj/machinery/airalarm) || istype(thing, /obj/machinery/power/apc) || istype(thing, /obj/machinery/power/smes) || istype(thing, /obj/machinery/particle_accelerator/control_box)) //Doesn't work on SMES and APCs or the PA control box, to prevent kekkery. Yogstation change: Air alarms included.
 			continue
 		if(prob(20))
 			if(prob(50))


### PR DESCRIPTION
# Document the changes in your pull request

The revenant "Malfunction" ability can no longer affect air alarms.

# Justification

In current code, revenants cannot use the malfunction ability on APCs, SMES units, or AI units. This was added long ago on /tg/ to prevent the revenant from insta-killing the AI super easily.

On yogstation, AI is unique where it actually requires cool air to function. This is an easy thing for revenants to exploit because they can just EMP an air alarm + surrounding cameras and kill the AI. I think this is an oversight because there are so many exceptions in the code that would fully protect the AI if it didn't require cold air.

Proof:

![image](https://user-images.githubusercontent.com/8602857/224902458-d6a95ed1-cd89-4162-a98e-7a7bbba4e5a9.png)

Note the exception that AIs are immune from EMP. Note APCs and SMES units are also immune.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Revenant

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  BurgerBB
rscdel: The revenant "Malfunction" ability can no longer affect air alarms.
/:cl:
