### PR TITLE
Makes SM the only roundstart engine, no generator for you edition

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 50, "Engine TEG" = 0)
+	template_names = list("Engine SM" = 100, "Engine Singulo And Tesla" = 0, "Engine TEG" = 0)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -137,7 +137,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Transfer 1", "Transfer 2", "Transfer 3", "Transfer 4", "Transfer 5", "Transfer 6", "Transfer 7", "Transfer 8", "Transfer 9", "Transfer 10")
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta Singulo And Tesla" = 50, "Meta SM" = 50, "Meta TEG" = 0)
+	template_names = list("Meta SM" = 100, "Meta Singulo And Tesla" = 0, , "Meta TEG" = 0)
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Alternative to https://github.com/yogstation13/Yogstation/pull/18250 but without giving people access to the singularity generator I guess.

This will make the SM engine spawn at roundstart every time. I added tesla & singulo generators in the secure storage for each map (as well as 4 field generators and emitters) so engineers can still build them if they feel like it.

# Why this is a good change
The SM engine is the superior engine out of the 3 remaining ones (rip TEG), admit it. The singulo and tesla are boring and bland engines with little to no depth or interaction. The most meaningful thing you do is wrench a few things, turn on the PA and close the shutters. After the initial setup, there is almost nothing interesting you can do with the engine. This is in stark contrast with the SM engine. It is equally easy to set up, however provides numerous interesting interactions with different gas combinations. For example, you can intentionally delaminate the SM to farm anomalies or create large amounts of interesting gases such as pluoxium. This allows players to go wild with various SM setups to experiment with. It additionally creates an additional reason for engineering and atmos to cooperate, as some of the more interesting gases are regularly produced by atmos.

The singulo and tesla are too easy and boring to sabotage, while having a ridiculous binary fail state. The engine is often sabotaged by simply messing with an emitter or field generator, which is easy to overlook if you're not actively looking for it as an engineer. Not to mention that once the tesla/singulo escape, it is next to impossible to re-contain and as a result, the shuttle is called immediately in 99% of cases. Meanwhile, the SM engine is more difficult and interesting to sabotage, and doesn't instantly doom the station. Rather it will create a huge crater in engineering and leave the station without power. However, determined players can fix it and recover from this. Additionally, sabotage isn't instant and gives players some time to find and fix the issue. This allowed players to feel more invested in trying to fix the engine rather than "singuloose, call the shuttle".

"but muh i liked the singulo/tesla". You'll be happy to know that this does **NOT** completely remove them from the game. Instead, I simply the tesla and singulary generators to the secure storage on each map. Granted, it takes some more effort to set up than before, but it's still possible to do. This will allow for engineers to potentially have all 3 engines running on boring rounds if they want to, while still having the ability to experiment with the SM.

Closes https://github.com/yogstation13/Yogstation/pull/18250

# Wiki Documentation
The supermatter engine will now spawn every round, with the tesla/singulo generators getting move to secure storage.

# Changelog

:cl:  
tweak: The Supermatter engine will now spawn every round
/:cl:
