### PR TITLE
Turns off reticence internal canister light

### DIFF
--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -25,6 +25,7 @@
 	. = ..()
 	if(internal_tank)
 		internal_tank.set_light_on(FALSE) //remove the light that is granted by the internal canister
+		internal_tank.set_light_range_power_color(0, 0, COLOR_BLACK) //just turning it off isn't enough apparently
 
 /obj/mecha/combat/reticence/loaded/Initialize()
 	. = ..()


### PR DESCRIPTION
the light makes the invisible mech quite visible
apparently just turning the light off doesn't actually turn the light off

closes: #18602

:cl:  
bugfix: Turns off reticence internal canister light
/:cl:
