### PR TITLE
Adds synth blood as preternis blood

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -14,6 +14,13 @@
 			C.bloodiness += bloodiness
 	return ..()
 
+/obj/effect/decal/cleanable/blood/synthetic //mainly for use in recolouring
+	name = "unusual blood"
+	desc = "It's unpleasant and gooey. Perhaps it's the chef's cooking?"
+	bloodiness = 0
+	icon_state = "genericsplatter1"
+	random_icon_states = list("genericsplatter1", "genericsplatter2", "genericsplatter3", "genericsplatter4", "genericsplatter5", "genericsplatter6")
+
 /obj/effect/decal/cleanable/blood/old
 	name = "dried blood"
 	desc = "Looks like it's been here a while.  Eew."

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -163,7 +163,7 @@
 			if(victim.stat == DEAD)
 				to_chat(H, span_notice("You need a living victim!"))
 				return
-			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits) || victim.dna.species.exotic_blood)))
+			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits))))
 				to_chat(H, span_notice("[victim] doesn't have blood!"))
 				return
 			V.drain_cooldown = world.time + 30

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -163,7 +163,7 @@
 			if(victim.stat == DEAD)
 				to_chat(H, span_notice("You need a living victim!"))
 				return
-			if(!victim.blood_volume || (victim.dna && ((NOBLOOD in victim.dna.species.species_traits))))
+			if(!victim.blood_volume || (NOBLOOD in victim?.dna?.species?.species_traits))
 				to_chat(H, span_notice("[victim] doesn't have blood!"))
 				return
 			V.drain_cooldown = world.time + 30

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -32,7 +32,6 @@
 			else
 				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM(C))
 
-
 /datum/reagent/blood/on_new(list/data)
 	if(istype(data))
 		SetViruses(src, data)
@@ -81,6 +80,19 @@
 		B = new(T)
 	if(data["blood_DNA"])
 		B.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
+
+/datum/reagent/synthblood
+	name = "Synthetic Blood"
+	description = "Specialized blood that adapts to the blood type of any host and is incapable of carrying diseases."
+	color = "#9000ffff" // rgb: 200, 0, 0
+	metabolization_rate = 5 //fast rate so it disappears fast.
+
+/datum/reagent/synthblood/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	. = ..()
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(C.get_blood_id() == /datum/reagent/blood && (method == INJECT || (method == INGEST && (DRINKSBLOOD in C?.dna?.species?.species_traits))))
+			C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM(C))
 
 /datum/reagent/liquidgibs
 	name = "Liquid gibs"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -84,7 +84,7 @@
 /datum/reagent/synthblood
 	name = "Synthetic Blood"
 	description = "Specialized blood that adapts to the blood type of any host and is incapable of carrying diseases."
-	color = "#9000ffff" // rgb: 200, 0, 0
+	color = "#9000ff" // rgb: 200, 0, 0
 	metabolization_rate = 5 //fast rate so it disappears fast.
 
 /datum/reagent/synthblood/reaction_mob(mob/living/M, method=TOUCH, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -81,18 +81,38 @@
 	if(data["blood_DNA"])
 		B.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 
-/datum/reagent/synthblood
+/datum/reagent/blood/synthetic
 	name = "Synthetic Blood"
 	description = "Specialized blood that adapts to the blood type of any host and is incapable of carrying diseases."
 	color = "#9000ff" // rgb: 200, 0, 0
-	metabolization_rate = 5 //fast rate so it disappears fast.
+	taste_mult = 1.5
+	glass_name = "glass of ...tomato juice?"
+	glass_desc = "there's literally no way this one is tomato juice!"
 
-/datum/reagent/synthblood/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	. = ..()
+/datum/reagent/blood/synthetic/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		if(C.get_blood_id() == /datum/reagent/blood && (method == INJECT || (method == INGEST && (DRINKSBLOOD in C?.dna?.species?.species_traits))))
+		if(!(C?.dna?.species?.exotic_blood) && (method == INJECT || (method == INGEST && (DRINKSBLOOD in C?.dna?.species?.species_traits))))
 			C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM(C))
+
+//just pretend these don't exist
+/datum/reagent/blood/synthetic/get_diseases()
+	return
+/datum/reagent/blood/synthetic/on_new(list/data)
+	return
+/datum/reagent/blood/synthetic/on_merge(list/mix_data)
+	return
+
+/datum/reagent/blood/synthetic/reaction_turf(turf/T, reac_volume)
+	if(!istype(T))
+		return
+	if(reac_volume < 3)
+		return
+	
+	var/obj/effect/decal/cleanable/blood/synthetic/B = locate() in T //find some blood here
+	if(!B)
+		B = new(T)
+		B.add_atom_colour(color, FIXED_COLOUR_PRIORITY)//rather than making a new decal, just recolour the white one
 
 /datum/reagent/liquidgibs
 	name = "Liquid gibs"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -77,7 +77,7 @@
 	name = "Synthblood"
 	id = /datum/reagent/synthblood
 	results = list(/datum/reagent/synthblood = 3)
-	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/water = 1)
+	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -73,6 +73,12 @@
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 
+/datum/chemical_reaction/synthblood
+	name = "Synthblood"
+	id = /datum/reagent/synthblood
+	results = list(/datum/reagent/synthblood = 3)
+	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/water = 1)
+
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"
 	id = /datum/reagent/medicine/styptic_powder

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -75,8 +75,8 @@
 
 /datum/chemical_reaction/synthblood
 	name = "Synthblood"
-	id = /datum/reagent/synthblood
-	results = list(/datum/reagent/synthblood = 3)
+	id = /datum/reagent/blood/synthetic
+	results = list(/datum/reagent/blood/synthetic = 3)
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/medicine/cryoxadone = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/styptic_powder

--- a/yogstation/code/game/gamemodes/vampire/vampire_bite.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_bite.dm
@@ -2,7 +2,7 @@
 	if(!is_vampire(M) || M == src || M.zone_selected != "head")
 		return FALSE
 	var/datum/antagonist/vampire/V = M.mind.has_antag_datum(/datum/antagonist/vampire)
-	if((NOBLOOD in dna.species.species_traits) || dna.species.exotic_blood || !blood_volume)
+	if((NOBLOOD in dna.species.species_traits) || !blood_volume)
 		to_chat(M, span_warning("They have no blood!"))
 		return FALSE
 	if(is_vampire(src))

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -19,7 +19,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	attack_verb = "assault"
 	skinned_type = /obj/item/stack/sheet/plasteel{amount = 5} //coated in plasteel
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
-	exotic_blood = /datum/reagent/synthblood
+	exotic_blood = /datum/reagent/blood/synthetic
 	toxic_food = NONE
 	liked_food = FRIED | SUGAR | JUNKFOOD
 	disliked_food = GROSS | VEGETABLES

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -19,7 +19,7 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	attack_verb = "assault"
 	skinned_type = /obj/item/stack/sheet/plasteel{amount = 5} //coated in plasteel
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat
-	exotic_blood = /datum/reagent/stable_plasma //helps with heat regulation
+	exotic_blood = /datum/reagent/synthblood
 	toxic_food = NONE
 	liked_food = FRIED | SUGAR | JUNKFOOD
 	disliked_food = GROSS | VEGETABLES


### PR DESCRIPTION
Basically universal donor blood (that also includes exotic bloodtypes)

![image](https://user-images.githubusercontent.com/108117184/231056166-08feae48-4823-4901-b4dc-75a1f29ce7a4.png)


Made via a reaction of 
1 unstable mutagen (since i can't use blood because of synthmeat recipe)
1 cryoxadone
1 water (can be swapped for something else to balance)(probably should, to prevent saline invalidation)


also removes the safety check that vampires have for blood sucking exotic blood since bloodsuckers didn't have one
this will let them succ preterni again, but they need to actually think for even a moment before trying to suck an ethereal or poly
also, it's funny watching them suck bad blood

:cl:  
rscadd: Adds new reagent Synthblood that acts like all blood types (exotic too)
tweak: Changes preternis exotic blood from stable plasma to synthblood
tweak: Removes safety check for vampires trying to drink exotic blood (bloodsuckers didn't have one)
/:cl:
