### PR TITLE
Nerfs blood cultist blood spear down from 41 force (what the fuck?)

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -669,8 +669,8 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	slot_flags = 0
-	force = 17
-	force_wielded = 24
+	force = 10
+	force_wielded = 25
 	throwforce = 40
 	throw_speed = 2
 	armour_penetration = 30

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -674,7 +674,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	throwforce = 40
 	throw_speed = 2
 	armour_penetration = 30
-	block_chance = 30
+	block_chance = 50
 	attack_verb = list("attacked", "impaled", "stabbed", "torn", "gored")
 	sharpness = SHARP_POINTY
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -724,8 +724,8 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	qdel(src)
 
 /obj/item/twohanded/cult_spear/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(wielded)
-		final_block_chance *= 2
+	if(!wielded)
+		final_block_chance = 0
 	if(prob(final_block_chance))
 		if(attack_type == PROJECTILE_ATTACK)
 			owner.visible_message(span_danger("[owner] deflects [attack_text] with [src]!"))


### PR DESCRIPTION
dualsabers are 
34 force (3 + 31 wielded)
35 AP
75 block chance
but literally cost 16TC and only purchasable by nukies

blood spears are
41 force (17 + 24 wielded)
40 throwforce (with an additional 10 second stun)(breaks the weapon)
30 AP
30 block chance (60 when wielded)
and can be made by literally any blood cultist once they get advanced rituals and build up 150 blood

reduced force to 35 (10 + 25 wielded) so they're not utterly ridiculous, but still pretty strong

apparently block is also fucked, so that's getting reduced too
only blocks when wielded, and has 50 instead of 60 when wielded

:cl:  
tweak: Blood cultist blood spear has 6 less force
tweak: Blood cultist blood spear can only block while wielded and has 10 less block
/:cl:
