### PR TITLE
tweaks IPC viruses (system cleaner and immunity redux pt2 FINAL (probably))

### DIFF
--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -32,7 +32,7 @@ Bonus
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",
 	)
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -32,6 +32,8 @@ Bonus
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",
 	)
+	affectrobot = TRUE
+
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -121,6 +121,7 @@ Bonus
 		"Stage Speed 8" = "Increases explosion radius and explosion damage to the host when the host is wet.",
 		"Transmission 8" = "Additionally synthesizes chlorine trifluoride and napalm inside the host. More chemicals are synthesized if the resistance 9 threshold has been met."
 	)
+	affectrobot = TRUE //is funny
 
 /datum/symptom/alkali/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -121,7 +121,7 @@ Bonus
 		"Stage Speed 8" = "Increases explosion radius and explosion damage to the host when the host is wet.",
 		"Transmission 8" = "Additionally synthesizes chlorine trifluoride and napalm inside the host. More chemicals are synthesized if the resistance 9 threshold has been met."
 	)
-	affectrobot = TRUE //is funny
+	process_flags = ORGANIC | SYNTHETIC //is funny
 
 /datum/symptom/alkali/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -32,7 +32,7 @@ Bonus
 		"Stage Speed 7" = "Increases the amount of hallucinations.",
 		"Stealth 4" = "The virus mimics positive symptoms.",
 	)
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -32,6 +32,7 @@ Bonus
 		"Stage Speed 7" = "Increases the amount of hallucinations.",
 		"Stealth 4" = "The virus mimics positive symptoms.",
 	)
+	affectrobot = TRUE
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -380,6 +380,7 @@
 		"Transmission 6" = "Increases temperature adjustment rate.",
 		"Stage Speed 7" = "Increases healing speed.",
 	)
+	affectrobot = TRUE //only really for temp stabilize
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -380,7 +380,7 @@
 		"Transmission 6" = "Increases temperature adjustment rate.",
 		"Stage Speed 7" = "Increases healing speed.",
 	)
-	affectrobot = TRUE //only really for temp stabilize
+	process_flags = ORGANIC | SYNTHETIC //only really for temp stabilize
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/nanites.dm
+++ b/code/datums/diseases/advance/symptoms/nanites.dm
@@ -14,7 +14,7 @@
 		"Transmission 5" = "Increases the virus' growth rate while nanites are present.",
 		"Stage Speed 7" = "Increases the replication boost."
 	)
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/nano_boost/Start(datum/disease/advance/A)
 	. = ..()
@@ -51,7 +51,7 @@
 		"Stage Speed 5" = "Increases the virus' growth rate while nanites are present.",
 		"Resistance 7" = "Severely increases the rate at which the nanites are destroyed."
 	)
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/nano_destroy/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/nanites.dm
+++ b/code/datums/diseases/advance/symptoms/nanites.dm
@@ -14,6 +14,7 @@
 		"Transmission 5" = "Increases the virus' growth rate while nanites are present.",
 		"Stage Speed 7" = "Increases the replication boost."
 	)
+	affectrobot = TRUE
 
 /datum/symptom/nano_boost/Start(datum/disease/advance/A)
 	. = ..()
@@ -50,6 +51,7 @@
 		"Stage Speed 5" = "Increases the virus' growth rate while nanites are present.",
 		"Resistance 7" = "Severely increases the rate at which the nanites are destroyed."
 	)
+	affectrobot = TRUE
 
 /datum/symptom/nano_destroy/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -21,6 +21,7 @@
 	var/list/cached_tentacle_turfs
 	var/turf/last_location
 	var/tentacle_recheck_cooldown = 100
+	affectrobot = TRUE
 
 /datum/symptom/necroseed/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -21,7 +21,7 @@
 	var/list/cached_tentacle_turfs
 	var/turf/last_location
 	var/tentacle_recheck_cooldown = 100
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/necroseed/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -15,6 +15,7 @@
 		"Transmission 12" = "Makes the host irradiate others around them as well.",
 		"Stage Speed 8" = "Host takes radiation damage faster."
 	)
+	affectrobot = TRUE
 
 /datum/symptom/radiation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -15,7 +15,7 @@
 		"Transmission 12" = "Makes the host irradiate others around them as well.",
 		"Stage Speed 8" = "Host takes radiation damage faster."
 	)
-	affectrobot = TRUE
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/radiation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -24,7 +24,7 @@
 	transmittable = 3
 	level = 5
 	severity = 0
-	affectrobot = TRUE //i don't think this needs to be here, but just in case
+	process_flags = ORGANIC | SYNTHETIC //i don't think this needs to be here, but just in case
 
 /datum/symptom/inorganic_adaptation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -24,6 +24,7 @@
 	transmittable = 3
 	level = 5
 	severity = 0
+	affectrobot = TRUE //i don't think this needs to be here, but just in case
 
 /datum/symptom/inorganic_adaptation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -55,13 +55,16 @@
 /datum/symptom/proc/Activate(datum/disease/advance/A)
 	if(neutered)
 		return FALSE
-	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_SYNTHETIC && !(process_flags & SYNTHETIC))//some symptoms don't affect synthetic mobs
-		return FALSE
-	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_ORGANIC && !(process_flags & ORGANIC))//some symptoms don't affect organic mobs
-		return FALSE
 	if(world.time < next_activation)
 		return FALSE
-	else
+
+	var/can_process = FALSE
+	if(!can_process && A.affected_mob?.dna?.species?.reagent_tag & PROCESS_SYNTHETIC && (process_flags & SYNTHETIC))//some symptoms don't affect synthetic mobs
+		can_process = TRUE
+	if(!can_process && A.affected_mob?.dna?.species?.reagent_tag & PROCESS_ORGANIC && (process_flags & ORGANIC))//some symptoms don't affect organic mobs
+		can_process = TRUE
+		
+	if(can_process)
 		next_activation = world.time + rand(symptom_delay_min * 10, symptom_delay_max * 10)
 		return TRUE
 

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -29,7 +29,7 @@
 	var/neutered = FALSE
 	var/list/thresholds
 	var/naturally_occuring = TRUE //if this symptom can appear from /datum/disease/advance/GenerateSymptoms()
-	var/affectrobot = FALSE //some symptoms don't affect robotic mobs
+	var/process_flags = ORGANIC //some symptoms don't affect robotic mobs
 
 /datum/symptom/New()
 	var/list/S = SSdisease.list_symptoms
@@ -55,7 +55,9 @@
 /datum/symptom/proc/Activate(datum/disease/advance/A)
 	if(neutered)
 		return FALSE
-	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_SYNTHETIC && !affectrobot)//some symptoms don't affect synthetic mobs
+	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_SYNTHETIC && !(process_flags & SYNTHETIC))//some symptoms don't affect synthetic mobs
+		return FALSE
+	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_ORGANIC && !(process_flags & ORGANIC))//some symptoms don't affect organic mobs
 		return FALSE
 	if(world.time < next_activation)
 		return FALSE

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -29,6 +29,7 @@
 	var/neutered = FALSE
 	var/list/thresholds
 	var/naturally_occuring = TRUE //if this symptom can appear from /datum/disease/advance/GenerateSymptoms()
+	var/affectrobot = FALSE //some symptoms don't affect robotic mobs
 
 /datum/symptom/New()
 	var/list/S = SSdisease.list_symptoms
@@ -53,6 +54,8 @@
 
 /datum/symptom/proc/Activate(datum/disease/advance/A)
 	if(neutered)
+		return FALSE
+	if(A.affected_mob?.dna?.species?.reagent_tag & PROCESS_SYNTHETIC && !affectrobot)//some symptoms don't affect synthetic mobs
 		return FALSE
 	if(world.time < next_activation)
 		return FALSE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -449,7 +449,7 @@
 	process_flags = SYNTHETIC
 
 /datum/reagent/medicine/system_cleaner/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	for(var/thing in M.diseases)//lets it cure viruses from IPC
+	for(var/thing in L.diseases)//lets it cure viruses from IPC
 		var/datum/disease/D = thing
 		D.cure()
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -448,6 +448,11 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	process_flags = SYNTHETIC
 
+/datum/reagent/medicine/system_cleaner/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+	for(var/thing in M.diseases)//lets it cure viruses from IPC
+		var/datum/disease/D = thing
+		D.cure()
+
 /datum/reagent/medicine/system_cleaner/on_mob_life(mob/living/M)
 	M.adjustToxLoss(-2*REM, 0)
 	. = 1

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -100,7 +100,6 @@
 	name = "Vaccine"
 	color = "#C81040" // rgb: 200, 16, 64
 	taste_description = "slime"
-	process_flags = ORGANIC | SYNTHETIC
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
 	if(islist(data) && ((method == INGEST && reac_volume >= 5) || method == INJECT))//drinking it requires at least 5u, injection doesn't


### PR DESCRIPTION
reverts #18452 (it's been over 48 hours since the merge, please don't close this bibby)


Vaccines no longer work on IPC because, why would they
Lets system cleaner instead be used to remove viruses (gives it a purpose more so than just for the 10% chance for toxin damage from emp)
Makes them ignore most virus symptoms that would make little sense for them to be affected by

this has better flavour since most symptoms mention targetting a specific organ in the body
lets IPC act mostly as virus carriers since most viruses target organic processes

This restores one of IPC's main identity of being nigh completely virus resistant, while not entirely ignoring the system like they did before

works using the same flag system as reagents do

:cl:  
tweak: Vaccines no longer work on IPCs
tweak: IPC can purge viruses with system cleaner
tweak: most virus symptoms no long affect mobs with synthetic chemical processing 
/:cl:
