### PR TITLE
Using a holoparasite injector now has a 75% chance to create a randomly placed single-use stand arrow on the station that anyone can use.

### DIFF
--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -10,8 +10,9 @@
 	var/used = FALSE
 	var/allow_special = FALSE
 	var/debug_mode = FALSE
+	var/create_arrow = FALSE
 
-/datum/guardianbuilder/New(mob_name, theme, failure_message, max_points, allow_special, debug_mode)
+/datum/guardianbuilder/New(mob_name, theme, failure_message, max_points, allow_special, debug_mode, create_arrow)
 	..()
 	if (mob_name)
 		src.mob_name = mob_name
@@ -23,6 +24,7 @@
 		src.max_points = max_points
 	src.allow_special = allow_special
 	src.debug_mode = debug_mode
+	src.create_arrow = create_arrow
 
 /datum/guardianbuilder/ui_state(mob/user)
 	return GLOB.always_state
@@ -226,12 +228,13 @@
 				G.Destroy()
 				return FALSE
 		if(create_arrow)
-			var/turf/desired_turf = find_safe_turf()
-			if(desired_turf)
-				var/obj/item/stand_arrow/SA = new(desired_turf)
-				SA.uses = 1
-				notify_ghosts("A new [SA] was created from \a [src]!",source=SA)
-				message_admins(span_adminnotice("[key_name_admin(user)] used \a [src] that spawned a new [SA] at [AREACOORD(SA)]."))
+			if(prob(75))
+				var/turf/desired_turf = find_safe_turf()
+				if(desired_turf)
+					var/obj/item/stand_arrow/SA = new(desired_turf)
+					SA.uses = 1
+					notify_ghosts("A new [SA] was created from \a [src]!",source=SA)
+					message_admins(span_adminnotice("[key_name_admin(user)] used \a [src] that spawned a new [SA] at [AREACOORD(SA)]."))
 			create_arrow = FALSE //Just in case.
 
 		return TRUE
@@ -264,7 +267,7 @@
 
 /obj/item/guardiancreator/Initialize()
 	. = ..()
-	builder = new(mob_name, theme, failure_message, max_points, allowspecial, debug_mode)
+	builder = new(mob_name, theme, failure_message, max_points, allowspecial, debug_mode, create_arrow)
 
 /obj/item/guardiancreator/ComponentInitialize()
 	. = ..()

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -225,6 +225,13 @@
 				used = TRUE
 				G.Destroy()
 				return FALSE
+		if(create_arrow)
+			var/turf/desired_turf = find_safe_turf()
+			if(desired_turf)
+				var/obj/item/stand_arrow/SA = new(desired_turf)
+				SA.uses = 1
+			create_arrow = FALSE //Just in case.
+
 		return TRUE
 	else
 		to_chat(user, "[failure_message]")
@@ -251,6 +258,7 @@
 	var/max_points = 15
 	var/allowspecial = FALSE
 	var/debug_mode = FALSE
+	var/create_arrow = FALSE
 
 /obj/item/guardiancreator/Initialize()
 	. = ..()
@@ -259,7 +267,7 @@
 /obj/item/guardiancreator/ComponentInitialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_REFUND, .proc/refund_check)
-	
+
 /obj/item/guardiancreator/proc/refund_check()
 	return !builder.used
 

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -230,6 +230,8 @@
 			if(desired_turf)
 				var/obj/item/stand_arrow/SA = new(desired_turf)
 				SA.uses = 1
+				notify_ghosts("A new [SA] was created from \a [src]!",source=SA)
+				message_admins(span_adminnotice("[key_name_admin(user)] used \a [src] that spawned a new [SA] at [AREACOORD(SA)]."))
 			create_arrow = FALSE //Just in case.
 
 		return TRUE
@@ -347,7 +349,7 @@
 
 /obj/item/guardiancreator/tech
 	name = "holoparasite injector"
-	desc = "It contains an alien nanoswarm of unknown origin. Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, it requires an organic host as a home base and source of fuel."
+	desc = "It contains an alien nanoswarm of unknown origin. Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, it requires an organic host as a home base and source of fuel. Notice: The syndicate is not responsible for any shenanigans involving strange stand-related artifacts appearing in the local area due to messing around with the power of universe."
 	icon = 'icons/obj/syringe.dmi'
 	icon_state = "old_combat_hypo"
 	theme = "tech"


### PR DESCRIPTION
# Document the changes in your pull request

Using a holoparasite injector now has a 75% chance to create a randomly placed single-use stand arrow on the station that anyone can use.

# Justification

Traitor buff because you can use the stand arrow to requiem, and the traitor will know that an arrow spawned before anyone else.
Traitor nerf because it means that a non-crew can actually have a stand that can fight you.
Observer buff because it means that someone can be a stand.
Everyone buff because it is entirely entertaining to watch two stands fight eachother.
Gambling addiction nerf because the arrow has a 50% chance to dust you on use.


# Wiki Documentation

https://wiki.yogstation.net/wiki/Holoparasite
https://wiki.yogstation.net/wiki/Syndicate_Items

# Changelog

:cl: BurgerBB
rscadd: Using a holoparasite injector now has a 75% chance to create a randomly placed single-use stand arrow on the station that anyone can use.
/:cl:
