### PR TITLE
Removes Eguns And Batons

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -189,6 +189,10 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/unpowered)
+"gi" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark/lavaland,
+/area/ruin/unpowered)
 "gw" = (
 /obj/structure/table/glass,
 /obj/item/clothing/mask/cigarette,
@@ -646,13 +650,6 @@
 /turf/open/floor/plating/lavaland_baseturf{
 	icon_state = "panelscorched"
 	},
-/area/ruin/unpowered)
-"xz" = (
-/obj/structure/table/reinforced,
-/obj/item/melee/baton/loaded{
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/dark/lavaland,
 /area/ruin/unpowered)
 "xE" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -1149,6 +1146,11 @@
 /obj/structure/table,
 /turf/open/floor/plating/lavaland_baseturf,
 /area/ruin/unpowered)
+"Tm" = (
+/obj/structure/rack,
+/obj/item/gun/energy/laser,
+/turf/open/floor/plasteel/dark/lavaland,
+/area/ruin/unpowered)
 "TG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -1210,11 +1212,6 @@
 "VD" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/lavaland,
-/area/ruin/unpowered)
-"VR" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun,
 /turf/open/floor/plasteel/dark/lavaland,
 /area/ruin/unpowered)
 "VT" = (
@@ -3071,7 +3068,7 @@ ab
 ab
 ab
 Gf
-VR
+Tm
 hL
 TG
 TG
@@ -3123,7 +3120,7 @@ ab
 ab
 ab
 Gf
-xz
+gi
 eP
 gP
 gP

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -189,10 +189,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/unpowered)
-"gi" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark/lavaland,
-/area/ruin/unpowered)
 "gw" = (
 /obj/structure/table/glass,
 /obj/item/clothing/mask/cigarette,
@@ -620,6 +616,13 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
+"uS" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/m1911{
+	spawnwithmagazine = 0
+	},
+/turf/open/floor/plasteel/dark/lavaland,
+/area/ruin/unpowered)
 "vE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -751,6 +754,10 @@
 /turf/open/floor/plating/lavaland_baseturf{
 	icon_state = "panelscorched"
 	},
+/area/ruin/unpowered)
+"AT" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark/lavaland,
 /area/ruin/unpowered)
 "Bj" = (
 /obj/item/stack/rods,
@@ -1145,11 +1152,6 @@
 "SR" = (
 /obj/structure/table,
 /turf/open/floor/plating/lavaland_baseturf,
-/area/ruin/unpowered)
-"Tm" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser,
-/turf/open/floor/plasteel/dark/lavaland,
 /area/ruin/unpowered)
 "TG" = (
 /obj/effect/turf_decal/tile/red{
@@ -3068,7 +3070,7 @@ ab
 ab
 ab
 Gf
-Tm
+uS
 hL
 TG
 TG
@@ -3120,7 +3122,7 @@ ab
 ab
 ab
 Gf
-gi
+AT
 eP
 gP
 gP

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -619,7 +619,7 @@
 "uS" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/pistol/m1911{
-	spawnwithmagazine = 0
+	spawnwithmagazine = 1
 	},
 /turf/open/floor/plasteel/dark/lavaland,
 /area/ruin/unpowered)


### PR DESCRIPTION

# Document the changes in your pull request

Removes the Egun and Baton from the scp ruin on lavaland infavor of the m1911

# Spriting

# Wiki Documentation

# Changelog

:cl:  

mapping: replaces the stunbaton and egun from the scp lavaland ruin for a m1911

/:cl:
