### PR TITLE
Buffs the speed given by MK1 Bluespace Armor

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -492,7 +492,7 @@
 	name = "MK.I bluespace plating"
 	desc = "Incredibly light bluespace-infused armor plating that offers great movement while also providing some protection."
 	name_set = "MK.I bluespace"
-	slowdown_set = -0.075 // Speeds you up a bit in exchange for giving up some armor
+	slowdown_set = -0.1 // Speeds you up a bit in exchange for giving up some armor
 	armor = list(MELEE = 15, BULLET = 20, LASER = 25, ENERGY = 5, BOMB = 5, BIO = 0, RAD = 0, FIRE = 30, ACID = 40, WOUND = 10) // Slightly worse than default armor
 	partial_coverage = 0
 


### PR DESCRIPTION
# Document the changes in your pull request

Despite being the most controversial armor, it consistently feels the most underwhelming. I personally haven't seen many people take it and I usually pass it up in favor of MK2 or MK3. MK4 on the other end of the spectrum is not always taken but still sees great value in tankiness, whereas MK1's benefit is extremely marginal with a big cost offset.

Values for reference

MK1
- MELEE = 15, BULLET = 20, LASER = 25, ENERGY = 5, BOMB = 5, BIO = 0, RAD = 0, FIRE = 30, ACID = 40, WOUND = 10
- Slowdown = ~~-0.15~~ **Now -0.2** (with suit and helm)

Armor vest/helmet
- MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15
- Slowdown = 0

MK2
- MELEE = 30, BULLET = 35, LASER = 35, ENERGY = 15, BOMB = 25, BIO = 0, RAD = 0, FIRE = 40, ACID = 50, WOUND = 20
- Slowdown = 0

MK3
- MELEE = 40, BULLET = 45, LASER = 45, ENERGY = 25, BOMB = 30, BIO = 0, RAD = 0, FIRE = 50, ACID = 60, WOUND = 35
- Slowdown = 0.3

MK4
- MELEE = 55, BULLET = 60, LASER = 60, ENERGY = 40, BOMB = 40, BIO = 0, RAD = 0, FIRE = 65, ACID = 75, WOUND = 50
- Slowdown = 0.8

Hardsuit/spacesuits
- Slowdown = 1.0

Fairy boots
- Slowdown = -0.3

Ephedrine
- Slowdown = -0.85

Ninja
- Slowdown = -1.0

# Changelog

:cl:  
tweak: MK1 Bluespace Armor speed has been improved
/:cl:
