### PR TITLE
Immersion Fix

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -162,11 +162,11 @@
 	src.add_fingerprint(user)
 	if(!src.requiresID())
 		user = null
-	else
-		//Yogstation change start. You need to swipe your ID to open doors.
+	//Yogstation change start. You need to swipe your ID to open doors. Can by bypassed by cutting a wire.
+	else if(length(req_access) || length(req_one_access))
 		do_animate("deny")
 		return
-		//Yogstation change end.
+	//Yogstation change end.
 
 	if(density && !(obj_flags & EMAGGED))
 		if(allowed(user))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -162,6 +162,11 @@
 	src.add_fingerprint(user)
 	if(!src.requiresID())
 		user = null
+	else
+		//Yogstation change start. You need to swipe your ID to open doors.
+		do_animate("deny")
+		return
+		//Yogstation change end.
 
 	if(density && !(obj_flags & EMAGGED))
 		if(allowed(user))

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -15,9 +15,10 @@
 		return TRUE
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		//if they are holding or wearing a card that has access, that works
+		//Yogstation change start. You need to swipe your ID.
 		if(check_access(H.get_active_held_item()) || src.check_access(H.wear_id))
 			return TRUE
+		//Yogstation change end.
 	else if(ismonkey(M) || isalienadult(M))
 		var/mob/living/carbon/george = M
 		//they can only hold things :(


### PR DESCRIPTION
# Document the changes in your pull request

ok so i was getting chased by a sec officer with two disablers (probably metafriended the warden to get an extra one) and somehow despite me closing all doors behind me to slow them down, they managed to open all the doors which confused me. i already law 2'd the ai that round not to fuck with me (had a player complaint template on standby just in case), so it wasn't that, so i know for sure that somehow the officer was opening doors **despite** having a disabler in each hand.

to me this makes zero sense because a) its immersion breaking and b) it's clearly a secret security buff put in by coders some time ago and security fucking sucks I FUCKING AHTE THEM JESUS CHRIST

anyways in order to open an access-requiring door, you need to swipe it with an id in hand. this is an immersion fix and not a salt pr anyone who says otherwise si getting reported and blocked and banned

# Changelog

:cl:  BurgerBB
experimental: Increases immersion by requiring all access-requiring doors to be swiped with ID to open.
/:cl:
