### PR TITLE
Blazing oil takes 30% more damage from extinguishers

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -14,7 +14,7 @@
 	reagent = /datum/reagent/blob/blazing_oil
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1, BURN, ENERGY)
+	B.take_damage(1.5, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -14,7 +14,7 @@
 	reagent = /datum/reagent/blob/blazing_oil
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1.5, BURN, ENERGY)
+	B.take_damage(1.3, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)


### PR DESCRIPTION
# Document the changes in your pull request

Blazing oil takes 30% more damage from extingiushers. Currently blazing oil is immune to burn damage (i.e. lasers), and extinguisher damage was also nerfed by 33% as well. This doesn't restore the old numbers, but it should hopefully make extinguishers actually viable again. 

# Changelog

:cl:  
tweak: Fire extinguishers deal 30% more damage to blazing oil.
/:cl:
