### PR TITLE
Removes old pda from plasmeme mining medic loadout

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -484,8 +484,7 @@
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	uniform = /obj/item/clothing/under/plasmaman/mining
 	l_hand = /obj/item/storage/firstaid/hypospray/qmc
-	l_pocket =  /obj/item/pda/medical
-	r_pocket = /obj/item/wormhole_jaunter
+	l_pocket = /obj/item/wormhole_jaunter
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med


### PR DESCRIPTION
huh, i wonder how much other plasmeme loadouts are outdated simply because no one plays them
also, how did i not notice this when doing the changes last time?

closes: #18390

:cl:  
rscdel: Removes old pda from plasmeme mining medic loadout
/:cl:
