### PR TITLE
Bluespace activity now actually has lower range and makes you ill

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -320,13 +320,17 @@
 
 /datum/plant_gene/trait/teleport/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))
-		var/teleport_radius = max(round(G.seed.potency / 10), 1)
+		var/teleport_radius = max(round(G.seed.potency * rate), 1)	//max of 5
 		var/turf/T = get_turf(target)
 		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
 		do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
+			C.adjust_disgust(15)	//Two teleports is safe
+			C.confused += 7
 
 /datum/plant_gene/trait/teleport/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
-	var/teleport_radius = max(round(G.seed.potency / 10), 1)
+	var/teleport_radius = max(round(G.seed.potency * rate), 1)	//max of 5
 	var/turf/T = get_turf(C)
 	to_chat(C, span_warning("You slip through spacetime!"))
 	do_teleport(C, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)


### PR DESCRIPTION
Actually implements the teleport range reduction of #18430 and makes squashing it (or being hit by it but that's less spammable) generate some disgust and confusion. After two teleports, any more will have a chance to start making you vomit. Teleport wisely.

# Wiki Documentation

Bluespace activity teleport range maxed at 5 and makes you ill.

# Changelog

:cl:  

tweak: Bluespace activity now actually has a max teleport range of 5
tweak: Getting hit by bluespace plants makes you slightly ill and confused

/:cl:
