### PR TITLE
Fixes Chubby's PR and the NTOS Bluescreen associated with resetting the keybinds they added to default

### DIFF
--- a/code/datums/keybinding/mob_actions.dm
+++ b/code/datums/keybinding/mob_actions.dm
@@ -20,21 +20,25 @@
 	return TRUE
 
 /datum/keybinding/mob/action_hotkey/action_1
+	hotkey_keys = list("Unbound")
 	name = "action_1"
 	full_name = "Quick Action 1"
 	action_num = 1
 
 /datum/keybinding/mob/action_hotkey/action_2
+	hotkey_keys = list("Unbound")
 	name = "action_2"
 	full_name = "Quick Action 2"
 	action_num = 2
 
 /datum/keybinding/mob/action_hotkey/action_3
+	hotkey_keys = list("Unbound")
 	name = "action_3"
 	full_name = "Quick Action 3"
 	action_num = 3
 
 /datum/keybinding/mob/action_hotkey/action_4
+	hotkey_keys = list("Unbound")
 	name = "action_4"
 	full_name = "Quick Action 4"
 	action_num = 4

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	41
+#define SAVEFILE_VERSION_MAX	42
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -57,6 +57,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if (current_version < 40)
 		migrate_preferences_to_tgui_prefs_menu()
+
+	if (current_version < 41)
+		key_bindings["action_1"] = GLOB.default_hotkeys["action_1"]
+		key_bindings["action_2"] = GLOB.default_hotkeys["action_2"]
+		key_bindings["action_3"] = GLOB.default_hotkeys["action_3"]
+		key_bindings["action_4"] = GLOB.default_hotkeys["action_4"]
+
 
 
 /datum/preferences/proc/update_character(current_version, savefile/S)


### PR DESCRIPTION
# Document the changes in your pull request

The action keybinds @Chubbygummibear added did not have an associated hotkey_keys variable, causing mayhem with the keybind code and making the keybind settings screen ntos bluescreen.

# Changelog
:cl:  
bugfix: Keybind settings no longer bluescreens on edge conditions.  
experimental: Updated preferences.
/:cl:
