### PR TITLE
Fix power suck oversight

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -1,18 +1,18 @@
 
 /datum/species/preternis/proc/drain_power_from(mob/living/carbon/human/H, atom/A)
 	if(!istype(H) || !A)
-		return FALSE
+		return
 
 	if(!A.can_consume_power_from())
-		return FALSE //if it returns text, we want it to continue so we can get the error message later.
+		return
 	
 	if(get_dist(H, A) > 1)
 		to_chat(H, span_warning("[A] is too far away to initiate CONSUME protocol!"))
-		return FALSE
+		return
 	
 	if(draining)
 		to_chat(H, span_info("CONSUME protocols can only be used on one object at any single time."))
-		return FALSE
+		return
 
 	draining = TRUE
 
@@ -24,24 +24,26 @@
 	if (charge >= PRETERNIS_LEVEL_FULL - 25) //just to prevent spam a bit
 		to_chat(H, span_notice("CONSUME protocol reports no need for additional power at this time."))
 		draining = FALSE
-		return TRUE
+		return
 
 	if(H.gloves)
 		if(!H.gloves.siemens_coefficient)
 			to_chat(H, span_info("NOTICE: [H.gloves] prevent electrical contact - CONSUME protocol aborted."))
 			draining = FALSE
-			return TRUE
+			return
 		else
 			if(H.gloves.siemens_coefficient < 1)
 				to_chat(H, span_info("NOTICE: [H.gloves] are interfering with electrical contact - advise removal before activating CONSUME protocol."))
 			siemens_coefficient *= H.gloves.siemens_coefficient
+
+	. = COMSIG_MOB_CANCEL_CLICKON
 
 	H.face_atom(A)
 	H.visible_message(span_warning("[H] starts placing their hands on [A]..."), span_warning("You start placing your hands on [A]..."))
 	if(!do_after(H, HAS_TRAIT(H, TRAIT_VORACIOUS)? 1.5 SECONDS : 2 SECONDS, A))
 		to_chat(H, span_info("CONSUME protocol aborted."))
 		draining = FALSE
-		return TRUE
+		return
 
 	to_chat(H, span_info("Extracutaneous implants detect viable power source. Initiating CONSUME protocol."))
 
@@ -52,8 +54,6 @@
 	var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
 	spark_system.attach(A)
 	spark_system.set_up(5, 0, A)
-
-
 
 	while(!done)
 		cycle++
@@ -90,7 +90,7 @@
 			done = TRUE
 	qdel(spark_system)
 	draining = FALSE
-	return TRUE
+	return
 
 /atom/proc/can_consume_power_from()
 	return FALSE //if a string is returned, it will evaluate as false and be output to the person draining.


### PR DESCRIPTION
# Document the changes in your pull request
Accidentally broke alt-clicking to unlock the APC as preternis. This updates the power suck proc to properly use ``COMSIG_MOB_CANCEL_CLICKON``.

# Changelog

:cl:  
bugfix: Fixed alt-clicking to unlock APCs as preternis
/:cl:
