### PR TITLE
Shuttle catastrophe should no longer remove the Build your own shuttle

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -232,6 +232,7 @@
 				SSshuttle.emag_shuttle_purchased = TRUE
 			SSshuttle.unload_preview()
 			SSshuttle.existing_shuttle = SSshuttle.emergency
+			SSshuttle.emergency.name = shuttle.name
 			SSshuttle.action_load(shuttle)
 			bank_account.adjust_money(-shuttle.credit_cost)
 			minor_announce("[authorize_name] has purchased [shuttle.name] for [shuttle.credit_cost] credits.[shuttle.extra_desc ? " [shuttle.extra_desc]" : ""]" , "Shuttle Purchase")

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -36,5 +36,6 @@
 	SSshuttle.unload_preview()
 	SSshuttle.load_template(new_shuttle)
 	SSshuttle.existing_shuttle = SSshuttle.emergency
+	SSshuttle.emergency.name = new_shuttle.name
 	SSshuttle.action_load(new_shuttle)
 	log_game("Shuttle Catastrophe set a new shuttle, [new_shuttle.name].")


### PR DESCRIPTION
# Document the changes in your pull request

closes: #18188

This is actually untested and I fully admit to it
UPDATE: Works

# Changelog

:cl:  
bugfix: Shuttle catastrophe no longer removes people
/:cl:
