### PR TITLE
makes surgical "tools" less useful as weapons

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -145,7 +145,7 @@
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
-	force = 8
+	force = 10
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 	attack_verb = list("drilled")
@@ -188,7 +188,7 @@
 	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
-	force = 3
+	force = 4
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
 	throw_speed = 3
@@ -247,7 +247,7 @@
 	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw"
-	force = 6
+	force = 8
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 9
 	throw_speed = 2

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -119,12 +119,12 @@
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
 	tool_behaviour = TOOL_DRILL
-	force = 15
+	force = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
 	sharpness = SHARP_POINTY
-	wound_bonus = 10
-	bare_wound_bonus = 10
+	wound_bonus = 7
+	bare_wound_bonus = 5
 
 /obj/item/surgicaldrill/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] rams [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -145,7 +145,7 @@
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
-	force = 10
+	force = 8
 	w_class = WEIGHT_CLASS_SMALL
 	toolspeed = 0.5
 	attack_verb = list("drilled")
@@ -163,7 +163,7 @@
 	item_flags = SURGICAL_TOOL
 	tool_behaviour = TOOL_SCALPEL
 
-	force = 10
+	force = 4
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
 	throw_speed = 3
@@ -172,8 +172,8 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
-	wound_bonus = 10
-	bare_wound_bonus = 15
+	wound_bonus = 2
+	bare_wound_bonus = 4
 
 /obj/item/scalpel/Initialize()
 	. = ..()
@@ -188,7 +188,7 @@
 	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel"
-	force = 10
+	force = 3
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
 	throw_speed = 3
@@ -223,7 +223,7 @@
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
 	tool_behaviour = TOOL_SAW
-	force = 15
+	force = 8
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 9
 	throw_speed = 2
@@ -231,8 +231,8 @@
 	materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharpness = SHARP_EDGED
-	wound_bonus = 15
-	bare_wound_bonus = 10
+	wound_bonus = 5
+	bare_wound_bonus = 3
 
 /obj/item/circular_saw/Initialize()
 	. = ..()
@@ -247,7 +247,7 @@
 	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "saw"
-	force = 10
+	force = 6
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 9
 	throw_speed = 2
@@ -392,7 +392,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel_a"
 	hitsound = 'sound/weapons/blade1.ogg'
-	force = 16
+	force = 10
 	toolspeed = 0.7
 	light_system = MOVABLE_LIGHT
 	light_range = 1


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Tools that are meant to be meant for surgery should remain that way, it makes no sense as to why a saw that is meant to slowly cut through someone's skull can do so much damage to a person, as well as the silly high wound bonus.
I feel like these changes will better reflect how they would actually function in combat (not well), as well as lightly reduce the average medical staffs validhunting capabilities, as these tools can be mass produced on a whim.
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  @Therandomhoboo @solwashere 
tweak: The circle saw, scalpel, laser scalpel, and surgical drill have all had their damage and wound bonus toned down

/:cl:
