### PR TITLE
Give CE access to the bridge fireaxe cabinet

### DIFF
--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -3,7 +3,7 @@
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
 /obj/structure/fireaxecabinet/bridge
-	req_access = list(ACCESS_CAPTAIN)
+	req_access = list(ACCESS_CAPTAIN, ACCESS_CE)
 
 /obj/structure/fireaxecabinet/Initialize()//<-- mirrored/overwritten proc
 	. = ..()

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -3,7 +3,7 @@
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
 /obj/structure/fireaxecabinet/bridge
-	req_access = list(ACCESS_CAPTAIN, ACCESS_CE)
+	req_one_access = list(ACCESS_CAPTAIN, ACCESS_CE)
 
 /obj/structure/fireaxecabinet/Initialize()//<-- mirrored/overwritten proc
 	. = ..()

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -3,6 +3,7 @@
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
 /obj/structure/fireaxecabinet/bridge
+	//bridge fireaxe has different access
 	req_one_access = list(ACCESS_CAPTAIN, ACCESS_CE)
 
 /obj/structure/fireaxecabinet/Initialize()//<-- mirrored/overwritten proc


### PR DESCRIPTION
# Changes

Prior art: https://github.com/yogstation13/Yogstation/pull/11984

Changes the fireaxe cabinet in the Bridge to give the Chief Engineer access. They already have access to the Atmospherics one, and the bridge itself, so seems a bit weird that they don't have access to this.

### wait but why

Obviously in most cases the CE can just ask the captain to unlock the cabinet for them.
But say for the sake of argument, there's nobody with captain access, and:

- Atmos is currently filled with space vines/fire/giant spiders/wizards, and therefore that fireaxe is not reachable
- The other fireaxe is in space in the hands of some poor atmos tech
- etc.

I don't think any other heads need access - HoS and RD likely have better options, CMO should probably be healing rather than hurting, HoP could give themselves all access anyway and probably will take over if there's no captain. The CE has legitimate reasons to hold a fireaxe (i.e. firefighting) wheras the other heads don't.

I'm told this will need a balance council review.

# Wiki Documentation

The access isn't currently documented on the wiki as far as I can see, but maybe it should be?

# Changelog

:cl:  
tweak: Gave the CE access to the bridge fireaxe cabinet
/:cl:
