### PR TITLE
Several AltClick improvements

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -2,6 +2,9 @@
 
 #define in_range(source, user) (get_dist(source, user) <= 1 && (get_step(source, 0)?:z) == (get_step(user, 0)?:z))
 
+/// Within given range, but not counting z-levels
+#define IN_GIVEN_RANGE(source, other, given_range) (get_dist(source, other) <= given_range && (get_step(source, 0)?:z) == (get_step(other, 0)?:z))
+
 #define isatom(A) (isloc(A))
 
 #define isweakref(D) (istype(D, /datum/weakref))

--- a/code/__DEFINES/{yogs_defines}/components.dm
+++ b/code/__DEFINES/{yogs_defines}/components.dm
@@ -1,5 +1,2 @@
-#define COMSIG_ALT_CLICK_ON "alt_click_on" 						//from base of mob/AltClickOn(): (atom/A)
-#define COMSIG_ATOM_POINTED_AT "atom_pointed_at"				//from base of atom/pointed_at(): (mob/user)
-#define COMSIG_PROCESS_MOVE "process_move"						//from base of client/Move(): (num/direction)
 #define COMSIG_STORAGE_INSERTED "storage_inserted"				//from base of /datum/component/storage/handle_item_insertion(): (obj/item/I, mob/M)
 #define COMSIG_STORAGE_REMOVED "storage_removed"				//from base of /datum/component/storage/remove_from_storage(): (atom/movable/AM, atom/new_location)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -353,19 +353,10 @@
 	Unused except for AI
 */
 /mob/proc/AltClickOn(atom/A)
-	var/result = SEND_SIGNAL(src, COMSIG_ALT_CLICK_ON, A) //yogs start - has to be like this, otherwise stuff breaks
-	if(!result)
-		A.AltClick(src)
-	return //yogs end
-
-/mob/living/carbon/AltClickOn(atom/A)
-	if(!stat && mind && iscarbon(A) && A != src)
-		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
-		if(C && C.chosen_sting)
-			C.chosen_sting.try_to_sting(src,A)
-			next_click = world.time + 5
-			return
-	..()
+	. = SEND_SIGNAL(src, COMSIG_MOB_ALTCLICKON, A)
+	if(. & COMSIG_MOB_CANCEL_CLICKON)
+		return
+	A.AltClick(src)
 
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -86,16 +86,23 @@
 /obj/structure/railing/corner/CheckExit()
 	return TRUE
 
-/obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/railing/proc/can_be_rotated(mob/user, rotation_type)
+	var/silent = FALSE
+	if(!Adjacent(user))
+		silent = TRUE
+
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
 		return FALSE
 
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir)) //Expanded to include rails, as well!
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
 		return FALSE
+
 	return TRUE
 
 /obj/structure/railing/proc/check_anchored(checked_anchored)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -318,15 +318,23 @@
 	var/static/rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS
 	AddComponent(/datum/component/simple_rotation, rotation_flags, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
 
-/obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/windoor_assembly/proc/can_be_rotated(mob/user, rotation_type)
+	var/silent = FALSE
+	if(!Adjacent(user))
+		silent = TRUE
+
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
 		return FALSE
+
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir))
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
 		return FALSE
+
 	return TRUE
 
 /obj/structure/windoor_assembly/proc/after_rotation(mob/user)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -284,16 +284,23 @@
 	if (fulltile)
 		. += new /obj/item/shard(location)
 
-/obj/structure/window/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/window/proc/can_be_rotated(mob/user, rotation_type)
+	var/silent = FALSE
+	if(!Adjacent(user))
+		silent = TRUE
+
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
 		return FALSE
 
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir))
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		if (!silent)
+			to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
 		return FALSE
+
 	return TRUE
 
 /obj/structure/window/proc/after_rotation(mob/user,rotation_type)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -378,19 +378,24 @@
 		add_new_profile(C)
 
 /datum/antagonist/changeling/apply_innate_effects()
+	var/mob/living/living_mob = owner.current
+	if(!isliving(living_mob))
+		return
+
+	RegisterSignals(living_mob, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), .proc/on_click_sting)
+
 	//Brains optional.
-	var/mob/living/carbon/C = owner.current
-	if(istype(C))
-		var/obj/item/organ/brain/B = C.getorganslot(ORGAN_SLOT_BRAIN)
-		if(B)
-			B.organ_flags &= ~ORGAN_VITAL
-			B.decoy_override = TRUE
+	var/obj/item/organ/brain/our_ling_brain = living_mob.getorganslot(ORGAN_SLOT_BRAIN)
+	if(our_ling_brain)
+		our_ling_brain.organ_flags &= ~ORGAN_VITAL
+		our_ling_brain.decoy_override = TRUE
 	update_changeling_icons_added()
-	return
 
 /datum/antagonist/changeling/remove_innate_effects()
+	var/mob/living/living_mob = owner.current
+
+	UnregisterSignal(living_mob, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON))
 	update_changeling_icons_removed()
-	return
 
 
 /datum/antagonist/changeling/greet()
@@ -518,6 +523,31 @@
 	var/datum/atom_hud/antag/hud = GLOB.huds[ANTAG_HUD_CHANGELING]
 	hud.leave_hud(owner.current)
 	set_antag_hud(owner.current, null)
+
+/**
+ * Signal proc for [COMSIG_MOB_MIDDLECLICKON] and [COMSIG_MOB_ALTCLICKON].
+ * Allows the changeling to sting people with a click.
+ */
+/datum/antagonist/changeling/proc/on_click_sting(mob/living/ling, atom/clicked)
+	SIGNAL_HANDLER
+
+	// nothing to handle
+	if(!chosen_sting)
+		return
+
+	if(!isliving(ling) || clicked == ling || ling.stat != CONSCIOUS)
+		return
+
+	// sort-of hack done here: we use in_given_range here because it's quicker.
+	// actual ling stings do pathfinding to determine whether the target's "in range".
+	// however, this is "close enough" preliminary checks to not block click
+	if(!isliving(clicked) || !IN_GIVEN_RANGE(ling, clicked, sting_range))
+		return
+	
+	chosen_sting.try_to_sting(ling, clicked)
+	ling.next_click = world.time + 5
+
+	return COMSIG_MOB_CANCEL_CLICKON
 
 /datum/antagonist/changeling/admin_add(datum/mind/new_owner,mob/admin)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -35,17 +35,23 @@
 	for(var/mob/living/silicon/S in range(2,user))
 		to_chat(S, span_userdanger("Your sensors are disabled by a shower of blood!"))
 		S.Paralyze(60)
-	var/turf = get_turf(user)
-	var/mob/living/simple_animal/horror/H = user.has_horror_inside()
-	H?.leave_victim()
+	var/turf/user_turf = get_turf(user)
+	var/mob/living/simple_animal/horror/horror = user.has_horror_inside()
+	if (horror)
+		horror.leave_victim()
+	user.transfer_observers_to(user_turf) // user is about to be deleted, store orbiters on the turf
 	user.gib()
 	. = TRUE
-	sleep(0.5 SECONDS) // So it's not killed in explosion
-	var/mob/living/simple_animal/hostile/headcrab/crab = new(turf)
+	addtimer(CALLBACK(src, .proc/spawn_headcrab, M, user_turf, organs), 0.5 SECONDS)
+
+/datum/action/changeling/headcrab/proc/spawn_headcrab(datum/mind/stored_mind, turf/spawn_location, list/organs)
+	var/mob/living/simple_animal/hostile/headcrab/crab = new(spawn_location)
 	for(var/obj/item/organ/I in organs)
 		I.forceMove(crab)
-	crab.origin = M
-	if(crab.origin)
-		crab.origin.active = 1
-		crab.origin.transfer_to(crab)
-		to_chat(crab, span_warning("You burst out of the remains of your former body in a shower of gore!"))
+	crab.origin = stored_mind
+	if(!crab.origin)
+		return
+	crab.origin.active = TRUE
+	crab.origin.transfer_to(crab)
+	spawn_location.transfer_observers_to(crab)
+	to_chat(crab, span_warning("You burst out of the remains of your former body in a shower of gore!"))

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -59,6 +59,7 @@
 				to_chat(target, "<span class='changeling bold'>You can now communicate in the changeling hivemind, say \"[MODE_TOKEN_CHANGELING] message\" to communicate!</span>")
 				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
 				addtimer(CALLBACK(src, .proc/sever_connection, user, target), 3 MINUTES)
+				return
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
 		if(!do_mob(user, target, 2 SECONDS))
 			to_chat(user, span_warning("Our link with [target] has ended!"))
@@ -66,14 +67,12 @@
 			target.mind.linglink = FALSE
 			return
 
-	changeling.islinking = FALSE
-	target.mind.linglink = FALSE
-	to_chat(user, span_notice("You cannot sustain the connection any longer, your victim fades from the hivemind"))
-	to_chat(target, span_userdanger("The link cannot be sustained any longer, your connection to the hivemind has faded!"))
-
 /datum/action/changeling/linglink/proc/sever_connection(mob/user, mob/living/carbon/human/target)
 	var/datum/antagonist/changeling/changeling = user.mind?.has_antag_datum(/datum/antagonist/changeling)
 	if (changeling)
 		changeling.islinking = FALSE
 	
 	target?.mind?.linglink = FALSE
+
+	to_chat(user, span_notice("You cannot sustain the connection any longer, your victim fades from the hivemind"))
+	to_chat(target, span_userdanger("The link cannot be sustained any longer, your connection to the hivemind has faded!"))

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -39,7 +39,7 @@
 /datum/action/changeling/linglink/sting_action(mob/user)
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	var/mob/living/carbon/human/target = user.pulling
-	changeling.islinking = 1
+	changeling.islinking = TRUE
 	for(var/i in 1 to 3)
 		switch(i)
 			if(1)
@@ -54,19 +54,26 @@
 					var/mob/M = mi
 					if(M.lingcheck() == LINGHIVE_LING)
 						to_chat(M, span_changeling("We can sense a foreign presence in the hivemind..."))
-				target.mind.linglink = 1
+				target.mind.linglink = TRUE
 				target.say("[MODE_TOKEN_CHANGELING] AAAAARRRRGGGGGHHHHH!!")
 				to_chat(target, "<span class='changeling bold'>You can now communicate in the changeling hivemind, say \"[MODE_TOKEN_CHANGELING] message\" to communicate!</span>")
 				target.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 40) // So they don't choke to death while you interrogate them
-				sleep(3 MINUTES)
+				addtimer(CALLBACK(src, .proc/sever_connection, user, target), 3 MINUTES)
 		SSblackbox.record_feedback("nested tally", "changeling_powers", 1, list("[name]", "[i]"))
-		if(!do_mob(user, target, 20))
+		if(!do_mob(user, target, 2 SECONDS))
 			to_chat(user, span_warning("Our link with [target] has ended!"))
-			changeling.islinking = 0
-			target.mind.linglink = 0
+			changeling.islinking = FALSE
+			target.mind.linglink = FALSE
 			return
 
-	changeling.islinking = 0
-	target.mind.linglink = 0
+	changeling.islinking = FALSE
+	target.mind.linglink = FALSE
 	to_chat(user, span_notice("You cannot sustain the connection any longer, your victim fades from the hivemind"))
 	to_chat(target, span_userdanger("The link cannot be sustained any longer, your connection to the hivemind has faded!"))
+
+/datum/action/changeling/linglink/proc/sever_connection(mob/user, mob/living/carbon/human/target)
+	var/datum/antagonist/changeling/changeling = user.mind?.has_antag_datum(/datum/antagonist/changeling)
+	if (changeling)
+		changeling.islinking = FALSE
+	
+	target?.mind?.linglink = FALSE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -128,7 +128,7 @@
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
 
-	var/handled = SEND_SIGNAL(L, COMSIG_PROCESS_MOVE, direct) //yogs start - movement components
+	var/handled = SEND_SIGNAL(L, COMSIG_MOB_CLIENT_PRE_MOVE, direct)
 	if(handled)
 		return FALSE//yogs end
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3551,7 +3551,6 @@
 #include "yogstation\code\datums\antagonists\vampire.dm"
 #include "yogstation\code\datums\components\backstabs.dm"
 #include "yogstation\code\datums\components\crawl.dm"
-#include "yogstation\code\datums\components\daniel.dm"
 #include "yogstation\code\datums\components\fishable.dm"
 #include "yogstation\code\datums\components\fishingbonus.dm"
 #include "yogstation\code\datums\components\radioactive.dm"

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -28,24 +28,25 @@
 /datum/component/crawl/Initialize()
 	if(!istype(parent, /mob/living))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, COMSIG_ALT_CLICK_ON, .proc/try_crawl)
+	RegisterSignal(parent, COMSIG_MOB_ALTCLICKON, .proc/try_crawl)
 	var/mob/living/M = parent
 	on_gain(M)
 
 /datum/component/crawl/proc/try_crawl(datum/source, atom/target)
 	set waitfor = FALSE
+
 	var/can_crawl = FALSE
 	for(var/type in crawling_types)
 		if(istype(target, type))
 			can_crawl = TRUE
 			break
 	if(!can_crawl)
-		return FALSE
+		return
 	var/mob/living/M = parent
 	if(M.incapacitated())
-		return FALSE
+		return
 
-	. = TRUE
+	. = COMSIG_MOB_CANCEL_CLICKON
 	if(holder && can_stop_crawling(target, M))
 		stop_crawling(target, M)
 	else if(!istype(M.loc, /obj/effect/dummy/crawling) && can_start_crawling(target, M)) //no crawling while crawling

--- a/yogstation/code/datums/components/daniel.dm
+++ b/yogstation/code/datums/components/daniel.dm
@@ -1,9 +1,0 @@
-/datum/component/daniel/Initialize()
-    if(!isobj(parent))
-        return COMPONENT_INCOMPATIBLE
-
-    RegisterSignal(parent, COMSIG_ATOM_POINTED_AT, .proc/damn)
-
-/datum/component/daniel/proc/damn(datum/source, mob/user)
-    spawn(10)
-        user.say("DAMN DANIEL!")

--- a/yogstation/code/datums/components/walks.dm
+++ b/yogstation/code/datums/components/walks.dm
@@ -7,7 +7,7 @@
 /datum/component/walk/Initialize()
 	if(!istype(parent, /mob/living))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, COMSIG_PROCESS_MOVE, .proc/handle_move)
+	RegisterSignal(parent, COMSIG_MOB_CLIENT_PRE_MOVE, .proc/handle_move)
 	var/datum/component/footstep/footsteps = parent.GetComponent(/datum/component/footstep)
 	if (footsteps)
 		qdel(footsteps)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -1,5 +1,5 @@
 /datum/species/jelly/slime/on_species_loss(mob/living/carbon/C)
-	UnregisterSignal(C, COMSIG_ALT_CLICK_ON)
+	UnregisterSignal(C, COMSIG_MOB_ALTCLICKON)
 	..()
 
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C)
@@ -8,12 +8,12 @@
 	// using component signals on something that isn't a component
 	// maybe we shouldn't call them component signals if they can be used for other things, maybe...
 	// hmmm.... what if we called it an event handler like any sane environment.
-	RegisterSignal(C, COMSIG_ALT_CLICK_ON, .proc/handle_altclick)
+	RegisterSignal(C, COMSIG_MOB_ALTCLICKON, .proc/handle_altclick)
 
 /datum/species/jelly/slime/proc/handle_altclick(mob/living/carbon/human/M, mob/living/carbon/human/target)
 	if(M && M.mind && swap_body && swap_body.can_swap(target))
 		swap_body.swap_to_dupe(M.mind, target)
-		return TRUE
+		return COMSIG_MOB_CANCEL_CLICKON
 
 /datum/action/innate/swap_body/swap_to_dupe(datum/mind/M, mob/living/carbon/human/dupe)
 	var/mob/living/carbon/human/old = M.current

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -1,23 +1,18 @@
-/mob/living/carbon/AltClickOn(atom/A)
-	dna?.species.spec_AltClickOn(A,src)
-	return ..()
-
-/datum/species/preternis/spec_AltClickOn(atom/A,H)
-	return drain_power_from(H, A)
 
 /datum/species/preternis/proc/drain_power_from(mob/living/carbon/human/H, atom/A)
-	if(get_dist(H, A) > 1)
-		to_chat(H, span_warning("[A] is too far away!"))
-		return FALSE
-
 	if(!istype(H) || !A)
 		return FALSE
 
-	if(draining)
-		to_chat(H,span_info("CONSUME protocols can only be used on one object at any single time."))
-		return FALSE
 	if(!A.can_consume_power_from())
 		return FALSE //if it returns text, we want it to continue so we can get the error message later.
+	
+	if(get_dist(H, A) > 1)
+		to_chat(H, span_warning("[A] is too far away to initiate CONSUME protocol!"))
+		return FALSE
+	
+	if(draining)
+		to_chat(H, span_info("CONSUME protocols can only be used on one object at any single time."))
+		return FALSE
 
 	draining = TRUE
 
@@ -27,28 +22,28 @@
 		siemens_coefficient *= 1.5
 
 	if (charge >= PRETERNIS_LEVEL_FULL - 25) //just to prevent spam a bit
-		to_chat(H,span_notice("CONSUME protocol reports no need for additional power at this time."))
+		to_chat(H, span_notice("CONSUME protocol reports no need for additional power at this time."))
 		draining = FALSE
 		return TRUE
 
 	if(H.gloves)
 		if(!H.gloves.siemens_coefficient)
-			to_chat(H,span_info("NOTICE: [H.gloves] prevent electrical contact - CONSUME protocol aborted."))
+			to_chat(H, span_info("NOTICE: [H.gloves] prevent electrical contact - CONSUME protocol aborted."))
 			draining = FALSE
 			return TRUE
 		else
 			if(H.gloves.siemens_coefficient < 1)
-				to_chat(H,span_info("NOTICE: [H.gloves] are interfering with electrical contact - advise removal before activating CONSUME protocol."))
+				to_chat(H, span_info("NOTICE: [H.gloves] are interfering with electrical contact - advise removal before activating CONSUME protocol."))
 			siemens_coefficient *= H.gloves.siemens_coefficient
 
 	H.face_atom(A)
 	H.visible_message(span_warning("[H] starts placing their hands on [A]..."), span_warning("You start placing your hands on [A]..."))
 	if(!do_after(H, HAS_TRAIT(H, TRAIT_VORACIOUS)? 1.5 SECONDS : 2 SECONDS, A))
-		to_chat(H,span_info("CONSUME protocol aborted."))
+		to_chat(H, span_info("CONSUME protocol aborted."))
 		draining = FALSE
 		return TRUE
 
-	to_chat(H,span_info("Extracutaneous implants detect viable power source. Initiating CONSUME protocol."))
+	to_chat(H, span_info("Extracutaneous implants detect viable power source. Initiating CONSUME protocol."))
 
 	var/done = FALSE
 	var/drain = 150 * siemens_coefficient
@@ -72,7 +67,7 @@
 			var/can_drain = A.can_consume_power_from()
 			if(!can_drain || istext(can_drain))
 				if(istext(can_drain))
-					to_chat(H,can_drain)
+					to_chat(H, can_drain)
 				done = TRUE
 			else
 				playsound(A.loc, "sparks", 50, 1)
@@ -80,17 +75,17 @@
 					spark_system.start()
 				var/drained = A.consume_power_from(drain)
 				if(drained < drain)
-					to_chat(H,span_info("[A]'s power has been depleted, CONSUME protocol halted."))
+					to_chat(H, span_info("[A]'s power has been depleted, CONSUME protocol halted."))
 					done = TRUE
 				charge = clamp(charge + (drained * ELECTRICITY_TO_NUTRIMENT_FACTOR),PRETERNIS_LEVEL_NONE,PRETERNIS_LEVEL_FULL)
 
 				if(!done)
 					if(charge > (PRETERNIS_LEVEL_FULL - 25))
-						to_chat(H,span_info("CONSUME protocol complete. Physical nourishment refreshed."))
+						to_chat(H, span_info("CONSUME protocol complete. Physical nourishment refreshed."))
 						done = TRUE
 					else if(!(cycle % 4))
 						var/nutperc = round((charge / PRETERNIS_LEVEL_FULL) * 100)
-						to_chat(H,span_info("CONSUME protocol continues. Current satiety level: [nutperc]%."))
+						to_chat(H, span_info("CONSUME protocol continues. Current satiety level: [nutperc]%."))
 		else
 			done = TRUE
 	qdel(spark_system)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -75,6 +75,8 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		if(istype(BP,/obj/item/bodypart/l_leg) || istype(BP,/obj/item/bodypart/r_leg))//my dudes skip leg day
 			BP.max_damage = 30
 
+	RegisterSignal(C, COMSIG_MOB_ALTCLICKON, .proc/drain_power_from)
+
 	if(ishuman(C))
 		maglock = new
 		maglock.Grant(C)
@@ -89,6 +91,8 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		BP.change_bodypart_status(ORGAN_ORGANIC,FALSE,TRUE)
 		BP.burn_reduction = initial(BP.burn_reduction)
 		BP.brute_reduction = initial(BP.brute_reduction)
+
+	UnregisterSignal(C, COMSIG_MOB_ALTCLICKON)
 		
 	var/datum/component/empprotection/empproof = C.GetExactComponent(/datum/component/empprotection)
 	empproof.RemoveComponent()//remove emp proof if they stop being a preternis


### PR DESCRIPTION
# Document the changes in your pull request

- Preternis will no longer get the ``X is too far away`` error message when alt-clicking anything
  - Made the error message a bit clearer
  - Uses component signal now instead of overriding ``/AltClickOn``
- Windows/windoors/railing will only print error message when alt-click if you are adjacent to them
- Converted a few old yogs component signal names to newer ones
  - Removed daniel component since it's unused and old code
  - Cleaned up ``/mob/proc/AltClickOn`` a bit
- Moved changeling sting over to component signal instead of overriding ``/AltClickOn``
- Added ``IN_GIVEN_RANGE`` macro

