### PR TITLE
No more Osprey reloading 🦀 🦀 

### DIFF
--- a/code/modules/projectiles/guns/ballistic/minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/minigun.dm
@@ -138,6 +138,8 @@
 
 	return ..()
 
+//To prevent unloading the gun
+/obj/item/gun/ballistic/minigunosprey/attack_hand(mob/user)
 /obj/item/gun/ballistic/minigunosprey/attack_self(mob/living/user)
 	return
 

--- a/code/modules/projectiles/guns/ballistic/minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/minigun.dm
@@ -141,6 +141,7 @@
 //To prevent unloading the gun
 /obj/item/gun/ballistic/minigunosprey/attack_hand(mob/user)
 	return
+
 /obj/item/gun/ballistic/minigunosprey/attack_self(mob/living/user)
 	return
 

--- a/code/modules/projectiles/guns/ballistic/minigun.dm
+++ b/code/modules/projectiles/guns/ballistic/minigun.dm
@@ -140,6 +140,7 @@
 
 //To prevent unloading the gun
 /obj/item/gun/ballistic/minigunosprey/attack_hand(mob/user)
+	return
 /obj/item/gun/ballistic/minigunosprey/attack_self(mob/living/user)
 	return
 


### PR DESCRIPTION
# Document the changes in your pull request
Adds a single check to fix yoinking out the Osprey magazine

Did you know you can do this btw
![image](https://user-images.githubusercontent.com/49160555/225926952-9857fcfa-60d8-4a6b-90b5-8c80873d5891.png)


closes: #18186

# Changelog

:cl:  
bugfix: You can no longer magically remove a minigun's magazine
/:cl:
