### PR TITLE
Reduces EMP damage to robotic eyes 

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -167,8 +167,6 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(20 * severity))
-		return
 	var/obj/item/organ/eyes/eyes = owner.getorganslot(ORGAN_SLOT_EYES)
 	to_chat(owner, span_danger("your eyes overload and blind you!"))
 	owner.flash_act(override_blindness_check = 1)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -174,7 +174,7 @@
 	owner.flash_act(override_blindness_check = 1)
 	owner.blind_eyes(5)
 	owner.blur_eyes(8)
-	eyes.applyOrganDamage(25)
+	eyes.applyOrganDamage(20 / severity)
 
 /obj/item/organ/eyes/robotic/xray
 	name = "\improper meson eyes"


### PR DESCRIPTION
Instead of it taking 2 EMPs (25 apiece) of any power to nuke robotic eyes it now takes 2 heavies (40) + 1 light (50) or heavy (60) or 5 lights (50) to completely destroy them. Also removes the RNG chance to not get hit by the EMP.

In numbers:
EMP damage reduced rom 25 to 20/10 based on severity
Eyes have 50 health, start failing at 20 and 30 damage and you go blind at 50.


# Wiki Documentation

EMPs do more damage to robot eyes based on severity, but overall do less damage now. It takes 3-5 EMPs to destroy them.

# Changelog

:cl:  

tweak: Robotic eyes survive a little longer against EMP spam

/:cl:
