### PR TITLE
NOHUSK trait prevents ling succ from applying BADDNA

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -78,7 +78,8 @@
 
 /mob/living/carbon/proc/Drain()
 	become_husk(CHANGELING_DRAIN)
-	ADD_TRAIT(src, TRAIT_BADDNA, CHANGELING_DRAIN)
+	if(!(NOHUSK in dna?.species?.species_traits))
+		ADD_TRAIT(src, TRAIT_BADDNA, CHANGELING_DRAIN)
 	blood_volume = 0
 	return TRUE
 	


### PR DESCRIPTION
This still lets the ling succ them, but it just removes the need to use dna recovery surgery (there's no visual indicator anyways)

:cl:  
tweak: NOHUSK trait prevents ling succ from applying BADDNA
/:cl:
