### PR TITLE
Makes gas masks fireproof

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -9,8 +9,8 @@
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
-	resistance_flags = NONE
-
+	resistance_flags = FIRE_PROOF
+	
 // **** Welding gas mask ****
 
 /obj/item/clothing/mask/gas/welding


### PR DESCRIPTION
both the fire fighter suit and fire fighter helmet are fireproof, why not the mask that literally comes with them

this also lets plasmamen that get the martial art have an actual option for not suffocating when they take their helmet off to do more damage

:cl:  
tweak: Makes basic gas masks fireproof
/:cl:
