### PR TITLE
Makes beanbag slugs fully non-lethal

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -100,7 +100,6 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
 	variance = 20
-	harmful = FALSE
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/improvised

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -18,6 +18,7 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
+	harmful = FALSE
 	projectile_type = /obj/item/projectile/bullet/shotgun/slug/beanbag
 	materials = list(/datum/material/iron=250)
 
@@ -99,6 +100,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
 	variance = 20
+	harmful = FALSE
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/improvised
@@ -167,6 +169,7 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
+	harmful = FALSE
 	projectile_type = /obj/item/projectile/bullet/reusable/dart/hidden
 
 /obj/item/ammo_casing/shotgun/dart/hidden/Initialize()

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -9,7 +9,6 @@
 	name = "beanbag slug"
 	stamina = 5 // gotta act like we did stamina
 	damage = 0 //regular beanbags don't do damage
-	harmful = FALSE
 	sharpness = SHARP_NONE
 
 // don't want our "beanbag slugs" dropping reagent darts everywhere

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -8,6 +8,8 @@
 /obj/item/projectile/bullet/reusable/dart/hidden
 	name = "beanbag slug"
 	stamina = 5 // gotta act like we did stamina
+	damage = 0 //regular beanbags don't do damage
+	harmful = FALSE
 	sharpness = SHARP_NONE
 
 // don't want our "beanbag slugs" dropping reagent darts everywhere

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -15,7 +15,6 @@
 	name = "beanbag slug"
 	damage = 0
 	stamina = 55
-	harmful = FALSE
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/incendiary/shotgun
@@ -121,7 +120,6 @@
 	name = "rubbershot pellet"
 	damage = 0
 	stamina = 13 //Total of 78 with less falloff (very big but landing all pellets means it's already basically melee range)
-	harmful = FALSE
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/shotgun_cryoshot

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -13,9 +13,9 @@
 
 /obj/item/projectile/bullet/shotgun/slug/beanbag
 	name = "beanbag slug"
-	damage = 5
-	stamina = 55
-	wound_bonus = 20
+	damage = 0
+	stamina = 65
+	harmful = FALSE
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/incendiary/shotgun
@@ -119,8 +119,9 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
-	stamina = 13 //Total of 78 with less falloff (very big)
+	damage = 0
+	stamina = 15 //Total of 90 with less falloff (very big but landing all pellets means it's already basically melee range)
+	harmful = FALSE
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/pellet/shotgun_cryoshot

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -14,7 +14,7 @@
 /obj/item/projectile/bullet/shotgun/slug/beanbag
 	name = "beanbag slug"
 	damage = 0
-	stamina = 65
+	stamina = 55
 	harmful = FALSE
 	sharpness = SHARP_NONE
 
@@ -120,7 +120,7 @@
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 0
-	stamina = 15 //Total of 90 with less falloff (very big but landing all pellets means it's already basically melee range)
+	stamina = 13 //Total of 78 with less falloff (very big but landing all pellets means it's already basically melee range)
 	harmful = FALSE
 	sharpness = SHARP_NONE
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -118,7 +118,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 0
+	damage = 3
 	stamina = 13 //Total of 78 with less falloff (very big but landing all pellets means it's already basically melee range)
 	sharpness = SHARP_NONE
 


### PR DESCRIPTION
This follows the similar logic as #18358 
This also lets warden fully non-lethally detain people in the brig area without relying on a baton or disabler
Also lets bartender be a bit more trigger happy in RP situations without causing damage and potentially wounding their target (getting them thrown in jail, or worse)

:cl:  
tweak: Beanbag slugs no longer do regular damage
tweak: Hidden reagent darts no longer do regular damage (to match the thing they're hiding as)
/:cl:
