### PR TITLE
Cherry bombs are no longer trash

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -175,21 +175,24 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/attack_self(mob/living/user)
 	user.visible_message(span_warning("[user] plucks the stem from [src]!"), span_userdanger("You pluck the stem from [src], which begins to hiss loudly!"))
 	log_bomber(user, "primed a", src, "for detonation")
-	prime()
+	preprime()
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		prime()
+		preprime()
 	if(!QDELETED(src))
 		qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/preprime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, 0)
-	reagents.chem_temp = 1000 //Sets off the black powder
+	addtimer(CALLBACK(src, .proc/prime), 5 SECONDS)
+
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
+	reagents.chem_temp = 1000 //Boom goes the blackpowder (Thanks chem nerfs)
 	reagents.handle_reactions()
 
 // aloe


### PR DESCRIPTION
# Document the changes in your pull request
Cherry bombs now have a hardcoded internal 5 second counter for priming.

closes: #18388

# Changelog

:cl:  
bugfix: Cherry bombs no longer explode in your hand 
/:cl:
