### PR TITLE
nerfs nitrium D:

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1309,6 +1309,8 @@
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2 * REM, FALSE)
+	M.adjustToxLoss(1 * REM,FALSE)
+	M.Jitter(15)
 	return ..()
 
 /datum/reagent/nitrium_high_metabolization

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1308,8 +1308,9 @@
 	return ..()
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)
-	M.adjustStaminaLoss(-2 * REM, FALSE)
-	M.adjustToxLoss(1 * REM,FALSE)
+	if(M.getStaminaLoss() > 0)
+		M.adjustStaminaLoss(-2 * REM, FALSE)
+		M.adjustToxLoss(1.5 *REM, FALSE)
 	M.Jitter(15)
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

Nitrium now deals 1 tox damage and makes you jitter.

Currently nitrium is easy to make compared to stimulum (which at least requires fusion temps) and has no downsides if inhaled in a low enough concentration with pluxonium (plux also being easy to make with the trit fire needed to make nitrium). This adds a downside, which shouldn't be too extreme, but enough to at least make huffing it 24/7 not an option anymore. The jitter is more to add a tell that said guy is stun immune, though I might also consider adding an examine text.

Just a reminder, nitrium is basically stimulum. (Which makes you stun immune and sleep immune and heals stamina damage faster.)

# Wiki Documentation

Nitrium deals 1.5 tox damage for every 2 points of stamina damage it heals and makes you jittery

# Changelog
:cl:  
tweak: Nitrium deals 1.5 tox damage per tick for every 2 points of stamina damage it heals and makes you jittery.
/:cl:
