### PR TITLE
Makes holy water splashes "inject" a percentage into the target

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -217,8 +217,7 @@
 		else if(iscultist(M))
 			to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Elder Goddess's influence!"))
 		M.reagents.add_reagent(type, reac_volume/4)
-		return
-	return ..()
+	..()
 
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)
 	if(M.blood_volume)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -211,9 +211,14 @@
 	..()
 
 /datum/reagent/water/holywater/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	if(is_servant_of_ratvar(M))
-		to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Justiciar's influence!"))
-	..()
+	if(method == TOUCH || method == VAPOR)
+		if(is_servant_of_ratvar(M))
+			to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Justiciar's influence!"))
+		else if(iscultist(M))
+			to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Elder Goddess's influence!"))
+		M.reagents.add_reagent(type, reac_volume/4)
+		return
+	return ..()
 
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)
 	if(M.blood_volume)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -216,7 +216,7 @@
 			to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Justiciar's influence!"))
 		else if(iscultist(M))
 			to_chat(M, span_userdanger("A darkness begins to spread its unholy tendrils through your mind, purging the Elder Goddess's influence!"))
-		M.reagents.add_reagent(type, reac_volume/4)
+		M.reagents.add_reagent(type, reac_volume/10)
 	..()
 
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
This makes it work similarly to unholy water, 
though at a weaker rate of 1/10 instead of the 1/4 of unholy water

a full bluespace beaker of it can convert a cultist if nothing is done
Brings back holy water foam grenades as anti-cult weaponry

:cl:  
rscadd: Splashing with holy water injects some into the target
/:cl:
