### PR TITLE
Lets preterni eat ores

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -20,6 +20,7 @@
 	var/refined_type = null //What this ore defaults to being refined into
 	novariants = TRUE // Ore stacks handle their icon updates themselves to keep the illusion that there's more going
 	var/list/stack_overlays
+	var/edible = FALSE //can a preternis eat it for some funny effect?
 
 /obj/item/stack/ore/update_icon()
 	var/difference = min(ORESTACK_OVERLAYS_MAX, amount) - (LAZYLEN(stack_overlays)+1)
@@ -65,6 +66,20 @@
 			new refined_type(drop_location(),amountrefined)
 			qdel(src)
 
+/obj/item/stack/ore/attack(mob/living/M, mob/living/user)
+	if(edible && M == user && ispreternis(user))
+		var/mob/living/carbon/human/H = user
+		H.visible_message("[H] takes a bite of [src], crunching happily.", "You take a bite of [src], minerals do a body good.")
+		playsound(H, 'sound/items/eatfood.ogg', 50, 1)
+		use(1)//only eat one at a time
+		eaten(H)
+		return
+	. = ..()
+	
+
+/obj/item/stack/ore/proc/eaten(mob/living/carbon/human/H)//override to give certain ores effects when eaten
+	return
+
 /obj/item/stack/ore/uranium
 	name = "uranium ore"
 	icon_state = "Uranium ore"
@@ -82,6 +97,10 @@
 	points = 1
 	materials = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/metal
+	edible = TRUE
+
+/obj/item/stack/ore/iron/eaten(mob/living/carbon/human/H)
+	H.heal_overall_damage(2, 0, 0, BODYPART_ANY)
 
 /obj/item/stack/ore/glass
 	name = "sand pile"
@@ -133,6 +152,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	points = 15
 	materials = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/plasma
+	edible = TRUE
+
+/obj/item/stack/ore/plasma/eaten(mob/living/carbon/human/H)
+	H.heal_overall_damage(0, 2, 0, BODYPART_ANY)
 
 /obj/item/stack/ore/plasma/welder_act(mob/living/user, obj/item/I)
 	to_chat(user, span_warning("You can't hit a high enough temperature to smelt [src] properly!"))

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -67,14 +67,21 @@
 			qdel(src)
 
 /obj/item/stack/ore/attack(mob/living/M, mob/living/user)
-	if(edible && M == user && ispreternis(user))
-		var/mob/living/carbon/human/H = user
-		H.visible_message("[H] takes a bite of [src], crunching happily.", "You take a bite of [src], minerals do a body good.")
-		playsound(H, 'sound/items/eatfood.ogg', 50, 1)
-		use(1)//only eat one at a time
-		eaten(H)
-		return
-	. = ..()
+	if(!edible || user.a_intent == INTENT_HARM)
+		return ..()
+	
+	if(M != user || !ispreternis(user))
+		return ..()
+
+	var/mob/living/carbon/human/H = user
+	H.visible_message("[H] takes a bite of [src], crunching happily.", "You take a bite of [src], minerals do a body good.")
+	playsound(H, 'sound/items/eatfood.ogg', 50, 1)
+	
+	if(HAS_TRAIT(H, TRAIT_VORACIOUS))//I'M VERY HONGRY
+		H.changeNext_move(CLICK_CD_MELEE * 0.5)
+
+	use(1)//only eat one at a time
+	eaten(H)
 	
 
 /obj/item/stack/ore/proc/eaten(mob/living/carbon/human/H)//override to give certain ores effects when eaten

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -109,7 +109,7 @@
 	edible = TRUE
 
 /obj/item/stack/ore/iron/eaten(mob/living/carbon/human/H)
-	H.heal_overall_damage(2, 0, 0, BODYPART_ANY)
+	H.heal_overall_damage(2, 0, 0, BODYPART_ROBOTIC)
 
 /obj/item/stack/ore/glass
 	name = "sand pile"
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	edible = TRUE
 
 /obj/item/stack/ore/plasma/eaten(mob/living/carbon/human/H)
-	H.heal_overall_damage(0, 2, 0, BODYPART_ANY)
+	H.heal_overall_damage(0, 2, 0, BODYPART_ROBOTIC)
 
 /obj/item/stack/ore/plasma/welder_act(mob/living/user, obj/item/I)
 	to_chat(user, span_warning("You can't hit a high enough temperature to smelt [src] properly!"))

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -67,13 +67,15 @@
 			qdel(src)
 
 /obj/item/stack/ore/attack(mob/living/M, mob/living/user)
-	if(!edible || user.a_intent == INTENT_HARM)
+	if(!edible || user.a_intent == INTENT_HARM || M != user || !ishuman(user))
 		return ..()
 	
-	if(M != user || !ispreternis(user))
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/stomach/S = H.getorganslot(ORGAN_SLOT_STOMACH)
+
+	if(!istype(S, /obj/item/organ/stomach/preternis))//need a fancy stomach for it
 		return ..()
 
-	var/mob/living/carbon/human/H = user
 	H.visible_message("[H] takes a bite of [src], crunching happily.", "You take a bite of [src], minerals do a body good.")
 	playsound(H, 'sound/items/eatfood.ogg', 50, 1)
 	

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -96,3 +96,21 @@
 	heat_level_2_damage = 7
 	heat_level_3_threshold = 35000 //are you on the fucking surface of the sun or something?
 	heat_level_3_damage = 25 //you should already be dead
+
+/obj/item/organ/stomach/preternis
+	name = "preternis stomach"
+	desc = "Calling it a stomach is perhaps a bit generous. It's better at grinding rocks than dissolving food."
+	icon_state = "stomach-c"
+	status = ORGAN_ROBOTIC
+	organ_flags = ORGAN_SYNTHETIC
+
+/obj/item/organ/stomach/preternis/on_life()
+	. = ..()
+	var/datum/reagent/nutri = locate(/datum/reagent/consumable/nutriment) in owner.reagents.reagent_list
+	if(nutri)
+		owner.reagents.remove_reagent(/datum/reagent/consumable/nutriment, 1) //worse for actually eating (not that it matters for preterni)
+
+/obj/item/organ/stomach/preternis/emp_act(severity)
+	owner.vomit()
+	owner.adjust_disgust(20)
+	to_chat(owner, "<span class='warning'>You feel violently ill as the EMP causes your stomach to kick into high gear.</span>")

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -352,7 +352,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 		list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "cookie-bite",
-			SPECIES_PERK_NAME = "Meal Plan",
+			SPECIES_PERK_NAME = "Stone eater",
 			SPECIES_PERK_DESC = "Preterni can eat ores to replenish their metal skin. All ores are not created equal.",
 		),
 		list(

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -39,6 +39,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	//mutant_bodyparts = list("head", "body_markings")
 	mutanteyes = /obj/item/organ/eyes/robotic/preternis
 	mutantlungs = /obj/item/organ/lungs/preternis
+	mutantstomach = /obj/item/organ/stomach/preternis
 	yogs_virus_infect_chance = 20
 	virus_resistance_boost = 10 //YEOUTCH,good luck getting it out
 	special_step_sounds = list('sound/effects/footstep/catwalk1.ogg', 'sound/effects/footstep/catwalk2.ogg', 'sound/effects/footstep/catwalk3.ogg', 'sound/effects/footstep/catwalk4.ogg')

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -350,6 +350,12 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	to_add += list(
 		list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+			SPECIES_PERK_ICON = "cookie-bite",
+			SPECIES_PERK_NAME = "Meal Plan",
+			SPECIES_PERK_DESC = "Preterni can eat ores to replenish their metal skin. All ores are not created equal.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
 			SPECIES_PERK_ICON = "thunderstorm", //if we update font awesome, please swap to bolt-slash
 			SPECIES_PERK_NAME = "Faraday \"Skin\"",
 			SPECIES_PERK_DESC = "Being incased in plasteel rather than standard metal allows Preterni to be completely unaffected by EMPs.",


### PR DESCRIPTION
More flavour for the species, they're growing metal plates as skin, how are they getting the metal?
Can't eat sheet metal (to hard for their teef) (also, haven't made the metal cocktail drink yet, that can come later)

currently just iron (heals 2 brute)
and plasma (heals 2 burn)

can be expanded to include other ores with funny effects in the future

:cl:  
rscadd: Preterni get a special stomach
rscadd: Preternis stomach lets people eat iron and plasma ore to heal for very small amounts
/:cl:
