### PR TITLE
Adds the mini energy gun to orderable cargo crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -321,6 +321,14 @@
 					/obj/item/ammo_box/magazine/recharge/ntusp)
 	crate_name = "nt-usp crate"
 
+/datum/supply_pack/security/energypistol
+	name = "Energy Pistol Single-Pack"
+	desc = "Contains one energy pistol for personal defense, capable of firing both lethal and nonlethal blasts of light. Requires Security access to open."
+	cost = 700
+	access_view = ACCESS_SECURITY
+	small_item = TRUE
+	contains = list(/obj/item/gun/energy/e_gun/mini)
+
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."


### PR DESCRIPTION
# Document the changes in your pull request

Game needs more sidearms. We have like 200000 rifles and like maybe 3 "pistols" not  counting the revolver because it goes in the primary slot


# Wiki Documentation

cargo: single order mini egun crate in security section, costs 700 credits and requires (obviously) security access

# Changelog

:cl:  
rscadd: cargo can now order mini eguns for home defense. "Can" does not mean "should", unfortunately.
/:cl:
