### PR TITLE
NT-USP no longer causes burn damage

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -78,13 +78,14 @@
 
 /obj/item/ammo_casing/caseless/c22hl
 	caliber = ENERGY
+	harmful = FALSE
 	projectile_type = /obj/item/projectile/bullet/c22hl
 
 /obj/item/projectile/bullet/c22hl //.22 HL
 	name = "hardlight beam"
 	icon_state = "disabler_bullet"
 	flag = ENERGY
-	damage = 2 //ouch ouch my skin ouchie
+	damage = 0 // maybe don't do actual damage so pacifists can use it and silicons won't be mad
 	damage_type = BURN
 	stamina = 25
 	speed = 0.55
@@ -111,6 +112,7 @@
 
 /obj/item/ammo_casing/caseless/c22ls
 	caliber = LASER
+	harmful = TRUE
 	projectile_type = /obj/item/projectile/bullet/c22ls
 
 /obj/item/projectile/bullet/c22ls //.22 LS


### PR DESCRIPTION
# Document the changes in your pull request

The NT-USP will no longer cause real damage. The burn damage gave silicons a valid justification to interfere with arrests and prevented it from being usable by pacifists, so I decided to make it completely non-lethal because it's already worse than the disabler in almost every way.

# Changelog

:cl:  
tweak: NT-USP is now fully non-lethal
/:cl:
