### PR TITLE
Fixes spacepods only updating every 10 ticks

### DIFF
--- a/yogstation/code/modules/spacepods/physics.dm
+++ b/yogstation/code/modules/spacepods/physics.dm
@@ -1,5 +1,4 @@
 /obj/spacepod/process(time)
-	time /= 10 // fuck off with your deciseconds // uh oh
 
 	if(world.time > last_slowprocess + 15)
 		last_slowprocess = world.time


### PR DESCRIPTION
# Document the changes in your pull request
There was a line of code in the spacepod physics that divided a "time" variable by 10, explicitly causing the spacepod to wait at least 10 ticks between each period of it updating its position, angle, or momentum. Deleting this one line makes the pod operate at the speed expected.

# Changelog
🆑
bugfix: spacepods no longer operate 10 times slower than intended
/🆑