### PR TITLE
Catsip the final Drink-tier to finish them all

### DIFF
--- a/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -13,7 +13,7 @@
 
 /datum/reagent/consumable/ethanol/catsip/on_mob_life(mob/living/M)
 	if(iscatperson(M))
-		M.adjustStaminaLoss(-5, 0)
+		M.adjustStaminaLoss(-2.5, 0)
 	if(prob(8) && meowcount)
 		M.say(pick("Nya.", "N-nya!", "NYA!"), forced = "catsip")
 		meowcount--

--- a/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/yogstation/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -12,6 +12,8 @@
 	var/meowcount = 2
 
 /datum/reagent/consumable/ethanol/catsip/on_mob_life(mob/living/M)
+	if(iscatperson(M))
+		M.adjustStaminaLoss(-5, 0)
 	if(prob(8) && meowcount)
 		M.say(pick("Nya.", "N-nya!", "NYA!"), forced = "catsip")
 		meowcount--


### PR DESCRIPTION
# Document the changes in your pull request

After the big drink PR, it only makes sense now to re-open another case to give Catsip its due. This should hopefully be considered more for the fact that every species that is playable that can drink has their own beneficial drink so this shouldn't be considered an advantage for one type of species. 

Come on, dont be cat haters on this.

# Wiki Documentation

Catsip now minorly heals stam-damage.

# Changelog

:cl:  
rscadd: Catsip heals stam damage minorly
/:cl:
