### PR TITLE
[Clown theft buff] Adds more departmental budget cards

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -844,3 +844,19 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/departmental_budget/sec
 	department_ID = ACCOUNT_SEC
 	department_name = ACCOUNT_SEC_NAME
+
+/obj/item/card/id/departmental_budget/eng
+	department_ID = ACCOUNT_ENG
+	department_name = ACCOUNT_ENG_NAME
+
+/obj/item/card/id/departmental_budget/sci
+	department_ID = ACCOUNT_SCI
+	department_name = ACCOUNT_SCI_NAME
+
+/obj/item/card/id/departmental_budget/med
+	department_ID = ACCOUNT_MED
+	department_name = ACCOUNT_MED_NAME
+
+/obj/item/card/id/departmental_budget/srv
+	department_ID = ACCOUNT_SRV
+	department_name = ACCOUNT_SRV_NAME

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -31,6 +31,7 @@
 	new /obj/item/barrier_taperoll/engineering(src)
 	new /obj/item/analyzer/ranged(src)
 	new /obj/item/multisurgeon/magboots(src)
+	new /obj/item/card/id/departmental_budget/eng(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -70,6 +70,7 @@
 	new /obj/item/clipboard/yog/paperwork/cmo(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/med/chief(src)
 	new /obj/item/storage/lockbox/medal/med(src)
+	new /obj/item/card/id/departmental_budget/med(src)
 
 
 /obj/structure/closet/secure_closet/paramedic

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -23,3 +23,4 @@
 	new /obj/item/clipboard/yog/paperwork/rd(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/rd(src)
 	new /obj/item/analyzer/ranged(src)
+	new /obj/item/card/id/departmental_budget/sci(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -45,6 +45,8 @@
 	new /obj/item/clipboard/yog/paperwork/hop(src)
 	new /obj/item/gun/energy/e_gun/mini(src) //hop doesn't get a proper gun
 	new /obj/item/storage/backpack/duffelbag/clothing/hop(src)
+	new /obj/item/card/id/departmental_budget/srv(src)
+	new /obj/item/card/id/departmental_budget(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "\proper head of security's locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -46,7 +46,6 @@
 	new /obj/item/gun/energy/e_gun/mini(src) //hop doesn't get a proper gun
 	new /obj/item/storage/backpack/duffelbag/clothing/hop(src)
 	new /obj/item/card/id/departmental_budget/srv(src)
-	new /obj/item/card/id/departmental_budget(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "\proper head of security's locker"


### PR DESCRIPTION
# Document the changes in your pull request
Each department now receives its own budget card in their respective head of staff locker, with the exception of the civilian budget, which remains in nobody's hands (Why would someone steal the clown's personal budget).

**This idea came to me in a dream and an unnamed individual is NOT holding me hostage to make this.**

The HoP gets the service card, the rest are self-evident.

# Reasoning
The main concern of PR #9133 (That being crew using the budgets to buy stuff) is obsolete as the NTOS program allows you to do so anyway.
Budget balance was achieved after the medbay mains got their payrates fixed.
Most other places have this and this would presumably improve RP.

# Wiki Documentation
A mention of these should be on either the respective office wiki pages or head of staff pages.

# Changelog
:cl:  
rscadd: Added new departmental cards to increase their use and to remind people of their existence
/:cl:
