### PR TITLE
Makes sec vibro blade look cooler

### DIFF
--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -97,7 +97,7 @@
 	hitsound = "swing_hit"
 	icon = 'icons/obj/weapons/swords.dmi'
 	icon_state = "hfrequency0"
-	icon_state_on = "hfrequency0_ext"
+	icon_state_on = "hfrequency1"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 0

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -112,8 +112,8 @@
 	sharpness = SHARP_EDGED
 	armour_penetration = 25
 	light_system = MOVABLE_LIGHT
-	light_range = 2
-	light_power = 1
+	light_range = 1
+	light_power = 0.5
 	light_color = "#40ceff" // badass sheen
 	light_on = FALSE
 	extend_sound = 'sound/weapons/batonextend.ogg'

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -112,8 +112,8 @@
 	sharpness = SHARP_EDGED
 	armour_penetration = 25
 	light_system = MOVABLE_LIGHT
-	light_range = 1
-	light_power = 0.5
+	light_range = 2
+	light_power = 1
 	light_color = "#40ceff" // badass sheen
 	light_on = FALSE
 	extend_sound = 'sound/weapons/batonextend.ogg'


### PR DESCRIPTION
swaps it to using the electrified extended sprite

![export](https://user-images.githubusercontent.com/108117184/227747644-0f191c75-ed15-4f2f-9ab2-72c04e770a34.gif)


:cl:  
tweak: Sec vibro blade uses the cooler vibroblade sprite
/:cl:
