### PR TITLE
buster style no longer totally negated by soap and flashes

### DIFF
--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -43,7 +43,7 @@
 /datum/martial_art/buster_style/can_use(mob/living/carbon/human/H)
 	var/obj/item/bodypart/r_arm/robot/buster/R = H.get_bodypart(BODY_ZONE_R_ARM)
 	var/obj/item/bodypart/l_arm/robot/buster/L = H.get_bodypart(BODY_ZONE_L_ARM)
-	if(H.restrained() || H.get_active_held_item() || HAS_TRAIT(H, TRAIT_PACIFISM) || !(H.mobility_flags & MOBILITY_STAND))
+	if(H.restrained() || H.get_active_held_item() || HAS_TRAIT(H, TRAIT_PACIFISM) || !(H.mobility_flags & MOBILITY_MOVE))
 		for(var/atom/movable/K in thrown)
 			thrown.Remove(K)
 			walk(K,0)
@@ -472,10 +472,10 @@
 	destroys it but uses up the attack. Attacking a living target uses up the attack and sends them flying and dismembers their limb if its damaged enough. Has a 15 second \
 	cooldown."
 
-	combined_msg +=  span_warning("You can't perform any of the moves besides megabuster if you're lying down or have an occupied hand. Additionally, if your buster arm should become \
-	disabled, so shall your moves.")
+	combined_msg +=  span_warning("You can't perform any of the moves besides if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall\
+	 your moves.")
 
-	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 65% for 2 seconds.</b>")
+	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 50% for 2 seconds.</b>")
 
 	to_chat(usr, examine_block(combined_msg.Join("\n")))
 

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -472,7 +472,7 @@
 	destroys it but uses up the attack. Attacking a living target uses up the attack and sends them flying and dismembers their limb if its damaged enough. Has a 15 second \
 	cooldown."
 
-	combined_msg +=  span_warning("You can't perform any of the moves besides if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall\
+	combined_msg +=  span_warning("You can't perform any of the moves if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall\
 	 your moves.")
 
 	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 50% for 2 seconds.</b>")

--- a/code/game/objects/items/devices/busterarm/wire_snatch.dm
+++ b/code/game/objects/items/devices/busterarm/wire_snatch.dm
@@ -82,7 +82,7 @@
 	. = ..()
 	ADD_TRAIT(src, HAND_REPLACEMENT_TRAIT, NOBLUDGEON)
 	if(ismob(loc))
-		loc.visible_message(span_warning("A long cable comes out from [loc.name]'s arm!"), span_warning("You extend the breaker's wire from your arm."))
+		loc.visible_message(span_warning("A long cable comes out from [loc.name]'s arm!"), span_warning("You extend the buster's wire from your arm."))
 
 /// Deletes the wire once it has no more shots left
 /obj/item/gun/magic/wire/process_chamber()


### PR DESCRIPTION
# Document the changes in your pull request

forgot to do this last pr but the old buster attacks were usable if the user was resting and it would be inconsistent for that to not still apply, also the "65% damage reduction" in the recall teachings blurb was fixed to be 50% like it actually is

# Changelog


:cl:  

tweak: tweaked buster arm use conditions
spellcheck: fixed incorrect number in buster arm's description

/:cl:
