### PR TITLE
Bloodsucker punches now care about armor a little more

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/brawn.dm
@@ -136,7 +136,8 @@
 		playsound(get_turf(target), 'sound/weapons/punch4.ogg', 60, TRUE, -1)
 		user.do_attack_animation(target, ATTACK_EFFECT_SMASH)
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(target.zone_selected))
-		target.apply_damage(hitStrength, BRUTE, affecting)
+		var/blocked = target.run_armor_check(affecting, MELEE, armour_penetration = 20)	//20 AP, will ignore light armor but not heavy stuff
+		target.apply_damage(hitStrength, BRUTE, affecting, blocked)
 		// Knockback
 		var/send_dir = get_dir(owner, target)
 		var/turf/turf_thrown_at = get_ranged_target_turf(target, send_dir, powerlevel)

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/tzimisce.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/tzimisce.dm
@@ -127,7 +127,7 @@
 					Ctarget.drop_all_held_items()
 					to_chat(user, span_warning("You hastly damage the ligaments in [Ctarget]'s [target_part] with a fierce blow."))
 				if(6 to INFINITY)
-					if(target_part.dismemberable)
+					if(target_part.dismemberable && (target.getarmor(target_part, MELEE) < 40))	//heavy armor, such as riot armor, stops the dismember
 						target_part.dismember()
 						to_chat(user, span_warning("You sever [Ctarget]'s [target_part] with a clean swipe."))
 					else

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/tzimisce.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/tzimisce.dm
@@ -122,8 +122,8 @@
 					Ctarget.apply_damage(50, STAMINA, selected_zone)
 					to_chat(user, span_warning("You swiftly disable the nerves in [Ctarget]'s [target_part] with a precise strike."))
 				if(3 to 6)
-					Ctarget.apply_damage(25, STAMINA, selected_zone)
-					Ctarget.apply_damage(25, BRUTE, selected_zone)
+					Ctarget.apply_damage(30, STAMINA, selected_zone)
+					Ctarget.apply_damage(20, BRUTE, selected_zone)
 					Ctarget.drop_all_held_items()
 					to_chat(user, span_warning("You hastly damage the ligaments in [Ctarget]'s [target_part] with a fierce blow."))
 				if(6 to INFINITY)
@@ -131,6 +131,7 @@
 						target_part.dismember()
 						to_chat(user, span_warning("You sever [Ctarget]'s [target_part] with a clean swipe."))
 					else
+						Ctarget.apply_damage(20, STAMINA, selected_zone)
 						Ctarget.apply_damage(30, BRUTE, selected_zone)
 						Ctarget.drop_all_held_items()
 						to_chat(user, span_warning("As [Ctarget]'s [target_part] is too tough to chop in a single action!"))


### PR DESCRIPTION
Brawn punch damage is now reduced by armor so you cant get free high-level bone wounds on people wearing riot armor.
Tzimisce dice ability now only dismembers if the targeted bodypart has less than 40 melee armor. Otherwise it just does a bunch of damage. I didn't make the damage reduced by armor because its a special ability for a single midround-only clan that is kinda themed to be pretty slicey and precise.


# Wiki Documentation

Dice can't dismember living humans with significant armor.

# Changelog

:cl:  

tweak: Bloodsucker brawn ability now respects armor (with 20 AP)
tweak: Tzimisce bloodsucker dice ability can no longer instantly dismember targets with significant armor
/:cl:
