### PR TITLE
A few flavour texts for the drinks

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,3 +1,8 @@
+/datum/mood_event/ally_power
+	description= "<span class='nicegreen'>There are Allies everywhere.</span>\n"
+	mood_change = 1
+	timeout = 2 MINUTES
+
 /datum/mood_event/hug
 	description = "<span class='nicegreen'>Hugs are nice.</span>\n"
 	mood_change = 1
@@ -103,7 +108,7 @@
 	description = "<span class='nicegreen'>I have seen the truth, praise the almighty one!</span>\n"
 	mood_change = 40 //maybe being a cultist isnt that bad after all
 	hidden = TRUE
-	
+
 /datum/mood_event/changeling
 	description = "<span class='nicegreen'>No feeling supersedes our hunger.</span>\n" //if i could i'd just make them not get all those human feelings
 	mood_change = 40

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1151,7 +1151,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/M)
 	if(is_syndicate(M))
-		to_chat(M, span_notice("The Syndicate will always Win!"))
 		M.heal_overall_damage(0.5, 0.5)
 	if(prob(5))
 		playsound(get_turf(M), 'sound/effects/explosionfar.ogg', 100, 1)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1212,7 +1212,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink for the drunks."
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin/on_mob_life(mob/living/carbon/M)
-	if (M.drunkness > 10)
+	if(M.drunkenness > 20)
 		if(prop(30))
 			to_chat(M, span_notice("This pool water taste is too much"))
 			M.adjust_disgust(3)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -944,7 +944,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
 /datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/carbon/M)
-	to_chat(M. span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
+	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
 /datum/reagent/consumable/ethanol/singulo
@@ -1060,7 +1060,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink made from your allies."
 
 /datum/reagent/consumable/ethanol/alliescocktail/on_mob_life(mob/living/carbon/M)
-	SEND_SIGNAL(M. COMSIG_ADD_MOOD_EVENT "ally_power"))
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ally_power", name)
 	return ..()
 
 /datum/reagent/consumable/ethanol/acid_spit
@@ -2395,26 +2395,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "alexanderam"
 	glass_name = "Amaretto Alexander"
 	glass_desc = "A creamy, indulgent delight that is in fact as gentle as it seems."
-
-/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_metabolize(mob/living/L)
-	if(ishuman(L))
-		var/mob/living/carbon/human/thehuman = L
-		for(var/obj/item/shield/theshield in thehuman.contents)
-			mighty_shield = theshield
-			mighty_shield.block_chance += 2
-			to_chat(thehuman, span_notice("[theshield] looks a bit more shiny than usual, though you can't recall why"))
-			return TRUE
-
-/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_life(mob/living/L)
-	..()
-	if(mighty_shield && !(mighty_shield in L.contents)) //If you had a shield and lose it, you lose the reagent as well. Otherwise this is just a normal drink.
-		L.reagents.del_reagent(/datum/reagent/consumable/ethanol/alexander)
-
-/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_end_metabolize(mob/living/L)
-	if(mighty_shield)
-		mighty_shield.block_chance -= 10
-		to_chat(L,span_notice("You notice [mighty_shield] looks worn again? Maybe? Weird."))
-	..()
 
 /datum/reagent/consumable/ethanol/ginger_amaretto
 	name = "Ginger Amaretto"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -830,8 +830,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			stomach.adjust_charge(M.reagents.get_reagent_amount(/datum/reagent/consumable/ethanol/manhattan_proj) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
-/datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(isethereal(M))
 			to_chat(M, span_notice("Danger! Danger! High Voltage!! When we drink..."))
 	return ..()
@@ -949,8 +949,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Bahama Mama"
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
-/datum/reagent/consumable/ethanol/bahama_mama/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/bahama_mama/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
@@ -1043,8 +1043,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.adjustFireLoss(-2)
 	return ..()
 
-/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		to_chat(M, span_notice("You remember that Aloe heals burns, so drinking it surely would work too right?"))
 	return ..()
 
@@ -1070,8 +1070,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Allies cocktail"
 	glass_desc = "A drink made from your allies."
 
-/datum/reagent/consumable/ethanol/alliescocktail/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/alliescocktail/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ally_power", name)
 	return ..()
 
@@ -1091,8 +1091,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustFireLoss(-0.5)
 	return ..()
 
-/datum/reagent/consumable/ethanol/acid_spit/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/acid_spit/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(ispolysmorph(M))
 			to_chat(M, span_notice("Ah! The sweet taste of Acid to wash the burns away"))
 	return ..()
@@ -1157,8 +1157,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		playsound(get_turf(M), 'sound/effects/explosionfar.ogg', 100, 1)
 	return ..()
 
-/datum/reagent/consumable/ethanol/syndicatebomb/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/syndicatebomb/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(is_syndicate(M))
 			to_chat(M, span_notice("The Syndicate will always Win!"))
 	return ..()
@@ -1234,8 +1234,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Drunken Blumpkin"
 	glass_desc = "A drink for the drunks."
 
-/datum/reagent/consumable/ethanol/drunkenblumpkin/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/drunkenblumpkin/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(prob(30))
 			to_chat(M, span_notice("This pool water taste is too much"))
 			M.adjust_disgust(3)
@@ -1288,8 +1288,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 				step_towards(O, get_turf(M))
 	return ..()
 
-/datum/reagent/consumable/ethanol/fetching_fizz/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/fetching_fizz/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(ispreternis(M))
 			to_chat(M, span_notice("You know how it feels to be a magnet now"))
 	return ..()
@@ -1488,8 +1488,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustOxyLoss(-3)
 	return ..()
 
-/datum/reagent/consumable/ethanol/hippies_delight/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/hippies_delight/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(ispodperson(M))
 			to_chat(M, span_notice("Man... You're so high, it feels like you're healing..."))
 	return ..()
@@ -2585,8 +2585,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.adjustToxLoss(-2, 0)
 	return ..()
 
-/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(ismoth(M))
 			to_chat(M, span_notice("You never knew how tasty shrooms in a drink could be. Until now!"))
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -823,6 +823,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manhattan_proj/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(30)
 	if(isethereal(M))
+		to_chat(M, span_notice("Danger! Danger! High Voltage!! When we drink..."))
 		var/mob/living/carbon/C = M
 		var/obj/item/organ/stomach/ethereal/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
 		if(istype(stomach))
@@ -942,6 +943,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Bahama Mama"
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
+/datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/carbon/M)
+	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball...")
+	return ..()
+
 /datum/reagent/consumable/ethanol/singulo
 	name = "Singulo"
 	description = "A blue-space beverage!"
@@ -1027,6 +1032,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Aloe"
 	glass_desc = "Very, very, very good."
 
+/datum/reagent/consumable/ethanol/aloe/on_mob_life(mob/living/carbon/M)
+	M.adjustFireLoss(-2)
+	to_chat(M, span_notice("You remember that Aloe heals burns, so drinking it surely would work too right?"))
+	return ..()
+
 /datum/reagent/consumable/ethanol/andalusia
 	name = "Andalusia"
 	description = "A nice, strangely named drink."
@@ -1049,6 +1059,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Allies cocktail"
 	glass_desc = "A drink made from your allies."
 
+/datum/reagent/consumable/ethanol/alliescocktail/on_mob_life(mob/living/carbon/M)
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT "ally_power")
+	return ..()
+
 /datum/reagent/consumable/ethanol/acid_spit
 	name = "Acid Spit"
 	description = "A drink for the daring, can be deadly if incorrectly prepared!"
@@ -1062,6 +1076,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/acid_spit/on_mob_life(mob/living/carbon/M)
 	if(ispolysmorph(M))
+		to_chat(M, span_notice("Ah! The sweet taste of Acid to wash the burns away"))
 		M.adjustFireLoss(-0.5)
 	return ..()
 
@@ -1119,6 +1134,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/syndicatebomb/on_mob_life(mob/living/carbon/M)
 	if(is_syndicate(M))
+		to_chat(M, span_notice("The Syndicate will always Win!"))
 		M.heal_overall_damage(0.5, 0.5)
 	if(prob(5))
 		playsound(get_turf(M), 'sound/effects/explosionfar.ogg', 100, 1)
@@ -1189,11 +1205,18 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	description = "A weird mix of whiskey and blumpkin juice."
 	color = "#1EA0FF" // rgb: 102, 67, 0
 	boozepwr = 50
-	quality = DRINK_VERYGOOD
+	quality = DRINK_GOOD
 	taste_description = "molasses and a mouthful of pool water"
 	glass_icon_state = "drunkenblumpkin"
 	glass_name = "Drunken Blumpkin"
 	glass_desc = "A drink for the drunks."
+
+/datum/reagent/consumable/ethanol/drunkenblumpkin/on_mob_life(mob/living/carbon/M)
+	if (M.drunkness > 10)
+		if(prop(30))
+			to_chat(M, span_notice("This pool water taste is too much"))
+			M.adjust_disgust(4)
+	return ..()
 
 /datum/reagent/consumable/ethanol/whiskey_sour //Requested since we had whiskey cola and soda but not sour.
 	name = "Whiskey Sour"
@@ -1237,6 +1260,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		step_towards(O, get_turf(M))
 
 	if(ispreternis(M))
+		to_chat(M, span_notice("You know how it feels to be a magnet now"))
 		for(var/obj/O in orange(2,M))
 			if(!O.anchored && (O.flags_1 & CONDUCT_1))
 				step_towards(O, get_turf(M))
@@ -1428,8 +1452,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			if(prob(30))
 				M.adjustToxLoss(2, 0)
 				. = 1
-	
+
 	if(ispodperson(M))
+		to_chat(M, span_notice("Man... You're so high, it feels like you're healing..."))
 		M.adjustBruteLoss(-1)
 		M.adjustFireLoss(-1)
 		M.adjustToxLoss(-0.5)
@@ -2371,6 +2396,26 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Amaretto Alexander"
 	glass_desc = "A creamy, indulgent delight that is in fact as gentle as it seems."
 
+/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_metabolize(mob/living/L)
+	if(ishuman(L))
+		var/mob/living/carbon/human/thehuman = L
+		for(var/obj/item/shield/theshield in thehuman.contents)
+			mighty_shield = theshield
+			mighty_shield.block_chance += 2
+			to_chat(thehuman, span_notice("[theshield] looks a bit more shiny than usual, though you can't recall why"))
+			return TRUE
+
+/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_life(mob/living/L)
+	..()
+	if(mighty_shield && !(mighty_shield in L.contents)) //If you had a shield and lose it, you lose the reagent as well. Otherwise this is just a normal drink.
+		L.reagents.del_reagent(/datum/reagent/consumable/ethanol/alexander)
+
+/datum/reagent/consumable/ethanol/amaretto_alexander/on_mob_end_metabolize(mob/living/L)
+	if(mighty_shield)
+		mighty_shield.block_chance -= 10
+		to_chat(L,span_notice("You notice [mighty_shield] looks worn again? Maybe? Weird."))
+	..()
+
 /datum/reagent/consumable/ethanol/ginger_amaretto
 	name = "Ginger Amaretto"
 	description = "A delightfully simple cocktail that pleases the senses."
@@ -2524,6 +2569,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/mushi_kombucha/on_mob_life(mob/living/carbon/M)
 	if(ismoth(M))
+		to_chat(M, span_notice("You never knew how tasty shrooms in a drink could be. Until now!"))
 		M.adjustToxLoss(-2, 0)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1213,7 +1213,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin/on_mob_life(mob/living/carbon/M)
 	if(M.drunkenness > 20)
-		if(prop(30))
+		if(prob(30))
 			to_chat(M, span_notice("This pool water taste is too much"))
 			M.adjust_disgust(3)
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -944,7 +944,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
 /datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/carbon/M)
-	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball...")
+	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
 /datum/reagent/consumable/ethanol/singulo
@@ -1060,7 +1060,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink made from your allies."
 
 /datum/reagent/consumable/ethanol/alliescocktail/on_mob_life(mob/living/carbon/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT "ally_power")
+	SEND_SIGNAL(M. COMSIG_ADD_MOOD_EVENT "ally_power")
 	return ..()
 
 /datum/reagent/consumable/ethanol/acid_spit

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -831,7 +831,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(isethereal(M))
 			to_chat(M, span_notice("Danger! Danger! High Voltage!! When we drink..."))
 	return ..()
@@ -950,7 +950,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
 /datum/reagent/consumable/ethanol/bahama_mama/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
@@ -1044,7 +1044,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		to_chat(M, span_notice("You remember that Aloe heals burns, so drinking it surely would work too right?"))
 	return ..()
 
@@ -1071,7 +1071,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink made from your allies."
 
 /datum/reagent/consumable/ethanol/alliescocktail/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ally_power", name)
 	return ..()
 
@@ -1092,7 +1092,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/acid_spit/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(ispolysmorph(M))
 			to_chat(M, span_notice("Ah! The sweet taste of Acid to wash the burns away"))
 	return ..()
@@ -1158,7 +1158,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/syndicatebomb/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(is_syndicate(M))
 			to_chat(M, span_notice("The Syndicate will always Win!"))
 	return ..()
@@ -1235,7 +1235,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink for the drunks."
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(prob(30))
 			to_chat(M, span_notice("This pool water taste is too much"))
 			M.adjust_disgust(3)
@@ -1289,7 +1289,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/fetching_fizz/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(ispreternis(M))
 			to_chat(M, span_notice("You know how it feels to be a magnet now"))
 	return ..()
@@ -1489,7 +1489,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/hippies_delight/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(ispodperson(M))
 			to_chat(M, span_notice("Man... You're so high, it feels like you're healing..."))
 	return ..()
@@ -2586,7 +2586,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(ismoth(M))
 			to_chat(M, span_notice("You never knew how tasty shrooms in a drink could be. Until now!"))
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -944,7 +944,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
 /datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/carbon/M)
-	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
+	to_chat(M. span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
 /datum/reagent/consumable/ethanol/singulo
@@ -1060,7 +1060,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink made from your allies."
 
 /datum/reagent/consumable/ethanol/alliescocktail/on_mob_life(mob/living/carbon/M)
-	SEND_SIGNAL(M. COMSIG_ADD_MOOD_EVENT "ally_power")
+	SEND_SIGNAL(M. COMSIG_ADD_MOOD_EVENT "ally_power"))
 	return ..()
 
 /datum/reagent/consumable/ethanol/acid_spit

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1236,10 +1236,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/drunkenblumpkin/reaction_mob(mob/living/M, method=INGEST)
 	if(method != INGEST)
-		if(M.drunkenness > 20)
-			if(prob(30))
-				to_chat(M, span_notice("This pool water taste is too much"))
-				M.adjust_disgust(3)
+		if(prob(30))
+			to_chat(M, span_notice("This pool water taste is too much"))
+			M.adjust_disgust(3)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskey_sour //Requested since we had whiskey cola and soda but not sour.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1215,7 +1215,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if (M.drunkness > 10)
 		if(prop(30))
 			to_chat(M, span_notice("This pool water taste is too much"))
-			M.adjust_disgust(4)
+			M.adjust_disgust(3)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskey_sour //Requested since we had whiskey cola and soda but not sour.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -830,6 +830,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			stomach.adjust_charge(M.reagents.get_reagent_amount(/datum/reagent/consumable/ethanol/manhattan_proj) * REM * ETHEREAL_CHARGE_SCALING_MULTIPLIER)
 	return ..()
 
+/datum/reagent/consumable/ethanol/manhattan_proj/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(isethereal(M))
+			to_chat(M, span_notice("Danger! Danger! High Voltage!! When we drink..."))
+	return ..()
+
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
 	description = "For the more refined griffon."
@@ -943,8 +949,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Bahama Mama"
 	glass_desc = "A tropical cocktail with a complex blend of flavors."
 
-/datum/reagent/consumable/ethanol/bahama_mama/on_mob_life(mob/living/carbon/M)
-	to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
+/datum/reagent/consumable/ethanol/bahama_mama/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		to_chat(M, span_notice("Bro, you totally have the need to shred some waves and play some beachball..."))
 	return ..()
 
 /datum/reagent/consumable/ethanol/singulo
@@ -1034,7 +1041,11 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/aloe/on_mob_life(mob/living/carbon/M)
 	M.adjustFireLoss(-2)
-	to_chat(M, span_notice("You remember that Aloe heals burns, so drinking it surely would work too right?"))
+	return ..()
+
+/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		to_chat(M, span_notice("You remember that Aloe heals burns, so drinking it surely would work too right?"))
 	return ..()
 
 /datum/reagent/consumable/ethanol/andalusia
@@ -1059,8 +1070,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Allies cocktail"
 	glass_desc = "A drink made from your allies."
 
-/datum/reagent/consumable/ethanol/alliescocktail/on_mob_life(mob/living/carbon/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ally_power", name)
+/datum/reagent/consumable/ethanol/alliescocktail/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "ally_power", name)
 	return ..()
 
 /datum/reagent/consumable/ethanol/acid_spit
@@ -1076,8 +1088,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/acid_spit/on_mob_life(mob/living/carbon/M)
 	if(ispolysmorph(M))
-		to_chat(M, span_notice("Ah! The sweet taste of Acid to wash the burns away"))
 		M.adjustFireLoss(-0.5)
+	return ..()
+
+/datum/reagent/consumable/ethanol/acid_spit/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(ispolysmorph(M))
+			to_chat(M, span_notice("Ah! The sweet taste of Acid to wash the burns away"))
 	return ..()
 
 /datum/reagent/consumable/ethanol/amasec
@@ -1138,6 +1155,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.heal_overall_damage(0.5, 0.5)
 	if(prob(5))
 		playsound(get_turf(M), 'sound/effects/explosionfar.ogg', 100, 1)
+	return ..()
+
+/datum/reagent/consumable/ethanol/syndicatebomb/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(is_syndicate(M))
+			to_chat(M, span_notice("The Syndicate will always Win!"))
 	return ..()
 
 /datum/reagent/consumable/ethanol/erikasurprise
@@ -1211,11 +1234,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Drunken Blumpkin"
 	glass_desc = "A drink for the drunks."
 
-/datum/reagent/consumable/ethanol/drunkenblumpkin/on_mob_life(mob/living/carbon/M)
-	if(M.drunkenness > 20)
-		if(prob(30))
-			to_chat(M, span_notice("This pool water taste is too much"))
-			M.adjust_disgust(3)
+/datum/reagent/consumable/ethanol/drunkenblumpkin/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(M.drunkenness > 20)
+			if(prob(30))
+				to_chat(M, span_notice("This pool water taste is too much"))
+				M.adjust_disgust(3)
 	return ..()
 
 /datum/reagent/consumable/ethanol/whiskey_sour //Requested since we had whiskey cola and soda but not sour.
@@ -1260,10 +1284,15 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		step_towards(O, get_turf(M))
 
 	if(ispreternis(M))
-		to_chat(M, span_notice("You know how it feels to be a magnet now"))
 		for(var/obj/O in orange(2,M))
 			if(!O.anchored && (O.flags_1 & CONDUCT_1))
 				step_towards(O, get_turf(M))
+	return ..()
+
+/datum/reagent/consumable/ethanol/fetching_fizz/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(ispreternis(M))
+			to_chat(M, span_notice("You know how it feels to be a magnet now"))
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.
@@ -1454,11 +1483,16 @@ All effects don't start immediately, but rather get worse over time; the rate is
 				. = 1
 
 	if(ispodperson(M))
-		to_chat(M, span_notice("Man... You're so high, it feels like you're healing..."))
 		M.adjustBruteLoss(-1)
 		M.adjustFireLoss(-1)
 		M.adjustToxLoss(-0.5)
 		M.adjustOxyLoss(-3)
+	return ..()
+
+/datum/reagent/consumable/ethanol/hippies_delight/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(ispodperson(M))
+			to_chat(M, span_notice("Man... You're so high, it feels like you're healing..."))
 	return ..()
 
 /datum/reagent/consumable/ethanol/eggnog
@@ -2549,8 +2583,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/mushi_kombucha/on_mob_life(mob/living/carbon/M)
 	if(ismoth(M))
-		to_chat(M, span_notice("You never knew how tasty shrooms in a drink could be. Until now!"))
 		M.adjustToxLoss(-2, 0)
+	return ..()
+
+/datum/reagent/consumable/ethanol/mushi_kombucha/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(ismoth(M))
+			to_chat(M, span_notice("You never knew how tasty shrooms in a drink could be. Until now!"))
 	return ..()
 
 /datum/reagent/consumable/ethanol/triumphal_arch

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -787,8 +787,8 @@
 	..()
 	. = TRUE
 
-/datum/reagent/consumable/chocolate/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/chocolate/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()
@@ -810,8 +810,8 @@
 	..()
 	. = TRUE
 
-/datum/reagent/consumable/vanillapudding/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/vanillapudding/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()
@@ -834,8 +834,8 @@
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
 
-/datum/reagent/consumable/cherryshake/reaction_mob(mob/living/C, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/cherryshake/reaction_mob(mob/living/C, method=TOUCH)
+	if(method = INGEST)
 		if(isjellyperson(C))
 			to_chat(C, span_notice("Just like us, just like jelly!"))
 	return ..()
@@ -857,8 +857,8 @@
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
 
-/datum/reagent/consumable/bluecherryshake/reaction_mob(mob/living/C, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/bluecherryshake/reaction_mob(mob/living/C, method=TOUCH)
+	if(method = INGEST)
 		if(isjellyperson(C))
 			to_chat(C, span_notice("Just like us, just like jelly!"))
 	return ..()
@@ -1091,8 +1091,8 @@
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2.5*REM)
 	..()
 
-/datum/reagent/consumable/mushroom_tea/reaction_mob(mob/living/M, method=INGEST)
-	if(method != INGEST)
+/datum/reagent/consumable/mushroom_tea/reaction_mob(mob/living/M, method=TOUCH)
+	if(method = INGEST)
 		if(islizard(M))
 			to_chat(M, span_notice("The most important thing to a Lizard is their brains.... Probably"))
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -788,7 +788,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/chocolate/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST
+	if(method == INGEST
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()
@@ -811,7 +811,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/vanillapudding/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST
+	if(method == INGEST
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()
@@ -835,7 +835,7 @@
 	..()
 
 /datum/reagent/consumable/cherryshake/reaction_mob(mob/living/C, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(isjellyperson(C))
 			to_chat(C, span_notice("Just like us, just like jelly!"))
 	return ..()
@@ -858,7 +858,7 @@
 	..()
 
 /datum/reagent/consumable/bluecherryshake/reaction_mob(mob/living/C, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(isjellyperson(C))
 			to_chat(C, span_notice("Just like us, just like jelly!"))
 	return ..()
@@ -1092,7 +1092,7 @@
 	..()
 
 /datum/reagent/consumable/mushroom_tea/reaction_mob(mob/living/M, method=TOUCH)
-	if(method = INGEST)
+	if(method == INGEST)
 		if(islizard(M))
 			to_chat(M, span_notice("The most important thing to a Lizard is their brains.... Probably"))
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -811,7 +811,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/vanillapudding/reaction_mob(mob/living/M, method=TOUCH)
-	if(method == INGEST
+	if(method == INGEST)
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -783,6 +783,7 @@
 
 /datum/reagent/consumable/chocolate/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+		to_chat(M, span_notice("This is like Milk, but better!?"))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
 	. = TRUE
@@ -800,6 +801,7 @@
 
 /datum/reagent/consumable/vanillapudding/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+		to_chat(M, span_notice("This is like Milk, but better!?"))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
 	. = TRUE
@@ -817,6 +819,7 @@
 
 /datum/reagent/consumable/cherryshake/on_mob_life(mob/living/carbon/C)
 	if(isjellyperson(C))
+		to_chat(C, span_notice("Just like us, just like jelly!"))
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
@@ -834,6 +837,7 @@
 
 /datum/reagent/consumable/bluecherryshake/on_mob_life(mob/living/carbon/C)
 	if(isjellyperson(C))
+		to_chat(C, span_notice("Just like us, just like jelly!"))
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
@@ -1063,5 +1067,6 @@
 
 /datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/C)
 	if(islizard(C))
+		to_chat(C, span_notice("The most important thing to a Lizard is their brains.... Probably"))
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2.5*REM)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -783,10 +783,15 @@
 
 /datum/reagent/consumable/chocolate/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
-		to_chat(M, span_notice("This is like Milk, but better!?"))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
 	. = TRUE
+
+/datum/reagent/consumable/chocolate/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+			to_chat(M, span_notice("This is like Milk, but better!?"))
+	return ..()
 
 /datum/reagent/consumable/vanillapudding
 	name = "Vanilla Pudding"
@@ -801,10 +806,15 @@
 
 /datum/reagent/consumable/vanillapudding/on_mob_life(mob/living/carbon/M)
 	if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
-		to_chat(M, span_notice("This is like Milk, but better!?"))
 		M.heal_bodypart_damage(2.0,0, 0)
 	..()
 	. = TRUE
+
+/datum/reagent/consumable/vanillapudding/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
+			to_chat(M, span_notice("This is like Milk, but better!?"))
+	return ..()
 
 /datum/reagent/consumable/cherryshake
 	name = "Cherry Shake"
@@ -824,6 +834,12 @@
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
 
+/datum/reagent/consumable/cherryshake/reaction_mob(mob/living/C, method=INGEST)
+	if(method != INGEST)
+		if(isjellyperson(C))
+			to_chat(C, span_notice("Just like us, just like jelly!"))
+	return ..()
+
 /datum/reagent/consumable/bluecherryshake
 	name = "Blue Cherry Shake"
 	description = "An exotic milkshake."
@@ -837,10 +853,15 @@
 
 /datum/reagent/consumable/bluecherryshake/on_mob_life(mob/living/carbon/C)
 	if(isjellyperson(C))
-		to_chat(C, span_notice("Just like us, just like jelly!"))
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL(C))
 			C.blood_volume = min(BLOOD_VOLUME_NORMAL(C), C.blood_volume + 4.0)
 	..()
+
+/datum/reagent/consumable/bluecherryshake/reaction_mob(mob/living/C, method=INGEST)
+	if(method != INGEST)
+		if(isjellyperson(C))
+			to_chat(C, span_notice("Just like us, just like jelly!"))
+	return ..()
 
 /datum/reagent/consumable/pumpkin_latte
 	name = "Pumpkin Latte"
@@ -1067,6 +1088,11 @@
 
 /datum/reagent/consumable/mushroom_tea/on_mob_life(mob/living/carbon/C)
 	if(islizard(C))
-		to_chat(C, span_notice("The most important thing to a Lizard is their brains.... Probably"))
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2.5*REM)
 	..()
+
+/datum/reagent/consumable/mushroom_tea/reaction_mob(mob/living/M, method=INGEST)
+	if(method != INGEST)
+		if(islizard(M))
+			to_chat(M, span_notice("The most important thing to a Lizard is their brains.... Probably"))
+	return ..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -788,7 +788,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/chocolate/reaction_mob(mob/living/M, method=TOUCH)
-	if(method == INGEST
+	if(method == INGEST)
 		if(HAS_TRAIT(M, TRAIT_CALCIUM_HEALER))
 			to_chat(M, span_notice("This is like Milk, but better!?"))
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

These just adds texts to the species drinks I released previously, adds a few additions to some drinks and a mood drink. This is what has been added below:
 
Syndicate bomb- Text "The Syndicate will always Win!"

Acid spit - Text "Ah! The sweet taste of Acid to wash the burns away!"

Drunken Blumpkin - Percentage to give digust with the prompt "This pool water taste is too much"

Positive event- Ally_power + 1, "There are Allies everywhere"

Allies cocktail - Gives mood buff Ally power (Added positive mood event for Ally power with prompt "There are allies everywhere!")

Blue/Cherry shake- Text prompt "Just like us, just like jelly"

Vanilia/Chocolate pudding- Text prompt "This is like Milk but better!?"

Hippie's Delight- Text prompt "Man... You're so high, it feels like you're healing"

Manhattan Project - Text prompt "Danger! Danger! HIGH VOLTAGE! When we drink..."

Fetching fizz- Text prompt "You know how it feels to be a magnet now"

Mushroom tea - Text prompt " The most important thing to a Lizard is their brains... Probably"

Mushi Kombucha - Text prompt - "You never knew how tasty shrooms in a drink could be. Until now"

Aloe- Added heals burn damage and text prompt "You remember that Aloe heals burns, so drinking it surely would work too right?"

Bahama mama - Text prompt - "Bro you totally have the need to shred some waves and play some beachball..."

# Wiki Documentation
Aloe- Heals burn damage
Allies cocktail- Provides mood buff
Amaretto Alexander- Provides a poorer block chance because it is inferior
Drunken Blumpkin- Has a chance to make player disgusted

# Changelog

:cl:  
rscadd: Text updates to some of the drinks  
rscadd: Aloe now heals
rscadd: Allies cocktail gives mood buff
rscadd: Drunken Blumpkin has a chance to give disgust

/:cl:
