### PR TITLE
fixes toy pistol magazine

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -22,7 +22,7 @@
 /obj/item/ammo_box/magazine/toy/pistol
 	name = "foam force pistol magazine"
 	icon_state = "9x19p"
-	max_ammo = 8
+	max_ammo = 10
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/ammo_box/magazine/toy/pistol/riot


### PR DESCRIPTION
# Document the changes in your pull request

ups the toy pistol to have ten bullets per mag because uh otherwise the sprite is broken

technically a riot dart pistol buff

# Wiki Documentation

May technically need to be documented regarding the toy pistol with riot darts

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: makes toy pistol have ten darts per magazine
bugfix: this also fixes its sprite when it has ammunition loaded in it
/:cl:
