### PR TITLE
Fixes certain emotes not being audible + lets IPCs use *warn

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -242,6 +242,9 @@
 		var/turf/T = loc
 		T.Entered(src)
 
+/datum/emote/living/carbon/human/robot_tongue
+	emote_type = EMOTE_AUDIBLE //emotes that require robotic voicebox are audible by default, because it's a sound-making device
+
 /datum/emote/living/carbon/human/robot_tongue/can_run_emote(mob/user, status_check = TRUE , intentional)
 	var/obj/item/organ/tongue/T = user.getorganslot("tongue")
 	return T?.status == ORGAN_ROBOTIC && ..()
@@ -287,6 +290,15 @@
 
 /datum/emote/living/carbon/human/robot_tongue/ping/get_sound(mob/living/user)
 	return 'sound/machines/ping.ogg'
+
+/datum/emote/living/carbon/human/robot_tongue/warn
+	key = "warn"
+	key_third_person = "warns"
+	message = "blares an alarm!"
+	message_param = "blares an alarm at %t!"
+
+/datum/emote/living/carbon/human/robot_tongue/warn/get_sound(mob/living/user)
+	return 'sound/machines/warning-buzzer.ogg'
 
  // Clown Robotic Tongue ONLY. Henk.
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -503,6 +503,7 @@
 	message_param = "beeps at %t."
 	sound = 'sound/machines/twobeep.ogg'
 	mob_type_allowed_typecache = list(/mob/living/brain, /mob/living/silicon)
+	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/circle
 	key = "circle"


### PR DESCRIPTION
# Document the changes in your pull request

Fixes emotes like ping and beep not being audible emotes despite making sound, and also lets IPCs use the warn emote (*blares an alarm!)

# Changelog

:cl:  
bugfix: fixed certain emotes being visible instead of audible
tweak: IPCs can use warn emote (*blares an alarm!)
/:cl:
