### PR TITLE
Lets mantis blades pry open doors if you have two

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1267,10 +1267,16 @@
 				return
 		INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 
-	if(istype(I, /obj/item/jawsoflife))
+	if(istype(I, /obj/item/jawsoflife) || istype(I, /obj/item/mantis/blade))
 		if(isElectrified())
 			shock(user,100)//it's like sticking a fork in a power socket
 			return
+
+		if(istype(I, /obj/item/mantis/blade))
+			var/obj/item/mantis/blade/secondsword = user.get_inactive_held_item()
+			if(!istype(secondsword, /obj/item/mantis/blade))
+				to_chat(user, span_warning("You need a second [I] to pry open doors!"))
+				return
 
 		if(!density)//already open
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1293,12 +1293,11 @@
 			to_chat(user, span_warning("The airlock won't budge!"))
 			return
 
-		var/time_to_open = 5
+		var/time_to_open = 7 SECONDS * I.toolspeed
+
 		if(hasPower() && !prying_so_hard)
 			if (I.tool_behaviour == TOOL_CROWBAR) //we need another check, futureproofing for if/when bettertools actually completely replaces the old jaws
-				time_to_open = 50
 				if(istype(I,/obj/item/jawsoflife/jimmy))
-					time_to_open = 30
 					var/obj/item/jawsoflife/jimmy/J = I
 					if(J.pump_charge >= J.pump_cost)
 						J.pump_charge = J.pump_charge - J.pump_cost
@@ -1306,7 +1305,7 @@
 							J.pump_charge = 0
 						playsound(src, 'sound/items/jimmy_pump.ogg', 100, TRUE)
 						if(J.obj_flags & EMAGGED)
-							time_to_open = 15
+							time_to_open /= 2
 					else
 						if(user)
 							to_chat(user, span_warning("You do not have enough charge in the [J] for this. You need at least [J.pump_cost]% "))

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -14,7 +14,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_CROWBAR // just a very "sharp" crowbar
-	toolspeed = 0.4 //for door prying speed
+	toolspeed = 0.45 //for door prying speed, ends up at about 3 seconds
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")
 
 /obj/item/mantis/blade/equipped(mob/user, slot, initial)

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -13,6 +13,7 @@
 	bare_wound_bonus = 20
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
+	tool_behaviour = TOOL_CROWBAR // just a very "sharp" crowbar
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")
 
 /obj/item/mantis/blade/equipped(mob/user, slot, initial)

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -14,7 +14,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_CROWBAR // just a very "sharp" crowbar
-	toolspeed = 0.7
+	toolspeed = 0.4 //for door prying speed
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")
 
 /obj/item/mantis/blade/equipped(mob/user, slot, initial)

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -14,6 +14,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_CROWBAR // just a very "sharp" crowbar
+	toolspeed = 0.7
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")
 
 /obj/item/mantis/blade/equipped(mob/user, slot, initial)

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -14,7 +14,6 @@
 	force = 15
 	toolspeed = 0.7
 	tool_behaviour = TOOL_CROWBAR
-	var/pryforce = 1 // the speed at which airlocks are pried open. Default is 1 .
 
 //jaws of life changing jaw code
 /obj/item/jawsoflife/attack_self(mob/user)
@@ -163,7 +162,6 @@
 	materials = list(MAT_METAL=400,MAT_SILVER=10,MAT_TITANIUM=80)
 	toolspeed = 0.3 // Starting minimum value. Pump it up by using it up to the max
 	tool_behaviour = TOOL_CROWBAR
-	pryforce = 0.4
 	var/pump_charge = 0
 	var/pump_max = 100
 	var/pump_min = 0


### PR DESCRIPTION
gives it some cool utility
also changes how prying open doors works to allow for tool speed to affect it (it didn't)
base speed of 7 rather than 5 (makes jaws of life still open at the same speed)

:cl:  
rscadd: Lets mantis blades pry open doors if you have two
tweak: prying open doors scales with tool speed (only makes jimmies faster)
/:cl:
