### PR TITLE
Remove peacekeeper as roundstart lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -465,8 +465,8 @@ LAW_WEIGHT drone,0
 ION_LAW_WEIGHT drone,2
 LAW_WEIGHT liveandletlive,0
 ION_LAW_WEIGHT liveandletlive,2
-LAW_WEIGHT peacekeeper,1
-ION_LAW_WEIGHT peacekeeper,2
+LAW_WEIGHT peacekeeper,0
+ION_LAW_WEIGHT peacekeeper,1
 LAW_WEIGHT reporter,0
 ION_LAW_WEIGHT reporter,1
 LAW_WEIGHT cowboy,0


### PR DESCRIPTION
Removes peacekeeper as roundstart and reduces its ion weight

Peacekeeper effectively removes AIs from round interaction, is completely unfun for the silicon players, also super annoying to deal with as an admin. 

# Changelog

:cl:  
tweak: Minor change to config for AI laws
/:cl:
