### PR TITLE
The presence of a Xeno Queen no longer delays the shuttle because I had to wait for the next round to start once.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -25,9 +25,6 @@
 	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Initialize()
-	if(!is_centcom_level(get_turf(src)))
-		SSshuttle.registerHostileEnvironment(src) //yogs: aliens delay shuttle
-		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //yogs: time until shuttle is freed/called
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in GLOB.carbon_list)
 		if(Q == src)
@@ -52,24 +49,6 @@
 	internal_organs += new /obj/item/organ/alien/neurotoxin
 	internal_organs += new /obj/item/organ/alien/eggsac
 	..()
-
-/mob/living/carbon/alien/humanoid/royal/queen/proc/game_end()
-	if(is_centcom_level(get_turf(src)))
-		return
-	if(stat == DEAD)
-		return
-	SSshuttle.clearHostileEnvironment(src)
-	if(EMERGENCY_IDLE_OR_RECALLED)
-		priority_announce("Xenomorph infestation detected: Emergency shuttle will be sent to recover any survivors, if this is in error feel free to recall.")
-		SSshuttle.emergency.request(null, set_coefficient=0.5)
-
-/mob/living/carbon/alien/humanoid/royal/queen/death()//yogs start: dead queen doesnt stop shuttle
-	SSshuttle.clearHostileEnvironment(src)
-	..()
-
-/mob/living/carbon/alien/humanoid/royal/queen/Destroy()
-	SSshuttle.clearHostileEnvironment(src)
-	..() //yogs end
 
 //Queen verbs
 /obj/effect/proc_holder/alien/lay_egg


### PR DESCRIPTION
# Document the changes in your pull request

Xeno Queens can no longer delay the shuttle.
Xeno Queens no longer trigger a shuttle call 30 minutes after they spawn.

# Justification

It is pretty easy for a Xeno Queen to make a base to hold up in and delay the round near indefinitely to get enough Xenomorphs, even if the crew is mostly dead or hiding in pods. With this PR, they can still do that, but they are actually put on a timer (if the crew chooses) to Hijack the shuttle when it is called. This prevents rounds going on longer than they should.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Xenos

# Changelog

:cl:  BurgerBB
rscdel: Xeno Queens can no longer delay the shuttle.
/:cl:
