### PR TITLE
Chaplain head cage doesn't hide things underneath

### DIFF
--- a/code/game/objects/items/holy_armours.dm
+++ b/code/game/objects/items/holy_armours.dm
@@ -83,6 +83,7 @@
 	item_state = "cage"
 	armor = list(MELEE = -15, BULLET = -10, LASER = -10, ENERGY = -5, BOMB = -5, BIO = -2, RAD = 0, FIRE = 0, ACID = 0)
 	slowdown = -0.1 //very statistically significant
+	flags_inv = null //doesn't actually visibly hide anything
 	worn_x_dimension = 64
 	worn_y_dimension = 64
 	dynamic_hair_suffix = ""


### PR DESCRIPTION
you can see through the sprite
also witchhunter kinda does too

:cl:  
bugfix: insightful cage no longer hides facial features, hair, and masks
bugfix: witchhunter hat no longer hides facial features, and masks
/:cl:
