### PR TITLE
Should fix replacing your eyes not removing blindness from eye damage

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -46,6 +46,9 @@
 	owner.update_sight()
 	if(M.has_dna() && ishuman(M))
 		M.dna.species.handle_body(M) //updates eye icon
+	if(!damaged)
+		C.cure_blind(EYE_DAMAGE)	//cure any lingering blindness because we have new, undamaged eyeballs eyeballs
+		C.clear_fullscreen("eye_damage")
 
 /obj/item/organ/eyes/Remove(mob/living/carbon/M, special = 0)
 	..()


### PR DESCRIPTION
More relevant for robot eyes since they have a tendency to die on you from someone spitting a little iron/uranium your way. This should make replacing your eyes actually work for fixing blindness.


# Changelog

:cl:  

bugfix: Replacing your eyes should actually cure eye damage blindness now

/:cl:
