### PR TITLE
Makes traitor playercount based on a number of specific factors instead of just popcount.

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -129,6 +129,8 @@
 	else if(command_count >= 2 || has_captain || engineering_count >= 3)
 		final_calculation *= 1.05 //;SOMEONE OPEN PLEASE
 
+	final_calculation += other_count*0.05 //Is it fair to claim that 5% of people are validhunters?
+
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)
 
 	return min(round(final_calculation), round(GLOB.joined_player_list.len / (tsc * 2)) + 2 + num_modifier, round(GLOB.joined_player_list.len / tsc) + num_modifier)


### PR DESCRIPTION
# Document the changes in your pull request

Traitor maximum playercount **at round start** will always be 3.
Traitor mid-round playercount is now based on security playercount, with additional modifiers to that count based on other roles (See below).


## THE NITTY GRITTY

- **"leadership" is defined as one head of security, or one warden or captain with at least 3 command members**
- Security members are considered anyone in the security department that isn't a warden or a head of security.
- Cyborg population is distributed and considered "crew" based on missing roles, prioritizing engineering first, medical second, and security last, meaning some portion of cyborgs can be considered "security members".
- If the amount of security members is less than 3 and there is **"leadership"** then 10% of the crew will be considered a security member (up to 3).
- If there are 3 or more medical members, the security member count is 25% more.
1. If there is an AI present, the security member count is 20% more. 
2. If there is no AI, but there are at least 2 borgs, the security member count is 10% more. 
3. If there is neither AI nor at least 2 borgs, but there is **"leadership"**, a captain, or 3 or more engineers, then the security member count is 5% more.
- 5% of the crew's population count are considered validhunters and are added the security member count.
- Base traitor count is 0.75 traitors for every security member.

Note that the maximum traitor count will never exceed the maximum traitor count of the old formula.

# Changelog

:cl:  BurgerBB
tweak: Traitor maximum playercount roundstart is now 3.
tweak: Traitor maximum playercount midround is now based on security count, with modifiers incoming from other departments.
/:cl:
