### PR TITLE
xenoqueen QoL

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -48,8 +48,9 @@
 
 /mob/living/carbon/alien/humanoid/royal/queen/get_status_tab_items()
 	. = ..()
-	. += ""
-	. += "Blocked Shuttle Timer: [round(timeleft(time_to_shuttle) / 600, 1)] minutes" //weird conversion but works
+	if(time_to_shuttle)
+		. += ""
+		. += "Blocked Shuttle Timer: [round(timeleft(time_to_shuttle) / 600, 1)] minutes" //weird conversion but works
 
 /mob/living/carbon/alien/humanoid/royal/queen/proc/kill_shuttle_timer()
 	SSshuttle.clearHostileEnvironment(src)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -12,6 +12,7 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3)
 
 	var/alt_inhands_file = 'icons/mob/alienqueen.dmi'
+	var/datum/timedevent/time_to_shuttle
 
 /mob/living/carbon/alien/humanoid/royal/can_inject()
 	return 0
@@ -22,12 +23,12 @@
 	maxHealth = 400
 	health = 400
 	icon_state = "alienq"
-	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
+	var/datum/action/small_sprite/smallsprite = new /datum/action/small_sprite/queen()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Initialize()
 	if(!is_centcom_level(get_turf(src)))
 		SSshuttle.registerHostileEnvironment(src) //yogs: aliens delay shuttle
-		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //yogs: time until shuttle is freed/called
+		time_to_shuttle = addtimer(CALLBACK(src, PROC_REF(game_end)), 30 MINUTES, TIMER_STOPPABLE) //yogs: time until shuttle is freed/called
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in GLOB.carbon_list)
 		if(Q == src)
@@ -45,6 +46,16 @@
 	smallsprite.Grant(src)
 	return ..()
 
+/mob/living/carbon/alien/humanoid/royal/queen/get_status_tab_items()
+	. = ..()
+	. += ""
+	. += "Blocked Shuttle Timer: [round(timeleft(time_to_shuttle) / 600, 1)] minutes" //weird conversion but works
+
+/mob/living/carbon/alien/humanoid/royal/queen/proc/kill_shuttle_timer()
+	SSshuttle.clearHostileEnvironment(src)
+	if(time_to_shuttle)
+		deltimer(time_to_shuttle)
+
 /mob/living/carbon/alien/humanoid/royal/queen/create_internal_organs()
 	internal_organs += new /obj/item/organ/alien/plasmavessel/large/queen
 	internal_organs += new /obj/item/organ/alien/resinspinner
@@ -58,17 +69,17 @@
 		return
 	if(stat == DEAD)
 		return
-	SSshuttle.clearHostileEnvironment(src)
+	kill_shuttle_timer()
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		priority_announce("Xenomorph infestation detected: Emergency shuttle will be sent to recover any survivors, if this is in error feel free to recall.")
 		SSshuttle.emergency.request(null, set_coefficient=0.5)
 
 /mob/living/carbon/alien/humanoid/royal/queen/death()//yogs start: dead queen doesnt stop shuttle
-	SSshuttle.clearHostileEnvironment(src)
+	kill_shuttle_timer()
 	..()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Destroy()
-	SSshuttle.clearHostileEnvironment(src)
+	kill_shuttle_timer()
 	..() //yogs end
 
 //Queen verbs
@@ -98,8 +109,6 @@
 	plasma_cost = 500 //Plasma cost used on promotion, not spawning the parasite.
 
 	action_icon_state = "alien_queen_promote"
-
-
 
 /obj/effect/proc_holder/alien/royal/queen/promote/fire(mob/living/carbon/alien/user)
 	var/obj/item/queenpromote/prom

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -17,8 +17,10 @@
 	. = ..()
 
 /obj/machinery/computer/emergency_shuttle/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(istype(user, /mob/living/carbon/alien/humanoid/royal/queen))
-		SSshuttle.clearHostileEnvironment(user)
+	if(isalienqueen(user))
+		var/mob/living/carbon/alien/humanoid/royal/queen/queenuser = user
+		queenuser.kill_shuttle_timer()
+		balloon_alert(user, "shuttle ready to launch!")
 
 /obj/machinery/computer/emergency_shuttle/ui_state(mob/user)
 	return GLOB.human_adjacent_state
@@ -311,8 +313,9 @@
 			continue
 		if(shuttle_areas[get_area(player)])
 			//Non-xeno present. Can't hijack.
-			if(!istype(player, /mob/living/carbon/alien))
-				return FALSE
+			if(!isalien(player))
+				if(!HAS_TRAIT(player, TRAIT_XENO_HOST) && !player.getorganslot(ORGAN_SLOT_PARASITE_EGG)) //if they are hosts / egged skip them,
+					return FALSE																  //checks twice just incase cause the system is wacky
 			has_xenos = TRUE
 
 	return has_xenos


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71668564/228093519-96c3237f-6399-45dc-9c64-64827996750d.png)
# Document the changes in your pull request

xeno hosts don't count as alive anymore so you don't have to kill all hosts when on the shuttle

xeno queen gets a shuttle block timer tell to see when you need to leave

:cl:  
rscadd: xeno QoL: shuttle timer and host mercy
/:cl:
