### PR TITLE
Blazing Oil blobs can no longer gain points by taking laser-based burn damage.

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -18,7 +18,6 @@
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)
-		var/mob/camera/blob/O = overmind
 		damage = 0 //completely and entirely immune to burn damage!
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -19,7 +19,6 @@
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)
 		var/mob/camera/blob/O = overmind
-		O.add_points(damage / 10)//burn damage causes the blob to gain a very small amount of points: the 20 damage of a laser will generate 2 BP.
 		damage = 0 //completely and entirely immune to burn damage!
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T


### PR DESCRIPTION
# Document the changes in your pull request

Blazing Oil blobs can no longer gain resource points by taking laser-based burn damage.

# Justification

I think gaining resource points by damage is kind of insane. While the PR that added it claims that it is low, the amount of resources the blob can gain just by laser or emitter fire is actually pretty significant.

I am also arguing for a removal here because there is no non-github documentation that explains this ability (examining the blob, the wiki, or the changelog), and this is a feature exclusive to yogstation. A lot of players (like me) might use laser weapons against the blob regardless as on other servers, this feature does not exist.

# Wiki Documentation

No changes needed because the wiki was not updated with this information.

# Changelog

:cl:  BurgerBB
rscdel: Blazing Oil blobs can no longer gain points by taking laser-based burn damage.
/:cl:
