### PR TITLE
HFR without power will only force some bad settings

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -45,6 +45,12 @@
 		if (start_cooling)
 			inject_from_side_components(delta_time)
 			process_internal_cooling(delta_time)
+	else
+		// No power forces some bad settings
+		magnetic_constrictor = 100
+		current_damper = 0
+		waste_remove = FALSE
+		iron_content += 0.02 * power_level * delta_time
 
 	update_temperature_status(delta_time)
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -45,15 +45,6 @@
 		if (start_cooling)
 			inject_from_side_components(delta_time)
 			process_internal_cooling(delta_time)
-	else
-		// No power forces bad settings
-		magnetic_constrictor = 100
-		heating_conductor = 500
-		current_damper = 0
-		fuel_injection_rate = 20
-		moderator_injection_rate = 50
-		waste_remove = FALSE
-		iron_content += 0.02 * power_level * delta_time
 
 	update_temperature_status(delta_time)
 


### PR DESCRIPTION
# Document the changes in your pull request
It no longer changes ``heating_conductor``, ``fuel_injection_rate`` and ``moderator_injection_rate`` since they don't have that much to do with power usage anyway. Left the others because they are semi-relevant and to (hopefully) stop cheese strats by turning off the APC.

# Changelog

:cl:  
tweak: The HFR will only change a few settings upon losing power
/:cl:
