### PR TITLE
Removes Augmentation Kits from the Uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -730,6 +730,28 @@
 	for(var/i in 1 to 7)
 		new /obj/item/poster/random_official(src)
 
+/obj/item/storage/box/syndie_kit/augmentation
+	real_name = "augmentation kit"
+
+/obj/item/storage/box/syndie_kit/augmentation/PopulateContents()
+	new /obj/item/autosurgeon/limb/head/robot(src)
+	new /obj/item/autosurgeon/limb/chest/robot(src)
+	new /obj/item/autosurgeon/limb/l_arm/robot(src)
+	new /obj/item/autosurgeon/limb/r_arm/robot(src)
+	new /obj/item/autosurgeon/limb/l_leg/robot(src)
+	new /obj/item/autosurgeon/limb/r_leg/robot(src)
+
+/obj/item/storage/box/syndie_kit/augmentation/superior
+	real_name = "superior augmentation kit"
+
+/obj/item/storage/box/syndie_kit/augmentation/superior/PopulateContents()
+	..()
+	new /obj/item/autosurgeon/upgraded_cyberheart(src)
+	new /obj/item/autosurgeon/upgraded_cyberliver(src)
+	new /obj/item/autosurgeon/upgraded_cyberlungs(src)
+	new /obj/item/autosurgeon/upgraded_cyberstomach(src)
+	new /obj/item/implanter/empshield(src)
+
 /obj/item/storage/box/beanbag/syndie_darts/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun/dart/hidden(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -730,28 +730,6 @@
 	for(var/i in 1 to 7)
 		new /obj/item/poster/random_official(src)
 
-/obj/item/storage/box/syndie_kit/augmentation
-	real_name = "augmentation kit"
-
-/obj/item/storage/box/syndie_kit/augmentation/PopulateContents()
-	new /obj/item/autosurgeon/limb/head/robot(src)
-	new /obj/item/autosurgeon/limb/chest/robot(src)
-	new /obj/item/autosurgeon/limb/l_arm/robot(src)
-	new /obj/item/autosurgeon/limb/r_arm/robot(src)
-	new /obj/item/autosurgeon/limb/l_leg/robot(src)
-	new /obj/item/autosurgeon/limb/r_leg/robot(src)
-
-/obj/item/storage/box/syndie_kit/augmentation/superior
-	real_name = "superior augmentation kit"
-
-/obj/item/storage/box/syndie_kit/augmentation/superior/PopulateContents()
-	..()
-	new /obj/item/autosurgeon/upgraded_cyberheart(src)
-	new /obj/item/autosurgeon/upgraded_cyberliver(src)
-	new /obj/item/autosurgeon/upgraded_cyberlungs(src)
-	new /obj/item/autosurgeon/upgraded_cyberstomach(src)
-	new /obj/item/implanter/empshield(src)
-
 /obj/item/storage/box/beanbag/syndie_darts/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/ammo_casing/shotgun/dart/hidden(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2086,6 +2086,24 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	limited_stock = 1
 
+/datum/uplink_item/implants/augmentation
+	name = "Full Augmentation Kit"
+	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Provides superior damage resistance, immunity to cold and vacuum, \
+			but renders the subject vulnerable to electromagnetic pulses. They will also require repair with a welder and wires, rather than traditional medicine."
+	item = /obj/item/storage/box/syndie_kit/augmentation
+	cost = 15
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/implants/superior_augmentation
+	name = "Superior Augmentation Kit"
+	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
+			Finally, it includes an implant to render the subject and their innards immune to EMP; however, it will shut down briefly if triggered too often. Repair of the body will still require a welder and wires."
+	item = /obj/item/storage/box/syndie_kit/augmentation/superior
+	cost = 45
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/implants/emp_shield
 	name = "EMP Shield Implant"
 	desc = "An implant that will render you and your insides immune to electromagnetic interference, protecting you from ion-based weaponry and EMPs. \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2086,24 +2086,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	limited_stock = 1
 
-/datum/uplink_item/implants/augmentation
-	name = "Full Augmentation Kit"
-	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Provides superior damage resistance, immunity to cold and vacuum, \
-			but renders the subject vulnerable to electromagnetic pulses. They will also require repair with a welder and wires, rather than traditional medicine."
-	item = /obj/item/storage/box/syndie_kit/augmentation
-	cost = 15
-	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/implants/superior_augmentation
-	name = "Superior Augmentation Kit"
-	desc = "A kit containing six limb autosurgeons to transform you into a fully augmented humanoid. Also contains autosurgeons to replace the subject's vital organs with cybernetic ones. \
-			Finally, it includes an implant to render the subject and their innards immune to EMP; however, it will shut down briefly if triggered too often. Repair of the body will still require a welder and wires."
-	item = /obj/item/storage/box/syndie_kit/augmentation/superior
-	cost = 45
-	surplus = 0
-	include_modes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/implants/emp_shield
 	name = "EMP Shield Implant"
 	desc = "An implant that will render you and your insides immune to electromagnetic interference, protecting you from ion-based weaponry and EMPs. \


### PR DESCRIPTION
# Document the changes in your pull request

Full augmentation kit: Overpriced, but also lets species that aren't supposed to get augmented be augmented. Grr. Also with the EMP shield, some cheese potential now. Go get real augments if you want to cheese.

Superior augmentation kit: I shouldn't have to say why this is being removed

The invincible nukies will now be slightly easier to kill, hopefully

# Wiki Documentation

Both items should be removed from the Syndicate items page

# Changelog

:cl:  
rscdel: Removes augmentation kits from the Syndicate uplink
/:cl:
