### PR TITLE
Fixes some nitrium-related oversights

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -26,10 +26,8 @@
 #define N2O_DECOMPOSITION_RATE				0.5		//maximum percentage of n2o that can decompose in one tick
 
 // Nitrium:
-/// The minimum temperature necessary for nitrium to form from tritium, nitrogen, and BZ.
+/// The minimum temperature necessary for nitrium to form from plasma, nitrogen, and BZ (with N2O as a catalyst)
 #define NITRIUM_FORMATION_MIN_TEMP 50000
-/// A scaling divisor for the rate of nitrium formation relative to mix temperature.
-#define NITRIUM_FORMATION_TEMP_DIVISOR NITRIUM_FORMATION_MIN_TEMP / 8
 /// The amount of thermal energy consumed when a mole of nitrium is formed
 #define NITRIUM_FORMATION_ENERGY 100000
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -381,7 +381,7 @@ nobliumformation = 1001
 
 /datum/gas_reaction/nitrium_formation/init_reqs()
 	min_requirements = list(
-		/datum/gas/nitrogen = 20,
+		/datum/gas/nitrogen = 50,
 		/datum/gas/plasma = 20,
 		/datum/gas/bz = 20,
 		/datum/gas/nitrous_oxide = 5,
@@ -392,15 +392,15 @@ nobliumformation = 1001
 	var/temperature = air.return_temperature()
 	var/old_heat_capacity = air.heat_capacity()
 
-	var/heat_efficency = min(temperature / NITRIUM_FORMATION_TEMP_DIVISOR, air.get_moles(/datum/gas/nitrogen), air.get_moles(/datum/gas/plasma), air.get_moles(/datum/gas/bz))
+	var/heat_efficency = min(temperature / NITRIUM_FORMATION_ENERGY, air.get_moles(/datum/gas/nitrogen) / 2, air.get_moles(/datum/gas/plasma), air.get_moles(/datum/gas/bz))
 	//Shouldn't produce gas from nothing.
 	if (heat_efficency <= 0 || (air.get_moles(/datum/gas/nitrogen) - heat_efficency < 0 ) || (air.get_moles(/datum/gas/plasma) - heat_efficency < 0) || (air.get_moles(/datum/gas/bz) - heat_efficency < 0))
 		return NO_REACTION
 
-	air.adjust_moles(/datum/gas/nitrogen, -heat_efficency)
+	air.adjust_moles(/datum/gas/nitrogen, -heat_efficency * 2)
 	air.adjust_moles(/datum/gas/plasma, -heat_efficency)
 	air.adjust_moles(/datum/gas/bz, -heat_efficency)
-	air.adjust_moles(/datum/gas/nitrium, heat_efficency * 2)
+	air.adjust_moles(/datum/gas/nitrium, heat_efficency / 10)
 
 	var/energy_used = heat_efficency * NITRIUM_FORMATION_ENERGY
 	var/new_heat_capacity = air.heat_capacity()
@@ -526,7 +526,7 @@ nobliumformation = 1001
 	var/energy_released = (reaction_rate*NITRO_BALL_HEAT_SCALE) + (plasma_burned*NITRO_BALL_PLASMA_ENERGY)
 	air.adjust_moles(/datum/gas/nitrium, -reaction_rate)
 	air.adjust_moles(/datum/gas/pluoxium, -reaction_rate)
-	air.adjust_moles(/datum/gas/nitrium, reaction_rate*5)
+	air.adjust_moles(/datum/gas/antinoblium, reaction_rate) // an actual purpose for this reaction other than bombs and flamethrowers
 	air.adjust_moles(/datum/gas/plasma, -plasma_burned)
 	if(balls_shot && !isnull(location))
 		var/angular_increment = 360/balls_shot

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	max_temp = 12000
 	energy_release = -350000
 	dangerous = TRUE
-	requirements = list(/datum/gas/nitrium = 1200, /datum/gas/freon = 500)
+	requirements = list(/datum/gas/nitrium = 500, /datum/gas/freon = 500, /datum/gas/tritium = 500)
 	products = list(/obj/machinery/the_singularitygen/tesla = 1)
 
 /datum/gas_recipe/crystallizer/supermatter_silver

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	max_temp = 12000
 	energy_release = -350000
 	dangerous = TRUE
-	requirements = list(/datum/gas/nitrium = 500, /datum/gas/freon = 500, /datum/gas/nitrium = 800)
+	requirements = list(/datum/gas/nitrium = 1200, /datum/gas/freon = 500)
 	products = list(/obj/machinery/the_singularitygen/tesla = 1)
 
 /datum/gas_recipe/crystallizer/supermatter_silver


### PR DESCRIPTION
# Document the changes in your pull request

Changes nitrium production to be closer to what stimulum production used to be due to them being very similar in effect:
- Requires twice as much nitrogen
- Makes 0.05x as much nitrium, the same as stimulum used to be
- Heat scale is 8x higher, use fusion if you want to make a significant amount of it.

Nitrium decomposition will now make antinoblium instead of duplicating nitrium.

Also fixes the tesla generator recipe in the crystallizer.

# Changelog

:cl:   
bugfix: fixes nitrium decomposition duplicating nitrium
bugfix: fixes tesla generator recipe requiring two separate instances of nitrium
tweak: makes nitrium formation more like what stimulum formation used to be
tweak: nitrium decomposition now makes antinoblium instead of duplicating itself
/:cl:
