### PR TITLE
I spy with my little eye (Fixes High Luminosity Eyes)

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -345,20 +345,22 @@
 	return ..()
 
 /obj/item/organ/eyes/robotic/glow/proc/activate(silent = FALSE)
-	start_visuals()
 	if(!silent)
 		to_chat(owner, span_warning("Your [src] clicks and makes a whining noise, before shooting out a beam of light!"))
 	active = TRUE
+	start_visuals()
 	cycle_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/deactivate(silent = FALSE)
-	clear_visuals()
 	if(!silent)
 		to_chat(owner, span_warning("Your [src] shuts off!"))
 	active = FALSE
+	clear_visuals()
 	remove_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/update_visuals(datum/source, olddir, newdir)
+	if(!active)
+		return
 	if((LAZYLEN(eye_lighting) < light_beam_distance) || !on_mob)
 		regenerate_light_effects()
 	var/turf/scanfrom = get_turf(owner)


### PR DESCRIPTION
# Document the changes in your pull request
Thanks to Adzi-Neetra (Wolf751#3787) for bringing this to my attention.

They no longer glow when off.
This is one of the moments where I realize most people don't check their code.

# Changelog

:cl: 
bugfix: High luminosity eyes now only glow when on
/:cl:
