### PR TITLE
sotps peopel from going to snetral snommand

### DIFF
--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -28,7 +28,7 @@
 				if(ishuman(living_cheaterson))
 					shake_camera(living_cheaterson, 20, 1)
 					addtimer(CALLBACK(living_cheaterson, /mob/living/carbon.proc/vomit), 2 SECONDS)
-			phasing_in.forceMove(find_safe_turf(z))
+			phasing_in.forceMove(find_safe_turf(min(z,2)))
 	return ..()
 
 /obj/effect/dummy/phased_mob/ex_act()

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -28,7 +28,7 @@
 				if(ishuman(living_cheaterson))
 					shake_camera(living_cheaterson, 20, 1)
 					addtimer(CALLBACK(living_cheaterson, /mob/living/carbon.proc/vomit), 2 SECONDS)
-			phasing_in.forceMove(find_safe_turf(min(z,2)))
+			phasing_in.forceMove(find_safe_turf(max(z,2)))
 	return ..()
 
 /obj/effect/dummy/phased_mob/ex_act()


### PR DESCRIPTION

# Document the changes in your pull request

if you jaunt on the wizard ship you get sent to the station rather than somewhere on the cc z level. This shouldn't be happening anyway but :shrug:


:cl:  
bugfix: you can no longer infiltrate snetral snommand through gang wizard bullshit
/:cl:
