### PR TITLE
X-ray bolts and lasers can now pass through doors, lockers, and machines

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -151,10 +151,10 @@
 /obj/machinery/door/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
 	if(istype(mover)) //yogs start
-		if(mover.pass_flags & PASSGLASS)
-			return !opacity
 		if(mover.pass_flags & PASSDOOR)
-			return TRUE //yogs end
+			return TRUE
+		if(mover.pass_flags & PASSGLASS)
+			return !opacity //yogs end
 
 /obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -74,7 +74,7 @@
 	damage = 10
 	irradiate = 300
 	range = 15
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINES | PASSSTRUCTURE | PASSDOOR
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -177,7 +177,7 @@
 	wound_bonus = -30
 	irradiate = 500
 	range = 20
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINES | PASSSTRUCTURE | PASSDOOR
 	embed_type = /obj/item/ammo_casing/caseless/arrow/energy/xray
 
 /obj/item/projectile/energy/arrow/clockbolt


### PR DESCRIPTION
# Document the changes in your pull request

If x-ray bolts and lasers can go through reinforced walls they should probably be able to get through a locker or computer

# Changelog

:cl:  
tweak: x-ray bolts and lasers can pass through doors, lockers and machines
bugfix: a door not having glass no longer prevents things from passing through if they're supposed to be able to pass through doors
/:cl:
