### PR TITLE
Fixes an update_internals runtime

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -883,7 +883,7 @@
 /mob/living/carbon/proc/update_internals()
 	if(getorganslot(ORGAN_SLOT_BREATHING_TUBE))
 		return TRUE
-	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal.loc && internal.loc == src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
+	if(wear_mask && (wear_mask.clothing_flags & MASKINTERNALS) && !wear_mask.mask_adjusted && ((internal && internal.loc == src) || (wear_mask.clothing_flags & MASKEXTENDRANGE)))
 		return TRUE
 	if(head && (head.clothing_flags & STOPSPRESSUREDAMAGE) && (head.flags_cover & HEADCOVERSMOUTH))
 		return TRUE


### PR DESCRIPTION
Code checked for internal.loc without checking for internals in the first place and threw a runtime when they didn't exist. If it exists it should have a location probably.


# Changelog


:cl:  

bugfix: fixes an unpdate_internals runtime

/:cl:
