### PR TITLE
Fixes hypernoblium crystals

### DIFF
--- a/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
+++ b/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
@@ -24,8 +24,6 @@
 		worn_item.add_atom_colour("#00fff7", FIXED_COLOUR_PRIORITY)
 		worn_item.cold_protection |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 		worn_item.heat_protection |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
-		//worn_item.body_parts_covered |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
-		//worn_item.flags_prot |= HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 		worn_item.max_heat_protection_temperature = INFINITY
 		worn_item.min_cold_protection_temperature = -INFINITY
 		worn_item.resistance_flags |= FIRE_PROOF|ACID_PROOF|FREEZE_PROOF

--- a/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
+++ b/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
@@ -1,5 +1,5 @@
 /obj/item/stack/hypernoblium_crystal
-	name = "Hypernoblium Crystal"
+	name = "hypernoblium crystal"
 	desc = "Crystalized bz, oxygen and hypernoblium stored in a bottle to environmental proof your clothes."
 	icon_state = "hypernoblium_crystal"
 	resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | UNACIDABLE
@@ -18,19 +18,16 @@
 			worn_item.clothing_flags |= STOPSPRESSUREDAMAGE
 		if(!(worn_item.clothing_flags & THICKMATERIAL))
 			worn_item.clothing_flags |= THICKMATERIAL
-		if(istype(worn_item, /obj/item/clothing/under))
-			to_chat(user, span_notice("Cannot apply \the [src] to this type of clothing!"))
-			return
-		to_chat(user, span_notice("You see how the [worn_item] changes color, it's now environmental proof."))
+		to_chat(user, span_notice("You crush [src] against [worn_item], making it resistant to nearly all hazardous environmnents."))
 		worn_item.name = "environmental-proof [worn_item.name]"
 		worn_item.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		worn_item.add_atom_colour("#00fff7", FIXED_COLOUR_PRIORITY)
 		worn_item.cold_protection |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 		worn_item.heat_protection |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
-		worn_item.body_parts_covered |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
-		worn_item.flags_prot |= HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-		worn_item.max_heat_protection_temperature = 1e31
-		worn_item.min_cold_protection_temperature = -1e31
+		//worn_item.body_parts_covered |= CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
+		//worn_item.flags_prot |= HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+		worn_item.max_heat_protection_temperature = INFINITY
+		worn_item.min_cold_protection_temperature = -INFINITY
 		worn_item.resistance_flags |= FIRE_PROOF|ACID_PROOF|FREEZE_PROOF
 	amount--
 	if(amount<1)


### PR DESCRIPTION
# Document the changes in your pull request

Hypernoblium crystals no longer makes your clothes cover parts of the body they shouldn't which caused problems like allowing helmets' armor to protect the rest of your body.

Also allows using the crystals on jumpsuits, this doesn't make them spaceproof but still prevents them from being destroyed by fire like any other clothes you use it on.

And also changed the message slightly for when you use it and made the name not a proper noun.

:cl:  
tweak: hypernoblium crystal can be applied to jumpsuits and has a slightly different text when you use it
bugfix: hypernoblium crystals no longer cause armor to protect parts of the body they shouldn't
spellcheck: hypernoblium crystal no longer a proper noun
/:cl:
