### PR TITLE
ebow cost reduced from 8 to 5 tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -693,7 +693,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	be silenced. It can produce an infinite number \
 	of bolts, but takes time to automatically recharge after each shot."
 	item = /obj/item/gun/energy/kinetic_accelerator/crossbow
-	cost = 8
+	cost = 5
 	surplus = 30
 	exclude_modes = list(/datum/game_mode/nuclear)
 


### PR DESCRIPTION
# Document the changes in your pull request

Utility weapon more expensive than real weapons??

# Wiki Documentation

ebow cost 5 tc

# Changelog

:cl:  
tweak: energy crossbow now costs 5 tc down from 8
/:cl:
