### PR TITLE
buster arm can no longer be used while unconscious (unbased)

### DIFF
--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -43,7 +43,7 @@
 /datum/martial_art/buster_style/can_use(mob/living/carbon/human/H)
 	var/obj/item/bodypart/r_arm/robot/buster/R = H.get_bodypart(BODY_ZONE_R_ARM)
 	var/obj/item/bodypart/l_arm/robot/buster/L = H.get_bodypart(BODY_ZONE_L_ARM)
-	if(H.restrained() || H.get_active_held_item() || HAS_TRAIT(H, TRAIT_PACIFISM) || !(H.mobility_flags & MOBILITY_MOVE))
+	if(H.restrained() || H.get_active_held_item() || HAS_TRAIT(H, TRAIT_PACIFISM) || !(H.mobility_flags & MOBILITY_MOVE) || H.stat != CONSCIOUS)
 		for(var/atom/movable/K in thrown)
 			thrown.Remove(K)
 			walk(K,0)

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -481,8 +481,14 @@
 
 /datum/martial_art/buster_style/teach(mob/living/carbon/human/H, make_temporary=0)
 	..()
+	var/datum/species/S = H.dna?.species
+	ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, type)
+	S.add_no_equip_slot(H, SLOT_GLOVES)
 	usr.click_intercept = src 
 
 /datum/martial_art/buster_style/on_remove(mob/living/carbon/human/H)
-	..()
+	var/datum/species/S = H.dna?.species
+	REMOVE_TRAIT(H, TRAIT_SHOCKIMMUNE, type)
+	S.remove_no_equip_slot(H, SLOT_GLOVES)
 	usr.click_intercept = null 
+	..()

--- a/code/game/objects/items/devices/busterarm/buster_limb.dm
+++ b/code/game/objects/items/devices/busterarm/buster_limb.dm
@@ -23,22 +23,16 @@
 /// Set up our actions, disable gloves
 /obj/item/bodypart/l_arm/robot/buster/attach_limb(mob/living/carbon/N, special)
 	. = ..()
-	var/datum/species/S = N.dna?.species
-	S.add_no_equip_slot(N, SLOT_GLOVES)
 	megabuster_action.Grant(N)
 	buster_style.teach(N)
 	to_chat(owner, "[span_boldannounce("You've gained the ability to use Buster Style!")]")
-	ADD_TRAIT(N, TRAIT_SHOCKIMMUNE, type)
 
 /// Remove our actions, re-enable gloves
 /obj/item/bodypart/l_arm/robot/buster/drop_limb(special)
 	var/mob/living/carbon/N = owner
-	var/datum/species/S = N.dna?.species
-	S.remove_no_equip_slot(N, SLOT_GLOVES)
 	megabuster_action.Remove(N)
 	buster_style.remove(N)
 	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
-	REMOVE_TRAIT(N, TRAIT_SHOCKIMMUNE, type)
 	..()
 
 /// Attacking a human mob with the arm causes it to instantly replace their arm
@@ -75,22 +69,16 @@
 /// Set up our actions, disable gloves
 /obj/item/bodypart/r_arm/robot/buster/attach_limb(mob/living/carbon/N, special)
 	. = ..()
-	var/datum/species/S = N.dna?.species
-	S.add_no_equip_slot(N, SLOT_GLOVES)
 	megabuster_action.Grant(N)
 	buster_style.teach(N)
 	to_chat(owner, span_boldannounce("You've gained the ability to use Buster Style!"))
-	ADD_TRAIT(N, TRAIT_SHOCKIMMUNE, type)
 
 /// Remove our actions, re-enable gloves
 /obj/item/bodypart/r_arm/robot/buster/drop_limb(special)
 	var/mob/living/carbon/N = owner
-	var/datum/species/S = N.dna?.species
-	S.remove_no_equip_slot(N, SLOT_GLOVES)
 	megabuster_action.Remove(N)
 	buster_style.remove(N)
 	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
-	REMOVE_TRAIT(N, TRAIT_SHOCKIMMUNE, type)
 	..()
 
 /// Attacking a human mob with the arm causes it to instantly replace their arm


### PR DESCRIPTION
# Document the changes in your pull request

buster arm moves were available while not conscious oops, also fixes the martial art not being removed when the arm is, thanks to @slicerv and @milk-is-cool for pointing it out to me

# Changelog


:cl:  

bugfix: fixes buster arm being usable when it shouldnt be  

/:cl:
