### PR TITLE
Nitrium makes you more vulnerable to burn damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1334,10 +1334,16 @@
 	. = ..()
 	ADD_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		H.physiology.burn_mod *= 1.25
 
 /datum/reagent/nitrium_low_metabolization/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	if(ishuman(L)) // physiology gets reset anyway if you get turned into something that doesn't have it
+		var/mob/living/carbon/human/H = L
+		H.physiology.burn_mod /= 1.25
 	return ..()
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1336,14 +1336,14 @@
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.physiology.burn_mod *= 1.25
+		H.physiology.burn_mod *= 1.5
 
 /datum/reagent/nitrium_low_metabolization/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	if(ishuman(L)) // physiology gets reset anyway if you get turned into something that doesn't have it
 		var/mob/living/carbon/human/H = L
-		H.physiology.burn_mod /= 1.25
+		H.physiology.burn_mod /= 1.5
 	return ..()
 
 /datum/reagent/nitrium_low_metabolization/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
# Document the changes in your pull request

Breathing nitrium will now make you 50% more vulnerable to burn damage, similar to the effect teslium has on preternis but less severe. This makes it situational, instead of something you always want to have regardless of what kind of weapons you expect other people to be using.

Alternative to:
closes #18585 
closes #18590 

# Changelog

:cl:  
tweak: nitrium makes you weak to burn damage
/:cl:
