### PR TITLE
Makes less-lethals more lethal

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -17,8 +17,9 @@
 
 /obj/item/projectile/bullet/a556/rubber
 	name = "5.56mm rubber bullet"
-	damage = 10
+	damage = 20
 	stamina = 47
+	sharpness = SHARP_NONE
 
 // .308 (LWT-650 DMR)
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -23,7 +23,7 @@
 
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
-	damage = 5
+	damage = 7
 
 /obj/item/projectile/bullet/shotgun/slug/stun
 	name = "stunslug"
@@ -118,7 +118,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 4.5
+	damage = 5.5
 	stamina = 13 //Total of 78 with less falloff (very big)
 	sharpness = SHARP_NONE
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -13,9 +13,8 @@
 
 /obj/item/projectile/bullet/shotgun/slug/beanbag
 	name = "beanbag slug"
-	damage = 5
+	damage = 18
 	stamina = 55
-	wound_bonus = 20
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/incendiary/shotgun
@@ -119,7 +118,7 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
+	damage = 4.5
 	stamina = 13 //Total of 78 with less falloff (very big)
 	sharpness = SHARP_NONE
 

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -48,5 +48,6 @@
 
 /obj/item/projectile/bullet/c46x30mm/rubber
 	name = "4.6x30mm rubber bullet"
-	damage = 5
+	damage = 7
 	stamina = 22
+	sharpness = SHARP_NONE

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -48,6 +48,6 @@
 
 /obj/item/projectile/bullet/c46x30mm/rubber
 	name = "4.6x30mm rubber bullet"
-	damage = 7
+	damage = 8
 	stamina = 22
 	sharpness = SHARP_NONE


### PR DESCRIPTION
# Document the changes in your pull request

I have decided that instead of pacifying less-lethals we should make them more lethal

Main point of concern I have is the bartender, but I still question why we give a service role a shotgun capable of being sawn off and then loaded with lethal shot. More damaging beanbags matter less if they just stamcrit you (then kill you). Almost like this will happen with less-lethals anyway.

NOTE: All slugs lose 3 damage and 2.25 stamina per tile traveled.
All pellets lose 0.4 damage and 0.3 stamina per tile traveled.

Beanbag slugs now do 18 damage up from 5, but they have lost their positive wound bonus
Rubbershot pellets now do 5.5 damage up from 3
4.6x30mm rubber bullets now do 8 damage up from 5
5.56mm rubber bullets (you will never see these) now do 20 damage up from 10

ADDED BONUS: Dragonsbreath pellets now do 7 damage up from 5

# Wiki Documentation

Values should be updated on Guide to Combat

# Changelog

:cl:  
tweak: Rubber bullets, rubber shot, and beanbags should now all actually hurt significantly more
tweak: Dragonsbreath pellets now do slightly more damage per pellet (notable jump in overall damage)
tweak: Less-lethal bullets that were sharp are now properly blunt
/:cl:
