### PR TITLE
The RD's Bag of Holding is a steal objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -89,6 +89,12 @@
 	difficulty = 5
 	excludefromjob = list("Research Director")
 
+/datum/objective_item/steal/boh
+	name = "the Research Director's prototype bag of holding."
+	targetitem = /obj/item/storage/backpack/holding/rd
+	difficulty = 10
+	excludefromjob = list("Research Director")
+
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization."
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's
@@ -226,11 +232,6 @@
 /datum/objective_item/special/ddrill
 	name = "a diamond drill."
 	targetitem = /obj/item/pickaxe/drill/diamonddrill
-	difficulty = 10
-
-/datum/objective_item/special/boh
-	name = "the Research Director's bag of holding."    //Just in case these are activated again this one is updated to reference the only one on station now. - Aquizit Jan '23
-	targetitem = /obj/item/storage/backpack/holding
 	difficulty = 10
 
 /datum/objective_item/special/hypercell

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -65,6 +65,8 @@
 	component_type = /datum/component/storage/concrete/bluespace/bag_of_holding
 
 /obj/item/storage/backpack/holding/rd
+	name = "prototype bag of holding"
+	desc = "A backpack that opens into a localized pocket of bluespace. This is the Research Director's special prototype version that is sturdier than those manufactured on station."
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	cryo_preserve = TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

This slides the old BoH steal objective from the ninja list into the regular traitor steal objective list. It also differentiates the RD's bag from the others that can be made later on in the round. Really all I took was the already coded rd version (with the indestructible flag etc.) and added some flair text to it to differentiate it.

![image](https://user-images.githubusercontent.com/70451213/233639422-a7902275-9308-4bae-abaf-089be9047623.png)

![image](https://user-images.githubusercontent.com/70451213/233640084-eb90104d-94a9-433a-94c5-92263a110005.png)

# Wiki Documentation

New name of "prototype bag of holding." Nothing else that I can think of.

# Changelog

:cl:  
rscadd: Adds RD's specific Bag of Holding as steal objective
rscdel: Removes BoH steal from old ninja steal list (in case it's ever reactivated)
tweak: Made RD's BoH its own thing, different from ones made using a shell and anomaly core
/:cl:
