### PR TITLE
Hemophiliac, brain damage, and cybernetic quirk adjustments

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -218,6 +218,7 @@
 #define TRAIT_NO_PASSIVE_COOLING "no-passive-cooling"
 #define TRAIT_NO_PASSIVE_HEATING "no-passive-heating"
 #define TRAIT_BLOODY_MESS		"bloody_mess" //from heparin, makes open bleeding wounds rapidly spill more blood
+#define TRAIT_BLOODY_MESS_LITE	"bloody_mess_lite" //weak heparin, otherwise the same
 #define TRAIT_COAGULATING		"coagulating" //from coagulant reagents, this doesn't affect the bleeding itself but does affect the bleed warning messages
 #define TRAIT_NOPULSE           "nopulse" // Your heart doesn't beat
 #define TRAIT_MASQUERADE        "masquerade" // Falsifies Health analyzer blood levels

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -313,7 +313,7 @@
 	name = "Cybernetic Organ"
 	desc = "Due to a past incident you lost function of one of your organs, but now have a fancy upgraded cybernetic organ!"
 	icon = "building-ngo"
-	value = 6
+	value = 4
 	var/slot_string = "organ"
 	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic organ."
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -747,12 +747,12 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
 
-/datum/quirk/hemophilia //basically permanent heparin
+/datum/quirk/hemophilia //basically permanent weak heparin
 	name = "Hemophiliac"
 	desc = "You can't naturally clot bleeding wounds and bleed much more from them than most people, making even small cuts possibly life threatening."
 	icon = "droplet"
-	value = -6
-	mob_trait = TRAIT_BLOODY_MESS
+	value = -4
+	mob_trait = TRAIT_BLOODY_MESS_LITE
 	gain_text = span_danger("You feel like your blood is thin.")
 	lose_text = span_notice("You feel like your blood is of normal thickness once more.")
 	medical_record_text = "Patient appears unable to naturally form blood clots."
@@ -773,7 +773,7 @@
 	name = "Brain Damage"
 	desc = "The shuttle ride was a bit bumpy to the station."
 	icon = "brain"
-	value = -7
+	value = -6
 	gain_text = span_danger("Your head hurts.")
 	lose_text = span_notice("Your head feels good again.")
 	medical_record_text = "Patient appears to have brain damage."
@@ -782,7 +782,7 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/datum/brain_trauma/badtimes = list(BRAIN_TRAUMA_MILD, BRAIN_TRAUMA_SEVERE)
 	var/amount = 0 // Pray you dont get fucked
-	amount = rand(1, 4)
+	amount = rand(1, 3)
 
 	for(var/i = 0 to amount)
 		H.gain_trauma_type(pick(badtimes), TRAUMA_RESILIENCE_ABSOLUTE) // Mr bones wild rides takes no breaks

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -345,7 +345,7 @@
  * Returns BLOOD_FLOW_STEADY if we're not bleeding or there's no change (like piercing), BLOOD_FLOW_DECREASING if we're clotting (non-critical slashes, gauzed, coagulant, etc), BLOOD_FLOW_INCREASING if we're opening up (crit slashes/heparin)
  */
 /datum/wound/proc/get_bleed_rate_of_change()
-	if(blood_flow && HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
+	if(blood_flow && HAS_TRAIT(victim, TRAIT_BLOODY_MESS) || HAS_TRAIT(victim, TRAIT_BLOODY_MESS_LITE))
 		return BLOOD_FLOW_INCREASING
 	return BLOOD_FLOW_STEADY
 

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -50,7 +50,7 @@
 				victim.add_splatter_floor(get_step(victim.loc, victim.dir))
 
 /datum/wound/pierce/get_bleed_rate_of_change()
-	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) || HAS_TRAIT(victim, TRAIT_BLOODY_MESS_LITE))
 		return BLOOD_FLOW_INCREASING
 	if(limb.current_gauze)
 		return BLOOD_FLOW_DECREASING
@@ -66,7 +66,10 @@
 
 	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat != DEAD))
 		blood_flow += 0.5 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
-
+	
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS_LITE) && (victim.stat != DEAD)) //hemophiliac version, half strength
+		blood_flow += 0.25
+		
 	if(limb.current_gauze)
 		blood_flow -= limb.current_gauze.absorption_rate * gauzed_clot_rate
 		limb.current_gauze.absorption_capacity -= limb.current_gauze.absorption_rate

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -83,7 +83,7 @@
 	return bleed_amt
 
 /datum/wound/slash/get_bleed_rate_of_change()
-	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) || HAS_TRAIT(victim, TRAIT_BLOODY_MESS_LITE))
 		return BLOOD_FLOW_INCREASING
 	if(limb.current_gauze || clot_rate > 0)
 		return BLOOD_FLOW_DECREASING
@@ -104,6 +104,8 @@
 
 	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS) && (victim.stat != DEAD))
 		blood_flow += 0.5 // old heparin used to just add +2 bleed stacks per tick, this adds 0.5 bleed flow to all open cuts which is probably even stronger as long as you can cut them first
+	if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS_LITE) && (victim.stat != DEAD)) //hemophiliac version, half strength
+		blood_flow += 0.25
 	if(limb.current_gauze)
 		if(clot_rate > 0)
 			blood_flow -= clot_rate


### PR DESCRIPTION
Tweaks hemophiliac, brain damage, and cybernetic organ traits. 
A lot of negative quirks are insanely bad for you, so it's better to have them give less points but have less downsides, so that you can actually pick them without severely impacting your play.

Hemophiliac makes you bleed out at half the old rate, which makes it much more survivable. Gives -4 points instead of -6.
Previously it was really, really hard to survive even a small cut, which made the trait kind of a really bad choice to pick. You'll still bleed out pretty quick if you don't get medical attention, but it's tenable now. In exchange it gives 4 points instead of 6, since it kills you a whole lot less.
(also uh, i dont know if its just me but hemophiliac is not even selectable, this wasn't introduced by this PR but i'm too lazy to be dealing with it right now)

Brain damage quirk now only rolls 1-3 brain traumas instead of 1-4. Gives -6 points instead of -7.
Having the chance to get 4 entire brain traumas is kind of mean and too random. Slightly less brutal, though 1 less point is given to compensate.

Cybernetic Organ costs 4 points instead of 6.
Having one upgraded cybernetic organ isn't really that great and comes with severe EMP vulnerability, so probably not worth the whole 6 points.

# Changelog

:cl:  
tweak: Cybernetic organ trait costs less points. Brain damage and Hemophiliac less punishing, but give less points.
/:cl:
