### PR TITLE
Drinking teslium grants temporary emp immunity

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -215,7 +215,16 @@
 	taste_description = "charged metal"
 	self_consuming = TRUE
 	var/shock_timer = 0
+	var/empremoval = TRUE
 
+/datum/reagent/teslium/on_mob_metabolize(mob/living/L)
+	. = ..()
+	var/datum/component/empprotection/empproof = L.GetExactComponent(/datum/component/empprotection)
+	if(empproof)//only grant and remove emp protection if they didn't have it when drinking it
+		empremoval = FALSE
+	else
+		L.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
+	
 /datum/reagent/teslium/on_mob_life(mob/living/carbon/M)
 	shock_timer++
 	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
@@ -223,6 +232,13 @@
 		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, 1)
 	..()
+
+/datum/reagent/teslium/on_mob_end_metabolize(mob/living/L)
+	. = ..()
+	if(empremoval)
+		var/datum/component/empprotection/empproof = L.GetExactComponent(/datum/component/empprotection)
+		if(empproof)
+			empproof.Destroy()	
 
 /datum/reagent/teslium/energized_jelly
 	name = "Energized Jelly"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -214,6 +214,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "charged metal"
 	self_consuming = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 	var/shock_timer = 0
 	var/empremoval = TRUE
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -216,15 +216,14 @@
 	self_consuming = TRUE
 	process_flags = ORGANIC | SYNTHETIC
 	var/shock_timer = 0
-	var/empremoval = TRUE
+	var/empremoval = FALSE
 
 /datum/reagent/teslium/on_mob_metabolize(mob/living/L)
 	. = ..()
 	var/datum/component/empprotection/empproof = L.GetExactComponent(/datum/component/empprotection)
-	if(empproof)//only grant and remove emp protection if they didn't have it when drinking it
-		empremoval = FALSE
-	else
+	if(!empproof)//only grant and remove emp protection if they didn't have it when drinking it
 		L.AddComponent(/datum/component/empprotection, EMP_PROTECT_SELF)
+		empremoval = TRUE
 	
 /datum/reagent/teslium/on_mob_life(mob/living/carbon/M)
 	shock_timer++


### PR DESCRIPTION
Emps are pretty oppressive
teslium is mostly useless
this attempts to help with both by letting people take a dangerous swig of teslium to potentially protect their limbs, organs, and implants from emps for the duration. just hope to be lucky to not get shocked.

also lets synthetic mobs use teslium because it already doesn't require a living host to function, why should it require an organic one

:cl:  
tweak: Drinking teslium grants temporary emp immunity
tweak: Teslium can now be processed by synthetic mobs
/:cl:
