### PR TITLE
Removes saltpetre  from the Biogenerator after it was stealth-added by Majkl-j

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -162,14 +162,6 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
 	category = list("initial","Botany Chemicals")
 
-/datum/design/saltpetre
-	name = "Saltpetre"
-	id = "saltpetre"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 200)
-	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
-	category = list("initial","Botany Chemicals")
-
 /datum/design/weed_killer
 	name = "Weed Killer"
 	id = "weed_killer"
@@ -273,11 +265,3 @@
 	materials = list(/datum/material/biomass = 300)
 	build_path = /obj/item/clothing/head/rice_hat
 	category = list("initial","Organic Materials")
-
-/datum/design/mutagen
-	name = "Unstable Mutagen"
-	id = "unstable_mutagen"
-	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 600)
-	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
-	category = list("initial","Botany Chemicals")

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -273,4 +273,3 @@
 	materials = list(/datum/material/biomass = 600)
 	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
 	category = list("initial","Botany Chemicals")
-	

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -265,3 +265,12 @@
 	materials = list(/datum/material/biomass = 300)
 	build_path = /obj/item/clothing/head/rice_hat
 	category = list("initial","Organic Materials")
+
+/datum/design/mutagen
+	name = "Unstable Mutagen"
+	id = "unstable_mutagen"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 600)
+	build_path = /obj/item/reagent_containers/glass/bottle/mutagen
+	category = list("initial","Botany Chemicals")
+	


### PR DESCRIPTION
For some reason, https://github.com/yogstation13/Yogstation/pull/18326 added saltpetre to the biogen and the person making it didn't see fit to tell anyone. This removes it.

:cl:    
rscdel: Botany's Biogenerator can no longer make saltpetre.  
/:cl: