### PR TITLE
Vampires can now see their nemesis growing in botany

### DIFF
--- a/code/modules/hydroponics/grown/garlic.dm
+++ b/code/modules/hydroponics/grown/garlic.dm
@@ -2,7 +2,7 @@
 	name = "pack of garlic seeds"
 	desc = "A packet of extremely pungent seeds."
 	icon_state = "seed-garlic"
-	species = /datum/reagent/consumable/garlic
+	species = "garlic"
 	plantname = "Garlic Sprouts"
 	product = /obj/item/reagent_containers/food/snacks/grown/garlic
 	yield = 6


### PR DESCRIPTION
The species name is not supposed to be the full reagent.


# Changelog



:cl:  

bugfix: Fixes invisible garlic

/:cl:
