### PR TITLE
Increase bluespace activity maximum throw range to 3 tiles

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -316,7 +316,7 @@
 
 /datum/plant_gene/trait/teleport/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()
-	G.throw_range = min(G.throw_range, 2)
+	G.throw_range = min(G.throw_range, 3)
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

2 tiles is almost melee range, 3 tiles should be a "thrown" weapon without being able to effectively outrange an actual gun/thrown weapon

This is just under half the default 15x15 view range

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: bluespace activity maximum throw range now 3 from 2
/:cl:
