### PR TITLE
Changes nullrod hammer to work nicer and throw a bit further

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -136,6 +136,7 @@
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_STUNIMMUNE		"stun_immunity"
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"
+#define TRAIT_IMPACTIMMUNE		"impact_immunity" //protects from the damage of getting launched into a wall hard
 #define TRAIT_PUSHIMMUNE		"push_immunity"
 #define TRAIT_SHOCKIMMUNE		"shock_immunity"
 #define TRAIT_STABLEHEART		"stable_heart"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -433,7 +433,7 @@
 	if(M == user)
 		return
 	var/atom/throw_target = get_edge_target_turf(M, user.dir)
-	ADD_TRAIT(M, TRAIT_IMPACTIMMUNE, "Nullrod Hammer")///mainly so emps don't end you instantly, they still do damage though
+	ADD_TRAIT(M, TRAIT_IMPACTIMMUNE, "Nullrod Hammer")
 	var/distance = rand(1,5)
 	if(prob(1))
 		distance = 50 //hehe funny hallway launch

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -432,16 +432,15 @@
 	. = ..()
 	if(M == user)
 		return
-	var/throw_direction = get_dir(user, M)
-	var/atom/throw_target = get_edge_target_turf(M, throw_direction)
-	var/turf/throw_location = get_step_towards(M, throw_target)
-	M.SpinAnimation(5, 1)
-	if(throw_location.density)
-		return
-	for(var/obj/D in throw_location.contents)
-		if(D.density)
-			return
-	M.forceMove(throw_location)
+	var/atom/throw_target = get_edge_target_turf(M, user.dir)
+	ADD_TRAIT(M, TRAIT_IMPACTIMMUNE, "Nullrod Hammer")///mainly so emps don't end you instantly, they still do damage though
+	var/distance = rand(1,5)
+	if(prob(1))
+		distance = 50 //hehe funny hallway launch
+	M.throw_at(throw_target, distance, 3, user, TRUE, TRUE, callback = CALLBACK(src, .proc/afterimpact, M))
+
+/obj/item/twohanded/required/nullrod/proc/afterimpact(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_IMPACTIMMUNE, "Nullrod Hammer")
 
 /*---------------------------------------------------------------------------
 |

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -93,6 +93,8 @@
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(mind?.martial_art.handle_throw(hit_atom, src))
 		return
+	if(HAS_TRAIT(src, TRAIT_IMPACTIMMUNE))
+		return
 	. = ..()
 	var/hurt = TRUE
 	var/extra_speed = 0


### PR DESCRIPTION
it was coded in a janky pseudo throw way that made it difficult to throw the target farther than a single tile

now it just uses a regular throw, but gives the person being thrown a temporary trait that removes the impact effect of the throw

increased the throw distance from only 1 to between 1 and 5 tiles

also has a 1% chance to throw someone 50 tiles (very funny)

:cl:  
tweak: Nullrod hammer hit now throws between 1 and 5 tiles (still no knockdown)
/:cl:
