### PR TITLE
Adds a timer on squashing fruits because people were complaining

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -109,7 +109,9 @@
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		if(seed.get_gene(/datum/plant_gene/trait/teleport))
 			to_chat(user, span_notice("You start squashing the [src]"))
-			do_after(user, 2 SECONDS, src)
+			if(do_after(user, 2 SECONDS, src))
+				squash(user)
+			return ..()
 		squash(user)
 	..()
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -107,8 +107,9 @@
 // Various gene procs
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
-		to_chat(user, span_notice("You start squashing the [src]"))
-		do_after(user, 2 SECONDS, src)
+		if(seed.get_gene(/datum/plant_gene/trait/teleport))
+			to_chat(user, span_notice("You start squashing the [src]"))
+			do_after(user, 2 SECONDS, src)
 		squash(user)
 	..()
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -107,6 +107,8 @@
 // Various gene procs
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
+		to_chat(user, span_notice("You start squashing the [src]"))
+		do_after(user, 2 SECONDS, src)
 		squash(user)
 	..()
 


### PR DESCRIPTION
# Document the changes in your pull request
Botanists can no longer jump willy nilly and have to wait 2 seconds to squash something in their hands.
This makes it so they have to take cover to actually use it.



If #18430 gets in, this shouldn't.

# Changelog
:cl:  
tweak: Squashing bluespace fruits in hand is no longer instant
/:cl:
