### PR TITLE
Limits the rad storm to only affect the station z-level

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -10,4 +10,4 @@
 	//sound not longer matches the text, but an audible warning is probably good
 
 /datum/round_event/radiation_storm/start()
-	SSweather.run_weather(/datum/weather/rad_storm)
+	SSweather.run_weather(/datum/weather/rad_storm, 2)//only the station has protected areas, so only target the station. also "detected near the station"


### PR DESCRIPTION
only the station has protected areas for it
closes: #18370

:cl:  
tweak: radiation storm only affects the station z-level
/:cl:
