### PR TITLE
Makes chasm fishing less annoying but still a chore

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -216,8 +216,12 @@
 	if(do_after(user, 3 SECONDS, src.parent))
 		if(!rod.wielded)
 			return
-		var/atom/parent = src.parent
-		var/list/fishing_contents = parent.GetAllContents()
+
+		var/list/fishing_contents = list()
+		for(var/turf/T in range(3, src.parent))
+			if(ischasm(T))
+				fishing_contents += T.GetAllContents()
+
 		if(!length(fishing_contents))
 			to_chat(user, span_warning("There's nothing here!"))
 			return
@@ -226,6 +230,7 @@
 			M.forceMove(get_turf(user))
 			UnregisterSignal(M, COMSIG_LIVING_REVIVE)
 			found = TRUE
+			break //only one mob rather than all
 		if(found)
 			to_chat(user, span_warning("You reel in something!"))
 		else

--- a/yogstation/code/game/objects/items/fishing/rods.dm
+++ b/yogstation/code/game/objects/items/fishing/rods.dm
@@ -170,6 +170,7 @@
 	desc = "A collapsable fishing rod! This one can fit into your backpack for space hikes and the like."
 	icon_state = "fishing_rod_collapse_c"
 	fishing_power = 15
+	w_class = WEIGHT_CLASS_SMALL //it starts collapsed and small
 	var/opened = FALSE
 	var/rod_icon_state = "fishing_rod_collapse"
 	


### PR DESCRIPTION
Now fishes all chasms in a 3 radius area rather than just the selected one
Only fishes up a single mob rather than all mobs at once

:cl:  
bugfix: Collapsible fishing rods now have properly collapsed size
tweak: Chasm fishing fishes from chasms in a 3 radius area
tweak: Chasm fishing only pulls up one corpse at a time
/:cl:
