### PR TITLE
Disable Lavaland Beach Dome Ruin

### DIFF
--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -6,7 +6,7 @@
 ##BIODOMES
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter_inn.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
 _maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
 


### PR DESCRIPTION
# Document the changes in your pull request

Every time this ruin spawns currently it's glitched out with large areas just pitch black. Right clicking on the tile says it's what it is supposed to be, but the tile just isn't appearing.

![image](https://user-images.githubusercontent.com/70451213/229624021-575cdfc9-942d-4546-b4a8-dc608cd57f15.png)


:cl:  
tweak: Disables Lavaland Beach Dome ruin until the visual glitches on it can be fixed.
/:cl:
