### PR TITLE
Nettle variant acid amount significantly nerfed, death nettle throwforce reduced by 5

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -11,7 +11,7 @@
 	growthstages = 5
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy)
 	mutatelist = list(/obj/item/seeds/nettle/death)
-	reagents_add = list(/datum/reagent/toxin/acid = 0.5)
+	reagents_add = list(/datum/reagent/toxin/acid = 0.1)
 
 /obj/item/seeds/nettle/death
 	name = "pack of death-nettle seeds"
@@ -25,7 +25,7 @@
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.5, /datum/reagent/toxin/acid = 0.5)
+	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.1, /datum/reagent/toxin/acid = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/nettle // "snack"
@@ -93,7 +93,7 @@
 	desc = "The <span class='danger'>glowing</span> nettle incites <span class='boldannounce'>rage</span> in you just from looking at it!"
 	icon_state = "deathnettle"
 	force = 30
-	throwforce = 15
+	throwforce = 10
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/add_juice()
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

Nettles have always had 50% sacid and death nettles 50% sacid 50% fluoroacid

Not only does this remove any chance to produce a "deathmix plant" since acid double-dips in damage (from liquid contents and prickles) but it also makes nettles excessively damaging to get hit by when they are thrown

# Wiki Documentation

Guide to plants
Nettle: 10% sacid
Deathnettle: 10% sacid, 10% fluoroacid

Throwforce likely undocumented, now 10

# Changelog

:cl:  
tweak: deathnettle throwforce reduced from 15 to 10
tweak: nettles and deathnettles have had their acid trait %s reduced from 50% to 10%
/:cl:
