### PR TITLE
Makes resonators replicating to ALL adjacent tiles a feature rather than a bug so the admins cant ban me for using it

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -121,5 +121,5 @@
 	if(!istype(M) || !M.mineralType) // so we don't end up in the ultimate chain reaction
 		return
 	for(var/turf/closed/mineral/T in orange(1, M))
-		if(istype(T) && !locate(/obj/effect/temp_visual/resonance) in T && M.mineralType == T.mineralType)
+		if(istype(T) && !(locate(/obj/effect/temp_visual/resonance) in T))
 			new /obj/effect/temp_visual/resonance(T, creator, null, duration)	//yogs end


### PR DESCRIPTION
# Document the changes in your pull request

Allows the resonator to break rocks extremely quickly in the case there's a mineral vein, regardless of its contents, giving it a small but hopefully notable niche in the pre-plasmacutter early-game

Also it might potentially not stack resonator bubbles on eachother now. I think.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: resonators replicating to all nearby rocks is no longer a bug
bugfix: probably stops resonator bubbles from overlapping when replicating because it is annoying
/:cl:
