### PR TITLE
Fixes a bug involving dropping pocket items or belts when stripped

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -163,6 +163,10 @@
 				update_inv_w_uniform()
 			update_inv_wear_suit()
 	else if(I == w_uniform)
+		w_uniform = null
+		update_suit_sensors()
+		if(!QDELETED(src))
+			update_inv_w_uniform()
 		if(invdrop)
 			if(r_store && !can_equip(r_store, SLOT_R_STORE, TRUE))
 				dropItemToGround(r_store, TRUE) //Again, makes sense for pockets to drop.
@@ -172,10 +176,6 @@
 				dropItemToGround(wear_id)
 			if(belt && !can_equip(belt, SLOT_BELT, TRUE))
 				dropItemToGround(belt)
-		w_uniform = null
-		update_suit_sensors()
-		if(!QDELETED(src))
-			update_inv_w_uniform()
 	else if(I == gloves)
 		gloves = null
 		if(!QDELETED(src))


### PR DESCRIPTION
Closes: #18540

Fixes a bug introduced by #18445 where no one would drop pockets when stripped, not just the intended cases

Gotta remove the uniform before checking to remove items from pockets

:cl:  
bugfix: Fixes a bug involving dropping pocket items or belts when stripped
/:cl:
