### PR TITLE
Preternis mutation toxin (atomized edition)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -602,6 +602,13 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/ethereal
 	mutationtext = span_danger("The pain subsides. You feel... ecstatic.")
+	
+/datum/reagent/mutationtoxin/preternis
+	name = "Preternis Mutation Toxin"
+	description = "A metallic precursor toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/preternis
+	mutationtext = span_danger("The pain subsides. You feel... optimized.")
 
 /datum/reagent/mutationtoxin/polysmorph
 	name = "Polysmorph Mutation Toxin"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -88,6 +88,14 @@
 	required_reagents = list(/datum/reagent/lithium = 1) //battery material makes electricity people
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
+	
+/datum/chemical_reaction/slime/slimepreternis
+	name = "Preternis Mutation Toxin"
+	id = "preternismuttoxin"
+	results = list(/datum/reagent/mutationtoxin/preternis = 1)
+	required_reagents = list(/datum/reagent/stable_plasma = 1)
+	required_other = TRUE
+	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slime/slimemoth
 	name = "Moth Mutation Toxin"


### PR DESCRIPTION
every other roundstart species has them

also, IPC mutation toxin was competing with another PR, so i've atomized it because preternis mut toxin should be added regardless

:cl:  
rscadd: Preternis mutation toxin
/:cl:
