### PR TITLE
Switches Lavaland Syndicate hardsuit to modified Elder Atmosian harsuit

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -234,6 +234,11 @@
 	flags_1 = RAD_PROTECT_CONTENTS_1
 	slowdown = 0.6
 
+/obj/item/clothing/suit/space/hardsuit/elder_atmosian/lavaland
+	name = "Modified Elder Atmosian Hardsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Has thermal shielding. This one is made with the toughest and rarest materials available to man. It also appears to be slightly modified to allow the wearer easier movement."
+	slowdown = 0
+
 	//Chief Engineer's hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	name = "advanced hardsuit helmet"

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -189,7 +189,7 @@
 			new /obj/item/ammo_box/a762(src)
 			new /obj/item/ammo_box/no_direct/n762(src)
 			new /obj/item/ammo_box/foambox/riot
-			new /obj/item/clothing/suit/space/hardsuit/syndi(src)
+			new /obj/item/clothing/suit/space/hardsuit/elder_atmosian/lavaland(src)
 			new /obj/item/storage/firstaid(src)
 			new /obj/item/storage/firstaid/toxin(src)
 			return


### PR DESCRIPTION
# Document the changes in your pull request

As the title states, the syndi suit loot from the crate is now a modified elder atmosian. Modified how you say? I'm glad you asked. It has no hardsuit slowdown. It keeps the armor values for it too, which while different from the syndi suit, are not drastic except for a couple (like bomb) and in that case it is the atmosian suit that is better.

# Changelog

:cl:  
tweak: Swaps the red hardsuit for the blue one in lavaland loot.
/:cl:
