### PR TITLE
americanizes the surplus carbine

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -43,7 +43,7 @@
 	variance = 30
 	projectile_type = /obj/item/projectile/bullet/c46x30mm/airburst_pellet
 
-// .45 (M1911 + C20r)
+// .45 (M1911 + Surplus Carbine + C20r)
 
 /obj/item/ammo_casing/c45
 	name = ".45 bullet casing"

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,11 +1,11 @@
 //Surplus Carbine
 
 /obj/item/ammo_box/magazine/m10mm/rifle
-	name = "rifle magazine (10mm)"
+	name = "rifle magazine (.45)"
 	desc = "A well-worn magazine fitted for the surplus carbine."
 	icon_state = "75-8"
-	ammo_type = /obj/item/ammo_casing/c10mm
-	caliber = "10mm"
+	ammo_type = /obj/item/ammo_casing/c45
+	caliber = ".45"
 	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m10mm/rifle/update_icon()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -395,12 +395,12 @@
 
 /obj/item/gun/ballistic/automatic/surplus
 	name = "\improper surplus carbine"
-	desc = "One of several antique carbines that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
+	desc = "One of several antique carbines that still sees use as a cheap deterrent. Uses .45 ammo, and its bulky frame prevents one-hand firing."
 	icon_state = "surplus"
 	item_state = "moistnugget"
 	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/m10mm/rifle
-	fire_delay = 12
+	fire_delay = 10
 	burst_size = 1
 	can_unsuppress = TRUE
 	can_suppress = TRUE

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -1,4 +1,4 @@
-// .45 (M1911 & C-20r SMG)
+// .45 (M1911 & Surplus Carbine & C-20r SMG)
 
 /obj/item/projectile/bullet/c45
 	name = ".45 bullet"


### PR DESCRIPTION
# Document the changes in your pull request

With the Illegal Ammo Design Disk, you could theoretically load this thing with goofy 10mm ammo without buying a stechkin. Is this good? Not really, but .45 just feels better for this gun.

Doesn't actually increase the damage, but it DOES make it more likely to wound

Also buffs up its fire rate just slightly to make it feel a little less bad (it's still bad)

# Wiki Documentation

Caliber change should be noted on the guide to combat

# Changelog

:cl:  
tweak: Surplus Carbine now loads .45, instead of 10mm
tweak: Surplus Carbine fire rate slightly increased (every 1 second instead of every 1.2 seconds)
/:cl:
