### PR TITLE
Makes blood cult emp an aimed spell rather than centered on the caster

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -930,3 +930,19 @@
 							X.resize = reresize
 							X.update_transform()
 		.=..()
+
+/obj/item/projectile/magic/ion //magic version of ion rifle bullets
+	name = "ion bolt"
+	icon_state = "ion"
+	damage = 0
+	damage_type = BURN
+	nodamage = TRUE
+	flag = ENERGY
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
+	var/light_emp_radius = 3
+	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles
+
+/obj/item/projectile/magic/ion/on_hit(atom/target, blocked = FALSE)
+	..()
+	empulse(target, heavy_emp_radius, light_emp_radius)
+	return BULLET_ACT_HIT


### PR DESCRIPTION
A "fuck you" button that can't be avoided is kinda wack
this makes it take time to use rather than a single click
gives it the functionality of range, but makes it smaller as a trade-off

https://user-images.githubusercontent.com/108117184/233900429-1425e5c1-035c-4c8a-b8f4-99cc4eb0120b.mp4


:cl:  
tweak: Blood cult emp is an aimed projectile rather than centered on the caster
tweak: Blood cult emp size is 1 heavy 3 light instead of 2 heavy 5 light
/:cl:
