### PR TITLE
[admin] Record player living playtime in notes

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,12 +2,16 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.11; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 11);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 12);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 11);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 12);
 
 In any query remember to add a prefix to the table names if you use one.
 
+version 5.12 2023-04-10
+Adds playtime to notes
+
+ALTER TABLE `messages` ADD `playtime` int(10) unsigned DEFAULT NULL
 
 version 5.11 2023-01-03
 Adds comment to credentials binding

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,6 +1,6 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.11; The query to update the schema revision table is:
+The latest database version is 5.12; The query to update the schema revision table is:
 
 INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 12);
 or
@@ -11,7 +11,10 @@ In any query remember to add a prefix to the table names if you use one.
 version 5.12 2023-04-10
 Adds playtime to notes
 
-ALTER TABLE `messages` ADD `playtime` int(10) unsigned DEFAULT NULL
+ALTER TABLE `messages` ADD `playtime` int(10) unsigned DEFAULT NULL;
+CREATE TRIGGER messagesTloghours
+    BEFORE INSERT ON `messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 version 5.11 2023-01-03
 Adds comment to credentials binding

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -14,7 +14,7 @@ Adds playtime to notes
 ALTER TABLE `messages` ADD `playtime` int(10) unsigned DEFAULT NULL;
 CREATE TRIGGER messagesTloghours
     BEFORE INSERT ON `messages` FOR EACH ROW
-    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
+    SET NEW.playtime = (SELECT minutes FROM role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 version 5.11 2023-01-03
 Adds comment to credentials binding

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -561,7 +561,7 @@ END//
 DELIMITER ;
 SET SQL_MODE=@OLDTMP_SQL_MODE;
 
-DROP TRIGGER IF EXISTS `messagesTloghours`
+DROP TRIGGER IF EXISTS `messagesTloghours`;
 CREATE TRIGGER `messagesTloghours`
     BEFORE INSERT ON `messages` FOR EACH ROW
     SET NEW.playtime = (SELECT minutes FROM role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -326,6 +326,7 @@ CREATE TABLE IF NOT EXISTS `messages` (
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` mediumtext DEFAULT NULL,
   `deleted` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `playtime` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`,`deleted`),
   KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`,`deleted`),

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -333,6 +333,11 @@ CREATE TABLE IF NOT EXISTS `messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
+DROP TRIGGER IF EXISTS `messagesTloghours`
+CREATE TRIGGER `messagesTloghours`
+    BEFORE INSERT ON `messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
+
 DROP TABLE IF EXISTS `mfa_logins`;
 CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -333,11 +333,6 @@ CREATE TABLE IF NOT EXISTS `messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
-DROP TRIGGER IF EXISTS `messagesTloghours`
-CREATE TRIGGER `messagesTloghours`
-    BEFORE INSERT ON `messages` FOR EACH ROW
-    SET NEW.playtime = (SELECT minutes FROM role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
-
 DROP TABLE IF EXISTS `mfa_logins`;
 CREATE TABLE IF NOT EXISTS `mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
@@ -565,6 +560,11 @@ CREATE TRIGGER `role_timeTlogupdate` AFTER UPDATE ON `role_time` FOR EACH ROW BE
 END//
 DELIMITER ;
 SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+DROP TRIGGER IF EXISTS `messagesTloghours`
+CREATE TRIGGER `messagesTloghours`
+    BEFORE INSERT ON `messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -336,7 +336,7 @@ CREATE TABLE IF NOT EXISTS `messages` (
 DROP TRIGGER IF EXISTS `messagesTloghours`
 CREATE TRIGGER `messagesTloghours`
     BEFORE INSERT ON `messages` FOR EACH ROW
-    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
+    SET NEW.playtime = (SELECT minutes FROM role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 DROP TABLE IF EXISTS `mfa_logins`;
 CREATE TABLE IF NOT EXISTS `mfa_logins` (

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -563,8 +563,8 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 
 DROP TRIGGER IF EXISTS messagesTloghours;
 CREATE TRIGGER messagesTloghours
-    BEFORE INSERT ON `ss13_messages` FOR EACH ROW
-    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
+    BEFORE INSERT ON `SS13_messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM SS13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -333,11 +333,6 @@ CREATE TABLE IF NOT EXISTS `SS13_messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
-DROP TRIGGER IF EXISTS messagesTloghours
-CREATE TRIGGER messagesTloghours
-    BEFORE INSERT ON `ss13_messages` FOR EACH ROW
-    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
-
 DROP TABLE IF EXISTS `SS13_mfa_logins`;
 CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
 	`ckey` varchar(32) NOT NULL,
@@ -565,6 +560,11 @@ CREATE TRIGGER `role_timeTlogupdate` AFTER UPDATE ON `SS13_role_time` FOR EACH R
 END//
 DELIMITER ;
 SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+DROP TRIGGER IF EXISTS messagesTloghours
+CREATE TRIGGER messagesTloghours
+    BEFORE INSERT ON `ss13_messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -333,6 +333,11 @@ CREATE TABLE IF NOT EXISTS `SS13_messages` (
   KEY `idx_msg_type_ckey_time_odr` (`type`,`targetckey`,`timestamp`,`deleted`)
 ) ENGINE=InnoDB AUTO_INCREMENT=75629 DEFAULT CHARSET=utf8;
 
+DROP TRIGGER IF EXISTS messagesTloghours
+CREATE TRIGGER messagesTloghours
+    BEFORE INSERT ON `ss13_messages` FOR EACH ROW
+    SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');
+
 DROP TABLE IF EXISTS `SS13_mfa_logins`;
 CREATE TABLE IF NOT EXISTS `SS13_mfa_logins` (
 	`ckey` varchar(32) NOT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -561,7 +561,7 @@ END//
 DELIMITER ;
 SET SQL_MODE=@OLDTMP_SQL_MODE;
 
-DROP TRIGGER IF EXISTS messagesTloghours
+DROP TRIGGER IF EXISTS messagesTloghours;
 CREATE TRIGGER messagesTloghours
     BEFORE INSERT ON `ss13_messages` FOR EACH ROW
     SET NEW.playtime = (SELECT minutes FROM ss13_role_time rt WHERE rt.ckey = NEW.targetckey AND rt.job = 'Living');

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -326,6 +326,7 @@ CREATE TABLE IF NOT EXISTS `SS13_messages` (
   `lasteditor` varchar(32) DEFAULT NULL,
   `edits` mediumtext DEFAULT NULL,
   `deleted` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `playtime` int(10) unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_msg_ckey_time` (`targetckey`,`timestamp`,`deleted`),
   KEY `idx_msg_type_ckeys_time` (`type`,`targetckey`,`adminckey`,`timestamp`,`deleted`),

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -21,7 +21,7 @@
   * make sure you add an update to the schema_version stable in the db changelog
   */
 
-#define DB_MINOR_VERSION 11
+#define DB_MINOR_VERSION 12
 
 //! ## Timing subsystem
 /**

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -61,7 +61,7 @@ GLOBAL_PROTECT(exp_to_update)
 	if(!prefs.exp || !prefs.exp[EXP_TYPE_LIVING])
 		return pure_numeric ? 0 : "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
-	return get_exp_format(exp_living)
+	return pure_numeric ? exp_living : get_exp_format(exp_living)
 
 /proc/get_exp_format(expnum)
 	if(expnum > 60)


### PR DESCRIPTION
# Document the changes in your pull request

Makes it easier for admins to determine frequency of rule breaks. 

![image](https://user-images.githubusercontent.com/4607006/231208575-fb4428a1-dca1-42da-b52c-3dc134dd36c3.png)

# Changelog

:cl:  
rscadd: Admin notes now record the living playtime of a player when they were noted. 
/:cl:
