### PR TITLE
updates some random nukies locker to having a new PDA

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -25,7 +25,7 @@
 	new /obj/item/storage/box/flashbangs(src)
 	new /obj/item/storage/box/teargas(src)
 	new /obj/item/storage/backpack/duffelbag/syndie/med(src)
-	new /obj/item/pda/syndicate(src)
+	new /obj/item/modular_computer/tablet/pda/preset/basic/syndicate(src)
 
 /obj/structure/closet/syndicate/resources
 	desc = "An old, dusty locker."

--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -101,3 +101,15 @@
 /obj/item/modular_computer/tablet/pda/preset/basic/clown/Initialize()
 	. = ..()
 	AddComponent(/datum/component/slippery, 120, NO_SLIP_WHEN_WALKING)
+
+//for inside one of the nukie lockers
+/obj/item/modular_computer/tablet/pda/preset/basic/syndicate
+	desc = "A standard issue PDA often given to syndicate agents."
+
+/obj/item/modular_computer/tablet/pda/preset/basic/syndicate/Initialize()
+	. = ..()
+	obj_flags |= EMAGGED //starts emagged
+	starting_files |= list(
+		new /datum/computer_file/program/bomberman
+	)	
+	


### PR DESCRIPTION
requested by @RG4ORDR 

Came pre-installed with a detomatix cartidge, but since no one uses old PDAs anymore, it was useless
This one comes pre-installed with bomberman, though i have no clue how to also give them the codes to actually use it

:cl:  
tweak: updates some random nukies locker to having a new PDA
/:cl:
