### PR TITLE
Fixes a bug that meant preterni weren't melee attacking slower like intended

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -274,8 +274,9 @@ adjust_charge - take a positive or negative value to adjust the charge level
 
 /datum/species/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)//make them attack slower
 	. = ..()
-	if(ispreternis(user) && !attacker_style?.nonlethal && !user.mind.has_martialart() && !(user.gloves && istype(user.gloves, /obj/item/clothing/gloves/rapid)))
-		user.next_move += 3 //adds 0.3 second delay to combat
+	if(!ispreternis(user) || attacker_style?.nonlethal || (user.gloves && istype(user.gloves, /obj/item/clothing/gloves/rapid)) || (user.mind.martial_art.type in subtypesof(/datum/martial_art)))
+		return	
+	user.next_move += 2 //adds 0.2 second delay to combat
 
 /datum/species/preternis/has_toes()//their toes are mine, they shall never have them back
 	return FALSE


### PR DESCRIPTION
Throw back to when i coded this, turns out it stopped working when i added that martial art line
1: that's now how that proc works
2: everyone starts with a martial art, it just does nothing

tweaks it to 0.2 instead of 0.3 because it was never actually tested at the 0.2 value

:cl:  
bugfix: Preterni now actually have slower melee attacks
/:cl:
