### PR TITLE
Removes the completely undocumented and unexplained change of fire damage giving Blazing Oil blobs resource points.

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -18,7 +18,6 @@
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)
-		var/mob/camera/blob/O = overmind
 		damage = 0 //completely and entirely immune to burn damage!
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -19,7 +19,6 @@
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)
 		var/mob/camera/blob/O = overmind
-		O.add_points(damage / 10)//burn damage causes the blob to gain a very small amount of points: the 20 damage of a laser will generate 2 BP.
 		damage = 0 //completely and entirely immune to burn damage!
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T


### PR DESCRIPTION
# Document the changes in your pull request

PR #14956 added a feature that made it so that blazing oil blobs are immune to fire damage. This was documented and fine.
This PR also added a feature, unlisted in the changelog or the PR itself, that made it so that blazing oil blobs gain resource generation from taking burn damage. This can cause a massive amount of generation to occur if people use lasers against it.

# Wiki Documentation

Nothing needs to be changed because this was undocumented lmao.

# Changelog

:cl:  BurgerBB
rscdel: Removes the completely undocumented and unexplained change of fire damage giving Blazing Oil blobs resource points.
/:cl:
