### PR TITLE
reduces slug damage falloff

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,8 +1,8 @@
 /obj/item/projectile/bullet/shotgun/slug
 	name = "12g shotgun slug"
 	speed = 0.5 //Shotgun = slower
-	var/tile_dropoff = 3
-	var/tile_dropoff_s = 2.25
+	var/tile_dropoff = 1.5
+	var/tile_dropoff_s = 1
 	damage = 46 //About 2/3's the damage of buckshot but doesn't suffer from spread or negative AP
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
@@ -10,7 +10,7 @@
 /obj/item/projectile/bullet/shotgun/slug/syndie
 	name = "12g syndicate shotgun slug"
 	damage = 60
-	tile_dropoff = 1.5
+	tile_dropoff = 0.5
 
 /obj/item/projectile/bullet/shotgun/slug/beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
# Document the changes in your pull request

Default shotgun slug dropoff is now 1.5 damage per tile instead of 3
Stamina damage dropoff is 1 per tile instead of 2.25
Syndicate slugs have 0.5 damage lost per tile instead of 1.5

# Wiki Documentation

Don't believe the wiki actually has perfect damage falloff numbers so I don't believe anything is needed on Guide to Combat

# Changelog

:cl:  
tweak: Slugs have much less damage falloff now
/:cl:
