### PR TITLE
Possessed sword no longer deletes itself if trying to catch it with full hands

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -915,7 +915,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 			else
 				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
 				owner.take_overall_damage(5)
-				visible_message("[src] smacks [owner] in the face as they try to catch it with [owner.p_their()] hands full!")
+				visible_message("[src] smacks [owner] in the face as [owner.p_they()] try to catch it with [owner.p_their()] hands full!")
 	else if(possessed)
 		transform = initial(transform)//to reset rotation for when it drops to the ground
 		blade = new /mob/living/simple_animal/nullrod(get_turf(src))
@@ -1033,7 +1033,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 			else
 				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
 				sword.owner.take_overall_damage(5)
-				visible_message("The flying blade smacks [sword.owner] in the face as they try to catch it with [owner.p_their()] hands full!")
+				visible_message("The flying blade smacks [sword.owner] in the face as [sword.owner.p_they()] try to catch it with [sword.owner.p_their()] hands full!")
 	else
 		..()
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -1033,7 +1033,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 			else
 				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
 				sword.owner.take_overall_damage(5)
-				visible_message("The flying blade smacks [sword.owner] in the face as they try to catch it with full hands!")
+				visible_message("The flying blade smacks [sword.owner] in the face as they try to catch it with [owner.p_their()] hands full!")
 	else
 		..()
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -915,7 +915,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 			else
 				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
 				owner.take_overall_damage(5)
-				visible_message("[src] smacks [owner] in the face as they try to catch it with full hands!")
+				visible_message("[src] smacks [owner] in the face as they try to catch it with [owner.p_their()] hands full!")
 	else if(possessed)
 		transform = initial(transform)//to reset rotation for when it drops to the ground
 		blade = new /mob/living/simple_animal/nullrod(get_turf(src))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -909,8 +909,13 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 	if(isliving(hit_atom))//only transform if it doesn't hit a person
 		var/mob/living/target = hit_atom
 		if(owner && target == owner)
-			owner.put_in_active_hand(src)
-			visible_message("[owner] catches the flying [src] out of the air!")
+			var/caught = owner.put_in_hands(src)
+			if(caught)
+				visible_message("[owner] catches the flying [src] out of the air!")
+			else
+				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
+				owner.take_overall_damage(5)
+				visible_message("[src] smacks [owner] in the face as they try to catch it with full hands!")
 	else if(possessed)
 		transform = initial(transform)//to reset rotation for when it drops to the ground
 		blade = new /mob/living/simple_animal/nullrod(get_turf(src))
@@ -1019,11 +1024,16 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 	if(isliving(hit_atom))
 		var/mob/living/target = hit_atom
 		if(sword?.owner && target == sword.owner)
-			sword.owner.put_in_active_hand(sword)
+			var/caught = sword.owner.put_in_hands(sword)
 			mind.transfer_to(sword.soul)
 			sword.walking = FALSE
-			visible_message("[sword.owner] catches the flying blade out of the air!")
 			qdel(src)
+			if(caught)
+				visible_message("[sword.owner] catches the flying blade out of the air!")
+			else
+				playsound(target, 'sound/weapons/rapierhit.ogg', 30, 1, -1)
+				sword.owner.take_overall_damage(5)
+				visible_message("The flying blade smacks [sword.owner] in the face as they try to catch it with full hands!")
 	else
 		..()
 


### PR DESCRIPTION
Closes: #18535
Closes: #18517

This lets people still recall with full hands, and also prevents people from throwing your sword at you to delete it
also adds a funny flavour to the check where the blade smacks you in the face instead of being caught, dealing 5 damage

:cl:  
bugfix: Possessed sword no longer deletes itself if trying to catch it with full hands
/:cl:
