### PR TITLE
Nitrium now deals a small amount of liver damage while active instead of a pitiful amount of toxin damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1342,6 +1342,7 @@
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 1)
+	M.adjustStaminaLoss(-2 * REM, FALSE)
 	M.Jitter(15)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1341,9 +1341,7 @@
 	return ..()
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)
-	if(M.getStaminaLoss() > 0)
-		M.adjustStaminaLoss(-2 * REM, FALSE)
-		M.adjustToxLoss(1.5 *REM, FALSE)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 1)
 	M.Jitter(15)
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

Having a passive full antistun with 0 downsides is bullshit, if it's annoying to use proactively that's fine because it's a full immunity to stun weaponry


# Wiki Documentation

nitryl now deals liver damage instead of toxin damage, and no longer has the check for stamina damage

# Changelog

:cl:  
tweak: nitryl now deals liver damage instead of toxin damage
tweak: nitryl's damage is now constant, rather than only occuring if it starts healing stamina damage. No more ignoring beepsky, sorry.
/:cl:
