### PR TITLE
Licking pie off your face is no longer a lizard monopoly

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -727,9 +727,9 @@
 				to_chat(src, span_notice("You succesfuly remove the durathread strand."))
 				remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			return
-		else if(istype(src.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard) && creamed)
-			visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] forked tongue."), 
-							"<span class='notice'>You eat the pie off your face with your forked tongue.")
+		else if(creamed)
+			visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] tongue."), 
+							"<span class='notice'>You eat the pie off your face with your tongue.")
 			reagents.add_reagent(/datum/reagent/consumable/banana, 1)
 			wash_cream()
 			return

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -727,7 +727,7 @@
 				to_chat(src, span_notice("You succesfuly remove the durathread strand."))
 				remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			return
-		else if(creamed)
+		else if(istype(src.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue) && creamed)
 			visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] tongue."), 
 							"<span class='notice'>You eat the pie off your face with your tongue.")
 			reagents.add_reagent(/datum/reagent/consumable/banana, 1)


### PR DESCRIPTION
All tongues: forked, spooned, sporked, or not, can now eat pie off their owner's face. No longer shall the evil lizards hold a monopoly over this precious ability.

Good for the game because increases RP.

# Changelog

:cl:  
tweak: All tongue owners may now lick pie off their face.
/:cl:
