### PR TITLE
Prevents Ghosts from Antag Fishing

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -487,12 +487,14 @@
   * * ignore_category: Define, ignore_category: People with this category(defined in poll_ignore.dm) turned off dont get the message
   * * flashwindow: Bool, Flash their window to grab their attention
   */
-/proc/pollGhostCandidates(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, ignore_category = null, flashwindow = TRUE)
+/proc/pollGhostCandidates(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, ignore_category = null, flashwindow = TRUE, disallow_started_as_observer = FALSE)
 	var/list/candidates = list()
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
 		return candidates
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
+		if(disallow_started_as_observer && G.started_as_observer && !IsAdminGhost(G))
+			continue
 		candidates += G
 
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates)
@@ -582,8 +584,8 @@
   * * M: Mob, /mob to offer
   * * ignore_category: Unknown
   */
-/proc/pollCandidatesForMob(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, mob/M, ignore_category = null)
-	var/list/L = pollGhostCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category)
+/proc/pollCandidatesForMob(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, mob/M, ignore_category = null, disallow_started_as_observer = FALSE)
+	var/list/L = pollGhostCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, disallow_started_as_observer = disallow_started_as_observer)
 	if(!M || QDELETED(M) || !M.loc)
 		return list()
 	return L
@@ -622,8 +624,8 @@
   * * mobs: List, list of mobs to offer up
   * * ignore_category: Unknown
   */
-/proc/pollCandidatesForMobs(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, list/mobs, ignore_category = null)
-	var/list/L = pollGhostCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category)
+/proc/pollCandidatesForMobs(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, list/mobs, ignore_category = null, disallow_started_as_observer = FALSE)
+	var/list/L = pollGhostCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, disallow_started_as_observer = disallow_started_as_observer)
 	var/i=1
 	for(var/v in mobs)
 		var/atom/A = v

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -45,7 +45,7 @@
 
 /datum/brain_trauma/special/imaginary_friend/proc/get_ghost()
 	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s imaginary friend?", ROLE_PAI, null, null, 75, friend, POLL_IGNORE_IMAGINARYFRIEND)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s imaginary friend?", ROLE_PAI, null, null, 75, friend, POLL_IGNORE_IMAGINARYFRIEND, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		friend.key = C.key

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -29,7 +29,7 @@
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s split personality?", ROLE_PAI, null, null, 75, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s split personality?", ROLE_PAI, null, null, 75, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		stranger_backseat.key = C.key
@@ -187,7 +187,7 @@
 
 /datum/brain_trauma/severe/split_personality/brainwashing/get_ghost()
 	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s brainwashed mind?", null, null, null, 75, stranger_backseat)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s brainwashed mind?", null, null, null, 75, stranger_backseat, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		stranger_backseat.key = C.key

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -100,7 +100,7 @@
 	message_admins("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
 	log_game("DYNAMIC: Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
 
-	candidates = pollGhostCandidates("The mode is looking for volunteers to become [antag_flag] for [name]", antag_flag, SSticker.mode, antag_flag_override ? antag_flag_override : antag_flag, poll_time = 300)
+	candidates = pollGhostCandidates("The mode is looking for volunteers to become [antag_flag] for [name]", antag_flag, SSticker.mode, antag_flag_override ? antag_flag_override : antag_flag, poll_time = 300, disallow_started_as_observer = TRUE)
 
 	if(!candidates || candidates.len <= 0)
 		message_admins("The ruleset [name] received no applications.")
@@ -372,7 +372,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/infiltration/acceptable(population=0, threat=0)
 	if (locate(/datum/dynamic_ruleset/roundstart/infiltration) in mode.executed_rules)
-		return FALSE 
+		return FALSE
 	indice_pop = min(agents_cap.len, round(living_players.len/5)+1)
 	required_candidates = agents_cap[indice_pop]
 	return ..()

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -75,7 +75,7 @@
 	spawn(rand(spawn_delay_min, spawn_delay_max))
 		message_admins("SWF is still pissed, sending another wizard - [max_mages - mages_made] left.")
 		var/banlist = list(ROLE_WIZARD, ROLE_SYNDICATE, ROLE_RAGINMAGES, ROLE_BULLSHITMAGES)
-		candidates = pollGhostCandidates("Do you wish to be considered for the position of Space Wizard Federation 'diplomat'?", banlist, src, bullshit_mode ? ROLE_BULLSHITMAGES : ROLE_RAGINMAGES, ignore_category = POLL_IGNORE_RAGINMAGES)
+		candidates = pollGhostCandidates("Do you wish to be considered for the position of Space Wizard Federation 'diplomat'?", banlist, src, bullshit_mode ? ROLE_BULLSHITMAGES : ROLE_RAGINMAGES, ignore_category = POLL_IGNORE_RAGINMAGES, disallow_started_as_observer = TRUE)
 		if(!candidates.len)
 			message_admins("This is awkward, sleeping until another mage check...")
 			notify_ghosts("There was an attempt to spawn in another ragin' mage, but none of you qualified!")

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -50,7 +50,7 @@
 	ADD_TRAIT(H, TRAIT_NOCRITDAMAGE, CLONING_POD_TRAIT)
 	H.Unconscious(80)
 
-	var/list/candidates = pollCandidatesForMob("Do you want to play as [clonename]'s defective clone?", null, null, null, 100, H, POLL_IGNORE_DEFECTIVECLONE)
+	var/list/candidates = pollCandidatesForMob("Do you want to play as [clonename]'s defective clone?", null, null, null, 100, H, POLL_IGNORE_DEFECTIVECLONE, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		H.key = C.key

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -289,7 +289,7 @@
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
 
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?", ROLE_PAI, null, null, 100, S, POLL_IGNORE_PYROSLIME, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/chosen = pick(candidates)
 		S.key = chosen.key

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -82,8 +82,8 @@
 	var/charges = 5 //how many times can we use the emag before needing to reload it?
 	var/max_charges = 5
 	var/emagging //are we currently emagging something
-	
-/obj/item/card/emag/improvised/afterattack(atom/target, mob/user, proximity)	
+
+/obj/item/card/emag/improvised/afterattack(atom/target, mob/user, proximity)
 	if(charges > 0)
 		if(emagging)
 			return
@@ -297,7 +297,7 @@
 					critter = new /mob/living/simple_animal/pet/gondola(get_turf(src))
 				if(250 to INFINITY)
 					critter = new /mob/living/simple_animal/cheese(get_turf(src))
-					var/list/candidates = pollCandidatesForMob("Do you want to play as cheese?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 5 SECONDS, critter, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
+					var/list/candidates = pollCandidatesForMob("Do you want to play as cheese?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 5 SECONDS, critter, POLL_IGNORE_SENTIENCE_POTION, disallow_started_as_observer = TRUE) // see poll_ignore.dm
 					if(!LAZYLEN(candidates))
 						return
 					var/mob/dead/observer/O = pick(candidates)
@@ -658,7 +658,7 @@ update_label("John Doe", "Clowny")
 /obj/item/card/id/ert/occupying/Initialize()
     access = list(ACCESS_SECURITY,ACCESS_BRIG,ACCESS_WEAPONS,ACCESS_SEC_DOORS,ACCESS_MAINT_TUNNELS)+get_ert_access("sec")
     . = ..()
-    
+
 /obj/item/card/id/ert/Initialize()
 	access = get_all_accesses()+get_ert_access("commander")-ACCESS_CHANGE_IDS
 	. = ..()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -27,7 +27,7 @@
 
 	var/selected_category = MENU_ALL
 	var/list/show_categories = list(MENU_ALL, MENU_WEAPON, MENU_ARM, MENU_CLOTHING, MENU_MISC)
-	/// this text will show on the tgui menu when picking the nullrod form they want. should give a better idea of the nullrod's gimmick or quirks without giving away numbers 
+	/// this text will show on the tgui menu when picking the nullrod form they want. should give a better idea of the nullrod's gimmick or quirks without giving away numbers
 	var/additional_desc = "How are you seeing this? This is the default Nullrod bonus description. I makey a mistakey."
 
 /obj/item/nullrod/Initialize()
@@ -49,7 +49,7 @@
 		var/mob/living/carbon/human/H = user
 		H.dropItemToGround(src, TRUE, TRUE)
 	qdel(user, TRUE)
-	
+
 /obj/item/nullrod/attack_self(mob/user)
 	if(user?.mind?.holy_role && check_menu(user))
 		ui_interact(user)
@@ -62,13 +62,13 @@
 	if(user.incapacitated() || !user.is_holding(src))
 		return FALSE
 	return TRUE
-	
+
 /obj/item/nullrod/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NullRodMenu", name)
 		ui.open()
-	
+
 /obj/item/nullrod/ui_static_data(mob/user)
 	var/list/data = list()
 	data["categories"] = list()
@@ -76,9 +76,9 @@
 	for(var/category in show_categories)
 		var/list/category_data = list()
 		category_data["name"] = category
-		
+
 		var/list/nullrods = list()
-		
+
 		for(var/shaft in subtypesof(/obj/item/nullrod))
 			var/obj/item/nullrod/rod = new shaft
 			if(!rod?.chaplain_spawnable)
@@ -89,19 +89,19 @@
 			details["menu_tab"] = rod.menutab
 			details["type_path"] = rod.type
 			details["additional_description"] = rod.additional_desc
-			
+
 			var/icon/rod_pic = getFlatIcon(rod)
 			var/md5 = md5(fcopy_rsc(rod_pic))
 			if(!SSassets.cache["photo_[md5]_[rod.name]_icon.png"])
 				SSassets.transport.register_asset("photo_[md5]_[rod.name]_icon.png", rod_pic)
 			SSassets.transport.send_assets(user, list("photo_[md5]_[rod.name]_icon.png" = rod_pic))
 			details["rod_pic"] = SSassets.transport.get_asset_url("photo_[md5]_[rod.name]_icon.png")
-			
+
 			if(category == MENU_ALL || category == rod.menutab)
 				nullrods += list(details)
-				
+
 			qdel(rod)
-		
+
 		category_data["nullrods"] = nullrods
 		data["categories"] += list(category_data)
 
@@ -349,7 +349,7 @@
 
 	to_chat(user, "You attempt to wake the spirit of the blade...")
 	possessed = TRUE
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		var/mob/living/simple_animal/shade/S = new(src)
@@ -469,7 +469,7 @@
 	hitsound = 'sound/weapons/chainhit.ogg'
 	menutab = MENU_WEAPON
 	additional_desc = "A holy weapon, capable at meting out righteousness from a distance."
-	
+
 /obj/item/nullrod/whip/Initialize()
 	. = ..()
 	weapon_stats[REACH] = 3
@@ -576,7 +576,7 @@
 
 /obj/item/nullrod/godhand/ignition_effect(atom/A, mob/user)
 	. = span_notice("[user] grasps [A] with [user.p_their()] flaming hand, igniting it in a burst of holy flame. Holy hot damn, that is badass. ")
-	
+
 /obj/item/nullrod/chainsaw
 	name = "chainsaw hand"
 	desc = "Good? Bad? You're the guy with the chainsaw hand."
@@ -665,7 +665,7 @@
 	var/hud_type2 = DATA_HUD_MEDICAL_ADVANCED
 	menutab = MENU_CLOTHING
 	additional_desc = "This mysterious floating skull can communicate diagnostic reports to you regarding both mechanical and organic disciples around you."
-	
+
 /obj/item/nullrod/servoskull/equipped(mob/living/carbon/human/user, slot)
 	..()
 	if(hud_type && slot == SLOT_NECK)
@@ -683,7 +683,7 @@
 		var/datum/atom_hud/H2 = GLOB.huds[hud_type2]
 		H2.remove_hud_from(user)
 
-/obj/item/nullrod/hermes 
+/obj/item/nullrod/hermes
 	name = "fairy boots"
 	desc = "Boots blessed by the god Hermes. Some say that they were discarded after being tainted by fae magic."
 	gender = PLURAL //Carn: for grammarically correct text-parsing, but over here too
@@ -787,7 +787,7 @@
 		return PROCESS_KILL // something has gone terribly wrong
 	if(!isliving(loc))
 		return PROCESS_KILL // something has gone terribly wrong
-	
+
 	var/notify = FALSE
 	if(COOLDOWN_FINISHED(src, holy_notification))
 		COOLDOWN_START(src, holy_notification, 0.8 SECONDS)

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -72,7 +72,7 @@
 			if(used)
 				to_chat(H, "You already used this contract!")
 				return
-			var/list/candidates = pollCandidatesForMob("Do you want to play as a wizard's [href_list["school"]] apprentice?", ROLE_WIZARD, null, ROLE_WIZARD, 150, src)
+			var/list/candidates = pollCandidatesForMob("Do you want to play as a wizard's [href_list["school"]] apprentice?", ROLE_WIZARD, null, ROLE_WIZARD, 150, src, disallow_started_as_observer = TRUE)
 			if(LAZYLEN(candidates))
 				if(QDELETED(src))
 					return
@@ -137,7 +137,7 @@
 		return
 
 	to_chat(user, span_notice("You activate [src] and wait for confirmation."))
-	var/list/nuke_candidates = pollGhostCandidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE)
+	var/list/nuke_candidates = pollGhostCandidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", ROLE_OPERATIVE, null, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(nuke_candidates))
 		if(QDELETED(src) || !check_usability(user))
 			return
@@ -257,7 +257,7 @@
 		return
 	if(used)
 		return
-	var/list/candidates = pollCandidatesForMob("Do you want to play as a [initial(demon_type.name)]?", ROLE_ALIEN, null, ROLE_ALIEN, 50, src)
+	var/list/candidates = pollCandidatesForMob("Do you want to play as a [initial(demon_type.name)]?", ROLE_ALIEN, null, ROLE_ALIEN, 50, src, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		if(used || QDELETED(src))
 			return

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -169,7 +169,7 @@
 
 	B.naut = TRUE	//temporary placeholder to prevent creation of more than one per factory.
 	to_chat(src, span_notice("You attempt to produce a blobbernaut."))
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as a [blobstrain.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50) //players must answer rapidly
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as a [blobstrain.name] blobbernaut?", ROLE_BLOB, null, ROLE_BLOB, 50, disallow_started_as_observer = TRUE) //players must answer rapidly
 	if(LAZYLEN(candidates)) //if we got at least one candidate, they're a blobbernaut now.
 		B.max_integrity = initial(B.max_integrity) * 0.25 //factories that produced a blobbernaut have much lower health
 		B.obj_integrity = min(B.obj_integrity, B.max_integrity)

--- a/code/modules/antagonists/clockcult/clock_structures/eminence_spire.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/eminence_spire.dm
@@ -126,7 +126,7 @@
 	else if(eminence_nominee == "ghosts")
 		kingmaking = TRUE
 		hierophant_message(span_brass("<b>The eminence spire is now selecting a ghost to be the Eminence...</b>"))
-		var/list/candidates = pollGhostCandidates("Would you like to play as the servants' Eminence?", ROLE_SERVANT_OF_RATVAR, null, ROLE_SERVANT_OF_RATVAR, poll_time = 100)
+		var/list/candidates = pollGhostCandidates("Would you like to play as the servants' Eminence?", ROLE_SERVANT_OF_RATVAR, null, ROLE_SERVANT_OF_RATVAR, poll_time = 100, disallow_started_as_observer = TRUE)
 		kingmaking = FALSE
 		if(!LAZYLEN(candidates))
 			for(var/mob/M in servants_and_ghosts())

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -156,7 +156,7 @@
 			return
 		if(7)
 			to_chat(user, "<span class='neovgre'>You feel [I] attempting to communicate with you.</span>")
-			var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s [I]?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
+			var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s [I]?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE, disallow_started_as_observer = TRUE)
 			if(LAZYLEN(candidates))
 				var/mob/dead/observer/C = pick(candidates)
 				var/mob/living/simple_animal/shade/S = new(src)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -640,7 +640,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		user.adjustBruteLoss(damage4invoker)
 	if(!mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [mob_to_revive.name], an inactive blood cultist?", ROLE_CULTIST, null, ROLE_CULTIST, 50, mob_to_revive)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [mob_to_revive.name], an inactive blood cultist?", ROLE_CULTIST, null, ROLE_CULTIST, 50, mob_to_revive, disallow_started_as_observer = TRUE)
 		if(LAZYLEN(candidates))
 			var/mob/dead/observer/C = pick(candidates)
 			to_chat(mob_to_revive.mind, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")

--- a/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
@@ -109,7 +109,7 @@
 	//we need to spawn the mob first so that we can use it in pollCandidatesForMob, we will move it from nullspace down the code
 	var/mob/living/summoned = new mob_to_summon(loc)
 	message_admins("[summoned.name] is being summoned by [user.real_name] in [loc]")
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [summoned.name]", ROLE_HERETIC, null, FALSE, 100, summoned)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [summoned.name]", ROLE_HERETIC, null, FALSE, 100, summoned, disallow_started_as_observer = TRUE)
 	if(!LAZYLEN(candidates))
 		to_chat(user,span_warning("No ghost could be found..."))
 		qdel(summoned)

--- a/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/transmutations/flesh_transmutations.dm
@@ -29,7 +29,7 @@
 	humie.grab_ghost()
 
 	if(!humie.mind || !humie.client)
-		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a Voiceless Dead?", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie)
+		var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [humie.real_name], a Voiceless Dead?", ROLE_HERETIC, null, ROLE_HERETIC, 50,humie, disallow_started_as_observer = TRUE)
 		if(!LAZYLEN(candidates))
 			return
 		var/mob/dead/observer/C = pick(candidates)
@@ -94,7 +94,7 @@
 		if("No")
 			var/mob/living/summoned = new /mob/living/simple_animal/hostile/eldritch/armsy(loc)
 			message_admins("[summoned.name] is being summoned by [user.real_name] in [loc].")
-			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, null, ROLE_HERETIC, 100,summoned)
+			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, null, ROLE_HERETIC, 100,summoned, disallow_started_as_observer = TRUE)
 			user.SetImmobilized(0)
 			if(LAZYLEN(candidates) == 0)
 				to_chat(user,span_warning("No ghost could be found..."))

--- a/code/modules/antagonists/horror/horror_datums.dm
+++ b/code/modules/antagonists/horror/horror_datums.dm
@@ -94,7 +94,7 @@
 	used = TRUE
 	to_chat(user, "You're attempting to wake up the creature inside the box...")
 	sleep(5 SECONDS)
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the eldritch horror in service of [user.real_name]?", ROLE_HORROR, null, FALSE, 100)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the eldritch horror in service of [user.real_name]?", ROLE_HORROR, null, FALSE, 100, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		var/mob/living/simple_animal/horror/H = new /mob/living/simple_animal/horror(get_turf(src))

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -412,7 +412,7 @@
 				break
 	if(!key_of_revenant)
 		message_admins("The new revenant's old client either could not be found or is in a new, living mob - grabbing a random candidate instead...")
-		var/list/candidates = pollCandidatesForMob("Do you want to be [revenant.name] (reforming)?", ROLE_REVENANT, null, ROLE_REVENANT, 50, revenant)
+		var/list/candidates = pollCandidatesForMob("Do you want to be [revenant.name] (reforming)?", ROLE_REVENANT, null, ROLE_REVENANT, 50, revenant, disallow_started_as_observer = TRUE)
 		if(!LAZYLEN(candidates))
 			qdel(revenant)
 			message_admins("No candidates were found for the new revenant. Oh well!")

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -165,7 +165,7 @@
 	if (.)
 		to_chat(user, span_notice("The uplink vibrates quietly, connecting to nearby agents..."))
 
-		var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Contractor Support Unit for [user.real_name]?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_CONTRACTOR_SUPPORT)
+		var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Contractor Support Unit for [user.real_name]?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_CONTRACTOR_SUPPORT, disallow_started_as_observer = TRUE)
 
 		if(LAZYLEN(candidates))
 			var/mob/dead/observer/C = pick(candidates)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -314,7 +314,7 @@
 			break
 
 	if(!chosen_ghost)	//Failing that, we grab a ghost
-		var/list/consenting_candidates = pollGhostCandidates("Would you like to play as a Shade?", "Cultist", null, ROLE_CULTIST, 150, POLL_IGNORE_SHADE)
+		var/list/consenting_candidates = pollGhostCandidates("Would you like to play as a Shade?", "Cultist", null, ROLE_CULTIST, 150, POLL_IGNORE_SHADE, disallow_started_as_observer = TRUE)
 		if(consenting_candidates.len)
 			chosen_ghost = pick(consenting_candidates)
 	if(!T)

--- a/code/modules/antagonists/zombie/abilities/necromance.dm
+++ b/code/modules/antagonists/zombie/abilities/necromance.dm
@@ -17,7 +17,7 @@
 		return FALSE
 
 	necromancing = TRUE
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as a Necromanced Zombie?", ROLE_ZOMBIE, null, ROLE_ZOMBIE, 150)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as a Necromanced Zombie?", ROLE_ZOMBIE, null, ROLE_ZOMBIE, 150, disallow_started_as_observer = TRUE)
 	necromancing = FALSE //Incase we runtime during the process below
 
 

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -119,7 +119,7 @@
 
 	if(!current_wizard)
 		return
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as Wizard Academy Defender?", ROLE_WIZARD, null, ROLE_WIZARD, 50, current_wizard)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as Wizard Academy Defender?", ROLE_WIZARD, null, ROLE_WIZARD, 50, current_wizard, disallow_started_as_observer = TRUE)
 
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
@@ -328,7 +328,7 @@
 			A.setup_master(user)
 			servant_mind.transfer_to(H)
 
-			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [user.real_name] Servant?", ROLE_WIZARD, null, ROLE_WIZARD, 50, H)
+			var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [user.real_name] Servant?", ROLE_WIZARD, null, ROLE_WIZARD, 50, H, disallow_started_as_observer = TRUE)
 			if(LAZYLEN(candidates))
 				var/mob/dead/observer/C = pick(candidates)
 				message_admins("[ADMIN_LOOKUPFLW(C)] was spawned as Dice Servant")

--- a/code/modules/events/ghost_role.dm
+++ b/code/modules/events/ghost_role.dm
@@ -62,7 +62,7 @@
 	var/list/mob/dead/observer/regular_candidates
 	// don't get their hopes up
 	if(priority_candidates.len < minimum_required)
-		regular_candidates = pollGhostCandidates("Do you wish to be considered for the special role of '[role_name]'?", jobban, gametypecheck, be_special)
+		regular_candidates = pollGhostCandidates("Do you wish to be considered for the special role of '[role_name]'?", jobban, gametypecheck, be_special, disallow_started_as_observer = TRUE)
 	else
 		regular_candidates = list()
 

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -76,7 +76,7 @@
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
 /datum/round_event/santa/start()
-	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be Santa?", poll_time=150)
+	var/list/candidates = pollGhostCandidates("Santa is coming to town! Do you want to be Santa?", poll_time=150, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		santa = new /mob/living/carbon/human(pick(GLOB.blobstart))

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -83,7 +83,7 @@
 	qdel(beacon)
 	shuttle_spawned = TRUE
 
-	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)
+	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR, disallow_started_as_observer = TRUE)
 	shuffle_inplace(candidates)
 
 	var/datum/map_template/shuttle/pirate/default/ship = new

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -10,7 +10,7 @@
 		if(!ishuman(M.current))
 			continue
 		var/mob/living/carbon/human/W = M.current
-		var/list/candidates = pollGhostCandidates("Would you like to be an imposter wizard?", ROLE_WIZARD)
+		var/list/candidates = pollGhostCandidates("Would you like to be an imposter wizard?", ROLE_WIZARD, disallow_started_as_observer = TRUE)
 		if(!candidates)
 			return //Sad Trombone
 		var/mob/dead/observer/C = pick(candidates)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -81,7 +81,7 @@
 
 	bursting = TRUE
 
-	var/list/candidates = pollGhostCandidates("Do you want to play as an alien larva that will burst out of [owner]?", ROLE_ALIEN, null, ROLE_ALIEN, 100, POLL_IGNORE_ALIEN_LARVA)
+	var/list/candidates = pollGhostCandidates("Do you want to play as an alien larva that will burst out of [owner]?", ROLE_ALIEN, null, ROLE_ALIEN, 100, POLL_IGNORE_ALIEN_LARVA, disallow_started_as_observer = TRUE)
 
 	if(QDELETED(src) || QDELETED(owner))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -311,7 +311,7 @@
 	INVOKE_ASYNC(src, .proc/get_player)
 
 /mob/living/simple_animal/hostile/regalrat/controlled/proc/get_player()
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Royal Rat, cheesey be their crown?", ROLE_MOUSE, null, FALSE, 100, POLL_IGNORE_SENTIENCE_POTION)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Royal Rat, cheesey be their crown?", ROLE_MOUSE, null, FALSE, 100, POLL_IGNORE_SENTIENCE_POTION, disallow_started_as_observer = TRUE)
 	if(LAZYLEN(candidates) && !mind)
 		var/mob/dead/observer/C = pick(candidates)
 		key = C.key

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -301,7 +301,7 @@
 	M.dropItemToGround(M.get_inactive_held_item())
 	B.temporary = !forced
 	B.stored_mob = M
-	M.forceMove(B)	
+	M.forceMove(B)
 	M.log_message("became [B.real_name]", LOG_ATTACK, color="orange")
 	B.desc = "What appears to be [M.real_name] reformed into a wheel of delicious parmesan..."
 	B.name = "[M.name] Parmesan"
@@ -396,7 +396,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	armour_penetration = 20
-	flag = MAGIC 
+	flag = MAGIC
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
 /obj/item/projectile/magic/locker
@@ -580,7 +580,7 @@
 		var/datum/antagonist/A = M.mind.has_antag_datum(/datum/antagonist/)
 		if(A)
 			poll_message = "[poll_message] Status:[A.name]."
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob(poll_message, ROLE_PAI, null, FALSE, 100, M)
+	var/list/mob/dead/observer/candidates = pollCandidatesForMob(poll_message, ROLE_PAI, null, FALSE, 100, M, disallow_started_as_observer = TRUE)
 	if(M.stat == DEAD)//boo.
 		return
 	if(LAZYLEN(candidates))

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -724,7 +724,7 @@
 	to_chat(user, span_notice("You offer [src] to [SM]..."))
 	being_used = TRUE
 
-	var/list/candidates = pollCandidatesForMob("Do you want to play as [SM.name]?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 50, SM, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
+	var/list/candidates = pollCandidatesForMob("Do you want to play as [SM.name]?", ROLE_SENTIENCE, null, ROLE_SENTIENCE, 50, SM, POLL_IGNORE_SENTIENCE_POTION, disallow_started_as_observer = TRUE) // see poll_ignore.dm
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		SM.key = C.key

--- a/yogstation/code/modules/events/infiltrators.dm
+++ b/yogstation/code/modules/events/infiltrators.dm
@@ -25,7 +25,7 @@
 	role_name = "infiltration team"
 
 /datum/round_event/ghost_role/infiltrators/spawn_role()
-	var/list/candidates = pollGhostCandidates("Do you wish to be considered for an infiltration team?", ROLE_INFILTRATOR)
+	var/list/candidates = pollGhostCandidates("Do you wish to be considered for an infiltration team?", ROLE_INFILTRATOR, disallow_started_as_observer = TRUE)
 
 	var/list/mob/dead/observer/chosen = list()
 	var/mob/dead/observer/theghost = null

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -639,7 +639,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 			var/mob/living/simple_animal/hostile/guardian/G = para
 			if(G.summoner?.current.ckey == src.ckey)
 				users += carbon_minds
-				
+
 
 	for(var/datum/mind/user_minds in users)
 		if(!user_minds.current || user_minds.current == src)
@@ -665,7 +665,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	/// Will yield a "?"
 	else
 		to_chat(src, span_notice("There are no users nearby."))
-		
+
 /mob/living/simple_animal/hostile/guardian/verb/Battlecry()
 	set name = "Set Battlecry"
 	set category = "Guardian"
@@ -701,7 +701,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	G.reset()
 
 /mob/living/simple_animal/hostile/guardian/proc/reset(silent = FALSE, initiated_by = "user")
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as [summoner.current.real_name]'s [real_name]? ([stats.short_info()])", ROLE_HOLOPARASITE, null, FALSE, 10 SECONDS)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as [summoner.current.real_name]'s [real_name]? ([stats.short_info()])", ROLE_HOLOPARASITE, null, FALSE, 10 SECONDS, disallow_started_as_observer = TRUE)
 	if (!LAZYLEN(candidates))
 		if (!silent)
 			to_chat(src, span_holoparasite("There were no ghosts willing to take control of <font color=\"[namedatum.color]\"><b>[real_name]</b></font>. Looks like you're stuck with it for now."))

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -189,7 +189,7 @@
 			used = FALSE
 			return FALSE
 	// IMPORTANT - if we're debugging, the user gets thrown into the stand
-	var/list/mob/dead/observer/candidates = debug_mode ? list(user) : pollGhostCandidates("Do you want to play as the [mob_name] of [user.real_name]? ([saved_stats.short_info()])", ROLE_HOLOPARASITE, null, FALSE, 100, POLL_IGNORE_HOLOPARASITE)
+	var/list/mob/dead/observer/candidates = debug_mode ? list(user) : pollGhostCandidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_HOLOPARASITE, null, FALSE, 100, POLL_IGNORE_HOLOPARASITE, disallow_started_as_observer = TRUE)
 	if (LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		var/mob/living/simple_animal/hostile/guardian/G = new(user, theme)
@@ -259,7 +259,7 @@
 /obj/item/guardiancreator/ComponentInitialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_REFUND, .proc/refund_check)
-	
+
 /obj/item/guardiancreator/proc/refund_check()
 	return !builder.used
 

--- a/yogstation/code/modules/guardian/standarrow.dm
+++ b/yogstation/code/modules/guardian/standarrow.dm
@@ -153,7 +153,7 @@
 	INVOKE_ASYNC(src, .proc/get_stand, H, stats)
 
 /obj/item/stand_arrow/proc/get_stand(mob/living/carbon/H, datum/guardian_stats/stats)
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Guardian Spirit of [H.real_name]?", ROLE_HOLOPARASITE, null, FALSE, 100, POLL_IGNORE_HOLOPARASITE)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Guardian Spirit of [H.real_name]?", ROLE_HOLOPARASITE, null, FALSE, 100, POLL_IGNORE_HOLOPARASITE, disallow_started_as_observer = TRUE)
 	if (LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		var/mob/living/simple_animal/hostile/guardian/G = new(H, arrowtype)


### PR DESCRIPTION
# Document the changes in your pull request

Ghosts who observed round start cannot play non-admin spawned ghost roles, with exception to special spawners, like cyborg, AI, clockwork scarab, ashwalkers, etc. Admins are exempt from this in hopes that they won't abuse this.

Note that this only affects people who joined via the observe button. People who ghost in-game or used the cryogenic storage system can still role these roles. 

# Justification

The reasoning for this is that it makes it easier for admins to tell if someone is trying to game the system by observing round start just to get special ghost roles, which is legitimately a problem that people actually fully and openly admit to doing. To me, this is no different from trying to antag roll other roles like traitor.

This is also in place so that the impact of death is less bad considering you now have priority over fun ghost roles and you don't have to "compete" with people who observed just to fish for antag roles.

This is a bit of a nerf to nuke ops since you can't spawn reinforcements right off the bat and you actually have to kill someone. I'm sure that's fine though.

# Changelog

:cl:  BurgerBB
experimental: Ghosts who observed round start cannot play non-admin spawned ghost roles, with exception to spawners, like cyborg, AI, clockwork scarab, ashwalkers, etc. Admins are exempt from this in hopes that they won't abuse this.
/:cl:
