### PR TITLE
Reduces the mantis blades cost by 1 tc, adds slower attack for dual wielding. 

### DIFF
--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -32,6 +32,7 @@
 	if(istype(secondsword, /obj/item/mantis/blade) && !secondattack)
 		sleep(0.2 SECONDS)
 		secondsword.attack(M, user, TRUE)
+		user.changeNext_move(CLICK_CD_MELEE)
 	return
 
 /obj/item/mantis/blade/syndicate

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2070,7 +2070,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "G.O.R.L.E.X. Mantis Blade"
 	desc = "One G.O.R.L.E.X Mantis blade implant able to be retracted inside your body at will for easy storage and concealing. Two blades can be used at once."
 	item = /obj/item/autosurgeon/arm/syndicate/syndie_mantis
-	cost = 7
+	cost = 6
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

What it says on the tin, I reduced the mantis blades price to 6 tc from 7 as I feel like they aren't worth 7, and also to allow for more creativity with other items when you run dual mantis blades. To compensate a bit there is a dual wielding attack cooldown. 

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

Change price of GORLEX Mantis Blades to 6 tc

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Mantis Blades are now 6 tc
tweak: Mantis Blades attack slower when attacking with both

/:cl:
