### PR TITLE
Reduces Cargo Technician max job slots from 3 to 2 and roundstart from 2 to 1

### DIFF
--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -8,8 +8,8 @@
 	department_head = list("Head of Personnel")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 2
+	spawn_positions = 1
 	supervisors = "the quartermaster and the head of personnel"
 	selection_color = "#dcba97"
 

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -12,7 +12,7 @@ Chief Medical Officer=1,1
 Assistant=-1,-1
 
 Quartermaster=1,1
-Cargo Technician=3,2
+Cargo Technician=2,1
 Shaft Miner=3,3
 
 Bartender=1,1


### PR DESCRIPTION
# Document the changes in your pull request

1) Cargo Technician's entire job functions are superseded by the Quartermaster.
2) Cargo Technician is a noob-bait job. New players log in, pick cargo tech because it's easy, and then go SSD because they stand there while QM/experienced tech does everything.
3) Even for experienced players, there's only two "roles" in non-miner Cargo: Delivering mail and taking orders. This leaves 1 Cargo Technician standing there bored (who will then go SSD/Cryo). They can beg for bounties but after the 8 minute span of "Can I have 3 shotguns for bounty" "No." they go back to standing in their AFK role.
4) We removed everything fun from cargo so less people should be playing it.

# Changelog

:cl:  
tweak: Cargo Technician has 1 less available job slot total and roundstart.
/:cl:
