### PR TITLE
Stops the Lizard Monopoly of getting rid of pie from their face, try using your HANDS.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -735,7 +735,7 @@
 
 			else if(M.get_num_arms()) //make sure you have arms with which to wipe
 				visible_message(span_notice("[src] wipes the pie off [p_their()] face with [p_their()] hand."), 
-								span_notice(You wipe the pie off your face with your hand."))
+								span_notice("You wipe the pie off your face with your hand."))
 			wash_cream()
 			return
 		check_self_for_injuries()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -727,10 +727,14 @@
 				to_chat(src, span_notice("You succesfuly remove the durathread strand."))
 				remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			return
-		else if(istype(src.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard) && creamed)
-			visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] forked tongue."), 
-							"<span class='notice'>You eat the pie off your face with your forked tongue.")
-			reagents.add_reagent(/datum/reagent/consumable/banana, 1)
+		else if(creamed)
+			if(istype(src.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
+				visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] forked tongue."), 
+								"<span class='notice'>You eat the pie off your face with your forked tongue.")
+				reagents.add_reagent(/datum/reagent/consumable/banana, 1)
+			else if(M.get_num_arms() >= 0) //make sure you have arms with which to wipe
+				visible_message(span_notice("[src] wipes the pie off [p_their()] face with [p_their()] hand."), 
+								"<span class='notice'>You wipe the pie off your face with your hand.")
 			wash_cream()
 			return
 		check_self_for_injuries()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -728,13 +728,14 @@
 				remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			return
 		else if(creamed)
-			if(istype(src.getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
+			if(istype(getorganslot(ORGAN_SLOT_TONGUE), /obj/item/organ/tongue/lizard))
 				visible_message(span_notice("[src] eats the pie off [p_their()] face with [p_their()] forked tongue."), 
-								"<span class='notice'>You eat the pie off your face with your forked tongue.")
+								span_notice("You eat the pie off your face with your forked tongue."))
 				reagents.add_reagent(/datum/reagent/consumable/banana, 1)
-			else if(M.get_num_arms() >= 0) //make sure you have arms with which to wipe
+
+			else if(M.get_num_arms()) //make sure you have arms with which to wipe
 				visible_message(span_notice("[src] wipes the pie off [p_their()] face with [p_their()] hand."), 
-								"<span class='notice'>You wipe the pie off your face with your hand.")
+								span_notice(You wipe the pie off your face with your hand."))
 			wash_cream()
 			return
 		check_self_for_injuries()


### PR DESCRIPTION
We've done it, a logical way to remove pie from your face that can't be refuted!

If you're a lizard, you'll lick pie off your face. Otherwise you'll use your hands (you cant do it if you don't have any) to wipe it off. Since you're not eating the cream you won't get the 1 unit of banana reagent like lizards do.

Would replace #18354

# Changelog

:cl:  
tweak: You can wipe pie off your face with help intent, just like how a lizard can lick it off.
/:cl:
