### PR TITLE
Adds EMP shield implant to the uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -763,3 +763,9 @@
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/snacks/monkeycube(src)
 	new /obj/item/bodypart/l_arm/robot/buster(src)
+
+/obj/item/storage/box/syndie_kit/emp_shield
+	real_name = "EMP shield implant kit"
+
+/obj/item/storage/box/syndie_kit/emp_shield/PopulateContents()
+	new /obj/item/implanter/empshield(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2102,6 +2102,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/implants/emp_shield
+	name = "EMP Shield Implant"
+	desc = "An implant that will render you and your insides immune to electromagnetic interference, protecting you from ion-based weaponry and EMPs. \
+			Due to technical limitations, it will overload and shut down for a short time if triggered too often."
+	item = /obj/item/storage/box/syndie_kit/emp_shield
+	cost = 6
+
 // Events
 /datum/uplink_item/services
 	category = "Services"


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://user-images.githubusercontent.com/93578146/226742559-9057d090-ba7d-4dc5-9c79-70c418303fa7.png)

Makes the EMP protection implant available on its own in the uplink, costing 6tc. This does not protect any stored/worn/held items, just limbs and organs.

# Wiki Documentation

If there's a list of things you can get from the uplink, this will need to be added to it.

# Changelog

:cl:  
rscadd: Adds EMP shield implant to the uplink
/:cl:
