### PR TITLE
Autolathes can now be EMAG'd + Adds Illegal Ammo Design Disk

### DIFF
--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -31,7 +31,7 @@
 		if(WIRE_HACK)
 			if(!(A.obj_flags & EMAGGED))
 				A.adjust_hacked(!A.hacked)
-				addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
+				addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/autolathe, reset), wire), 6 SECONDS)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
 			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -29,7 +29,7 @@
 	var/obj/machinery/autolathe/A = holder
 	switch(wire)
 		if(WIRE_HACK)
-			if(!A.obj_flags & EMAGGED)
+			if(!(A.obj_flags & EMAGGED))
 				A.adjust_hacked(!A.hacked)
 				addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_SHOCK)
@@ -43,7 +43,7 @@
 	var/obj/machinery/autolathe/A = holder
 	switch(wire)
 		if(WIRE_HACK)
-			if(!A.obj_flags & EMAGGED)
+			if(!(A.obj_flags & EMAGGED))
 				A.adjust_hacked(!mend)
 		if(WIRE_HACK)
 			A.shocked = !mend

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -19,15 +19,19 @@
 	var/obj/machinery/autolathe/A = holder
 	var/list/status = list()
 	status += "The red light is [A.disabled ? "on" : "off"]."
-	status += "The blue light is [A.hacked ? "on" : "off"]."
+	if(A.obj_flags & EMAGGED)
+		status += "The blue light is flickering rapidly."
+	else
+		status += "The blue light is [A.hacked ? "on" : "off"]."
 	return status
 
 /datum/wires/autolathe/on_pulse(wire)
 	var/obj/machinery/autolathe/A = holder
 	switch(wire)
 		if(WIRE_HACK)
-			A.adjust_hacked(!A.hacked)
-			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
+			if(!A.obj_flags & EMAGGED)
+				A.adjust_hacked(!A.hacked)
+				addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
 			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
@@ -39,7 +43,8 @@
 	var/obj/machinery/autolathe/A = holder
 	switch(wire)
 		if(WIRE_HACK)
-			A.adjust_hacked(!mend)
+			if(!A.obj_flags & EMAGGED)
+				A.adjust_hacked(!mend)
 		if(WIRE_HACK)
 			A.shocked = !mend
 		if(WIRE_DISABLE)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -275,7 +275,8 @@
 	switch(wire)
 		if(WIRE_HACK)
 			if(!wires.is_cut(wire))
-				adjust_hacked(FALSE)
+				if(!obj_flags & EMAGGED)
+					adjust_hacked(FALSE)
 		if(WIRE_SHOCK)
 			if(!wires.is_cut(wire))
 				shocked = FALSE
@@ -309,6 +310,19 @@
 /obj/machinery/autolathe/hacked/Initialize()
 	. = ..()
 	adjust_hacked(TRUE)
+
+/obj/machinery/autolathe/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	if(!hacked)
+		adjust_hacked(TRUE)
+	for(var/id in SSresearch.techweb_designs)
+		var/datum/design/D = SSresearch.techweb_design_by_id(id)
+		if((D.build_type & AUTOLATHE) && ("emagged" in D.category))
+			stored_research.add_design(D)
+	playsound(src, "sparks", 75, TRUE, -1)
+	to_chat(user, span_notice("You use the cryptographic sequencer on [src]."))
 
 //Called when the object is constructed by an autolathe
 //Has a reference to the autolathe so you can do !!FUN!! things with hacked lathes

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -317,10 +317,6 @@
 	obj_flags |= EMAGGED
 	if(!hacked)
 		adjust_hacked(TRUE)
-	for(var/id in SSresearch.techweb_designs)
-		var/datum/design/D = SSresearch.techweb_design_by_id(id)
-		if((D.build_type & AUTOLATHE) && ("emagged" in D.category))
-			stored_research.add_design(D)
 	playsound(src, "sparks", 75, TRUE, -1)
 	to_chat(user, span_notice("You use the cryptographic sequencer on [src]."))
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -275,7 +275,7 @@
 	switch(wire)
 		if(WIRE_HACK)
 			if(!wires.is_cut(wire))
-				if(!obj_flags & EMAGGED)
+				if(!(obj_flags & EMAGGED))
 					adjust_hacked(FALSE)
 		if(WIRE_SHOCK)
 			if(!wires.is_cut(wire))

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -14,6 +14,26 @@
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 20
 
+/obj/item/ammo_box/no_direct/a357/ironfeather
+	name = "ammo box (.357 Ironfeather)"
+	ammo_type = /obj/item/ammo_casing/a357/ironfeather
+
+/obj/item/ammo_box/no_direct/a357/nutcracker
+	name = "ammo box (.357 Nutcracker)"
+	ammo_type = /obj/item/ammo_casing/a357/nutcracker
+
+/obj/item/ammo_box/no_direct/a357/metalshock
+	name = "ammo box (.357 Metalshock)"
+	ammo_type = /obj/item/ammo_casing/a357/metalshock
+
+/obj/item/ammo_box/no_direct/a357/heartpiercer
+	name = "ammo box (.357 Heartpiercer)"
+	ammo_type = /obj/item/ammo_casing/a357/heartpiercer
+
+/obj/item/ammo_box/no_direct/a357/wallstake
+	name = "ammo box (.357 Wallstake)"
+	ammo_type = /obj/item/ammo_casing/a357/wallstake
+
 /obj/item/ammo_box/no_direct/n762
 	name = "ammo box (7.62x38mmR)"
 	icon_state = "10mmbox"
@@ -110,6 +130,26 @@
 	ammo_type = /obj/item/ammo_casing/c10mm
 	caliber = "10mm"
 	max_ammo = 20
+
+/obj/item/ammo_box/c10mm/sp
+	name = "ammo box (10mm soporific)"
+	ammo_type = /obj/item/ammo_casing/c10mm/sp
+
+/obj/item/ammo_box/c10mm/ap
+	name = "ammo box (10mm armor-piercing)"
+	ammo_type = /obj/item/ammo_casing/c10mm/ap
+
+/obj/item/ammo_box/c10mm/hp
+	name = "ammo box (10mm hollow-point)"
+	ammo_type = /obj/item/ammo_casing/c10mm/hp
+
+/obj/item/ammo_box/c10mm/inc
+	name = "ammo box (10mm incendiary)"
+	ammo_type = /obj/item/ammo_casing/c10mm/inc
+
+/obj/item/ammo_box/c10mm/emp
+	name = "ammo box (10mm EMP)"
+	ammo_type = /obj/item/ammo_casing/c10mm/emp
 
 /obj/item/ammo_box/c45
 	name = "ammo box (.45)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -912,6 +912,11 @@
 	build_path = /obj/item/ammo_casing/a357
 	category = list("hacked", "Security")
 
+/datum/design/a357/ironfeather
+	name = ".357 Ironfeather Bullet"
+	id = "a357_ironfeather"
+	build_path = /obj/item/ammo_casing/a357/ironfeather
+
 /datum/design/c10mm
 	name = "Ammo Box (10mm)"
 	id = "c10mm"
@@ -919,6 +924,39 @@
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("hacked", "Security")
+
+/datum/design/c10mm/sp
+	name = "Ammo Box (10mm soporific)"
+	id = "c10mm_sp"
+	build_path = /obj/item/ammo_box/c10mm/sp
+
+/datum/design/c10mm/ap
+	name = "Ammo Box (10mm armor-piercing)"
+	id = "c10mm_ap"
+	materials = list(/datum/material/iron = 45000)
+	build_path = /obj/item/ammo_box/c10mm/ap
+	category = list("emagged", "Security")
+
+/datum/design/c10mm/hp
+	name = "Ammo Box (10mm hollow-point)"
+	id = "c10mm_hp"
+	materials = list(/datum/material/iron = 45000)
+	build_path = /obj/item/ammo_box/c10mm/hp
+	category = list("emagged", "Security")
+
+/datum/design/c10mm/inc
+	name = "Ammo Box (10mm incendiary)"
+	id = "c10mm_inc"
+	materials = list(/datum/material/iron = 45000)
+	build_path = /obj/item/ammo_box/c10mm/inc
+	category = list("emagged", "Security")
+
+/datum/design/c10mm/emp
+	name = "Ammo Box (10mm EMP)"
+	id = "c10mm_emp"
+	materials = list(/datum/material/iron = 45000)
+	build_path = /obj/item/ammo_box/c10mm/emp
+	category = list("emagged", "Security")
 
 /datum/design/c45
 	name = "Ammo Box (.45)"
@@ -943,6 +981,39 @@
 	materials = list(/datum/material/iron = 40000)
 	build_path = /obj/item/ammo_box/no_direct/a357
 	category = list("hacked", "Security")
+
+/datum/design/box_a357/ironfeather
+	name = "Ammo Box (.357 Ironfeather)"
+	id = "box_a357_ironfeather"
+	build_path = /obj/item/ammo_box/no_direct/a357/ironfeather
+
+/datum/design/box_a357/nutcracker
+	name = "Ammo Box (.357 Nutcracker)"
+	id = "box_a357_nutcracker"
+	materials = list (/datum/material/iron = 60000)
+	build_path = /obj/item/ammo_box/no_direct/a357/nutcracker
+	category = list ("emagged", "Security")
+
+/datum/design/box_a357/metalshock
+	name = "Ammo Box (.357 Metalshock)"
+	id = "box_a357_metalshock"
+	materials = list (/datum/material/iron = 60000)
+	build_path = /obj/item/ammo_box/no_direct/a357/metalshock
+	category = list ("emagged", "Security")
+
+/datum/design/box_a357/heartpiercer
+	name = "Ammo Box (.357 Heartpiercer)"
+	id = "box_a357_heartpiercer"
+	materials = list (/datum/material/iron = 60000)
+	build_path = /obj/item/ammo_box/no_direct/a357/heartpiercer
+	category = list ("emagged", "Security")
+
+/datum/design/box_a357/wallstake
+	name = "Ammo Box (.357 Wallstake)"
+	id = "box_a357_wallstake"
+	materials = list (/datum/material/iron = 60000)
+	build_path = /obj/item/ammo_box/no_direct/a357/wallstake
+	category = list ("emagged", "Security")
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -930,33 +930,47 @@
 	id = "c10mm_sp"
 	build_path = /obj/item/ammo_box/c10mm/sp
 
+/obj/item/disk/design_disk/illegal_ammo
+	name = "Illegal Ammo Design Disk"
+	desc = "A disk containing designs for both standard and non-standard 10mm and .357 bullet designs."
+	icon_state = "datadisk1"
+	var/list/ammo_types = list(/datum/design/c10mm, /datum/design/c10mm/sp, /datum/design/c10mm/ap, /datum/design/c10mm/hp, /datum/design/c10mm/inc, /datum/design/c10mm/emp, 
+								/datum/design/box_a357, /datum/design/box_a357/ironfeather, /datum/design/box_a357/nutcracker, /datum/design/box_a357/metalshock, /datum/design/box_a357/heartpiercer, /datum/design/box_a357/wallstake)
+
+/obj/item/disk/design_disk/illegal_ammo/Initialize()
+	. = ..()
+	max_blueprints = ammo_types.len
+	for(var/design in ammo_types)
+		var/datum/design/new_design = design
+		blueprints += new new_design
+
 /datum/design/c10mm/ap
 	name = "Ammo Box (10mm armor-piercing)"
 	id = "c10mm_ap"
 	materials = list(/datum/material/iron = 45000)
 	build_path = /obj/item/ammo_box/c10mm/ap
-	category = list("emagged", "Security")
+	category = list("Security")
 
 /datum/design/c10mm/hp
 	name = "Ammo Box (10mm hollow-point)"
 	id = "c10mm_hp"
 	materials = list(/datum/material/iron = 45000)
 	build_path = /obj/item/ammo_box/c10mm/hp
-	category = list("emagged", "Security")
+	category = list("Security")
 
 /datum/design/c10mm/inc
 	name = "Ammo Box (10mm incendiary)"
 	id = "c10mm_inc"
 	materials = list(/datum/material/iron = 45000)
 	build_path = /obj/item/ammo_box/c10mm/inc
-	category = list("emagged", "Security")
+	category = list("Security")
 
 /datum/design/c10mm/emp
 	name = "Ammo Box (10mm EMP)"
 	id = "c10mm_emp"
 	materials = list(/datum/material/iron = 45000)
 	build_path = /obj/item/ammo_box/c10mm/emp
-	category = list("emagged", "Security")
+	category = list("Security")
 
 /datum/design/c45
 	name = "Ammo Box (.45)"
@@ -992,28 +1006,28 @@
 	id = "box_a357_nutcracker"
 	materials = list (/datum/material/iron = 60000)
 	build_path = /obj/item/ammo_box/no_direct/a357/nutcracker
-	category = list ("emagged", "Security")
+	category = list ("Security")
 
 /datum/design/box_a357/metalshock
 	name = "Ammo Box (.357 Metalshock)"
 	id = "box_a357_metalshock"
 	materials = list (/datum/material/iron = 60000)
 	build_path = /obj/item/ammo_box/no_direct/a357/metalshock
-	category = list ("emagged", "Security")
+	category = list ("Security")
 
 /datum/design/box_a357/heartpiercer
 	name = "Ammo Box (.357 Heartpiercer)"
 	id = "box_a357_heartpiercer"
 	materials = list (/datum/material/iron = 60000)
 	build_path = /obj/item/ammo_box/no_direct/a357/heartpiercer
-	category = list ("emagged", "Security")
+	category = list ("Security")
 
 /datum/design/box_a357/wallstake
 	name = "Ammo Box (.357 Wallstake)"
 	id = "box_a357_wallstake"
 	materials = list (/datum/material/iron = 60000)
 	build_path = /obj/item/ammo_box/no_direct/a357/wallstake
-	category = list ("emagged", "Security")
+	category = list ("Security")
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -925,17 +925,25 @@
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("hacked", "Security")
 
+/datum/design/c10mm/disk
+	id = "c10mm_disk"
+	category = list("Security")
+
 /datum/design/c10mm/sp
 	name = "Ammo Box (10mm soporific)"
 	id = "c10mm_sp"
 	build_path = /obj/item/ammo_box/c10mm/sp
 
+/datum/design/c10mm/sp/disk
+	id = "c10mm_sp_disk"
+	category = list("Security")
+
 /obj/item/disk/design_disk/illegal_ammo
 	name = "Illegal Ammo Design Disk"
 	desc = "A disk containing designs for both standard and non-standard 10mm and .357 bullet designs."
 	icon_state = "datadisk1"
-	var/list/ammo_types = list(/datum/design/c10mm, /datum/design/c10mm/sp, /datum/design/c10mm/ap, /datum/design/c10mm/hp, /datum/design/c10mm/inc, /datum/design/c10mm/emp, 
-								/datum/design/box_a357, /datum/design/box_a357/ironfeather, /datum/design/box_a357/nutcracker, /datum/design/box_a357/metalshock, /datum/design/box_a357/heartpiercer, /datum/design/box_a357/wallstake)
+	var/list/ammo_types = list(/datum/design/c10mm/disk, /datum/design/c10mm/sp/disk, /datum/design/c10mm/ap, /datum/design/c10mm/hp, /datum/design/c10mm/inc, /datum/design/c10mm/emp, 
+								/datum/design/box_a357/disk, /datum/design/box_a357/ironfeather/disk, /datum/design/box_a357/nutcracker, /datum/design/box_a357/metalshock, /datum/design/box_a357/heartpiercer, /datum/design/box_a357/wallstake)
 
 /obj/item/disk/design_disk/illegal_ammo/Initialize()
 	. = ..()
@@ -996,10 +1004,18 @@
 	build_path = /obj/item/ammo_box/no_direct/a357
 	category = list("hacked", "Security")
 
+/datum/design/box_a357/disk
+	id = "box_a357_disk"
+	category = list("Security")
+
 /datum/design/box_a357/ironfeather
 	name = "Ammo Box (.357 Ironfeather)"
 	id = "box_a357_ironfeather"
 	build_path = /obj/item/ammo_box/no_direct/a357/ironfeather
+
+/datum/design/box_a357/ironfeather/disk
+	id = "box_a357_ironfeather_disk"
+	category = list("Security")
 
 /datum/design/box_a357/nutcracker
 	name = "Ammo Box (.357 Nutcracker)"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1734,6 +1734,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 7
 	manufacturer = /datum/corporation/traitor/cybersun
 
+/datum/uplink_item/device_tools/illegal_ammo_disk
+	name = "Illegal Ammo Design Disk"
+	desc = "A design disk for an autolathe that permits it to print all types of 10mm and .357 ammunition."
+	item = /obj/item/disk/design_disk/illegal_ammo
+	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear) //Buy your own ammo you lazy sods
+
 /datum/uplink_item/device_tools/medgun
 	name = "Medbeam Gun"
 	desc = "A wonder of Syndicate engineering, the Medbeam gun, or Medi-Gun enables a medic to keep his fellow \


### PR DESCRIPTION
# Document the changes in your pull request

You can now EMAG autolathes (even if you don't use harm intent, it'll work and it won't eat the EMAG). This permanently hacks the autolathe (which is indicated by the blue light rapidly flickering in the hack menu).

Furthermore, adds the Illegal Ammo Design Disk to the uplink for 4 TC, which can be slotted into an autolathe to allow it to unlock the ability to print every kind of 10mm and .357 ammo box.

For now, the disk-unique designs are:
For 45000 metal:
- 10mm AP Ammo Box
- 10mm HP Ammo Box
- 10mm Incendiary Ammo Box
- 10mm EMP Ammo Box

For 60000 metal:
- .357 Nutcracker Ammo Box 
- .357 Metalshock Ammo Box
- .357 Heartpiercer Ammo Box
- .357 Wallstake Ammo Box

In addition, the following hacked designs have been added (no disk required: just the blue light on, but the disk will unlock them):
- .357 Ironfeather bullet, 2000 metal (same cost as the individual .357 one)
- .357 Ironfeather Ammo Box, 40000 metal (same cost as the normal .357 ammo box)
- 10mm Soporific Ammo Box, 30000 metal (same cost as the normal 10mm ammo box)

Considering ironfeather/soporific are the same TC cost as the default bullet, and they shouldn't be *too detrimental to give to crew* (one can only go to an already powergaming detective gun, the other would only slot in a surplus carbine if you find one), I don't think this should be too much of an issue.

# Wiki Documentation

EMAG functionality should be documented on the Emag page
Autolathe designs should go on the Designs... page? I forgot what it's called, but I know it exists
New disk should be included on the Syndicate items page

# Changelog

:cl:  
rscadd: Adds the Illegal Ammo Design Disk to the uplink for 4 TC, which allows you to print every type of 10mm and .357 ammo box at the lathe (this includes stuff like 10mm AP, soporific, .357 Heartpiercer, Ironfeather, and more)
rscadd: You can now EMAG autolathes to render them permanently hacked
rscadd: Hacked autolathes can now print individual .357 Ironfeather bullets, as well as 10mm soporific and .357 Ironfeather ammo boxes
/:cl:
