### PR TITLE
Removes nitrium from most HFR moderator reactions

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -298,19 +298,16 @@
 			if(moderator_list[/datum/gas/pluonium] > 20)
 				radiation *= 1.55
 				heat_output *= 1.025
-				internal_output.adjust_moles(/datum/gas/nitrium, scaled_production * 1.05)
 				moderator_internal.adjust_moles(/datum/gas/pluonium, -min(moderator_internal.get_moles(/datum/gas/pluonium), scaled_production * 1.35))
 
 		if(3, 4)
 			if(moderator_list[/datum/gas/plasma] > 10)
 				internal_output.adjust_moles(/datum/gas/freon, scaled_production * 0.15)
-				internal_output.adjust_moles(/datum/gas/nitrium, scaled_production * 1.05)
 				moderator_internal.adjust_moles(/datum/gas/plasma, -min(moderator_internal.get_moles(/datum/gas/plasma), scaled_production * 0.45))
 			if(moderator_list[/datum/gas/freon] > 50)
 				heat_output *= 0.9
 				radiation *= 0.8
 			if(moderator_list[/datum/gas/pluonium]> 15)
-				internal_output.adjust_moles(/datum/gas/nitrium, scaled_production * 1.25)
 				internal_output.adjust_moles(/datum/gas/halon, scaled_production * 1.15)
 				moderator_internal.adjust_moles(/datum/gas/pluonium, -min(moderator_internal.get_moles(/datum/gas/pluonium), scaled_production * 1.55))
 				radiation *= 1.95
@@ -328,7 +325,6 @@
 				heat_output *= 0.5
 				radiation *= 0.2
 			if(moderator_list[/datum/gas/pluonium] > 50)
-				internal_output.adjust_moles(/datum/gas/nitrium, scaled_production * 1.95)
 				internal_output.adjust_moles(/datum/gas/pluoxium, scaled_production)
 				moderator_internal.adjust_moles(/datum/gas/pluonium, -min(moderator_internal.get_moles(/datum/gas/pluonium), scaled_production * 1.35))
 				radiation *= 1.95


### PR DESCRIPTION
# Document the changes in your pull request
Rushing nitrium on O2+plasma recipe is lame. This removes all the nitrium generating reactions except the one requiring pluonium + fusion level 6.

# Changelog

:cl:  
tweak: The HFR has had its nitrium generating capabilities tweaked
/:cl:
