### PR TITLE
The alert level no longer is raised to blue on shift start.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -54,6 +54,8 @@
 
 /datum/config_entry/flag/everyone_has_maint_access
 
+/datum/config_entry/flag/auto_blue_alert
+
 /datum/config_entry/flag/sec_start_brig	//makes sec start in brig instead of dept sec posts
 
 /datum/config_entry/flag/force_random_names

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -302,11 +302,14 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	. += generate_station_goal_report()
 
 	desc += "\n\n[generate_station_trait_announcement()]"
-
-	print_command_report(., "Central Command Status Summary", announce=FALSE)
-	priority_announce(desc, title, ANNOUNCER_INTERCEPT)
-	if(GLOB.security_level < SEC_LEVEL_BLUE)
-		set_security_level(SEC_LEVEL_BLUE)
+		
+	if(CONFIG_GET(flag/auto_blue_alert))
+		print_command_report(., "Central Command Status Summary", announce=FALSE)
+		priority_announce(desc, title, ANNOUNCER_INTERCEPT)
+		if(GLOB.security_level < SEC_LEVEL_BLUE)
+			set_security_level(SEC_LEVEL_BLUE)
+	else
+		print_command_report(., "Central Command Status Summary")
 
 	if(ISINRANGE(threat_level, 50, 80))
 		for(var/pack in SSshuttle.supply_packs)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -310,7 +310,13 @@
 
 	intercepttext += generate_station_goal_report()
 
-	print_command_report(intercepttext, "Central Command Status Summary")
+	if(CONFIG_GET(flag/auto_blue_alert))
+		print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
+		priority_announce("A summary has been copied and printed to all communications consoles.\n\n[generate_station_trait_announcement()]", "Enemy communication intercepted. Security level elevated.", ANNOUNCER_INTERCEPT)
+		if(GLOB.security_level < SEC_LEVEL_BLUE)
+			set_security_level(SEC_LEVEL_BLUE)
+	else
+		print_command_report(intercepttext, "Central Command Status Summary")
 		
 /*
  * Generate a list of station goals available to purchase to report to the crew.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -310,10 +310,7 @@
 
 	intercepttext += generate_station_goal_report()
 
-	print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
-	priority_announce("A summary has been copied and printed to all communications consoles.\n\n[generate_station_trait_announcement()]", "Enemy communication intercepted. Security level elevated.", ANNOUNCER_INTERCEPT)
-	if(GLOB.security_level < SEC_LEVEL_BLUE)
-		set_security_level(SEC_LEVEL_BLUE)
+	print_command_report(intercepttext, "Central Command Status Summary")
 		
 /*
  * Generate a list of station goals available to purchase to report to the crew.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -687,3 +687,5 @@ DYNAMIC_CONFIG_ENABLED
 
 ## Force Engine - 1 for SM, 2 for Sing/Tesla, 3 for any, 4 for TEG
 ENGINE_TYPE 3
+## Do we automatically raise to blue on shiftstart?
+#AUTO_BLUE_ALERT

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -687,5 +687,3 @@ DYNAMIC_CONFIG_ENABLED
 
 ## Force Engine - 1 for SM, 2 for Sing/Tesla, 3 for any, 4 for TEG
 ENGINE_TYPE 3
-## Do we automatically raise to blue on shiftstart?
-#AUTO_BLUE_ALERT


### PR DESCRIPTION
# Document the changes in your pull request

The alert level is no longer raised to blue on shift start.

(Extended shifts still do the special message. )
(The "Antagonist report" is still generated.)
(Of course, war declaration still is raised to gamma.)

# Justification

This is a bit of a security nerf because it means security can't do random searches on green (they can still do justified searches) or openly carry armory guns.
It's an antagonist buff because it means that heads setting to blue means the crew might be on to them.

(This PR should probably be testmerged to see the actual effect on the round.)

# Changelog

:cl:  BurgerBB
rscdel: The alert level is no longer raised to blue on shift start.
/:cl:
