### PR TITLE
Makes mechs not broken #1 - MMIs can go mine again

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -12,7 +12,7 @@
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 15
-	harmful = TRUE
+	harmful = FALSE
 	/// Time in deciseconds it takes to drill
 	var/drill_delay = 7
 	/// Affects if it can bust through reinforced walls (DRILL_HARDENED)

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -11,7 +11,7 @@
 	/// How much damage does it apply when used
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
-	harmful = TRUE
+	harmful = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/can_attach(obj/mecha/working/ripley/M as obj)
 	if(..())

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -160,7 +160,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	harmful = TRUE
+	harmful = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma/can_attach(obj/mecha/M)
 	if(..()) //combat mech
@@ -177,7 +177,7 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/kinetic/mech
 	fire_sound = 'sound/weapons/kenetic_accel.ogg'
-	harmful = TRUE
+	harmful = FALSE
 
 //attachable to all mechas, like the plasma cutter
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/mecha_kineticgun/can_attach(obj/mecha/M)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1093,8 +1093,6 @@
 	update_icon()
 	setDir(dir_in)
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
-	if(!istype(src, /obj/mecha/combat))
-		REMOVE_TRAIT(occupant, TRAIT_PACIFISM, POSIBRAIN_TRAIT)
 	if(istype(mmi_as_oc, /obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1093,6 +1093,8 @@
 	update_icon()
 	setDir(dir_in)
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
+	if(!istype(src, /obj/mecha/combat))
+		REMOVE_TRAIT(occupant, TRAIT_PACIFISM, POSIBRAIN_TRAIT)
 	if(istype(mmi_as_oc, /obj/item/mmi/posibrain))											//yogs start reminder to posibrain to not be shitlers
 		to_chat(brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
 		Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")


### PR DESCRIPTION
# Document the changes in your pull request

Mech mining equipment no longer checks pacifism. Why ynot didnt think of this when solving a Admin issue with code is beyond me.

# Changelog
:cl:  
tweak: MMIs in mechs can now mine again
/:cl:
