### PR TITLE
Ocular wardens no longer destroy bibles if the target has antimagic

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -109,6 +109,8 @@
 /obj/structure/destructible/clockwork/ocular_warden/proc/acquire_nearby_targets()
 	. = list()
 	for(var/mob/living/L in viewers(sight_range, src)) //Doesn't attack the blind
+		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
+			continue
 		var/obj/item/storage/book/bible/B = L.bible_check()
 		if(B)
 			if(!(B.resistance_flags & ON_FIRE))
@@ -116,8 +118,6 @@
 			for(var/obj/item/storage/book/bible/BI in L.GetAllContents())
 				if(!(BI.resistance_flags & ON_FIRE))
 					BI.fire_act()
-			continue
-		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
 			continue
 		if(L.stat || L.IsStun() || L.IsParalyzed()) //yogs: changes mobility flag to IsStun so people have to taze themselves to ignore warden attacks
 			continue


### PR DESCRIPTION
I think the idea is that it was supposed to be temporary protection from the wardens
however, if the target already has permanent protection via a nullrod or holy water it will still destroy the bible
this makes holy light chaplains literally useless against clock cultists

YES i'm salty
YES this is an ided

:cl:  
tweak: Ocular wardens no longer destroy bibles if the target has antimagic
/:cl:
