### PR TITLE
Improves the analyzer description for Blazing Oil blobs

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -3,7 +3,7 @@
 /datum/blobstrain/reagent/blazing_oil
 	name = "Blazing Oil"
 	description = "will do medium burn damage and set targets on fire."
-	effectdesc = "will gain blob points from burn damage and will also release bursts of flame when burnt, but takes damage from water."
+	effectdesc = "is immune to, and will gain blob points from burn damage. Will also release bursts of flame when burnt, but takes damage from water."
 	analyzerdescdamage = "Does medium burn damage and sets targets on fire."
 	analyzerdesceffect = "Releases fire when burnt and will gain power when exposed to heat, but takes damage from water and other extinguishing liquids."
 	color = "#B68D00"

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -3,9 +3,9 @@
 /datum/blobstrain/reagent/blazing_oil
 	name = "Blazing Oil"
 	description = "will do medium burn damage and set targets on fire."
-	effectdesc = "is completely immune to burn damage and will also release bursts of flame when burnt, but takes damage from water."
+	effectdesc = "will gain blob points from burn damage and will also release bursts of flame when burnt, but takes damage from water."
 	analyzerdescdamage = "Does medium burn damage and sets targets on fire."
-	analyzerdesceffect = "Releases fire when burnt and is completely immune to burning, but takes damage from water and other extinguishing liquids."
+	analyzerdesceffect = "Releases fire when burnt and will gain power when exposed to heat, but takes damage from water and other extinguishing liquids."
 	color = "#B68D00"
 	complementary_color = "#BE5532"
 	blobbernaut_message = "splashes"


### PR DESCRIPTION
An alternative to #18408
I'm open to recommendations for wording this
# Wiki Documentation
**https://wiki.yogstation.net/wiki/Blob#Blob_Chemicals**
Update Blazing Oil here to specifically say that it gains BP from being burned
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl: ShadowDeath6
tweak: Updated the medical HUD description of the Blazing Oil blob strain to reflect the fact that it gains points from being shot with lasers.
/:cl:
