### PR TITLE
Fixes changelings being able to absorb and ling husk you if you can't be husked and sometimes getting objectives to escape as someone that can't be absorbed

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_EMPTY(objectives)
 		if(!M.has_antag_datum(/datum/antagonist/changeling))
 			continue
 		var/datum/mind/T = possible_target
-		if(!istype(T) || isipc(T.current))
+		if(!istype(T) || HAS_TRAIT(T.current, NOHUSK) || HAS_TRAIT(T.current, NO_DNA_COPY)) // if you can't absorb them you shouldn't have an objective to do so
 			return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_EMPTY(objectives)
 		if(!M.has_antag_datum(/datum/antagonist/changeling))
 			continue
 		var/datum/mind/T = possible_target
-		if(!istype(T) || HAS_TRAIT(T.current, NOHUSK) || HAS_TRAIT(T.current, NO_DNA_COPY)) // if you can't absorb them you shouldn't have an objective to do so
+		if(!istype(T) || (NO_DNA_COPY in target.dna.species.species_traits) || (NOHUSK in target.dna.species.species_traits)) // if you can't absorb them you shouldn't have an objective to do so
 			return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -532,8 +532,12 @@ GLOBAL_LIST_EMPTY(objectives)
 		if(!M.has_antag_datum(/datum/antagonist/changeling))
 			continue
 		var/datum/mind/T = possible_target
-		if(!istype(T) || (NO_DNA_COPY in T.current.dna.species.species_traits) || (NOHUSK in T.current.dna.species.species_traits)) // if you can't absorb them you shouldn't have an objective to do so
+		if(!istype(T)) // if you can't absorb them you shouldn't have an objective to do so
 			return FALSE
+		if(ishuman(T.current))
+			var/mob/living/carbon/human/H = T.current
+			if((NO_DNA_COPY in H.dna.species.species_traits) || (NOHUSK in H.dna.species.species_traits))
+				return FALSE
 	return TRUE
 
 /datum/objective/escape/escape_with_identity

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_EMPTY(objectives)
 		if(!M.has_antag_datum(/datum/antagonist/changeling))
 			continue
 		var/datum/mind/T = possible_target
-		if(!istype(T) || (NO_DNA_COPY in target.dna.species.species_traits) || (NOHUSK in target.dna.species.species_traits)) // if you can't absorb them you shouldn't have an objective to do so
+		if(!istype(T) || (NO_DNA_COPY in T.current.dna.species.species_traits) || (NOHUSK in T.current.dna.species.species_traits)) // if you can't absorb them you shouldn't have an objective to do so
 			return FALSE
 	return TRUE
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -266,7 +266,7 @@
 			return
 	if(!target)
 		return
-	if(NO_DNA_COPY in target.dna.species.species_traits)
+	if((NO_DNA_COPY in target.dna.species.species_traits) || (NOHUSK in target.dna.species.species_traits)) // if they can't be husked absorbing them will break and make them unrevivable
 		if(verbose)
 			to_chat(user, span_warning("[target] is not compatible with our biology."))
 		return


### PR DESCRIPTION
# Document the changes in your pull request

Changelings will no longer be able to absorb you if you can't be husked due to it breaking things and sometimes making you unrevivable. Also fixes an issue where sometimes you get an objective to absorb someone and escape as them when they're unable to be absorbed.

# Changelog

:cl:  
bugfix: you can no longer be absorbed and ling husked if you can't be husked
bugfix: fixes getting an objective to absorb and escape as someone if you can't absorb them
/:cl:
