### PR TITLE
more buster fixes 

### DIFF
--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -486,7 +486,7 @@
 	set desc = "You recalibrate the arm to restore missing functionality."
 	set category = "Buster Style"
 	var/list/combined_msg = list()
-	combined_msg +=  "<b><i>You recalibrate your arm in an attempt to restore its functions.</i></b>"
+	combined_msg +=  "<b><i>You recalibrate your arm in an attempt to restore its functionality.</i></b>"
 	to_chat(usr, examine_block(combined_msg.Join("\n")))
 
 	usr.click_intercept = usr.mind.martial_art

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -475,7 +475,7 @@
 
 	combined_msg +=  span_warning("You can't perform any of the moves if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall your moves.")
 
-	combined_msg +=  span_warning("Should your moves cease function altogether, utilize the 'Recalibrate Arm' function.")
+	combined_msg +=  span_warning("Should your moves cease to function altogether, utilize the 'Recalibrate Arm' function.")
 
 	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 50% for 2 seconds.</b>")
 

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -14,6 +14,7 @@
 	COOLDOWN_DECLARE(next_mop)
 	COOLDOWN_DECLARE(next_grapple)
 	COOLDOWN_DECLARE(next_slam)
+	var/recalibration = /mob/living/carbon/human/proc/buster_recalibration
 	var/old_density //so people grappling something arent pushed by it until it's thrown
 
 //proc the moves will use for damage dealing
@@ -363,7 +364,7 @@
 /datum/martial_art/buster_style/proc/slam(mob/living/user, mob/living/target)
 	var/supdam = 20
 	var/crashdam = 10
-	var/walldam = 30
+	var/walldam = 20
 	var/turf/Z = get_turf(user)
 	if(!COOLDOWN_FINISHED(src, next_slam))
 		to_chat(user, span_warning("You can't do that yet!"))
@@ -385,8 +386,8 @@
 		playsound(user, 'sound/effects/gravhit.ogg', 20, 1)
 		if(!istype(W, /turf/closed/wall/r_wall)) // Attempt to destroy the wall
 			W.dismantle_wall(1)
-			target.forceMove(Q) // Move the mob behind us
 		else		
+			grab(user, target, walldam) 
 			target.forceMove(Z) // If we couldn't smash the wall, put them under our tile
 			return // Stop here, don't apply any more damage or checks
 	for(var/obj/D in Q.contents) // If there's dense objects behind us, apply damage to the mob for each one they are slammed into
@@ -472,23 +473,36 @@
 	destroys it but uses up the attack. Attacking a living target uses up the attack and sends them flying and dismembers their limb if its damaged enough. Has a 15 second \
 	cooldown."
 
-	combined_msg +=  span_warning("You can't perform any of the moves if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall\
-	 your moves.")
+	combined_msg +=  span_warning("You can't perform any of the moves if you have an occupied hand. Additionally, if your buster arm should become disabled, so shall your moves.")
+
+	combined_msg +=  span_warning("Should your moves cease function altogether, utilize the 'Recalibrate Arm' function.")
 
 	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 50% for 2 seconds.</b>")
 
 	to_chat(usr, examine_block(combined_msg.Join("\n")))
+
+/mob/living/carbon/human/proc/buster_recalibration()
+	set name = "Recalibrate Arm"
+	set desc = "You stabilize the arm in the case of missing functions."
+	set category = "Buster Style"
+	var/list/combined_msg = list()
+	combined_msg +=  "<b><i>You recalibrate your arm in an attempt to restore its functions.</i></b>"
+	to_chat(usr, examine_block(combined_msg.Join("\n")))
+
+	usr.click_intercept = usr.mind.martial_art
 
 /datum/martial_art/buster_style/teach(mob/living/carbon/human/H, make_temporary=0)
 	..()
 	var/datum/species/S = H.dna?.species
 	ADD_TRAIT(H, TRAIT_SHOCKIMMUNE, type)
 	S.add_no_equip_slot(H, SLOT_GLOVES)
+	add_verb(H, recalibration)
 	usr.click_intercept = src 
 
 /datum/martial_art/buster_style/on_remove(mob/living/carbon/human/H)
 	var/datum/species/S = H.dna?.species
 	REMOVE_TRAIT(H, TRAIT_SHOCKIMMUNE, type)
 	S.remove_no_equip_slot(H, SLOT_GLOVES)
+	remove_verb(H, recalibration)
 	usr.click_intercept = null 
 	..()

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -483,7 +483,7 @@
 
 /mob/living/carbon/human/proc/buster_recalibration()
 	set name = "Recalibrate Arm"
-	set desc = "You stabilize the arm in the case of missing functions."
+	set desc = "You recalibrate the arm to restore missing functionality."
 	set category = "Buster Style"
 	var/list/combined_msg = list()
 	combined_msg +=  "<b><i>You recalibrate your arm in an attempt to restore its functions.</i></b>"

--- a/code/game/objects/items/devices/busterarm/buster_limb.dm
+++ b/code/game/objects/items/devices/busterarm/buster_limb.dm
@@ -32,6 +32,7 @@
 	var/mob/living/carbon/N = owner
 	megabuster_action.Remove(N)
 	buster_style.remove(N)
+	N.click_intercept = null
 	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
 	..()
 
@@ -81,6 +82,7 @@
 	var/mob/living/carbon/N = owner
 	megabuster_action.Remove(N)
 	buster_style.remove(N)
+	N.click_intercept = null
 	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
 	..()
 


### PR DESCRIPTION
# Document the changes in your pull request

- fixes #18464 where the buster arm moveset would break when another ability that uses interceptclickon is used by adding a 'recalibrate arm' action to the buster arm tab which attempts to reset clicking to work as intended.
- did my math wrong last time and slam did 70 damage when mashing a target into a wall so rearranged things so slamming into walls does 40 instead
- fixed a typo in the buster style recollection where there was a missing space
- THE MARTIAL ART IS PROPERLY REMOVED ON SEVERING THE ARM NOW

# Changelog

:cl:   
bugfix: fixed buster arm permanently breaking on using aimed abilities  
tweak: tweak slam damage
spellcheck: soshall becomes so shall
/:cl:
