### PR TITLE
Makes upgraded cybernetic liver always heal toxin rather than deal it sometimes

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -111,7 +111,7 @@
 	. = ..()
 	var/mob/living/carbon/C = owner
 	if(!(organ_flags & ORGAN_FAILING)) //Passive Toxin damage healing
-		C.adjustToxLoss(-0.5, TRUE, FALSE)
+		C.adjustToxLoss(-0.5, TRUE, TRUE)
 
 /obj/item/organ/liver/cybernetic/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
it wasn't forced, so those with toxinlover just got killed

:cl:  
tweak: upgraded cybernetic livers no longer kill toxin lovers
/:cl:
