### PR TITLE
[Gax] Corrects Evac Airlock Protocols

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -634,15 +634,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"anE" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/security/processing)
 "anH" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -1139,17 +1130,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aCs" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "aCD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"aCE" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "aCJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -3336,6 +3331,19 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"bHK" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "bHY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3516,6 +3524,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"bOF" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/processing)
 "bOI" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3710,16 +3731,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bSd" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/processing)
 "bSD" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4942,17 +4953,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"cyz" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "cyB" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -5602,6 +5602,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"cMQ" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cNs" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
@@ -6004,6 +6014,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cWD" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "cXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6167,6 +6191,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"daP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "dbb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8242,14 +8278,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"eet" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "eew" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
@@ -9257,6 +9285,16 @@
 "ezF" = (
 /turf/closed/mineral/random/labormineral,
 /area/science/test_area)
+"eAe" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/security/processing)
 "eAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -9839,15 +9877,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"eLR" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "eMf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11179,18 +11208,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ftd" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "ftr" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -13388,15 +13405,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"gvL" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -14487,14 +14495,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hbH" = (
-/obj/machinery/door/airlock/external{
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "hbL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -14592,10 +14592,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"heE" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "heG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14755,18 +14751,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"hiY" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "hjd" = (
 /obj/machinery/light{
 	dir = 1
@@ -15812,13 +15796,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"hFy" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hFP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
@@ -15891,6 +15868,16 @@
 	dir = 4
 	},
 /area/chapel/main)
+"hIC" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hII" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -16053,6 +16040,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"hOw" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hOz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -17222,15 +17224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ivM" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "iwb" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -18706,14 +18699,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"jmf" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "jmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -19679,6 +19664,18 @@
 /obj/effect/spawner/lootdrop/tanks,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"jLy" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "jMK" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air to distro";
@@ -20655,6 +20652,20 @@
 "kma" = (
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"kmd" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "kmh" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable{
@@ -20708,18 +20719,6 @@
 "knf" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos_distro)
-"knl" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "knp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22196,6 +22195,14 @@
 "laH" = (
 /turf/closed/wall,
 /area/quartermaster/office)
+"laK" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "laL" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/cable{
@@ -22870,6 +22877,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lqZ" = (
+/obj/machinery/door/airlock/external{
+	name = "Security Escape Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "lrP" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -23143,18 +23159,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lxF" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "lxG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28554,6 +28558,18 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/main)
+"oha" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ohb" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -29810,15 +29826,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"oTZ" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "oUD" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -32021,6 +32028,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pXP" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "pXU" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -32890,14 +32912,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"qrX" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "qsy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -38360,6 +38374,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"tal" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tar" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable,
@@ -39446,6 +39471,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tHe" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "tHh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42409,6 +42447,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vha" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vhc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -46733,17 +46780,6 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"xmw" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
 "xmW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -69000,9 +69036,9 @@ ctL
 jPk
 lah
 ewm
-knl
+tHe
 uIF
-cyz
+cWD
 wKL
 wKL
 wKL
@@ -72019,9 +72055,9 @@ vRP
 vRP
 vRP
 seS
-anE
+eAe
 lUn
-bSd
+bOF
 qfO
 eNb
 rUN
@@ -73047,9 +73083,9 @@ vRP
 vRP
 vRP
 vRP
-anE
+eAe
 hII
-bSd
+bOF
 qfO
 hRF
 tdd
@@ -74069,7 +74105,7 @@ vRP
 vRP
 vRP
 eRC
-gvL
+daP
 eRC
 gOA
 gOA
@@ -74583,7 +74619,7 @@ vRP
 vRP
 eRC
 eRC
-ftd
+pXP
 eRC
 jYQ
 kVu
@@ -77999,9 +78035,9 @@ pun
 pun
 lAn
 lHR
-oTZ
+cMQ
 uDe
-eet
+tal
 tkl
 iUq
 aCD
@@ -85969,9 +86005,9 @@ hQr
 glR
 mhe
 tpB
-hiY
+bHK
 ipc
-xmw
+kmd
 crc
 crc
 qPn
@@ -90272,9 +90308,9 @@ vRP
 vRP
 vRP
 vRP
-hbH
+lqZ
 kGm
-eLR
+jLy
 tYk
 sHR
 fvK
@@ -90786,9 +90822,9 @@ vRP
 vRP
 vRP
 jzc
-aCE
+laK
 hCF
-jmf
+aCs
 ddt
 tYq
 vps
@@ -91301,7 +91337,7 @@ vRP
 vRP
 vRP
 vRP
-heE
+aCD
 eqc
 adM
 amf
@@ -91557,8 +91593,8 @@ vRP
 vRP
 vRP
 vRP
-heE
-vRP
+aCD
+aCD
 eqc
 wGz
 kxF
@@ -91815,7 +91851,7 @@ vRP
 vRP
 vRP
 vRP
-heE
+aCD
 eqc
 adM
 kxF
@@ -92328,9 +92364,9 @@ vRP
 vRP
 vRP
 vRP
-aCE
+laK
 pqy
-jmf
+aCs
 wqQ
 ibW
 qJT
@@ -92648,9 +92684,9 @@ tkl
 tkl
 tkl
 sqz
-ivM
+oha
 sqz
-ivM
+oha
 sqz
 tkl
 tkl
@@ -92842,9 +92878,9 @@ vRP
 vRP
 vRP
 vRP
-aCE
+laK
 hCF
-jmf
+aCs
 bbe
 dkW
 lOQ
@@ -93162,9 +93198,9 @@ sqz
 sqz
 sqz
 sqz
-lxF
+hOw
 rKC
-lxF
+hOw
 rrx
 lMA
 lMA
@@ -93681,9 +93717,9 @@ aAR
 giq
 nOX
 wUk
-qrX
+vha
 aJn
-hFy
+hIC
 hAq
 vRP
 vRP


### PR DESCRIPTION
# Document the changes in your pull request

A bunch of airlock pairs on Gax were missing airlock helpers; the things that make sure one door closes to allow the other to open. I've added them on the doors that need them. There are some that *look* like they should need them but I think are built differently because how escape pods work on this thing.

Also fixed nearstation area on the 4 tiles of lattice at evac.

# Changelog

:cl:  
bugfix: Crew should stop being sucked out into space at evac on Gax because the doors work now.
/:cl:
