### PR TITLE
Revert "Prevents mechs from shotgun swapping"

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -563,11 +563,6 @@
 		if(!target)
 			return
 
-	// No shotgun swapping
-	for(var/obj/item/mecha_parts/mecha_equipment/weapon/W in equipment)
-		if(!W.equip_ready)
-			return
-
 	var/mob/living/L = user
 	if(!Adjacent(target))
 		if(selected && selected.is_ranged())


### PR DESCRIPTION
Reverts yogstation13/Yogstation#17706

This made multiple mechs with long cooldown equipment (Namely HONK) completely unusable. Also it blocks melee from happening aswell. 

 # Changelog

🆑 
tweak: Mecha weapon cooldowns are no longer shared
/🆑 