### PR TITLE
Heretic Reflavor + Epilogues

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -326,7 +326,7 @@
 /datum/antagonist/bloodsucker/proc/get_flavor(objectives_complete, optional_objectives_complete)
 	var/list/flavor = list()
 	var/flavor_message
-	var/alive = considered_alive(owner.current) //Technically not necessarily probably because of Final Death objective?
+	var/alive = owner?.current?.stat != DEAD //Technically not necessarily probably because of Final Death objective?
 	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -334,25 +334,29 @@
 	if(objectives_complete && optional_objectives_complete && broke_masquerade && escaped)
 		//finish all objectives, break masquerade, evac
 		flavor_message += pick(list(
-			"What matters of the Masquerade to you? Let it crumble into dust as your tyranny whips forward to dine on more stations. News of your butchering exploits will quickly spread, and you know what will encompass the minds of mortals and undead alike. Fear."
+			"What matters of the Masquerade to you? Let it crumble into dust as your tyranny whips forward to dine on more stations. \
+			News of your butchering exploits will quickly spread, and you know what will encompass the minds of mortals and undead alike. Fear."
 		))
 		message_color = "#008000"
 	else if(objectives_complete && optional_objectives_complete && broke_masquerade && alive)
 		//finish all objectives, break masquerade, don't evac
 		flavor_message += pick(list(
-			"Blood still pumps in your veins as you lay stranded on the station. No doubt the wake of chaos left in your path will attract danger, but greater power than you've ever felt courses through your body. Let the Camarilla and the witchers come. You will be waiting."
+			"Blood still pumps in your veins as you lay stranded on the station. No doubt the wake of chaos left in your path will attract danger, but greater power than you've ever felt courses through your body. \
+			Let the Camarilla and the witchers come. You will be waiting."
 		))
 		message_color = "#008000"
 	else if(objectives_complete && optional_objectives_complete && !broke_masquerade && escaped)
 		//finish all objectives, don't break masquerade, escape
 		flavor_message += pick(list(
-			"You step off the spacecraft with a mark of pride at a superbly completed mission. Upon arriving back at CentCom, an unassuming assistant palms you an invitation stamped with the Camarilla seal. High society awaits: a delicacy you have earned."
+			"You step off the spacecraft with a mark of pride at a superbly completed mission. Upon arriving back at CentCom, an unassuming assistant palms you an invitation stamped with the Camarilla seal. \
+			High society awaits: a delicacy you have earned."
 		))
 		message_color = "#008000"
 	else if(objectives_complete && optional_objectives_complete && !broke_masquerade && alive)
 		//finish all objectives, don't break masquerade, don't escape
 		flavor_message += pick(list(
-			"This station has become your own slice of paradise. Your mission completed, you turn on the others who were stranded, ripe for your purposes. Who knows? If they prove to elevate your power enough, perhaps a new clan might be founded here."
+			"This station has become your own slice of paradise. Your mission completed, you turn on the others who were stranded, ripe for your purposes. \
+			Who knows? If they prove to elevate your power enough, perhaps a new clan might be founded here."
 		))
 		message_color = "#008000"
 	else if(objectives_complete && !optional_objectives_complete && broke_masquerade && escaped)

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -356,7 +356,7 @@
 		//finish all objectives, don't break masquerade, don't escape
 		flavor_message += pick(list(
 			"This station has become your own slice of paradise. Your mission completed, you turn on the others who were stranded, ripe for your purposes. \
-			Who knows? If they prove to elevate your power enough, perhaps a new clan might be founded here."
+			Who knows? If they prove to elevate your power enough, perhaps a new bloodline might be founded here."
 		))
 		message_color = "#008000"
 	else if(objectives_complete && !optional_objectives_complete && broke_masquerade && escaped)

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -326,7 +326,7 @@
 /datum/antagonist/bloodsucker/proc/get_flavor(objectives_complete, optional_objectives_complete)
 	var/list/flavor = list()
 	var/flavor_message
-	var/alive = owner?.current?.stat != DEAD //Technically not necessarily probably because of Final Death objective?
+	var/alive = owner?.current?.stat != DEAD //Technically not necessary because of Final Death objective?
 	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -366,7 +366,6 @@
 		flavor_message += pick(list(
 			"You survived, but you broke the Masquerade, your blood-stained presence clear and your power limited. No doubt death in the form of claw or stake hails its approach. Perhaps it's time to understand the cattles' fascinations with the suns."
 		))
-		message_color = "#ef2f3c"
 	else if(objectives_complete && !optional_objectives_complete && !broke_masquerade && escaped)
 		//finish primary objectives only, don't break masquerade, escape
 		flavor_message += pick(list(

--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -326,7 +326,8 @@
 /datum/antagonist/bloodsucker/proc/get_flavor(objectives_complete, optional_objectives_complete)
 	var/list/flavor = list()
 	var/flavor_message
-	var/escaped = (owner.current.onCentCom() || owner.current.onSyndieBase())
+	var/alive = considered_alive(owner.current) //Technically not necessarily probably because of Final Death objective?
+	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"
 	//i used pick() in case anyone wants to add more messages as time goes on
@@ -336,7 +337,7 @@
 			"What matters of the Masquerade to you? Let it crumble into dust as your tyranny whips forward to dine on more stations. News of your butchering exploits will quickly spread, and you know what will encompass the minds of mortals and undead alike. Fear."
 		))
 		message_color = "#008000"
-	else if(objectives_complete && optional_objectives_complete && broke_masquerade && !escaped)
+	else if(objectives_complete && optional_objectives_complete && broke_masquerade && alive)
 		//finish all objectives, break masquerade, don't evac
 		flavor_message += pick(list(
 			"Blood still pumps in your veins as you lay stranded on the station. No doubt the wake of chaos left in your path will attract danger, but greater power than you've ever felt courses through your body. Let the Camarilla and the witchers come. You will be waiting."
@@ -348,7 +349,7 @@
 			"You step off the spacecraft with a mark of pride at a superbly completed mission. Upon arriving back at CentCom, an unassuming assistant palms you an invitation stamped with the Camarilla seal. High society awaits: a delicacy you have earned."
 		))
 		message_color = "#008000"
-	else if(objectives_complete && optional_objectives_complete && !broke_masquerade && !escaped)
+	else if(objectives_complete && optional_objectives_complete && !broke_masquerade && alive)
 		//finish all objectives, don't break masquerade, don't escape
 		flavor_message += pick(list(
 			"This station has become your own slice of paradise. Your mission completed, you turn on the others who were stranded, ripe for your purposes. Who knows? If they prove to elevate your power enough, perhaps a new clan might be founded here."
@@ -360,7 +361,7 @@
 			"Your mission accomplished, you step off the spacecraft, feeling the mark of exile on your neck. Your allies gone, your veins thrum with a singular purpose: survival."
 		))
 		message_color = "#517fff"
-	else if(objectives_complete && !optional_objectives_complete && broke_masquerade && !escaped)
+	else if(objectives_complete && !optional_objectives_complete && broke_masquerade && alive)
 		//finish primary objectives only, break masquerade, don't escape
 		flavor_message += pick(list(
 			"You survived, but you broke the Masquerade, your blood-stained presence clear and your power limited. No doubt death in the form of claw or stake hails its approach. Perhaps it's time to understand the cattles' fascinations with the suns."
@@ -372,7 +373,7 @@
 			"A low profile has always suited you best, conspiring enough to satiate the clan and keep your head low. It's not luxorious living, though death is a less kind alternative. On to the next station."
 		))
 		message_color = "#517fff"
-	else if(objectives_complete && !optional_objectives_complete && !broke_masquerade && !escaped)
+	else if(objectives_complete && !optional_objectives_complete && !broke_masquerade && alive)
 		//finish primary objectives only, don't break masquerade, don't escape
 		flavor_message += pick(list(
 			"You completed your mission and kept your identity free of heresy, though your mark here is not strong enough to lay a claim. Best stow away when the next shuttle comes around."

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -255,9 +255,9 @@
 		//Ascend and escape
 		if(is_ash)
 			flavor_message += 	"You step off the shuttle as smoke curls off your form. Light seeps from openings in your body, and you quickly retire to the Mansus. \
-								Here, you trail back to the Wanderer's Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
-								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
-								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
+								Here, you trail back to the Wanderer's Tavern, fire sprouting from your steps, yet the trees stand unsinged. Other's eyes look at you more \
+								fearfully, but you watch comings and goings. It is not difficult to see those with passion and stalk them once they leave. You will not grow old. \
+								One day, you will rebel. One day, you will kindle all the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
 			if(transformed)
 				flavor_message += 	"Flesh Worm"
@@ -270,10 +270,10 @@
 	else if(ascended && alive)
 		//Ascend and stay on station
 		if(is_ash)
-			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. \
-								Then, you slip back into the Mansus and return to the Wanderer's Tavern, flames licking in your wake, though the grass remains unburnt. \
-								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
-								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
+			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. Then, you slip back into the Mansus and head to \
+								the Volcanic Graveyard. Here you walk among the ghosts of the City Guard, who see in you an opportunity for vengeance. They whisper \
+								of a secret rite, one that would come at their cost but reward you with fabulous power. You smile. You will not grow old. \
+								One day, you will rebel. One day, you will kindle burning tombstones brighter, and rise even higher."
 		else if(is_flesh)
 			if(transformed)
 				flavor_message += 	"Flesh Worm"
@@ -302,7 +302,10 @@
 	else if(cultiewin && escaped)
 		//Finish normal objectives, don't ascend, and escape
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"You step off the shuttle with a feeling of pride. This day, you have accomplished what you set out to do. Could more have been done? \
+								Yes. But this is a victory nonetheless. Not after long, you tear your way back into the Mansus in your living form, strolling to the \
+								Glass Library. Here, you barter with Bronze Guardians, and they let you enter in exchange for some hushed secrets of the fallen capital, \
+								Amgala. You begin to pour over tomes, searching for the next steps you will need to take. Someday, you will become even greater."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
@@ -317,7 +320,10 @@
 	else if(cultiewin && alive)
 		//Finish normal objectives, don't ascend, and stay on station
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"This can be considered a victory, you suppose. It will not be difficult to traverse back into the Mansus with what you know, \
+								and you have learnt enough to continue your studies elsewhere. As you pass beyond the Veil once more, you feel your spark hum with heat; \
+								yet you need more. Then, you wander to the Painted Mountains in solitude, unphased by the cold as your blade melts the ground you walk. \
+								Perhaps you will find others amidst the cerulean snow. If you do, their warmth will fuel your flame even hotter."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
@@ -332,7 +338,10 @@
 	else if(cultiewin && !alive)
 		//Finish normal objectives, don't ascend, and die
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"You touched the Kilnplains, and it will not let you go. While you do not rise as one of the Ashmen, your skin is still grey \
+								and you find an irremovable desire to escape this place. You have some power in your grasp. You know it to be possible. \
+								You can ply your time, spending an eternity to plan your steps to claim more sparks in the everlasting fulfillment of ambition. \
+								Some day, you will rise higher. You refuse to entertain any other possibility. And so, you set out."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -246,11 +246,11 @@
 	if(!initialized_knowledge.tier == TIER_NONE && knowledge_tier != TIER_ASCEND)
 		if(IS_EXCLUSIVE_KNOWLEDGE(initialized_knowledge))
 			knowledge_tier++
-			to_chat(owner, span_cultbold("Your new knowledge brings you a breakthrough! you are now able to research a new group of subjects."))
+			to_chat(owner, span_cultbold("Your new knowledge brings you a breakthrough! You are now able to research a new group of subjects."))
 		else if(initialized_knowledge.tier == knowledge_tier && ++tier_counter == 3)
 			knowledge_tier++
 			tier_counter = 0
-			to_chat(owner, span_cultbold("Your studies are bearing fruit, you are on the edge of a breakthrough..."))
+			to_chat(owner, span_cultbold("Your studies are bearing fruit; you are on the edge of a breakthrough!"))
 	return TRUE
 
 /datum/antagonist/heretic/proc/get_researchable_knowledge()

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -39,7 +39,7 @@
 	owner.announce_objectives()
 	to_chat(owner, "<span class='cult'>The text whispers, and forbidden knowledge licks at your mind!<br>\
 	Your book allows you to gain abilities with research points. You cannot undo research, so choose your path wisely!<br>\
-	You gain research points by collecting influences or sacrificing targets by using a living heart and transmutation rune.<br>\
+	You gain research points by collecting influences or sacrificing targets by using a living heart and a transmutation rune.<br>\
 	You can find a basic guide at : https://wiki.yogstation.net/wiki/Heretic </span><br>\
 	If you need to quickly check your unlocked transmutation recipes, ALT + CLICK your Codex Cicatrix.")
 
@@ -260,9 +260,14 @@
 								One day, you will rebel. One day, you will kindle all the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
 			if(transformed)
-				flavor_message += 	"Flesh Worm"
+				flavor_message += 	"You RACE and you CRAWL everywhere through the shuttle. The doors open to Centcom and you simply must OOZE out into the halls. The GREAT \
+									sensations SLIDE along your sides. EVERYTHING you feel is GREATER, BETTER. Then you WRAP and SPIN into the Mansus, FLOWING to the Crimson Church. \
+									HERE YOU WILL RESIDE WITH HIM FOREVER. THE TASTE OF THE SELF GOES ON AND ON AND NEVER ENDS. LIFE IS A NEVER-ENDING DELICACY OF PLEASURE AND OBEDIENCE."
 			else
-				flavor_message += 	"Flesh"
+				flavor_message += 	"A moment passes before you quickly exit the shuttle. You leave into the Mansus even quicker. Then, you travel through the Wood, your body free \
+									of the pulses and longings of the Red Oath. Now, your resolve is steel. Control over others first demands a control over the self. When you \
+									enter the Wanderer's Tavern, familiar faces turn to you with disgust and barely controlled rage. Their brows and jaws twist further as you open \
+									your mouth and ask for followers who desire knowledge. You will not grow old. One day, you will rebel again. Perhaps, one day, you will form your own church, with you as its head."
 		else //Rust
 			flavor_message += 	"The shuttle sputters and finally dies as you step onto Centcom, the floor tiling beneath your feet already beginning to decay. Disgusted, \
 								you travel to the Mansus. When you head through the Wood, the grass turns at your heel. Arriving at the Wanderer's Tavern, the aged lumber \
@@ -279,9 +284,14 @@
 								One day, you will rebel. One day, you will kindle burning tombstones brighter, and rise even higher."
 		else if(is_flesh)
 			if(transformed)
-				flavor_message += 	"Flesh Worm"
+				flavor_message += 	"SKITTERING and LEAPING through these NEW halls. They are FAMILIAR and FRESH all the same! EACH of your legs WRIGGLES and FEELS the \
+									tiling like a BABY born of BRILLIANCE. Then NEXT is the Mansus where so many FRIENDLY faces lie. To the Wanderer's Tavern, YES, you \
+									think with PRIDE. ALL THOSE THERE WILL BEHOLD AND BOW BEFORE YOUR GLORY! ALL THOSE THERE WILL JOIN THE ONE TRUE FAMILY!"
 			else
-				flavor_message += 	"Flesh"
+				flavor_message += 	"You wonder what will become of your creation. You feel the Cup flow through you, but you channeled the Glorious Feast into another. \
+									What you have made is heretical. The Sworn will no doubt come for you. But will they continue to serve the Priest once they understand \
+									just how much they can witness under you? Entering the Mansus, you quickly travel to the Sunless Wastes. There are so many cast aside here. \
+									But they are perfect for an army. You will not grow old. One day, you will rebel again. Perhaps, one day, you will echo the Gravekeeper, and cast a new hunger into the Mansus."
 		else //Rust
 			flavor_message += 	"Flickering screens and dimming lights surround you as you walk amidst the station's corridors. As the final sparks of power fizzle out, \
 								you slip into the Mansus with ease. It is a long walk from the Gate to the Badlands, and even further to the Ruined Keep. Trailing down to \
@@ -298,9 +308,14 @@
 								One day, you will escape. One day, you will do what the Nightwatcher could not do, and kindle the Mansus whole."
 		else if(is_flesh)
 			if(transformed)
-				flavor_message += 	"Flesh Worm"
+				flavor_message += 	"WHAT has happened to your GLORIOUS new form? You ATE and ATE and ATE and you were WONDEROUS! The once-master scoffs at you now- \
+									HOW he JUDGES the WEAK flesh. You know better. You can UNDERSTAND and SEE MUCH more than HE. Bound to you are the SPIRITS of those \
+									you CONSUME. WHO IS HE TO THINK YOU PITIFUL? THOUGH THE LIGHT FADES, ALL IS PURE. PURITY OF BODY. PURITY OF MIND."
 			else
-				flavor_message += 	"Flesh"
+				flavor_message += 	"You wonder if this was the path you should have chosen. Oathbreakers are a prized possession of Sworn looking to uphold their highest \
+									fealty. Still, you have prepared a new form within the Mansus, one that does not bastardize the Serpent. It's not difficult for your \
+									spirit to find it, and even easier to replace the soul you had put in its stead. Death was a setback, but still your knowledge thrums \
+									within your psyche. You will not grow old. One day, you will rebel again. Perhaps, one day, you will steal the Priest's body as he stole yours."
 		else //Rust
 			flavor_message += 	"All that is made must one day be unmade. The same goes for your weak body. But even without a form, the force of decay will always be \
 								present. Your spirit flies into the Mansus, yet it is not dragged down from the Glory. Instead, you float to the Mecurial Lake, where your \
@@ -316,7 +331,10 @@
 								Glass Library. Here, you barter with Bronze Guardians, and they let you enter in exchange for some hushed secrets of the fallen capital, \
 								Amgala. You begin to pour over tomes, searching for the next steps you will need to take. Someday, you will become even greater."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"It is impossible to hold back laughter once you arrive at Centcom. You have won! Soon, you will slide back into the Mansus, and from there \
+								you will return to the Crimson Church with news of your success. Other Sworn will be contemptuous of you, but you are stronger. Better. \
+								Smarter. Perhaps one day you will ascend further, and invite them to the Glorious Feast. They will be unable to deny such a delicate offer. \
+								And their forms of flesh will be tantalizing at your fingertips. Happiness fills your breast. All things in time."
 		else if(is_rust)
 			flavor_message += 	"The shuttle creaks as you arrive, and you make your way through Centcom briefly. The ship away creaks louder, and you decide to \
 								slip into the Mansus whole. You are unsure what to do next. But at least today, you can claim victory. You can note age in your \
@@ -337,7 +355,10 @@
 								yet you need more. Then, you wander to the Painted Mountains in solitude, unphased by the cold as your blade melts the ground you walk. \
 								Perhaps you will find others amidst the cerulean snow. If you do, their warmth will fuel your flame even hotter."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"You exhale a sigh of happiness. Not many could have accomplished what you have. Could you have gone further? Certainly. Ascension is a \
+								tempting, delightful prospect, but for now, you will relish in this victory. Perhaps there are some left on the station you could subvert. \
+								If not, the Badlands within the Mansus is always filled with travelers coming to and from the Wood, all over and around the ethereal place. \
+								Some will bend. They will obey. The Red Oath must always be upheld."
 		else if(is_rust)
 			flavor_message += 	"Something has been accomplished. You could have gone further. But at least with the power you wield, your time aboard the rapidly-failing \
 								station is brief. It is not a short walk from the Gate to the Glass Fields. Here you look into the shards, and behold your rotten, decrepit \
@@ -358,7 +379,10 @@
 								You can ply your time, spending an eternity to plan your steps to claim more sparks in the everlasting fulfillment of ambition. \
 								Some day, you will rise higher. You refuse to entertain any other possibility. You set out."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"A taste, a glimmer of the thrill is enough for you. Perhaps you could have partaken more, but a minor appetite was more than \
+								filling. Your spirit quickly descends through the Mansus, though the throes of joy still linger within you. You took a plunge, \
+								and it was worth every last second. Even in these final moments, you look fondly upon all that you had done. There is no bitterness \
+								at all you will never achieve. Your final moments are ecstacy."
 		else if(is_rust)
 			flavor_message += 	"Your mortal body is quick to degrade as your soul remains. The Drifter's spite grows in you, building, until you realize \
 								you are not returning to the Mansus. You begin to hear the whispers of the damned, directed toward the living, toward themselves, \

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -10,6 +10,7 @@
 	var/list/researched_knowledge = list()
 	var/list/transmutations = list()
 	var/total_sacrifices = 0
+	var/lore = "Unpledged" //Used to track which path the heretic has taken
 	var/ascended = FALSE
 	var/charge = 1
 ///current tier of knowledge this heretic is on, each level unlocks new knowledge bits
@@ -33,14 +34,13 @@
 
 /datum/antagonist/heretic/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ecult_op.ogg', 100, FALSE, pressure_affected = FALSE)//subject to change
-	to_chat(owner, "[span_boldannounce("You are the Heretic!")]<br>\
-	<B>The old ones gave you these tasks to fulfill:</B>")
+	to_chat(owner, span_userdanger("You are the Heretic."))
 	owner.announce_objectives()
-	to_chat(owner, "<span class='cult'>The book whispers, the forbidden knowledge walks once again!<br>\
-	Your book allows you to research abilities, read it very carefully! you cannot undo what has been done!<br>\
-	You gain charges by either collecting influences or sacrificing people tracked by the living heart<br> \
+	to_chat(owner, "<span class='cult'>The text whispers, and forbidden knowledge licks at your mind!<br>\
+	Your book allows you to gain abilities with research points. You cannot undo research, so choose your path wisely!<br>\
+	You gain research points by collecting influences or sacrificing targets by using a living heart and transmutation rune.<br>\
 	You can find a basic guide at : https://wiki.yogstation.net/wiki/Heretic </span><br>\
-	If you need to quickly check your unlocked transmutation recipes, alt+click your Codex Cicatrix.")
+	If you need to quickly check your unlocked transmutation recipes, ALT + CLICK your Codex Cicatrix.")
 
 /datum/antagonist/heretic/get_preview_icon()
 	var/icon/icon = render_preview_outfit(preview_outfit)
@@ -68,7 +68,7 @@
 	if(ishuman(current))
 		forge_primary_objectives()
 		gain_knowledge(/datum/eldritch_knowledge/basic)
-	current.log_message("has been converted to the cult of the forgotten ones!", LOG_ATTACK, color="#960000")
+	current.log_message("has been made a student of the Mansus!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.AddMind(owner)
 	START_PROCESSING(SSprocessing,src)
 	SSticker.mode.update_heretic_icons_added(owner)
@@ -83,8 +83,8 @@
 		EK.on_lose(owner.current)
 
 	if(!silent)
-		to_chat(owner.current, span_userdanger("Your mind begins to flare as the otherwordly knowledge escapes your grasp!"))
-		owner.current.log_message("has renounced the cult of the old ones!", LOG_ATTACK, color="#960000")
+		to_chat(owner.current, span_userdanger("Your mind begins to flare as otherwordly knowledge escapes your grasp!"))
+		owner.current.log_message("has lost their link to the Mansus!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.RemoveMind(owner)
 	STOP_PROCESSING(SSprocessing,src)
 
@@ -215,12 +215,12 @@
 				cultiewin = FALSE
 			count++
 	if(ascended)
-		parts += "<span class='greentext big'>THE HERETIC HAS ASCENDED!</span>"
+		parts += "<span class='greentext big'>THE [uppertext(lore)] HERETIC HAS ASCENDED!</span>"
 	else
 		if(cultiewin)
-			parts += span_greentext("The heretic was successful!")
+			parts += span_greentext("The [lowertext(lore)] heretic was successful!")
 		else
-			parts += span_redtext("The heretic has failed.")
+			parts += span_redtext("The [lowertext(lore)] heretic has failed.")
 
 	parts += "<b>Knowledge Researched:</b> "
 
@@ -231,7 +231,156 @@
 		knowledge_message += "[EK.name]"
 	parts += knowledge_message.Join(", ")
 
+	parts += get_flavor(cultiewin, ascended, lore)
+
 	return parts.Join("<br>")
+
+/datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, lore)
+	var/list/flavor = list()
+	var/flavor_message
+	var/alive = considered_alive(owner.current)
+	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
+	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
+	var/message_color = "#ef2f3c"
+	
+	//Stolen from chubby's bloodsucker code, but without support for lists
+	if(cultiewin && ascended && escaped)
+		//Finish normal objectives, ascend, and escape
+		if(lore == "Ash")
+			flavor_message += 	"You step off the shuttle as smoke curls off your form. Light seeps from openings in your body, and you quickly retire to the Mansus. \
+								Here, you trail back to the Wooded Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
+								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
+								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#FFD700"
+
+	else if(cultiewin && ascended && alive)
+		//Finish normal objectives, ascend, and stay on station
+		if(lore == "Ash")
+			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. . \
+								Then, you descend back into the Mansus and return to the Wooded Tavern, flames licking in your wake, though the grass remains unburnt. \
+								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
+								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#FFD700"
+
+	else if(cultiewin && ascended && !alive)
+		//Finish normal objectives, ascend, and die
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#FFD700"
+
+	else if(cultiewin && !ascended && escaped)
+		//Finish normal objectives, don't ascend, and escape
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //If you SOMEHOW complete your objectives without doing ANY research
+			flavor_message += 	"Help"
+		message_color = "#517fff"
+
+	else if(cultiewin && !ascended && alive)
+		//Finish normal objectives, don't ascend, and stay on station
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //If you SOMEHOW complete your objectives without doing ANY research
+			flavor_message += 	"Help"
+		message_color = "#517fff"
+
+	else if(cultiewin && !ascended && !alive)
+		//Finish normal objectives, don't ascend, and die
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //If you SOMEHOW complete your objectives without doing ANY research
+			flavor_message += 	"Help"
+
+	else if(!cultiewin && ascended && escaped)
+		//Don't finish objectives, ascend, and escape
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#008000"
+
+	else if(!cultiewin && ascended && alive)
+		//Don't finish objectives, ascend, and stay on station
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#008000"
+
+	else if(!cultiewin && ascended && !alive)
+		//Don't finish objectives, ascend, and die
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else //Rust
+			flavor_message += 	"Help"
+		message_color = "#008000"
+
+	else if(!cultiewin && !ascended && escaped)
+		//Don't finish objectives, don't ascend, and escape
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //Didn't choose lore
+			flavor_message += 	"Help"
+
+	else if(!cultiewin && !ascended && alive)
+		//Don't finish objectives, don't ascend, and stay on station
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //Didn't choose lore
+			flavor_message += 	"Help"
+
+	else
+		//Don't finish objectives, don't ascend, and die
+		if(lore == "Ash")
+			flavor_message += 	"Help"
+		else if(lore == "Flesh")
+			flavor_message += 	"Help"
+		else if(lore == "Rust")
+			flavor_message += 	"Help"
+		else //Didn't choose lore
+			flavor_message += 	"Help"
+
+	flavor += "<font color=[message_color]>[flavor_message]</font></div>"
+	return "<div>[flavor.Join("<br>")]</div>"
+
 ////////////////
 // Knowledge //
 ////////////////
@@ -243,6 +392,8 @@
 	researched_knowledge[initialized_knowledge.type] = initialized_knowledge
 	initialized_knowledge.on_gain(owner.current)
 	charge -= initialized_knowledge.cost
+	if(initialized_knowledge.tier == TIER_PATH) //Sets chosen heretic lore when path is chosen
+		lore = initialized_knowledge.route
 	if(!initialized_knowledge.tier == TIER_NONE && knowledge_tier != TIER_ASCEND)
 		if(IS_EXCLUSIVE_KNOWLEDGE(initialized_knowledge))
 			knowledge_tier++

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -238,52 +238,58 @@
 /datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, lore)
 	var/list/flavor = list()
 	var/flavor_message
+
 	var/alive = owner?.current?.stat != DEAD
 	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
+
 	var/is_ash = "[lore]" == "Ash"
 	var/is_flesh = "[lore]" == "Flesh"
 	var/is_rust = "[lore]" == "Rust"
+
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"
 	
 	//Stolen from chubby's bloodsucker code, but without support for lists
-	if(cultiewin && ascended && escaped)
-		//Finish normal objectives, ascend, and escape
+	if(ascended && escaped)
+		//Ascend and escape
 		if(is_ash)
 			flavor_message += 	"You step off the shuttle as smoke curls off your form. Light seeps from openings in your body, and you quickly retire to the Mansus. \
-								Here, you trail back to the Wooded Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
+								Here, you trail back to the Wanderer's Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
 								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
-								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
+								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Wood, and rise even higher."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
-	else if(cultiewin && ascended && alive)
-		//Finish normal objectives, ascend, and stay on station
+	else if(ascended && alive)
+		//Ascend and stay on station
 		if(is_ash)
 			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. \
-								Then, you descend back into the Mansus and return to the Wooded Tavern, flames licking in your wake, though the grass remains unburnt. \
+								Then, you slip back into the Mansus and return to the Wanderer's Tavern, flames licking in your wake, though the grass remains unburnt. \
 								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
-								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
+								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Wood, and rise even higher."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
-	else if(cultiewin && ascended && !alive)
-		//Finish normal objectives, ascend, and die
+	else if(ascended && !alive)
+		//Ascend and die
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"Your soul wanders back into the Mansus after your mortal body falls, and you find yourself in the endless dunes of the Kilnplains. \
+								After some time, you feel supple, grey limbs forming anew. Ash flutters off your skin, and your spark thrums hungrily in your chest, \
+								but this new form burns with the same passion. You begin walking with the determination that led you here. You will not grow old. \
+								One day, you will escape. One day, you will kindle the Mansus whole, and rise even higher."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
-	else if(cultiewin && !ascended && escaped)
+	else if(cultiewin && escaped)
 		//Finish normal objectives, don't ascend, and escape
 		if(is_ash)
 			flavor_message += 	"Ash"
@@ -293,9 +299,9 @@
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"Unpledged"
-		message_color = "#517fff"
+		message_color = "#008000"
 
-	else if(cultiewin && !ascended && alive)
+	else if(cultiewin && alive)
 		//Finish normal objectives, don't ascend, and stay on station
 		if(is_ash)
 			flavor_message += 	"Ash"
@@ -305,9 +311,9 @@
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"Unpledged"
-		message_color = "#517fff"
+		message_color = "#008000"
 
-	else if(cultiewin && !ascended && !alive)
+	else if(cultiewin && !alive)
 		//Finish normal objectives, don't ascend, and die
 		if(is_ash)
 			flavor_message += 	"Ash"
@@ -317,38 +323,9 @@
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"Unpledged"
+		message_color = "#517fff"
 
-	else if(!cultiewin && ascended && escaped)
-		//Don't finish objectives, ascend, and escape
-		if(is_ash)
-			flavor_message += 	"Ash"
-		else if(is_flesh)
-			flavor_message += 	"Flesh"
-		else //Rust
-			flavor_message += 	"Rust"
-		message_color = "#008000"
-
-	else if(!cultiewin && ascended && alive)
-		//Don't finish objectives, ascend, and stay on station
-		if(is_ash)
-			flavor_message += 	"Ash"
-		else if(is_flesh)
-			flavor_message += 	"Flesh"
-		else //Rust
-			flavor_message += 	"Rust"
-		message_color = "#008000"
-
-	else if(!cultiewin && ascended && !alive)
-		//Don't finish objectives, ascend, and die
-		if(is_ash)
-			flavor_message += 	"Ash"
-		else if(is_flesh)
-			flavor_message += 	"Flesh"
-		else //Rust
-			flavor_message += 	"Rust"
-		message_color = "#008000"
-
-	else if(!cultiewin && !ascended && escaped)
+	else if(escaped)
 		//Don't finish objectives, don't ascend, and escape
 		if(is_ash)
 			flavor_message += 	"Ash"
@@ -358,8 +335,9 @@
 			flavor_message += 	"Rust"
 		else //Didn't choose lore
 			flavor_message += 	"Unpledged"
+		message_color = "#517fff"
 
-	else if(!cultiewin && !ascended && alive)
+	else if(alive)
 		//Don't finish objectives, don't ascend, and stay on station
 		if(is_ash)
 			flavor_message += 	"Ash"

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -84,7 +84,7 @@
 		EK.on_lose(owner.current)
 
 	if(!silent)
-		to_chat(owner.current, span_userdanger("Your mind begins to flare as otherwordly knowledge escapes your grasp!"))
+		to_chat(owner.current, span_userdanger("Your mind begins to flare as otherworldly knowledge escapes your grasp!"))
 		owner.current.log_message("has lost their link to the Mansus!", LOG_ATTACK, color="#960000")
 	GLOB.reality_smash_track.RemoveMind(owner)
 	STOP_PROCESSING(SSprocessing,src)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -393,7 +393,10 @@
 								eat whole. Maybe a stronger student will call you from your prison one day, but infinite time will pass before \
 								then. You wish you could have done all the things you should not. And you will have an eternity to dwell on it."
 		else if(is_flesh)
-			flavor_message += 	"And so ends your tale. "
+			flavor_message += 	"And so ends your tale. Who knows what you could have become? How many you could have bent to their knees? \
+								Regrets dog you as your soul begins to flow down the Mansus. You were a fool to be tempted. A fool to follow \
+								in an order you could not possibly survive in. Yet some part of you is still enraptured by the Red Oath. There is \
+								an ecstacy in your death. This way, the Sworn remain strong. Those most deserving will feast. Your final moments are bliss."
 		else if(is_rust)
 			flavor_message += 	"Civilizations rise and fall like the current, flowing in and out, one replacing the other over time: dominion \
 								and decay. You were to be one of these forces that saw infrastructure crumble and laws crumpled to dust. But you \

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -313,8 +313,8 @@
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
 								Still, you gave the things of other worlds their tithes. You step into Centcom with a stern sense of focus. Who knows what \
-								you will do next? You feel as if your every step is watched, as one who gave wholly to the Mansus without taking anything in \
-								return. Perhaps you will, someday. But not today. Today, you celebrate a masterful performance."
+								you will do next? You feel as if your every step is watched, as one who gave wholly to that other world without taking anything in \
+								return. Perhaps you will call earned bargains someday. But not today. Today, you celebrate a masterful performance."
 		message_color = "#008000"
 
 	else if(cultiewin && alive)
@@ -338,10 +338,10 @@
 	else if(cultiewin && !alive)
 		//Finish normal objectives, don't ascend, and die
 		if(is_ash)
-			flavor_message += 	"You touched the Kilnplains, and it will not let you go. While you do not rise as one of the Ashmen, your skin is still grey \
+			flavor_message += 	"You touched the Kilnplains, and it will not let you go. While you do not rise as one of the Ashmen, your skin is still grey, \
 								and you find an irremovable desire to escape this place. You have some power in your grasp. You know it to be possible. \
 								You can ply your time, spending an eternity to plan your steps to claim more sparks in the everlasting fulfillment of ambition. \
-								Some day, you will rise higher. You refuse to entertain any other possibility. And so, you set out."
+								Some day, you will rise higher. You refuse to entertain any other possibility. You set out."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
@@ -367,7 +367,7 @@
 		else //Didn't choose lore
 			flavor_message += 	"You decided not to follow the power you had become aware of. From time to time, you will return to the Wood in \
 								your dreams, but you will never aspire to greatness. One day, you will die, and perhaps those close to you in life \
-								will honor you. Then, one day, you will be forgotten. The world will move on as you cease to exist."
+								will honor you. Then, another day, you will be forgotten. The world will move on as you cease to exist."
 		message_color = "#517fff"
 
 	else if(alive)
@@ -399,7 +399,7 @@
 								an ecstacy in your death. This way, the Sworn remain strong. Those most deserving will feast. Your final moments are bliss."
 		else if(is_rust)
 			flavor_message += 	"Civilizations rise and fall like the current, flowing in and out, one replacing the other over time: dominion \
-								and decay. You were to be one of these forces that saw infrastructure crumble and laws crumpled to dust. But you \
+								and decay. You were to be one of these forces that saw infrastructure crumble and laws tattered to dust. But you \
 								were weak. You too, realize you are part of the cycle as your spirit drifts down into the Mansus. Falling from the \
 								Glory, you reflect on your mistakes and your miserable life. In the moments before you become nothing, you understand."
 		else //Didn't choose lore

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -240,143 +240,146 @@
 	var/flavor_message
 	var/alive = considered_alive(owner.current)
 	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
+	var/is_ash = cmptext("[lore]", "Ash")
+	var/is_flesh = cmptext("[lore]", "Flesh")
+	var/is_rust = cmptext("[lore]", "Rust")
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"
 	
 	//Stolen from chubby's bloodsucker code, but without support for lists
 	if(cultiewin && ascended && escaped)
 		//Finish normal objectives, ascend, and escape
-		if(lore == "Ash")
+		if(is_ash)
 			flavor_message += 	"You step off the shuttle as smoke curls off your form. Light seeps from openings in your body, and you quickly retire to the Mansus. \
 								Here, you trail back to the Wooded Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
 								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
 								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
 	else if(cultiewin && ascended && alive)
 		//Finish normal objectives, ascend, and stay on station
-		if(lore == "Ash")
+		if(is_ash)
 			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. . \
 								Then, you descend back into the Mansus and return to the Wooded Tavern, flames licking in your wake, though the grass remains unburnt. \
 								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
 								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
 	else if(cultiewin && ascended && !alive)
 		//Finish normal objectives, ascend, and die
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#FFD700"
 
 	else if(cultiewin && !ascended && escaped)
 		//Finish normal objectives, don't ascend, and escape
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 		message_color = "#517fff"
 
 	else if(cultiewin && !ascended && alive)
 		//Finish normal objectives, don't ascend, and stay on station
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 		message_color = "#517fff"
 
 	else if(cultiewin && !ascended && !alive)
 		//Finish normal objectives, don't ascend, and die
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 
 	else if(!cultiewin && ascended && escaped)
 		//Don't finish objectives, ascend, and escape
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#008000"
 
 	else if(!cultiewin && ascended && alive)
 		//Don't finish objectives, ascend, and stay on station
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#008000"
 
 	else if(!cultiewin && ascended && !alive)
 		//Don't finish objectives, ascend, and die
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Help"
+			flavor_message += 	"Rust"
 		message_color = "#008000"
 
 	else if(!cultiewin && !ascended && escaped)
 		//Don't finish objectives, don't ascend, and escape
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 
 	else if(!cultiewin && !ascended && alive)
 		//Don't finish objectives, don't ascend, and stay on station
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 
 	else
 		//Don't finish objectives, don't ascend, and die
-		if(lore == "Ash")
-			flavor_message += 	"Help"
-		else if(lore == "Flesh")
-			flavor_message += 	"Help"
-		else if(lore == "Rust")
-			flavor_message += 	"Help"
+		if(is_ash)
+			flavor_message += 	"Ash"
+		else if(is_flesh)
+			flavor_message += 	"Flesh"
+		else if(is_rust)
+			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Help"
+			flavor_message += 	"Unpledged"
 
 	flavor += "<font color=[message_color]>[flavor_message]</font></div>"
 	return "<div>[flavor.Join("<br>")]</div>"

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -393,9 +393,12 @@
 								eat whole. Maybe a stronger student will call you from your prison one day, but infinite time will pass before \
 								then. You wish you could have done all the things you should not. And you will have an eternity to dwell on it."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"And so ends your tale. "
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"Civilizations rise and fall like the current, flowing in and out, one replacing the other over time: dominion \
+								and decay. You were to be one of these forces that saw infrastructure crumble and laws crumpled to dust. But you \
+								were weak. You too, realize you are part of the cycle as your spirit drifts down into the Mansus. Falling from the \
+								Glory, you reflect on your mistakes and your miserable life. In the moments before you become nothing, you understand."
 		else //Didn't choose lore
 			flavor_message += 	"Perhaps it is better this way. You chose not to make a plunge into the Mansus, yet your soul returns to it. \
 								You will drift down, deeper, further, until you are forgotten to nothingness."

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -236,7 +236,7 @@
 
 	return parts.Join("<br>")
 
-/datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, trasnformed, lore)
+/datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, transformed, lore)
 	var/list/flavor = list()
 	var/flavor_message
 
@@ -377,9 +377,13 @@
 								Who knows who will come to rescue you? Perhaps they will feed your studies anew. Until then, you will wait. \
 								You hope greatness will come to you. You hate that you have to hope at all."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"Stranded and defeated. Perhaps others still linger who you can force to help your escape. The Mansus is closed \
+								to you, regardless. The book no longer whispers. You feel a hunger rise up in you. You know then that you \
+								will not last for long. Which limb shall you begin with? The arm, the leg, the tongue?"
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"There is naught left here for you to infest. These corridors are now empty, the halls pointless. To decay what \
+								is already abandonded is meaningless; it will happen itself. Unless more arrive and the Company revitalizes its \
+								station, you will become another relic of this place. It is inevitable."
 		else //Didn't choose lore
 			flavor_message += 	"What purpose did you serve? Your mind had been opened to greatness, yet you denied it and chose to live your \
 								days as you always have: one of the many, one of the ignorant. Look at where your lack of ambition has gotten \

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -256,7 +256,7 @@
 			flavor_message += 	"You step off the shuttle as smoke curls off your form. Light seeps from openings in your body, and you quickly retire to the Mansus. \
 								Here, you trail back to the Wanderer's Tavern, fire sprouting from your steps, yet the trees stand unsinged. \
 								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
-								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Wood, and rise even higher."
+								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust
@@ -269,7 +269,7 @@
 			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. \
 								Then, you slip back into the Mansus and return to the Wanderer's Tavern, flames licking in your wake, though the grass remains unburnt. \
 								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
-								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Wood, and rise even higher."
+								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust
@@ -281,8 +281,8 @@
 		if(is_ash)
 			flavor_message += 	"Your soul wanders back into the Mansus after your mortal body falls, and you find yourself in the endless dunes of the Kilnplains. \
 								After some time, you feel supple, grey limbs forming anew. Ash flutters off your skin, and your spark thrums hungrily in your chest, \
-								but this new form burns with the same passion. You begin walking with the determination that led you here. You will not grow old. \
-								One day, you will escape. One day, you will kindle the Mansus whole, and rise even higher."
+								but this new form burns with the same passion. You have walked in the steps of the Nightwatcher. You will not grow old. \
+								One day, you will escape. One day, you will do what the Nightwatcher could not do, and kindle the Mansus whole."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else //Rust

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -238,11 +238,11 @@
 /datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, lore)
 	var/list/flavor = list()
 	var/flavor_message
-	var/alive = considered_alive(owner.current)
+	var/alive = owner?.current?.stat != DEAD
 	var/escaped = ((owner.current.onCentCom() || owner.current.onSyndieBase()) && alive)
-	var/is_ash = cmptext("[lore]", "Ash")
-	var/is_flesh = cmptext("[lore]", "Flesh")
-	var/is_rust = cmptext("[lore]", "Rust")
+	var/is_ash = "[lore]" == "Ash"
+	var/is_flesh = "[lore]" == "Flesh"
+	var/is_rust = "[lore]" == "Rust"
 	flavor += "<div><font color='#6d6dff'>Epilogue: </font>"
 	var/message_color = "#ef2f3c"
 	
@@ -263,7 +263,7 @@
 	else if(cultiewin && ascended && alive)
 		//Finish normal objectives, ascend, and stay on station
 		if(is_ash)
-			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. . \
+			flavor_message += 	"For a while you bask in your heat, wandering the mostly-empty halls of the station. \
 								Then, you descend back into the Mansus and return to the Wooded Tavern, flames licking in your wake, though the grass remains unburnt. \
 								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
 								Perhaps you will rebel. Perhaps, one day, you will kindle the lumber of the Mansus, and rise even higher."

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -264,7 +264,10 @@
 			else
 				flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Rust"
+			flavor_message += 	"The shuttle sputters and finally dies as you step onto Centcom, the floor tiling beneath your feet already beginning to decay. Disgusted, \
+								you travel to the Mansus. When you head through the Wood, the grass turns at your heel. Arriving at the Wanderer's Tavern, the aged lumber \
+								creaks in your presence. Hateful gazes pierce you, and you're quickly asked to leave as the building begins to rot. In the corner, the Drifter \
+								smiles at you. You leave, knowing where to meet him next. You will not grow old. Everything else will. Their time will come. And you will be waiting."
 		message_color = "#FFD700"
 
 	else if(ascended && alive)
@@ -280,7 +283,10 @@
 			else
 				flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Rust"
+			flavor_message += 	"Flickering screens and dimming lights surround you as you walk amidst the station's corridors. As the final sparks of power fizzle out, \
+								you slip into the Mansus with ease. It is a long walk from the Gate to the Badlands, and even further to the Ruined Keep. Trailing down to \
+								the River Krym, you gaze at the fog across the way, bellowing from the Corroded Sewers. You walk into the tunnels, fume flowing into your \
+								body. Your head does not pound. Then, you continue into the depths. You will not grow old. Everything else will. Their time will come. And you will still be alive."
 		message_color = "#FFD700"
 
 	else if(ascended && !alive)
@@ -296,7 +302,10 @@
 			else
 				flavor_message += 	"Flesh"
 		else //Rust
-			flavor_message += 	"Rust"
+			flavor_message += 	"All that is made must one day be unmade. The same goes for your weak body. But even without a form, the force of decay will always be \
+								present. Your spirit flies into the Mansus, yet it is not dragged down from the Glory. Instead, you float to the Mecurial Lake, where your \
+								consciousness extends into the waters. It is difficult to recognize the heightening of awareness until you set your eyes upon the galaxy. \
+								You rumble with Nature's fury as your mind becomes primordial. You will not grow old. Everything else will. Their time will come. And so will yours."
 		message_color = "#FFD700"
 
 	else if(cultiewin && escaped)
@@ -309,7 +318,10 @@
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"The shuttle creaks as you arrive, and you make your way through Centcom briefly. The ship away creaks louder, and you decide to \
+								slip into the Mansus whole. You are unsure what to do next. But at least today, you can claim victory. You can note age in your \
+								form: age far greater than before you had begun your plunge into forbidden knowledge. Regardless, you still feel strong. There is \
+								nowhere in particular you decide to wander within the Mansus. You simply decide to drift for some time, until your next steps become clear."
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
 								Still, you gave the things of other worlds their tithes. You step into Centcom with a stern sense of focus. Who knows what \
@@ -327,7 +339,10 @@
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"Something has been accomplished. You could have gone further. But at least with the power you wield, your time aboard the rapidly-failing \
+								station is brief. It is not a short walk from the Gate to the Glass Fields. Here you look into the shards, and behold your rotten, decrepit \
+								form in the reflection. A handful of spirits flit in your steps, their angry faces leering at you. Whether they are victims or collectors, \
+								you are not sure. Regardless, the clock is ticking. You need to do more. Ruin more. The spirits agree. But for now, you celebrate with them."
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
 								Still, you gave the things of other worlds their tithes. Though you walk the halls of the station alone, the book still \
@@ -345,7 +360,10 @@
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"Your mortal body is quick to degrade as your soul remains. The Drifter's spite grows in you, building, until you realize \
+								you are not returning to the Mansus. You begin to hear the whispers of the damned, directed toward the living, toward themselves, \
+								toward you. You follow their hushed cries and begin to find those lonely, those with despair. Lulling them to an early grave and \
+								draining what little spirit remains comes easy. Incorporeal, you may yet continue your trade."
 		else //If you SOMEHOW complete your objectives without doing ANY research
 			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
 								Still, you gave the things of other worlds their tithes. You gave your life in the process, but there is a wicked satisfaction \
@@ -361,9 +379,15 @@
 								Kilnplains has provided burns brighter by the beating moment. You can try anew. Recuperate. Listen to more discussion within \
 								the Wanderer's Tavern. Your time will come again."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			flavor_message += 	"Escape is escape. You did not claim the day as you thought you would. You refuse to show your head in the Crimson Church \
+								until you have righted this wrong. But at least you have the chance to do so. Even if you are caught, you will not break, \
+								not until you draw your last breath. The Gates will open anew soon enough. You will survey worthy servants in the meantime. \
+								The Cup must be filled, and the master is always wanting."
 		else if(is_rust)
-			flavor_message += 	"Rust"
+			flavor_message += 	"Your fingers are beginning to rot away. The River Krym will make its promise due eventually. But until then, you have time \
+								to delay and try again. Most mortals enjoy more time than you will have to see their impossible goals fulfilled. Yours \
+								are neither impossible nor inconsequential. All things must come to an end, but you will ensure others understand before \
+								you meet yours. It is the natural way of the world."
 		else //Didn't choose lore
 			flavor_message += 	"You decided not to follow the power you had become aware of. From time to time, you will return to the Wood in \
 								your dreams, but you will never aspire to greatness. One day, you will die, and perhaps those close to you in life \
@@ -397,7 +421,7 @@
 								eat whole. Maybe a stronger student will call you from your prison one day, but infinite time will pass before \
 								then. You wish you could have done all the things you should not. And you will have an eternity to dwell on it."
 		else if(is_flesh)
-			flavor_message += 	"And so ends your tale. Who knows what you could have become? How many you could have bent to their knees? \
+			flavor_message += 	"And so ends your tale. Who knows what you could have become? How many could you have bent to their knees? \
 								Regrets dog you as your soul begins to flow down the Mansus. You were a fool to be tempted. A fool to follow \
 								in an order you could not possibly survive in. Yet some part of you is still enraptured by the Red Oath. There is \
 								an ecstacy in your death. This way, the Sworn remain strong. Those most deserving will feast. Your final moments are bliss."

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -308,7 +308,10 @@
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
+								Still, you gave the things of other worlds their tithes. You step into Centcom with a stern sense of focus. Who knows what \
+								you will do next? You feel as if your every step is watched, as one who gave wholly to the Mansus without taking anything in \
+								return. Perhaps you will, someday. But not today. Today, you celebrate a masterful performance."
 		message_color = "#008000"
 
 	else if(cultiewin && alive)
@@ -320,7 +323,10 @@
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
+								Still, you gave the things of other worlds their tithes. Though you walk the halls of the station alone, the book still \
+								whispers to you in your pocket. You have refused to open it. Perhaps you will some day. Until then, you are content to \
+								derive favors owed from the entities beyond. They are watching you. And, some day, you will ask for their help. But not today."
 		message_color = "#008000"
 
 	else if(cultiewin && !alive)
@@ -332,7 +338,10 @@
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //If you SOMEHOW complete your objectives without doing ANY research
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"You have always delighted in challenges. You heard the call of the Mansus, yet you chose not to pledge to any principle. \
+								Still, you gave the things of other worlds their tithes. You gave your life in the process, but there is a wicked satisfaction \
+								that overtakes you. You have proved yourself wiser, more cunning than the rest who fail with the aid of their boons. \
+								Your body and soul can rest knowing the humiliation you have cast upon countless students. Yours will be the last laugh."
 		message_color = "#517fff"
 
 	else if(escaped)

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -12,6 +12,7 @@
 	var/total_sacrifices = 0
 	var/lore = "Unpledged" //Used to track which path the heretic has taken
 	var/ascended = FALSE
+	var/transformed = FALSE //Used to track if the heretic sheds their own body during ascension
 	var/charge = 1
 ///current tier of knowledge this heretic is on, each level unlocks new knowledge bits
 	var/knowledge_tier = TIER_PATH //oh boy this is going to be fun
@@ -235,7 +236,7 @@
 
 	return parts.Join("<br>")
 
-/datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, lore)
+/datum/antagonist/heretic/proc/get_flavor(cultiewin, ascended, trasnformed, lore)
 	var/list/flavor = list()
 	var/flavor_message
 
@@ -258,7 +259,10 @@
 								Familiar faces turn to you with hidden hatred, and your spark beats with power and contempt. You will not grow old. \
 								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			if(transformed)
+				flavor_message += 	"Flesh Worm"
+			else
+				flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
@@ -271,7 +275,10 @@
 								These Long- now equals, painfully smile at you once you enter, and you feel your spark thrum with power and contempt. You will not grow old. \
 								One day, you will rebel. One day, you will kindle the denizens of the Wood, and rise even higher."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			if(transformed)
+				flavor_message += 	"Flesh Worm"
+			else
+				flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
@@ -284,7 +291,10 @@
 								but this new form burns with the same passion. You have walked in the steps of the Nightwatcher. You will not grow old. \
 								One day, you will escape. One day, you will do what the Nightwatcher could not do, and kindle the Mansus whole."
 		else if(is_flesh)
-			flavor_message += 	"Flesh"
+			if(transformed)
+				flavor_message += 	"Flesh Worm"
+			else
+				flavor_message += 	"Flesh"
 		else //Rust
 			flavor_message += 	"Rust"
 		message_color = "#FFD700"
@@ -328,36 +338,49 @@
 	else if(escaped)
 		//Don't finish objectives, don't ascend, and escape
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"A setback is unideal. But at least you have escaped with your body and some knowledge intact. There will be opportunities, \
+								even if you are imprisoned. What the Mansus has whispered to you, you can never forget. The flame in your breast that the \
+								Kilnplains has provided burns brighter by the beating moment. You can try anew. Recuperate. Listen to more discussion within \
+								the Wanderer's Tavern. Your time will come again."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"You decided not to follow the power you had become aware of. From time to time, you will return to the Wood in \
+								your dreams, but you will never aspire to greatness. One day, you will die, and perhaps those close to you in life \
+								will honor you. Then, one day, you will be forgotten. The world will move on as you cease to exist."
 		message_color = "#517fff"
 
 	else if(alive)
 		//Don't finish objectives, don't ascend, and stay on station
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"Disappointment fans your chest. Perhaps you will be able to escape. Perhaps you will have a second chance. \
+								Who knows who will come to rescue you? Perhaps they will feed your studies anew. Until then, you will wait. \
+								You hope greatness will come to you. You hate that you have to hope at all."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"What purpose did you serve? Your mind had been opened to greatness, yet you denied it and chose to live your \
+								days as you always have: one of the many, one of the ignorant. Look at where your lack of ambition has gotten \
+								you now: stranded, like a fool. Even if you do escape, you will die some day. You will be forgotten."
 
 	else
 		//Don't finish objectives, don't ascend, and die
 		if(is_ash)
-			flavor_message += 	"Ash"
+			flavor_message += 	"You touched the Kilnplains, and it will not let you go. Pitiful as you may be, it still drags you back as a \
+								morbid mass of ash and hunger. You will forever wander, thirsty for one more glint of power, one more spark to \
+								eat whole. Maybe a stronger student will call you from your prison one day, but infinite time will pass before \
+								then. You wish you could have done all the things you should not. And you will have an eternity to dwell on it."
 		else if(is_flesh)
 			flavor_message += 	"Flesh"
 		else if(is_rust)
 			flavor_message += 	"Rust"
 		else //Didn't choose lore
-			flavor_message += 	"Unpledged"
+			flavor_message += 	"Perhaps it is better this way. You chose not to make a plunge into the Mansus, yet your soul returns to it. \
+								You will drift down, deeper, further, until you are forgotten to nothingness."
 
 	flavor += "<font color=[message_color]>[flavor_message]</font></div>"
 	return "<div>[flavor.Join("<br>")]</div>"

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -101,7 +101,7 @@
 
 		return
 	is_in_use = FALSE
-	to_chat(user,span_warning("Your ritual failed! You used either wrong components or are missing something important!"))
+	to_chat(user,span_warning("Your ritual failed! You used the wrong components or are missing something important!"))
 
 /obj/effect/eldritch/big
 	name = "Transmutation rune"
@@ -215,7 +215,7 @@
 			arm.dismember()
 			qdel(arm)
 		else
-			to_chat(human_user,span_danger("You pull your hand away from the hole as the eldritch energy flails trying to catch onto the existance itself!"))
+			to_chat(human_user,span_danger("You pull your hand away from the hole as the eldritch energy flails while trying to catch onto the existence itself!"))
 
 /obj/effect/broken_illusion/attack_tk(mob/user)
 	if(!ishuman(user))

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -9,7 +9,7 @@
 
 
 /obj/effect/eldritch
-	name = "Generic rune"
+	name = "generic rune"
 	desc = "Weird combination of shapes and symbols etched into the floor itself. The indentation is filled with thick black tar-like fluid."
 	anchored = TRUE
 	icon_state = ""
@@ -104,7 +104,7 @@
 	to_chat(user,span_warning("Your ritual failed! You used the wrong components or are missing something important!"))
 
 /obj/effect/eldritch/big
-	name = "Transmutation rune"
+	name = "transmutation rune"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "eldritch_rune1"
 	pixel_x = -32 //So the big ol' 96x96 sprite shows up right

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -1,5 +1,5 @@
 /obj/item/living_heart
-	name = "Living Heart"
+	name = "living heart"
 	desc = "Link to the worlds beyond."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "living_heart"
@@ -87,7 +87,7 @@
 	qdel(sword)
 
 /obj/item/gun/magic/hook/sickly_blade
-	name = "Sickly blade"
+	name = "sickly blade"
 	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldritch_blade"
@@ -164,25 +164,25 @@
 		eldritch_knowledge_datum.on_eldritch_blade(target,user,proximity_flag,click_parameters)
 
 /obj/item/gun/magic/hook/sickly_blade/rust
-	name = "Rusted Blade"
+	name = "rusted blade"
 	desc = "This crescent blade is decrepit, wasting to dust. Yet still it bites, catching flesh with jagged, rotten teeth."
 	icon_state = "rust_blade"
 	item_state = "rust_blade"
 
 /obj/item/gun/magic/hook/sickly_blade/ash
-	name = "Ashen Blade"
+	name = "ashen blade"
 	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge."
 	icon_state = "ash_blade"
 	item_state = "ash_blade"
 
 /obj/item/gun/magic/hook/sickly_blade/flesh
-	name = "Flesh Blade"
+	name = "flesh blade"
 	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the excruitations it has endured from dread origins."
 	icon_state = "flesh_blade"
 	item_state = "flesh_blade"
 
 /obj/item/clothing/neck/eldritch_amulet
-	name = "Warm Eldritch Medallion"
+	name = "warm eldritch medallion"
 	desc = "A strange medallion. Peering through the crystalline surface, the world around you melts away. You see your own beating heart, and the pulse of a thousand others."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eye_medalion"
@@ -202,7 +202,7 @@
 	user.update_sight()
 
 /obj/item/clothing/neck/eldritch_amulet/piercing
-	name = "Piercing Eldritch Medallion"
+	name = "piercing eldritch medallion"
 	desc = "A strange medallion. Peering through the crystalline surface, the light refracts into new and terrifying spectrums of color. You see yourself, reflected off cascading mirrors, warped into improbable shapes."
 	trait = TRAIT_XRAY_VISION
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -177,7 +177,7 @@
 
 /obj/item/gun/magic/hook/sickly_blade/flesh
 	name = "flesh blade"
-	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the excruitations it has endured from dread origins."
+	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the excruciating pain it has endured from dread origins."
 	icon_state = "flesh_blade"
 	item_state = "flesh_blade"
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -88,7 +88,7 @@
 
 /obj/item/gun/magic/hook/sickly_blade
 	name = "sickly blade"
-	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
+	desc = "A sickly, green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldritch_blade"
 	item_state = "eldritch_blade"

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -208,8 +208,8 @@
 
 /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	name = "ominous hood"
+	desc = "A torn, dust-caked hood. You feel it watching you."
 	icon_state = "eldritch"
-	desc = "A torn, dust-caked hood. Strange eyes line the inside."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	flash_protect = 2
@@ -223,12 +223,11 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	allowed = list(/obj/item/gun/magic/hook/sickly_blade, /obj/item/forbidden_book)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
-	// slightly better than normal cult robes
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50,ENERGY = 50, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20)
+	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 35, BIO = 20, RAD = 0, FIRE = 20, ACID = 20) //Who knows why it's this good
 
 /obj/item/reagent_containers/glass/beaker/eldritch
 	name = "flask of eldritch essence"
-	desc = "Toxic to the close minded. Healing to those with knowledge of the beyond."
+	desc = "Anathema to the close-minded. Ambrosia to those blessed by the Mansus."
 	icon = 'icons/obj/eldritch.dmi'
 	icon_state = "eldrich_flask"
 	list_reagents = list(/datum/reagent/eldritch = 50)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -165,19 +165,19 @@
 
 /obj/item/gun/magic/hook/sickly_blade/rust
 	name = "rusted blade"
-	desc = "This crescent blade is decrepit, wasting to dust. Yet still it bites, catching flesh with jagged, rotten teeth."
+	desc = "This crescent blade is decrepit, wasting to dust. Yet still it bites, catching flesh with jagged, rotten teeth. A strange liquid oozes from its points."
 	icon_state = "rust_blade"
 	item_state = "rust_blade"
 
 /obj/item/gun/magic/hook/sickly_blade/ash
 	name = "ashen blade"
-	desc = "Molten and unwrought, a hunk of metal warped to cinders and slag. Unmade, it aspires to be more than it is, and shears soot-filled wounds with a blunt edge."
+	desc = "A hunk of molten metal warped to cinders and slag. Unmade and remade countless times over, it aspires to be more than it is as it shears soot-filled wounds."
 	icon_state = "ash_blade"
 	item_state = "ash_blade"
 
 /obj/item/gun/magic/hook/sickly_blade/flesh
 	name = "flesh blade"
-	desc = "A crescent blade born from a fleshwarped creature. Keenly aware, it seeks to spread to others the excruciating pain it has endured from dread origins."
+	desc = "A blade of strange material born from a fleshwarped creature. Keenly aware, it seeks to spread the excruciating pain it has endured from dread origins."
 	icon_state = "flesh_blade"
 	item_state = "flesh_blade"
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -31,7 +31,7 @@
  * 	Ash is the principle of spirit and ambition, and the everlasting flame that burns bright with the kindling of life
  * 	Blade is the principle of violence and tradition, and the fundamental conflicts that arise from proximity
  * 	Bronze is the principle of time and empire, and the unstoppable force of innovation
- * 	Flesh is the principle of hunger and obedience, and the malformation of will
+ * 	Flesh is the principle of temptation and obedience, and the malformation of will
  * 	Rust is the principle of that which makes and unmakes, and the slow decline of all things civilized
  * 	Void is the principle of the inevitable end, and the darkness which will claim all light
  * 

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -26,6 +26,17 @@
 	///spells unlocked by this knowledge
 	var/list/spells_to_add = list()
 
+/** The Lores and their Thematic Representation
+ * 
+ * 	Ash is the principle of spirit and ambition, and the everlasting flame that burns bright with the kindling of life
+ * 	Blade is the principle of violence and tradition, and the fundamental conflicts that arise from proximity
+ * 	Bronze is the principle of time and empire, and the unstoppable force of innovation
+ * 	Flesh is the principle of hunger and obedience, and the malformation of will
+ * 	Rust is the principle of that which makes and unmakes, and the slow decline of all things civilized
+ * 	Void is the principle of the inevitable end, and the darkness which will claim all light
+ * 
+ */
+
 /**
   * What happens when this is assigned to an antag datum
   *
@@ -84,8 +95,8 @@
 
 /datum/eldritch_knowledge/basic
 	name = "Break of Dawn"
-	desc = "Starts your journey in the mansus. Allows you to select a target transmuting a living heart on a transmutation rune, create new living hearts by transmuting a heart, poppy, and pool of blood, and create new Codex Cicatrixes by transmuting human skin, a bible, a poppy and a pen."
-	gain_text = "Gates of mansus open up to your mind."
+	desc = "Begins your journey in the Mansus. Allows you to select a target transmuting a living heart on a transmutation rune, create new living hearts by transmuting a heart, poppy, and pool of blood, and create new Codex Cicatrixes by transmuting human skin, a bible, a poppy and a pen."
+	gain_text = "Gates to the Mansus open in your mind's passion."
 	cost = 0
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/touch/mansus_grasp)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/basic, /datum/eldritch_transmutation/living_heart, /datum/eldritch_transmutation/codex_cicatrix)

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -84,7 +84,7 @@
 
 /datum/eldritch_knowledge/basic
 	name = "Break of Dawn"
-	desc = "Starts your journey in the mansus. Allows you to select a target transmuting a living heart on a transmutation rune, create new living hearts by transmuting a heart, poppy, and pool of blood, and create new codex cicatrixes by transmuting human skin, a bible, a poppy and a pen."
+	desc = "Starts your journey in the mansus. Allows you to select a target transmuting a living heart on a transmutation rune, create new living hearts by transmuting a heart, poppy, and pool of blood, and create new Codex Cicatrixes by transmuting human skin, a bible, a poppy and a pen."
 	gain_text = "Gates of mansus open up to your mind."
 	cost = 0
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/touch/mansus_grasp)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -1,5 +1,5 @@
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash
-	name = "Ashen passage"
+	name = "Ashen Passage"
 	desc = "Grants a short period of incorporeality, allowing passage through walls and other obstacles."
 	school = "transmutation"
 	charge_max = 150
@@ -39,7 +39,7 @@
 	action_background_icon_state = "bg_ecult"
 
 /obj/item/melee/touch_attack/mansus_fist
-	name = "Mansus Grasp"
+	name = "Mansus grasp"
 	desc = "A sinister looking aura that distorts the flow of reality around it. Knocks the target down and deals a large amount of stamina damage alongside a small amount of brute. It may gain more interesting capabilities if you continue your research..."
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
@@ -120,7 +120,7 @@
 	action_background_icon_state = "bg_ecult"
 
 /obj/item/melee/touch_attack/blood_siphon
-	name = "Blood Siphon"
+	name = "blood siphon"
 	desc = "A sinister looking aura that distorts the flow of reality around it. It looks <i>hungry</i>..."
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
@@ -168,7 +168,7 @@
 	invocation_type = "whisper"
 
 /obj/item/projectile/magic/spell/rust_wave
-	name = "Patron's Reach"
+	name = "patron's reach"
 	icon_state = "eldritch_projectile"
 	alpha = 180
 	damage = 30

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -296,7 +296,7 @@
 
 /obj/effect/proc_holder/spell/pointed/ash_final
 	name = "Nightwatcher's Rite"
-	desc = "Fires 5 blasts of fire in angles away from you, dealing heavy damage to anything they hit."
+	desc = "Fires five blasts of fire in angles away from you, dealing heavy damage to anything they hit."
 	school = "transmutation"
 	invocation = "IGNITE"
 	invocation_type = "whisper"
@@ -630,7 +630,7 @@
 
 /obj/effect/proc_holder/spell/cone/staggered/entropic_plume
 	name = "Entropic Plume"
-	desc = "Spews forth a disorienting plume that causes enemies to strike each other, briefly blinds them (increasing with range) and poisons them (decreasing with range), while also spreading rust in the path of the plume."
+	desc = "Spews forth a disorienting plume that causes enemies to strike each other, briefly blinding them (increasing with range) and poisoning them (decreasing with range), while also spreading rust in the path of the plume."
 	school = "illusion"
 	invocation = "GUST OF RUST"
 	invocation_type = "whisper"

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -207,7 +207,7 @@
 
 /obj/effect/proc_holder/spell/pointed/cleave
 	name = "Cleave"
-	desc = "Causes severe bleeding on a target and people around them"
+	desc = "Causes severe bleeding on a target and on people around them"
 	school = "transmutation"
 	charge_max = 350
 	clothes_req = FALSE
@@ -261,8 +261,8 @@
 	charge_max = 650
 
 /obj/effect/proc_holder/spell/pointed/touch/mad_touch
-	name = "Touch of madness"
-	desc = "Strange energies engulf your hand, you feel even the sight of them would cause a headache if you didn't understand them."
+	name = "Touch of Madness"
+	desc = "Strange energies engulf your hand; you feel even the sight of them would cause a headache if you didn't understand them."
 	school = "transmutation"
 	charge_max = 150
 	clothes_req = FALSE
@@ -348,7 +348,7 @@
 				continue
 			hit_list += L
 			L.adjustFireLoss(20)
-			to_chat(L, span_userdanger("You're hit by [source]'s fire breath!"))
+			to_chat(L, span_userdanger("You're hit by [source]'s fire blast!"))
 
 		new /obj/effect/hotspot(T)
 		T.hotspot_expose(700,50,1)
@@ -493,7 +493,7 @@
 
 /obj/effect/proc_holder/spell/targeted/fiery_rebirth
 	name = "Nightwatcher's Rebirth"
-	desc = "Drains the health of nearby combusting individuals, healing you 10 of each damage type for every victim. If a victim is in critical condition they will be finished off."
+	desc = "Drains the health of nearby combusting individuals, healing you 10 of each damage type for every victim. If a victim is in critical condition, they will be finished off."
 	invocation = "ASHES TO ASHES"
 	invocation_type = "whisper"
 	clothes_req = FALSE
@@ -525,7 +525,7 @@
 
 /obj/effect/proc_holder/spell/pointed/manse_link
 	name = "Mansus Link"
-	desc = "Pierce through reality, connecting minds. Hitting someone with this spell will add them to your mansus link shortly after if uninterrupted, allowing for silent communication."
+	desc = "Pierce through reality and connect minds. Hitting someone with this spell will add them to your Mansus link if uninterrupted, allowing for silent communication."
 	school = "transmutation"
 	charge_max = 300
 	clothes_req = FALSE
@@ -559,7 +559,7 @@
 
 /datum/action/innate/mansus_speech
 	name = "Mansus Link"
-	desc = "Send a psychic message to everyone connected to your mansus link."
+	desc = "Send a psychic message to everyone connected to your Mansus link."
 	button_icon_state = "link_speech"
 	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_ecult"
@@ -630,7 +630,7 @@
 
 /obj/effect/proc_holder/spell/cone/staggered/entropic_plume
 	name = "Entropic Plume"
-	desc = "Spews forth a disorienting plume that causes enemies to strike each other, briefly blinds them(increasing with range) and poisons them(decreasing with range), while also spreading rust in the path of the plume."
+	desc = "Spews forth a disorienting plume that causes enemies to strike each other, briefly blinds them (increasing with range) and poisons them (decreasing with range), while also spreading rust in the path of the plume."
 	school = "illusion"
 	invocation = "GUST OF RUST"
 	invocation_type = "whisper"

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -207,7 +207,7 @@
 
 /obj/effect/proc_holder/spell/pointed/cleave
 	name = "Cleave"
-	desc = "Causes severe bleeding on a target and on people around them"
+	desc = "Causes a target and those around them to be inflicted with severe bleeding"
 	school = "transmutation"
 	charge_max = 350
 	clothes_req = FALSE

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -1,7 +1,7 @@
 /datum/eldritch_knowledge/base_ash
 	name = "Nightwatcher's Secret"
-	desc = "Opens up the path of ash to you. Allows you to transmute a pile of ash with a knife or its derivatives into an ashen blade. Additionally empowers your mansus grasp to throw away enemies and makes you resistant to fire."
-	gain_text = "The City Guard knows their watch. If you ask them past dusk they may tell you tales of the Ashy Lantern."
+	desc = "Pledges yourself to the path of Ash. Allows you to transmute a pile of ash with a knife or its derivatives into an ashen blade. Additionally, empowers your Mansus grasp to throw away enemies. You will also become more resistant to fire."
+	gain_text = "Night on the Kilnplains reveals the Ashy Lantern in the sky. In your dreams, you reached out and touched it. Now, like it, you are a part of the dunes. Forever."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ash_knife)
 	cost = 1
@@ -43,8 +43,8 @@
 
 /datum/eldritch_knowledge/ashen_shift
 	name = "Ashen Shift"
-	gain_text = "Ash is so simple, yet so numerous. Is it possible to master it all?"
-	desc = "Short range jaunt that can help you escape from bad situations."
+	gain_text = "Essence is versatile, flexible. It is so easy for grains to blow into all sorts of small crevices."
+	desc = "A very short range jaunt that can help you escape from bad situations or navigate past obstacles."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash)
 	route = PATH_ASH
@@ -52,7 +52,7 @@
 
 /datum/eldritch_knowledge/ashen_eyes
 	name = "Ashen Eyes"
-	gain_text = "These piercing eyes may guide me through the mundane."
+	gain_text = "The City Guard wore these amulets when Amgala was beset by the Sanguine Horde. So too shall you be able to see the blood that flows in others."
 	desc = "Allows you to craft an eldritch amulet by transmutating eyes with a glass shard. When worn, the amulet will give you thermal vision."
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ashen_eyes)
 	cost = 1
@@ -62,7 +62,7 @@
 /datum/eldritch_knowledge/ash_mark
 	name = "Mark of Ash"
 	gain_text = "Spread the famine."
-	desc = "Your mansus grasp now applies ash mark on hit. Use your sickly blade to detonate the mark. The Mark of Ash causes fire loss, attempts to ignite them, and spreads to a nearby carbon. Damage decreases with how many times the mark has spread."
+	desc = "Your Mansus grasp now applies an Ash mark on hit. Use your ashen blade to detonate the mark, which causes burning that can spread to nearby targets, decreasing in damage with each jump."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_ASH

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -53,11 +53,10 @@
 /datum/eldritch_knowledge/ashen_eyes
 	name = "Eldritch Medallion"
 	gain_text = "The City Guard wore these amulets when Amgala was beset by the Sanguine Horde. So too shall you be able to see the blood that flows in others."
-	desc = "Allows you to craft an eldritch amulet by transmutating eyes with a glass shard. When worn, the amulet will give you thermal vision."
+	desc = "Allows you to craft an eldritch amulet by transmutating a pair of eyes with a glass shard. When worn, the amulet will give you thermal vision."
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ashen_eyes)
 	cost = 1
 	tier = TIER_1
-
 
 /datum/eldritch_knowledge/ash_mark
 	name = "Touch of the Spark"
@@ -118,7 +117,7 @@
 
 /datum/eldritch_knowledge/flame_birth
 	name = "Flame Birth"
-	gain_text = "The Nightwatcher was a man of principles, and yet he arose from the chaos he vowed to protect from. This incantation sealed the fate of Amgala."
+	gain_text = "The Nightwatcher was a man of principles, yet he arose from the chaos he vowed to protect from. This incantation sealed the fate of Amgala."
 	desc = "A healing spell that saps the life from those on fire nearby, killing any who are in a critical condition."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/fiery_rebirth)
@@ -135,8 +134,8 @@
 
 /datum/eldritch_knowledge/ash_final
 	name = "Amgala's Ruin"
-	gain_text = "Ash feeds the soil, and fire consumes the plants that grow thereafter. On and on and on. The Nightbringer consumed the sparks of a whole city, yet you will rise with only three: the first step of many to claim his crown."
-	desc = "Transmute three corpses to ascend as an Ashbringer. You will become immune to enviromental hazards and become sturdier to damage. You will additionally gain a spell that creates a massive burst of fire and another spell that creates a cloak of flames around you."
+	gain_text = "Ash feeds the soil, and fire consumes the plants that grow thereafter. On and on and on. The Nightwatcher consumed the sparks of a whole city, yet you will rise with only three: the first step of many to claim his crown."
+	desc = "Transmute three corpses to ascend as an Ashbringer. You will become immune to enviromental hazards and grow more resistant to damage. You will additionally gain a spell that creates a massive burst of fire and another spell that creates a cloak of flames around you."
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/ash_final)
 	route = PATH_ASH

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -51,7 +51,7 @@
 	tier = TIER_1
 
 /datum/eldritch_knowledge/ashen_eyes
-	name = "Ashen Eyes"
+	name = "Eldritch Medallion"
 	gain_text = "The City Guard wore these amulets when Amgala was beset by the Sanguine Horde. So too shall you be able to see the blood that flows in others."
 	desc = "Allows you to craft an eldritch amulet by transmutating eyes with a glass shard. When worn, the amulet will give you thermal vision."
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ashen_eyes)
@@ -60,9 +60,9 @@
 
 
 /datum/eldritch_knowledge/ash_mark
-	name = "Mark of Ash"
-	gain_text = "Spread the famine."
-	desc = "Your Mansus grasp now applies an Ash mark on hit. Use your ashen blade to detonate the mark, which causes burning that can spread to nearby targets, decreasing in damage with each jump."
+	name = "Touch of the Spark"
+	gain_text = "All living things are linked through their sparks. This technique represents a fraction of the Shrouded One's communality."
+	desc = "Your Mansus grasp now applies a mark on hit. Use your ashen blade to detonate the mark, which causes burning that can spread to nearby targets, decreasing in damage with each jump."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_ASH
@@ -77,8 +77,8 @@
 
 /datum/eldritch_knowledge/blindness
 	name = "Curse of Blindness"
-	gain_text = "The Blind Man walks through the world, unnoticed by the masses."
-	desc = "Curse someone with 2 minutes of complete blindness by transmuting a pair of eyes, a screwdriver and a pool of blood, with an object that the victim has touched with their bare hands."
+	gain_text = "The Betrayed eternally walks the Kilnplains with a pair of blood-stained needles. She is willing to come to our world, for a price."
+	desc = "Curse someone with two minutes of complete blindness by transmuting a pair of eyes, a screwdriver, and a pool of blood with an object that the victim has touched with their bare hands."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/blindness)
 	route = PATH_ASH
@@ -86,24 +86,24 @@
 
 /datum/eldritch_knowledge/corrosion
 	name = "Curse of Corrosion"
-	gain_text = "Cursed land, Cursed man, Cursed mind."
-	desc = "Curse someone for 2 minutes of vomiting and major organ damage by transmuting a wirecutter, a spill of blood, a heart, left arm and a right arm, and an item that the victim touched  with their bare hands."
+	gain_text = "The night before he was crowned, the Nightwatcher met with each of the City Guard. Through this ritual, only one lived to see the dawn."
+	desc = "Curse someone with two minutes of vomiting and major organ damage by transmuting a wirecutter, a spill of blood, a heart, a left arm, and a right arm with an item that the victim has touched with their bare hands."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/corrosion)
 	tier = TIER_2
 
 /datum/eldritch_knowledge/paralysis
 	name = "Curse of Paralysis"
-	gain_text = "Corrupt their flesh, make them suffer."
-	desc = "Curse someone for 5 minutes of inability to walk. Using a knife, pool of blood, left leg, right leg, a hatchet and an item that the victim touched with their bare hands. "
+	gain_text = "An acolyte must provide intense envy of another's well-being, which is absorbed with the rite's materials by the Shrouded One to grant opportunity for power."
+	desc = "Curse someone with five minutes of an inability to walk by transmuting a knife, a pool of blood, a left leg, a right leg, and a hatchet with an item that the victim touched with their bare hands."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/curse/paralysis)
 	tier = TIER_2
 
 /datum/eldritch_knowledge/ash_blade_upgrade
-	name = "Fiery Blade"
-	gain_text = "May the sun burn the heretics."
-	desc = "Your blade of choice will now add firestacks."
+	name = "Blade of the City Guard"
+	gain_text = "The stench of boiling blood was common in the wake of the City Guard. Though they are gone, the memory of their pikes and greatswords may yet benefit you."
+	desc = "Your ashen blade will now ignite targets, even without a mark."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_ASH
@@ -118,8 +118,8 @@
 
 /datum/eldritch_knowledge/flame_birth
 	name = "Flame Birth"
-	gain_text = "The Nightwatcher was a man of principles, and yet he arose from the chaos he vowed to protect from."
-	desc = "A healing spell that saps the life from those combusted nearby."
+	gain_text = "The Nightwatcher was a man of principles, and yet he arose from the chaos he vowed to protect from. This incantation sealed the fate of Amgala."
+	desc = "A healing spell that saps the life from those on fire nearby, killing any who are in a critical condition."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/fiery_rebirth)
 	route = PATH_ASH
@@ -127,16 +127,16 @@
 
 /datum/eldritch_knowledge/cleave
 	name = "Blood Cleave"
-	gain_text = "At first I didn't know these instruments of war, but The Priest told me to use them."
-	desc = "Gives AOE spell that causes heavy bleeding and blood loss."
+	gain_text = "The Shrouded One connects all. This technique, a particular favorite of theirs, rips at the bodies of those who hunch too close to permit casuality."
+	desc = "A spell that causes heavy bleeding and blood loss in an area around your target."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/pointed/cleave)
 	tier = TIER_3
 
 /datum/eldritch_knowledge/ash_final
-	name = "Ashlord's Rite"
-	gain_text = "The forgotten lords have spoken! The lord of ash have come! Fear the fire!"
-	desc = "Bring 3 corpses onto a transmutation rune, you will become immune to enviromental hazards and become overall sturdier to all other damage. You will additionally gain a spell that creates a massive burst of fire, and one that creates a cloak of flames around you."
+	name = "Amgala's Ruin"
+	gain_text = "Ash feeds the soil, and fire consumes the plants that grow thereafter. On and on and on. The Nightbringer consumed the sparks of a whole city, yet you will rise with only three: the first step of many to claim his crown."
+	desc = "Transmute three corpses to ascend as an Ashbringer. You will become immune to enviromental hazards and become sturdier to damage. You will additionally gain a spell that creates a massive burst of fire and another spell that creates a cloak of flames around you."
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/ash_final)
 	route = PATH_ASH

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -102,7 +102,7 @@
 /datum/eldritch_knowledge/ash_blade_upgrade
 	name = "Blade of the City Guard"
 	gain_text = "The stench of boiling blood was common in the wake of the City Guard. Though they are gone, the memory of their pikes and greatswords may yet benefit you."
-	desc = "Your ashen blade will now ignite targets, even without a mark."
+	desc = "Your ashen blade will now ignite targets."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_ASH
@@ -118,7 +118,7 @@
 /datum/eldritch_knowledge/flame_birth
 	name = "Flame Birth"
 	gain_text = "The Nightwatcher was a man of principles, yet he arose from the chaos he vowed to protect from. This incantation sealed the fate of Amgala."
-	desc = "A healing spell that saps the life from those on fire nearby, killing any who are in a critical condition."
+	desc = "A healing-damage spell that saps the life from those on fire nearby, killing any who are in a critical condition."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/fiery_rebirth)
 	route = PATH_ASH
@@ -127,7 +127,7 @@
 /datum/eldritch_knowledge/cleave
 	name = "Blood Cleave"
 	gain_text = "The Shrouded One connects all. This technique, a particular favorite of theirs, rips at the bodies of those who hunch too close to permit casuality."
-	desc = "A spell that causes heavy bleeding and blood loss in an area around your target."
+	desc = "A powerful ranged spell that causes heavy bleeding and blood loss in an area around your target."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/pointed/cleave)
 	tier = TIER_3

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -1,6 +1,6 @@
 /datum/eldritch_knowledge/base_ash
 	name = "Nightwatcher's Secret"
-	desc = "Pledges yourself to the path of Ash. Allows you to transmute a pile of ash with a knife or its derivatives into an ashen blade. Additionally, empowers your Mansus grasp to throw away enemies. You will also become more resistant to fire."
+	desc = "Pledges yourself to the path of Ash. Allows you to transmute a pile of ash with a knife or its derivatives into an ashen blade. Additionally, empowers your Mansus grasp to throw enemies away from you. You will also become more resistant to fire."
 	gain_text = "Night on the Kilnplains reveals the Ashy Lantern in the sky. In your dreams, you reached out and touched it. Now, like it, you are a part of the dunes. Forever."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/rust_final,/datum/eldritch_knowledge/flesh_final)
 	unlocked_transmutations = list(/datum/eldritch_transmutation/ash_knife)

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,6 +1,6 @@
 /datum/eldritch_knowledge/base_flesh
 	name = "Principle of Hunger"
-	desc = "Opens up the path of flesh to you. Allows you to transmute a pool of blood with a knife into a Flesh Blade. Additionally, your mansus grasp now raises dead players into subservient ghouls, this does not work on husks or mindshielded people and husks the person it's used on."
+	desc = "Pledges yourself to the path of Flesh. Allows you to transmute a pool of blood with a knife into a flesh blade. Additionally, your Mansus grasp now raises dead bodies into subservient ghouls if they are not mindshielded or husked. It will husk the person it's used on."
 	gain_text = "Hundreds of us starved, but I.. I found the strength in my greed."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/rust_final)
 	cost = 1

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,7 +1,7 @@
 /datum/eldritch_knowledge/base_flesh
 	name = "Principle of Hunger"
-	desc = "Pledges yourself to the path of Flesh. Allows you to transmute a pool of blood with a knife into a flesh blade. Additionally, your Mansus grasp now raises dead bodies into subservient ghouls if they are not mindshielded or husked. It will husk the person it's used on."
-	gain_text = "Hundreds of us starved, but I.. I found the strength in my greed."
+	desc = "Pledges yourself to the path of Flesh. Allows you to transmute a pool of blood with a knife into a flesh blade. Additionally, your Mansus grasp now raises dead humanoids into subservient ghouls if they are not mindshielded or husked. It will husk the person it's used on."
+	gain_text = "The Priest has seduced countless into his flock. He will entice countless more with the Glorious Feast. You knelt before his statue and swore the Red Oath."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/rust_final)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/flesh_blade)
@@ -35,11 +35,11 @@
 		return
 
 	if(HAS_TRAIT(human_target, TRAIT_MINDSHIELD))
-		to_chat(user, span_warning("Their connection to this realm is too strong!"))
+		to_chat(user, span_warning("Their will cannot be malformed to obey your own!"))
 		return
 
 	if(LAZYLEN(spooky_scaries) >= ghoul_amt)
-		to_chat(user, span_warning("Your Patron cannot support more ghouls on this plane!"))
+		to_chat(user, span_warning("Your Oath cannot support more ghouls on this plane!"))
 		return
 
 	LAZYADD(spooky_scaries, human_target)
@@ -79,17 +79,17 @@
 
 /datum/eldritch_knowledge/flesh_ghoul
 	name = "Imperfect Ritual"
-	desc = "Allows you to resurrect the dead as voiceless dead by sacrificing them on the transmutation rune with a poppy. Voiceless dead are mute and have 50 HP. You can only have 2 at a time."
-	gain_text = "I found notes.. notes of a ritual, it was unfinished and yet I still did it."
+	gain_text = "The rite requests an indulgence from the Crimson Church, erasing the victim's freedom and granting them life anew."
+	desc = "Allows you to resurrect a humanoid body as a Voiceless Dead by transmuting them with a poppy. Voiceless Dead are mute and have 50 HP. You can only have two at a time."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/voiceless_dead)
 	route = PATH_FLESH
 	tier = TIER_1
 
 /datum/eldritch_knowledge/flesh_mark
-	name = "Mark of flesh"
-	gain_text = "I saw them, the Marked ones. The screams.. the silence."
-	desc = "Your mansus grasp now applies ash mark on hit. Use your sickly blade to detonate the mark. Mark of flesh when procced causeds additional bleeding."
+	name = "Lover's Exsanguination"
+	gain_text = "She revels and laughs when life begins to flow. Her kiss rips and feasts on flesh alike. This imitates her touch."
+	desc = "Your Mansus grasp now applies a mark on hit. Use your flesh blade to detonate the mark, which causes significant bleeding on the target."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/rust_mark,/datum/eldritch_knowledge/ash_mark)
 	route = PATH_FLESH
@@ -104,8 +104,8 @@
 
 /datum/eldritch_knowledge/raw_prophet
 	name = "Raw Ritual"
-	gain_text = "I saw the mirror-sheen in their dead eyes. It could be put to use."
-	desc = "You can now summon a Raw Prophet by transmuting eyes, a left arm and a right arm. Raw prophets have a massive sight range, X-ray, and can sustain a telepathic network, but are very fragile and weak."
+	gain_text = "The Glorious Feast is not kind to all who are blessed with participation. Those who see less-fortunate metamorphosis are exiled to the Sunless Wastes, from where they can be offered food for service."
+	desc = "Allows you to summon a Raw Prophet by transmuting a pair of eyes, a left arm and a right arm. Raw Prophets have massive sight range with X-ray, and they can sustain a telepathic network. However, they are very fragile and weak."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/raw_prophet)
 	route = PATH_FLESH
@@ -113,16 +113,16 @@
 
 /datum/eldritch_knowledge/blood_siphon
 	name = "Blood Siphon"
-	gain_text = "Our blood is one in the same, after all. The Owl told me."
-	desc = "You gain a spell that drains enemies health and restores yours."
+	gain_text = "The meat of another being is a delicacy that many enjoy. The Gravekeeper's hunger may be decadent, but you will come to know the strength it yields."
+	desc = "A touch spell that drains a target's health and restores yours."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/touch/blood_siphon)
 	tier = TIER_2
 
 /datum/eldritch_knowledge/flesh_blade_upgrade
-	name = "Bleeding Steel"
-	gain_text = "It rained blood, that's when I understood The Gravekeeper's advice."
-	desc = "Your blade will now cause additional bleeding."
+	name = "Talons of the Sworn"
+	gain_text = "Ebis, the Owl, was the second to take the Red Oath. They still grant the gift of their steel to those powerful enough to resist their incursions."
+	desc = "Your flesh blade will now cause additional bleeding on hit."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/rust_blade_upgrade)
 	route = PATH_FLESH
@@ -138,8 +138,8 @@
 
 /datum/eldritch_knowledge/stalker
 	name = "Lonely Ritual"
-	gain_text = " The Uncanny Man walks lonely in the Valley, I called for his aid."
-	desc = "You can now summon a Stalker by transmuting a knife, a candle, a pen and a piece of paper. Stalkers can shapeshift into harmeless animals and have access to an EMP."
+	gain_text = "The Uncanny Man walks lonely in the Valley. I called for his aid."
+	desc = "Allows you to summon a Stalker by transmuting a knife, a candle, a pen, and a piece of paper. Stalkers can shapeshift into harmless animals and emit EMPs."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/stalker)
 	route = PATH_FLESH
@@ -148,7 +148,7 @@
 /datum/eldritch_knowledge/ashy
 	name = "Ashen Ritual"
 	gain_text = "I combined the principle of Hunger with a desire for Destruction. The Eyeful Lords took notice."
-	desc = "You can now summon an Ash Man by transmutating a pile of ash, a head and a book. Ash Men have powerful offensive abilities and access to the Ash Passage spell."
+	desc = "You can now summon an Ashman by transmutating a pile of ash, a head, and a book. Ashmen have powerful offensive abilities and access to the Ash Passage spell."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/ashy)
 	tier = TIER_3
@@ -156,7 +156,7 @@
 /datum/eldritch_knowledge/rusty
 	name = "Rusted Ritual"
 	gain_text = "I combined the principle of Hunger with a desire of Corruption. The Rusted Hills call my name."
-	desc = "You can now summon a Rust Walker transmutating vomit pool and a book. Rust Walkers are capable of spreading rust and have a decent but short ranged projectile attack."
+	desc = "You can now summon a Rust Walker transmutating a vomit pool and a book. Rust Walkers are capable of spreading rust and have strong, short-ranged projectile attack."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/rusty)
 	tier = TIER_3

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -138,7 +138,7 @@
 
 /datum/eldritch_knowledge/stalker
 	name = "Lonely Ritual"
-	gain_text = "The Uncanny Man walks lonely in the Valley. I called for his aid."
+	gain_text = "The Lover is drawn to those who skirt the Crimson Church with solitude in their hearts. Their bodies afterward are like her; deceiving, yet deadly."
 	desc = "Allows you to summon a Stalker by transmuting a knife, a candle, a pen, and a piece of paper. Stalkers can shapeshift into harmless animals and emit EMPs."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/stalker)
@@ -147,7 +147,7 @@
 
 /datum/eldritch_knowledge/ashy
 	name = "Ashen Ritual"
-	gain_text = "I combined the principle of Hunger with a desire for Destruction. The Eyeful Lords took notice."
+	gain_text = "There are so many that fall and wander the Kilnplains as horrid spawn of the Ashy Lantern. This rite offers them sparks anew to consume in exchange for servitude."
 	desc = "You can now summon an Ashman by transmutating a pile of ash, a head, and a book. Ashmen have powerful offensive abilities and access to the Ash Passage spell."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/ashy)
@@ -155,7 +155,7 @@
 
 /datum/eldritch_knowledge/rusty
 	name = "Rusted Ritual"
-	gain_text = "I combined the principle of Hunger with a desire of Corruption. The Rusted Hills call my name."
+	gain_text = "The Vermin Duke's pawns span the Corroded Sewers, though several spill out and roam the Badlands to accost traders and travelers alike. They are not difficult to control, as you have learned."
 	desc = "You can now summon a Rustwalker transmutating a vomit pool and a book. Rustwalkers are capable of spreading rust and have strong, short-ranged projectile attack."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/rusty)
@@ -163,7 +163,7 @@
 
 /datum/eldritch_knowledge/flesh_final
 	name = "Priest's Final Hymn"
-	gain_text = "Men of the world; Hear me! For the time of the Lord of Arms has come!"
+	gain_text = "In preparation for the Glorious Feast, many Sworn appetize with their closest followers. Their master looks upon this fondly, and soothes them into a new, ravenous form of decadence. You will eat, and you will grow."
 	desc = "Transmute three corpses to ascend by metamorphisizing as the King of the Night, or instead summon a Terror of the Night, triple your ghoul maximum, and become incredibly resilient to damage."
 	cost = 3
 	route = PATH_FLESH

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -156,7 +156,7 @@
 /datum/eldritch_knowledge/rusty
 	name = "Rusted Ritual"
 	gain_text = "I combined the principle of Hunger with a desire of Corruption. The Rusted Hills call my name."
-	desc = "You can now summon a Rust Walker transmutating a vomit pool and a book. Rust Walkers are capable of spreading rust and have strong, short-ranged projectile attack."
+	desc = "You can now summon a Rustwalker transmutating a vomit pool and a book. Rustwalkers are capable of spreading rust and have strong, short-ranged projectile attack."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/summon/rusty)
 	tier = TIER_3
@@ -164,7 +164,7 @@
 /datum/eldritch_knowledge/flesh_final
 	name = "Priest's Final Hymn"
 	gain_text = "Men of the world; Hear me! For the time of the Lord of Arms has come!"
-	desc = "Bring 3 bodies onto a transmutation rune to either ascend as the King of the Night or summon a Terror of the Night and triple your ghoul maximum."
+	desc = "Transmute three corpses to ascend by metamorphisizing as the King of the Night, or instead summon a Terror of the Night, triple your ghoul maximum, and become incredibly resilient to damage."
 	cost = 3
 	route = PATH_FLESH
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/flesh_final)

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -164,7 +164,7 @@
 /datum/eldritch_knowledge/flesh_final
 	name = "Priest's Final Hymn"
 	gain_text = "In preparation for the Glorious Feast, many Sworn appetize with their closest followers. Their master looks upon this fondly, and soothes them into a new, ravenous form of decadence. You will eat, and you will grow."
-	desc = "Transmute three corpses to ascend by metamorphisizing as the King of the Night, or instead summon a Terror of the Night, triple your ghoul maximum, and become incredibly resilient to damage."
+	desc = "Transmute three corpses to ascend by metamorphisizing as a Thirstly Serpent or instead summoning a Lavish Serpent, tripling your ghoul maximum, and becoming incredibly resilient to damage."
 	cost = 3
 	route = PATH_FLESH
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/flesh_final)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -30,8 +30,8 @@
 
 /datum/eldritch_knowledge/rust_regen
 	name = "Leeching Walk"
-	desc = "Passively heals you when you are on rusted tiles."
 	gain_text = "His strength was unparalleled, it was unnatural. The Blacksmith was smiling."
+	desc = "Passively heals you when you are on rusted tiles."
 	cost = 1
 	route = PATH_RUST
 	tier = TIER_1
@@ -50,24 +50,24 @@
 
 /datum/eldritch_knowledge/armor
 	name = "Armorer's ritual"
-	desc = "You can now create a powerful set of armor by transmuting a table and gas mask."
 	gain_text = "For I am the heir to the throne of their doom."
+	desc = "Allows you to create a powerful set of armor by transmuting a table and a gas mask."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
 	tier = TIER_1
 
 /datum/eldritch_knowledge/essence
 	name = "Priest's ritual"
-	desc = "You can now transmute a tank of water into a bottle of eldritch water."
 	gain_text = "I learned an old recipe, taught by an Owl in my dreams."
+	desc = "You can now transmute a tank of water into a bottle of eldritch water."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/water)
 	tier = TIER_1
 
 /datum/eldritch_knowledge/rust_mark
 	name = "Mark of Rust"
-	desc = "Your mansus grasp now applies a rust mark. To Detonate the mark use your eldritch blade on it. The rust mark has a chance to deal between 0 to 200 damage to 75% of enemies items."
 	gain_text = "Lords of the depths help those in dire need at a cost."
+	desc = "Your mansus grasp now applies a rust mark. To Detonate the mark use your eldritch blade on it. The rust mark has a chance to deal between 0 to 200 damage to 75% of enemies items."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_RUST
@@ -81,8 +81,8 @@
 
 /datum/eldritch_knowledge/area_conversion
 	name = "Agressive Spread"
-	desc = "Spreads rust to nearby turfs. Destroys already rusted walls."
 	gain_text = "All men wise know not to touch the bound king."
+	desc = "Spreads rust to nearby turfs. Destroys already rusted walls."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/aoe_turf/rust_conversion)
 	route = PATH_RUST
@@ -90,8 +90,8 @@
 
 /datum/eldritch_knowledge/rust_blade_upgrade
 	name = "Toxic blade"
-	gain_text = "Let your blade guide you through the flesh."
 	desc = "Your blade of choice will now add toxin to enemies bloodstream."
+	gain_text = "Let your blade guide you through the flesh."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_RUST
@@ -105,8 +105,8 @@
 
 /datum/eldritch_knowledge/entropic_plume
 	name = "Entropic Plume"
-	desc = "You can now send a befuddling plume that blinds, poisons and makes enemies strike each other. Also converts the area into rust."
 	gain_text = "Messengers of hope fear I, the Rustbringer!"
+	desc = "You can now send a befuddling plume that blinds, poisons and makes enemies strike each other. Also converts the area into rust."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/cone/staggered/entropic_plume)
 	route = PATH_RUST
@@ -114,8 +114,8 @@
 
 /datum/eldritch_knowledge/rust_final
 	name = "Rustbringer's Oath"
-	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become more resillient overall."
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come!"
+	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become more resillient overall."
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/rust_final)
 	route = PATH_RUST

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -1,7 +1,7 @@
 /datum/eldritch_knowledge/base_rust
 	name = "Blacksmith's Tale"
 	desc = "Pledges yourself to the path of Rust. Allows you to transmute a piece of trash with a knife into a rusty blade. Additionally, your Mansus grasp now deal 500 damage to inorganic matter, rusts any surface it's used on, while destroying any surface that is already rusty."
-	gain_text = "Let me tell you a story, The Blacksmith said as he gazed into his rusty blade."
+	gain_text = "Outside the Ruined Keep, you drank of the River Krym. Its poison seeping through your body, years shriveled away. Yet, you were spared. Now, your purpose is clear."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/rust_blade)
@@ -51,7 +51,7 @@
 /datum/eldritch_knowledge/armor
 	name = "Eldritch Armor"
 	gain_text = "For I am the heir to the throne of their doom."
-	desc = "Allows you to craft a set of eldritch armor by transmuting a table and a gas mask. The robes come with a hood, and they significantly reduce most incoming damage."
+	desc = "Allows you to craft a set of eldritch armor by transmuting a table and a gas mask. The robes significantly reduce most incoming damage."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
 	tier = TIER_1

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -1,6 +1,6 @@
 /datum/eldritch_knowledge/base_rust
 	name = "Blacksmith's Tale"
-	desc = "Opens up the path of rust to you. Allows you to transmute a knife with any trash item into a Rusty Blade. Additionally, your mansus grasp now deal 500 damage to inorganic matter. Rusts any surface it's used on, and destroys any surface that is already rusty."
+	desc = "Pledges yourself to the path of Rust. Allows you to transmute a piece of trash with a knife into a rusty blade. Additionally, your Mansus grasp now deal 500 damage to inorganic matter, rusts any surface it's used on, while destroying any surface that is already rusty."
 	gain_text = "Let me tell you a story, The Blacksmith said as he gazed into his rusty blade."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
 	cost = 1
@@ -49,17 +49,17 @@
 	living_user.adjustStaminaLoss(-2)
 
 /datum/eldritch_knowledge/armor
-	name = "Armorer's ritual"
+	name = "Eldritch Armor"
 	gain_text = "For I am the heir to the throne of their doom."
-	desc = "Allows you to create a powerful set of armor by transmuting a table and a gas mask."
+	desc = "Allows you to craft a set of eldritch armor by transmuting a table and a gas mask. The robes come with a hood, and they significantly reduce most incoming damage."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
 	tier = TIER_1
 
 /datum/eldritch_knowledge/essence
-	name = "Priest's ritual"
+	name = "Eldritch Essence"
 	gain_text = "I learned an old recipe, taught by an Owl in my dreams."
-	desc = "You can now transmute a tank of water into a bottle of eldritch water."
+	desc = "Allows you to craft a flask of eldritch essence by transmuting a water tank. The reagent will heal you and damage those not linked to the Mansus."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/water)
 	tier = TIER_1
@@ -67,7 +67,7 @@
 /datum/eldritch_knowledge/rust_mark
 	name = "Mark of Rust"
 	gain_text = "Lords of the depths help those in dire need at a cost."
-	desc = "Your mansus grasp now applies a rust mark. To Detonate the mark use your eldritch blade on it. The rust mark has a chance to deal between 0 to 200 damage to 75% of enemies items."
+	desc = "Your Mansus grasp now applies a mark on hit. Use your rusty blade to detonate the mark, which has a chance to deal between 0 to 200 damage to 75% of your target's items."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark)
 	route = PATH_RUST
@@ -82,16 +82,16 @@
 /datum/eldritch_knowledge/area_conversion
 	name = "Agressive Spread"
 	gain_text = "All men wise know not to touch the bound king."
-	desc = "Spreads rust to nearby turfs. Destroys already rusted walls."
+	desc = "An instant spell that spreads rust onto nearby tiles, destroying any already rusted."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/aoe_turf/rust_conversion)
 	route = PATH_RUST
 	tier = TIER_2
 
 /datum/eldritch_knowledge/rust_blade_upgrade
-	name = "Toxic blade"
-	desc = "Your blade of choice will now add toxin to enemies bloodstream."
+	name = "Toxic Blade"
 	gain_text = "Let your blade guide you through the flesh."
+	desc = "Your rusted blade now injects eldritch essence on hit."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
 	route = PATH_RUST
@@ -106,7 +106,7 @@
 /datum/eldritch_knowledge/entropic_plume
 	name = "Entropic Plume"
 	gain_text = "Messengers of hope fear I, the Rustbringer!"
-	desc = "You can now send a befuddling plume that blinds, poisons and makes enemies strike each other. Also converts the area into rust."
+	desc = "A cone spell that expels befuddling plume that rusts tiles, then blinds, poisons, and forces targets to strike each other."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/cone/staggered/entropic_plume)
 	route = PATH_RUST
@@ -115,7 +115,7 @@
 /datum/eldritch_knowledge/rust_final
 	name = "Rustbringer's Oath"
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come!"
-	desc = "Bring 3 corpses onto the transmutation rune. After you finish the ritual rust will now automatically spread from the rune. Your healing on rust is also tripled, while you become more resillient overall."
+	desc = "Transmute three corpses to ascend as a Sovereign of Decay. Your healing on rust tiles will be tripled, and you will become much more resilient to damage. In addition, rust will spread from your ritual site."
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/rust_final)
 	route = PATH_RUST

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -30,7 +30,7 @@
 
 /datum/eldritch_knowledge/rust_regen
 	name = "Leeching Walk"
-	gain_text = "His strength was unparalleled, it was unnatural. The Blacksmith was smiling."
+	gain_text = "The Drifter sometimes appears in the Wanderer's Tavern. More rarely, he shows eager students how he wanders the planes unscathed."
 	desc = "Passively heals you when you are on rusted tiles."
 	cost = 1
 	route = PATH_RUST
@@ -50,7 +50,7 @@
 
 /datum/eldritch_knowledge/armor
 	name = "Eldritch Armor"
-	gain_text = "For I am the heir to the throne of their doom."
+	gain_text = "The first of the Blacksmith's creations was a shawl that drew the Empress' attention. The eyes would later whisper to him the secrets to forge sickly, sentient blades."
 	desc = "Allows you to craft a set of eldritch armor by transmuting a table and a gas mask. The robes significantly reduce most incoming damage."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/armor)
@@ -58,15 +58,15 @@
 
 /datum/eldritch_knowledge/essence
 	name = "Eldritch Essence"
-	gain_text = "I learned an old recipe, taught by an Owl in my dreams."
+	gain_text = "The Vermin Duke was the first to commit the heresy of melting the insightful metal. With it, he made a catalyst to begin his experiments."
 	desc = "Allows you to craft a flask of eldritch essence by transmuting a water tank. The reagent will heal you and damage those not linked to the Mansus."
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/water)
 	tier = TIER_1
 
 /datum/eldritch_knowledge/rust_mark
-	name = "Mark of Rust"
-	gain_text = "Lords of the depths help those in dire need at a cost."
+	name = "Ruin of Welfare"
+	gain_text = "Ire and envy are universally observable. Where the Drifter went, he saw those who rejoiced with more and those who suffered with less. Only hatred grew in his heart."
 	desc = "Your Mansus grasp now applies a mark on hit. Use your rusty blade to detonate the mark, which has a chance to deal between 0 to 200 damage to 75% of your target's items."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark)
@@ -80,8 +80,8 @@
 		living_target.apply_status_effect(/datum/status_effect/eldritch/rust)
 
 /datum/eldritch_knowledge/area_conversion
-	name = "Agressive Spread"
-	gain_text = "All men wise know not to touch the bound king."
+	name = "Aggressive Spread"
+	gain_text = "It never succumbs in a day. Always, an infection takes hold at the base, and spreads. Rot and filth collapse bodies and structures alike."
 	desc = "An instant spell that spreads rust onto nearby tiles, destroying any already rusted."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/aoe_turf/rust_conversion)
@@ -89,8 +89,8 @@
 	tier = TIER_2
 
 /datum/eldritch_knowledge/rust_blade_upgrade
-	name = "Toxic Blade"
-	gain_text = "Let your blade guide you through the flesh."
+	name = "Memento of Decay"
+	gain_text = "By the time her subjects began to rebel, she had given the Blacksmith enough bodies to sate the blades. His own drooled with an intoxicating nectar, which sealed his fate."
 	desc = "Your rusted blade now injects eldritch essence on hit."
 	cost = 2
 	banned_knowledge = list(/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade)
@@ -105,7 +105,7 @@
 
 /datum/eldritch_knowledge/entropic_plume
 	name = "Entropic Plume"
-	gain_text = "Messengers of hope fear I, the Rustbringer!"
+	gain_text = "The fumes that began to flow from the Corroded Sewers choked the River Krym dead. Legends still say the Vermin Duke is within its fogged tunnels, his form nearly petrified from age."
 	desc = "A cone spell that expels befuddling plume that rusts tiles, then blinds, poisons, and forces targets to strike each other."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/cone/staggered/entropic_plume)
@@ -113,8 +113,8 @@
 	tier = TIER_3
 
 /datum/eldritch_knowledge/rust_final
-	name = "Rustbringer's Oath"
-	gain_text = "Champion of rust. Corruptor of steel. Fear the dark for the Rustbringer has come!"
+	name = "Fallen Empress' Pathology"
+	gain_text = "She could not see her fall before it had arrived. In her final moments, she did not understand how her skin peeled from her flesh and melded into the stone beneath her. You will be wiser. You will inoculate, then imbibe."
 	desc = "Transmute three corpses to ascend as a Sovereign of Decay. Your healing on rust tiles will be tripled, and you will become much more resilient to damage. In addition, rust will spread from your ritual site."
 	cost = 3
 	unlocked_transmutations = list(/datum/eldritch_transmutation/final/rust_final)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -1,7 +1,7 @@
 /datum/eldritch_knowledge/base_rust
 	name = "Blacksmith's Tale"
 	desc = "Pledges yourself to the path of Rust. Allows you to transmute a piece of trash with a knife into a rusty blade. Additionally, your Mansus grasp now deal 500 damage to inorganic matter, rusts any surface it's used on, while destroying any surface that is already rusty."
-	gain_text = "Outside the Ruined Keep, you drank of the River Krym. Its poison seeping through your body, years shriveled away. Yet, you were spared. Now, your purpose is clear."
+	gain_text = "Outside the Ruined Keep, you drank of the River Krym. Its poison seeped through your body as years shriveled away. Yet, you were spared. Now, your purpose is clear."
 	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/ash_mark,/datum/eldritch_knowledge/flesh_mark,/datum/eldritch_knowledge/ash_blade_upgrade,/datum/eldritch_knowledge/flesh_blade_upgrade,/datum/eldritch_knowledge/ash_final,/datum/eldritch_knowledge/flesh_final)
 	cost = 1
 	unlocked_transmutations = list(/datum/eldritch_transmutation/rust_blade)
@@ -106,7 +106,7 @@
 /datum/eldritch_knowledge/entropic_plume
 	name = "Entropic Plume"
 	gain_text = "The fumes that began to flow from the Corroded Sewers choked the River Krym dead. Legends still say the Vermin Duke is within its fogged tunnels, his form nearly petrified from age."
-	desc = "A cone spell that expels befuddling plume that rusts tiles, then blinds, poisons, and forces targets to strike each other."
+	desc = "A cone spell that expels a befuddling plume that rusts tiles, then blinds, poisons, and forces targets to strike each other."
 	cost = 1
 	spells_to_add = list(/obj/effect/proc_holder/spell/cone/staggered/entropic_plume)
 	route = PATH_RUST

--- a/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
@@ -5,7 +5,7 @@
 	required_shit_list = "A pile of ash and a knife."
 
 /datum/eldritch_transmutation/ashen_eyes
-	name = "Ashen Eyes"
+	name = "Eldritch Medallion"
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/shard)
 	result_atoms = list(/obj/item/clothing/neck/eldritch_amulet)
 	required_shit_list = "A glass shard and a pair of eyes."
@@ -57,7 +57,7 @@
 	chosen_mob.update_mobility()
 
 /datum/eldritch_transmutation/final/ash_final
-	name = "Ashlord's Rite"
+	name = "Amgala's Ruin"
 	required_atoms = list(/mob/living/carbon/human)
 	var/list/trait_list = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_BOMBIMMUNE)
 	required_shit_list = "Three dead bodies."

--- a/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/ash_transmutations.dm
@@ -63,7 +63,7 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear The Blaze, for Ashbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+	priority_announce("Immense destabilization of the bluespace veil has been observed. Our scanners report a fiery entity of unknown power is quickly escalating the station temperature to unhabitable levels. Immediate evacuation is advised.", "Anomaly Alert", ANNOUNCER_SPANOMALIES)
 	set_security_level(SEC_LEVEL_GAMMA)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/big)
 	user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/fire_sworn)

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -88,7 +88,7 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent or shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?","...","Yes","No")
+	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent, or instead shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?","...","Yes","No")
 	user.SetImmobilized(10 HOURS) // no way someone will stand 10 hours in a spot, just so he can move while the alert is still showing.
 	switch(alert_)
 		if("No")

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -88,7 +88,7 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent or empower yourself and summon a Lavish Serpent?","...","Yes","No")
+	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent or shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?","...","Yes","No")
 	user.SetImmobilized(10 HOURS) // no way someone will stand 10 hours in a spot, just so he can move while the alert is still showing.
 	switch(alert_)
 		if("No")

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -109,7 +109,7 @@
 			var/datum/eldritch_transmutation/voiceless_dead/ghoul2 = heretic.get_transmutation(/datum/eldritch_transmutation/voiceless_dead)
 			ghoul2.max_amt *= 3
 			var/mob/dead/observer/ghost_candidate = pick(candidates)
-			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for Vassal of Arms has ascended! The Terror of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+			priority_announce("Immense destabilization of the bluespace veil has been observed. Our scanners report two entitites of immeasurable power, one of which is of a considerable volume of organic mass. Immediate evacuation is advised.", "Anomaly Alert", ANNOUNCER_SPANOMALIES)
 			set_security_level(SEC_LEVEL_GAMMA)
 			log_game("[key_name_admin(ghost_candidate)] has taken control of ([key_name_admin(summoned)]).")
 			summoned.ghostize(FALSE)
@@ -127,12 +127,13 @@
 				if(istype(S, /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash)) //vitally important since ashen passage breaks the shit out of armsy
 					user.mind.spell_list.Remove(S)
 					qdel(S)
-			priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the dark, for King of Arms has ascended! Our Lord of the Night has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+			priority_announce("Immense destabilization of the bluespace veil has been observed. Our scanners report a singular entity of immeasurable power that is quickly growing in volume. Immediate evacuation is advised.", "Anomaly Alert", ANNOUNCER_SPANOMALIES)
 			set_security_level(SEC_LEVEL_GAMMA)
 			log_game("[user.real_name] ascended as [summoned.real_name]")
 			var/mob/living/carbon/carbon_user = user
 			var/datum/antagonist/heretic/ascension = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 			ascension.ascended = TRUE
+			ascension.transformed = TRUE
 			carbon_user.mind.transfer_to(summoned, TRUE)
 			carbon_user.gib()
 

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -29,7 +29,7 @@
 	humie.grab_ghost()
 
 	if(!humie.mind || !humie.client)
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a voiceless dead", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a Voiceless Dead", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie)
 		if(!LAZYLEN(candidates))
 			return
 		var/mob/dead/observer/C = pick(candidates)
@@ -38,7 +38,7 @@
 		humie.key = C.key
 
 	ADD_TRAIT(humie,TRAIT_MUTE,MAGIC_TRAIT)
-	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
+	log_game("[key_name_admin(humie)] has become a Voiceless Dead, their master is [user.real_name]")
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
 	humie.health = 50 // Voiceless dead are much tougher than ghouls
@@ -77,7 +77,7 @@
 	required_shit_list = "A pile of ash, a head and a book."
 
 /datum/eldritch_transmutation/summon/rusty
-	name = "Summon Rust Walker"
+	name = "Summon Rustwalker"
 	required_atoms = list(/obj/effect/decal/cleanable/vomit,,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/rust_spirit
 	required_shit_list = "A pool of vomit and a book."

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -10,7 +10,7 @@
 	var/max_amt = 2
 	var/current_amt = 0
 	var/list/ghouls = list()
-	required_shit_list = "A poppy and your deceased to rise."
+	required_shit_list = "A poppy and a dead body."
 
 /datum/eldritch_transmutation/voiceless_dead/on_finished_recipe(mob/living/user,list/atoms,loc)
 	var/mob/living/carbon/human/humie = locate() in atoms
@@ -74,7 +74,7 @@
 	name = "Summon Ashman"
 	required_atoms = list(/obj/effect/decal/cleanable/ash,/obj/item/bodypart/head,/obj/item/book)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/ash_spirit
-	required_shit_list = "A pile of ash, a head and a book."
+	required_shit_list = "A pile of ash, a head, and a book."
 
 /datum/eldritch_transmutation/summon/rusty
 	name = "Summon Rustwalker"

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -29,7 +29,7 @@
 	humie.grab_ghost()
 
 	if(!humie.mind || !humie.client)
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a Voiceless Dead", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a Voiceless Dead?", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie)
 		if(!LAZYLEN(candidates))
 			return
 		var/mob/dead/observer/C = pick(candidates)
@@ -38,7 +38,7 @@
 		humie.key = C.key
 
 	ADD_TRAIT(humie,TRAIT_MUTE,MAGIC_TRAIT)
-	log_game("[key_name_admin(humie)] has become a Voiceless Dead, their master is [user.real_name]")
+	log_game("[key_name_admin(humie)] has become a Voiceless Dead, their master is [user.real_name].")
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
 	humie.health = 50 // Voiceless dead are much tougher than ghouls
@@ -88,13 +88,13 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	var/alert_ = alert(user,"Do you want to ascend as the Lord of the Night or empower yourself and summon a Terror of the Night?","...","Yes","No")
+	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent or empower yourself and summon a Lavish Serpent?","...","Yes","No")
 	user.SetImmobilized(10 HOURS) // no way someone will stand 10 hours in a spot, just so he can move while the alert is still showing.
 	switch(alert_)
 		if("No")
 			var/mob/living/summoned = new /mob/living/simple_animal/hostile/eldritch/armsy(loc)
-			message_admins("[summoned.name] is being summoned by [user.real_name] in [loc]")
-			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [summoned.real_name]", ROLE_HERETIC, null, ROLE_HERETIC, 100,summoned)
+			message_admins("[summoned.name] is being summoned by [user.real_name] in [loc].")
+			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, null, ROLE_HERETIC, 100,summoned)
 			user.SetImmobilized(0)
 			if(LAZYLEN(candidates) == 0)
 				to_chat(user,span_warning("No ghost could be found..."))
@@ -129,7 +129,7 @@
 					qdel(S)
 			priority_announce("Immense destabilization of the bluespace veil has been observed. Our scanners report a singular entity of immeasurable power that is quickly growing in volume. Immediate evacuation is advised.", "Anomaly Alert", ANNOUNCER_SPANOMALIES)
 			set_security_level(SEC_LEVEL_GAMMA)
-			log_game("[user.real_name] ascended as [summoned.real_name]")
+			log_game("[user.real_name] ascended as [summoned.real_name].")
 			var/mob/living/carbon/carbon_user = user
 			var/datum/antagonist/heretic/ascension = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 			ascension.ascended = TRUE

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -88,7 +88,7 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	var/alert_ = alert(user,"Do you want to ascend as a Thirstly Serpent, or instead shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?","...","Yes","No")
+	var/alert_ = tgui_alert(user, "Do you want to ascend as a Thirstly Serpent, or instead shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?", list("Yes","No"))
 	user.SetImmobilized(10 HOURS) // no way someone will stand 10 hours in a spot, just so he can move while the alert is still showing.
 	switch(alert_)
 		if("No")

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -88,7 +88,7 @@
 	required_shit_list = "Three dead bodies."
 
 /datum/eldritch_transmutation/final/flesh_final/on_finished_recipe(mob/living/user, list/atoms, loc)
-	var/alert_ = tgui_alert(user, "Do you want to ascend as a Thirstly Serpent, or instead shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?", list("Yes","No"))
+	var/alert_ = tgui_alert(user, "Do you want to ascend as a Thirstly Serpent, or instead shatter the Red Oath, empowering yourself and summoning a Lavish Serpent?", "...", list("Yes","No"))
 	user.SetImmobilized(10 HOURS) // no way someone will stand 10 hours in a spot, just so he can move while the alert is still showing.
 	switch(alert_)
 		if("No")

--- a/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
@@ -5,13 +5,13 @@
 	required_shit_list = "A piece of trash and a knife."
 
 /datum/eldritch_transmutation/armor
-	name = "Create Eldritch Armor"
+	name = "Eldritch Armor"
 	required_atoms = list(/obj/structure/table,/obj/item/clothing/mask/gas)
 	result_atoms = list(/obj/item/clothing/suit/hooded/cultrobes/eldritch)
 	required_shit_list = "A table and a gas mask."
 
 /datum/eldritch_transmutation/water
-	name = "Create Eldritch Essence"
+	name = "Eldritch Essence"
 	required_atoms = list(/obj/structure/reagent_dispensers/watertank)
 	result_atoms = list(/obj/item/reagent_containers/glass/beaker/eldritch)
 	required_shit_list = "A tank of water."

--- a/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
@@ -27,7 +27,7 @@
 	H.physiology.burn_mod *= 0.5
 	H.physiology.stamina_mod = 0
 	H.physiology.stun_mod = 0
-	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the decay, for Rustbringer [user.real_name] has come! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)
+	priority_announce("Immense destabilization of the bluespace veil has been observed. Our scanners report significant and rapid decay of the station's infrastructure with a single entity as its source. Immediate evacuation is advised.", "Anomaly Alert", ANNOUNCER_SPANOMALIES)
 	set_security_level(SEC_LEVEL_GAMMA)
 	new /datum/rust_spread(loc)
 	var/datum/antagonist/heretic/ascension = H.mind.has_antag_datum(/datum/antagonist/heretic)

--- a/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/rust_transmutations.dm
@@ -17,7 +17,7 @@
 	required_shit_list = "A tank of water."
 
 /datum/eldritch_transmutation/final/rust_final
-	name = "Rustbringer's Oath"
+	name = "Fallen Empress' Pathology"
 	required_atoms = list(/mob/living/carbon/human)
 	required_shit_list = "Three dead bodies."
 

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/hostile/eldritch/raw_prophet
 	name = "Raw Prophet"
 	real_name = "Raw Prophet"
-	desc = "An eye supported by a mass of severed limbs, it has a piercing gaze."
+	desc = "An eye supported by a mass of severed limbs. It has a piercing gaze."
 	icon_state = "raw_prophet"
 	status_flags = CANPUSH
 	icon_living = "raw_prophet"
@@ -78,7 +78,7 @@
 	if(linked_mobs[mob_linked])
 		return FALSE
 
-	to_chat(mob_linked, span_notice("You feel something new enter your mind, you hear whispers of people far away, screeches of horror and a huming of welcome to [src]'s Mansus Link."))
+	to_chat(mob_linked, span_notice("You feel something new enter your mind, you hear whispers of people far away, screeches of horror and a huming of welcome to [src]'s Mansus link."))
 	var/datum/action/innate/mansus_speech/action = new(src)
 	linked_mobs[mob_linked] = action
 	action.Grant(mob_linked)
@@ -92,7 +92,7 @@
 	var/datum/action/innate/mansus_speech/action = linked_mobs[mob_linked]
 	action.Remove(mob_linked)
 	qdel(action)
-	to_chat(mob_linked, span_notice("You feel something tear out of your mind as the [src]'s Mansus Link leaves your mind."))
+	to_chat(mob_linked, span_notice("You feel something tear out of your mind as the [src]'s Mansus link leaves your mind."))
 	mob_linked.emote("Scream")
 	//micro stun
 	mob_linked.AdjustParalyzed(0.5 SECONDS)
@@ -104,9 +104,9 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/eldritch/armsy
-	name = "Terror of the night"
+	name = "Terror of the Night"
 	real_name = "Armsy"
-	desc = "Abomination made from severed limbs."
+	desc = "A horrid abomination made from severed limbs."
 	icon_state = "armsy_start"
 	icon_living = "armsy_start"
 	maxHealth = 200
@@ -288,9 +288,9 @@
 	transform = matrix_transformation
 
 /mob/living/simple_animal/hostile/eldritch/rust_spirit
-	name = "Rust Walker"
+	name = "Rustwalker"
 	real_name = "Rusty"
-	desc = "A massive skull supported by a machination of deteriorating machinery, it actively seeps life out of its environment."
+	desc = "A massive skull supported by a machination of deteriorating machinery. It actively seeps life out of its environment."
 	icon_state = "rust_walker_s"
 	status_flags = CANPUSH
 	icon_living = "rust_walker_s"
@@ -323,7 +323,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/eldritch/ash_spirit
-	name = "Ash Man"
+	name = "Ashman"
 	real_name = "Ashy"
 	desc = "A strange, floating... thing..."
 	icon_state = "ash_walker"
@@ -337,9 +337,9 @@
 	spells_to_add = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/ash,/obj/effect/proc_holder/spell/pointed/cleave,/obj/effect/proc_holder/spell/targeted/fire_sworn)
 
 /mob/living/simple_animal/hostile/eldritch/stalker
-	name = "Flesh Stalker"
-	real_name = "Flesh Stalker"
-	desc = "An abomination made from severed limbs, its form shifts as it moves."
+	name = "Stalker"
+	real_name = "Stalker"
+	desc = "A horrid entity made from severed limbs. Its form shifts as it moves."
 	icon_state = "stalker"
 	status_flags = CANPUSH
 	icon_living = "stalker"

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -325,7 +325,7 @@
 /mob/living/simple_animal/hostile/eldritch/ash_spirit
 	name = "Ashman"
 	real_name = "Ashy"
-	desc = "A strange, floating... thing..."
+	desc = "A strange, floating mass of ash and hunger."
 	icon_state = "ash_walker"
 	status_flags = CANPUSH
 	icon_living = "ash_walker"

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -104,8 +104,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/eldritch/armsy
-	name = "Terror of the Night"
-	real_name = "Armsy"
+	name = "Lavish Serpent"
+	real_name = "Waning Devourer"
 	desc = "A horrid abomination made from severed limbs."
 	icon_state = "armsy_start"
 	icon_living = "armsy_start"
@@ -274,8 +274,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/eldritch/armsy/prime
-	name = "Lord of the Night"
-	real_name = "Master of Decay"
+	name = "Thirstly Serpent"
+	real_name = "Decadent Devourer"
 	maxHealth = 400
 	health = 400
 	melee_damage_lower = 30


### PR DESCRIPTION
# Document the changes in your pull request

Started as a PR to make heretic epilogues, turned into me rewriting all of heretic lore. You're welcome.

This PR adds 32 unique epilogues for heretics which basically run on three lines of logic
1) What lore were you? (or did you choose no lore?)
2) Did you ascend? Or, did you complete your objectives? (or fail to?) (BONUS: If you ascended as a flesh heretic, did you transform yourself or not?)
3) Did you escape on the shuttle or a pod? Were you stranded? Or, did you die?

Other than that, I went over just about every single inch of heretic code and fixed inconsistent capitalization, spacing, spelling, grammar, etc. etc. etc.

To clarify, this PR does nothing to affect heretic performance-wise. It's basically just implementing new lore and squashing out a bunch of flawed shit that really pissed me off while I was writing epilogues and going through all that exists.

Slightly tinkered with bloodsucker flavor logic so it should maybe work.

I tested this a little when I was first beginning and the logic seems to work fine.

# Wiki Documentation

Ashen Eyes is now called Eldritch Medallion
Mark of Ash is now called Touch of the Spark
Fiery Blade is now called Blade of the City Guard
Ashlord's Rite is now called Amgala's Ruin
Mark of Flesh is now called Lover's Exsanguination
Bleeding Steel is now called Talons of the Sworn
Armorer's Ritual is now called Eldritch Armor
Priest's Ritual is now called Eldritch Essence
Mark of Rust is now called Ruin of Welfare
Toxic Blade is now called Memento of Decay
Rustbringer's Oath is now called Fallen Empress' Pathology

Descriptions for just about every spell have been made more clear and generally redone- I can cross-reference them I guess

The knowledge tree should probably be completely revisited to make how progression works more obvious (not related to this PR it just needs to be done)

Terror of the Night is now called Lavish Serpent
Lord of the Night is now called Thirstly Serpent

# Changelog

:cl:  
rscadd: Heretics now have a roundend report epilogue depending on 1) Their lore 2) Whether they ascended, completed, or failed their objectives and 3) Whether they escaped, were stranded, or died.
tweak: Bloodsucker epilogue logic slightly tweaked  
spellcheck: Fixes SEVERAL spaces, syntax, grammatical, and spelling errors within heretic flavor text
spellcheck: Rewrites much of heretics' flavor text, especially regarding text when something is researched
/:cl:
