### PR TITLE
Roller bed is no longer roller-dead

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -228,5 +228,5 @@
 /obj/structure/bed/grip/Initialize()
 	. = ..()
 
-/obj/structure/bed/roller/post_unbuckle_mob(mob/living/M)
+/obj/structure/bed/grip/post_unbuckle_mob(mob/living/M)
 	qdel(src)


### PR DESCRIPTION
# Document the changes in your pull request

Nice martial art with a nice qdel, kinda on the wrong proc though 🤔 

closes: #18413

# Changelog

:cl:  
bugfix: rollerbeds no longer go to Narnia after one use
/:cl:
