### PR TITLE
Add 3rd Atmos Tech spawnpoint on Asteroid

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -68262,6 +68262,10 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"vXK" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos/foyer)
 "vXZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -116404,7 +116408,7 @@ aOl
 uzw
 jhF
 emc
-aCQ
+vXK
 aCQ
 kZw
 aOd


### PR DESCRIPTION
# Document the changes in your pull request
Simply adds a 3rd spawnpoint to atmos. I might have fucked this up with the HFR change. If 3 atmos techs ready up, 1 will fail to spawn since there's not enough spawnpoints.

# Changelog

:cl:  
bugfix: AsteroidStation will allow 3 atmos techs to spawn at the same time again.
/:cl:
