### PR TITLE
Lets people crawl while nuggeted

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -6,7 +6,7 @@
 		var/leg_amount = get_num_legs()
 		. += max(6 - 3*leg_amount, 0) //the fewer the legs, the slower the mob
 		if(!leg_amount)
-			. += max((6 - 3*get_num_arms()), 0) //crawling is harder with fewer arms
+			. += max((12 - 6*get_num_arms()), 0) //crawling is harder with fewer arms
 		if(legcuffed)
 			. += legcuffed.slowdown
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1223,7 +1223,7 @@
 	var/stun = IsStun()
 	var/knockdown = IsKnockdown()
 	var/ignore_legs = get_leg_ignore()
-	var/canmove = !IsImmobilized() && !stun && conscious && !paralyzed && !buckled && (!stat_softcrit || !pulledby) && !chokehold && !IsFrozen() && !IS_IN_STASIS(src) && (has_arms || ignore_legs || has_legs)
+	var/canmove = !IsImmobilized() && !stun && conscious && !paralyzed && !buckled && (!stat_softcrit || !pulledby) && !chokehold && !IsFrozen() && !IS_IN_STASIS(src)
 	if(canmove)
 		mobility_flags |= MOBILITY_MOVE
 	else


### PR DESCRIPTION
Full nuggeting making it impossible to move can allow for some pretty boring events where a nuggeted antag just has to sit around waiting for sec, or a nuggeted secoff just has to lie there waiting for someone to find them. 

The default speed for having no limbs was a bit too fast, so i made missing arms matter more for crawling
this should only make a slight difference for those using a wheelchair when they lose an arm

:cl:  
tweak: Can crawl while nuggeted
/:cl:
