### PR TITLE
Bluespace activity now has half teleport radius and caps plant throw range to 2 tiles

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -316,7 +316,7 @@
 
 /datum/plant_gene/trait/teleport/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()
-	throw_range = min(throw_range, 2)
+	G.throw_range = min(G.row_range, 2)
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -312,7 +312,11 @@
 	// Makes plant teleport people when squashed or slipped on.
 	// Teleport radius is calculated as max(round(potency*rate), 1)
 	name = "Bluespace Activity"
-	rate = 0.1
+	rate = 0.05
+
+/datum/plant_gene/trait/teleport/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	throw_range = min(throw_range, 2)
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -316,7 +316,7 @@
 
 /datum/plant_gene/trait/teleport/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()
-	G.throw_range = min(G.row_range, 2)
+	G.throw_range = min(G.throw_range, 2)
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))


### PR DESCRIPTION
# Document the changes in your pull request

Sorry you're on the same screen as me uhmmmmm piss off

# Wiki documentation

Botany page, bluespace activity trait reduces throw range of the plant to a maximum of 2 tiles

:cl:  
tweak: Bluespace activity now has half teleport radius and caps plant throw range to 2 tiles
/:cl:
