### PR TITLE
[meta] Adds a photocopier to the HoP office

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -28449,6 +28449,9 @@
 	pixel_x = -25;
 	pixel_y = 5
 	},
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bsN" = (


### PR DESCRIPTION
Adds a photocopier to the northwest section of the main HoP office on Yogsmeta, to match AsteroidStation and Yogstation. Specifically; tile X:91, Y:133, Z:1. 
![](https://cdn.discordapp.com/attachments/1049182110654660628/1100206489077043220/image.png)

# Changelog

:cl:  
mapping: Added a photocopier to the Yogsmeta HoP office.
/:cl:
