### PR TITLE
Bugfix - NT Script "replace" function

### DIFF
--- a/yogstation/code/modules/scripting/Implementations/_Logic.dm
+++ b/yogstation/code/modules/scripting/Implementations/_Logic.dm
@@ -338,6 +338,7 @@
 		var/found = findtext(text, find, last_found, 0)
 		if(!found)
 			break
+		. += copytext(text, last_found, found)
 		. += replacement
 		last_found = found + find_len
 	return . + copytext(text,last_found)


### PR DESCRIPTION
## Bug description
Recently i found bug in NT Script language regarding the "replace" function used on strings. The function was removing parts of the string before the part that was beeing replaced resulting in incomplete output string. For example replace(“Testing”, “n”, “N”) was returning “Ng” instead of “TestiNg”.

## Bugfix
This bugfix adds line removed that was removed as part of the changes made to this in previous commit file as this line is necessary for correct function behavior (functionality added in previous commit will remain unchanged).

Bugfix was tested on local instance:

![obraz](https://user-images.githubusercontent.com/130477010/231198636-fda8b287-7b9c-4597-b03e-29c90b55002f.png)


:cl:  
bugfix: fixed string "replace" function in NT Script language
/:cl:
