### PR TITLE
Disposal bin added to yogsmeta bridge

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -24698,6 +24698,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biP" = (
@@ -24708,6 +24711,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biQ" = (
@@ -24716,6 +24722,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
@@ -24734,10 +24743,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27762,6 +27771,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bqU" = (
@@ -28404,6 +28416,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bsK" = (
@@ -28648,6 +28663,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "btH" = (
@@ -29137,6 +29155,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvL" = (
@@ -29412,6 +29433,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bwI" = (
@@ -29804,6 +29828,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "byt" = (
@@ -70933,6 +70960,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qWw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "qWA" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -74466,6 +74502,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"tjn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "tkt" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -111161,7 +111211,7 @@ bjf
 bkG
 blU
 boz
-boy
+tjn
 bsU
 bsU
 bsU
@@ -111682,7 +111732,7 @@ bkn
 bvL
 bgp
 bhJ
-biA
+qWw
 bDt
 aJs
 aJy
@@ -111939,7 +111989,7 @@ bcj
 bvM
 bcj
 bBN
-biA
+qWw
 bDt
 aJs
 aJz
@@ -112196,7 +112246,7 @@ bwA
 bvR
 blE
 bcj
-biA
+qWw
 bEB
 bQG
 bVk
@@ -112453,7 +112503,7 @@ bfA
 bvR
 bfA
 byo
-biA
+qWw
 bEH
 aNs
 aAy
@@ -112967,7 +113017,7 @@ bfe
 bvZ
 bAe
 bcj
-biA
+qWw
 bDt
 aJt
 aJr
@@ -113738,7 +113788,7 @@ bfk
 bcj
 bcj
 bcj
-biA
+qWw
 bDt
 bzJ
 aJr

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -24698,6 +24698,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biP" = (
@@ -24708,6 +24711,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biQ" = (
@@ -24716,6 +24722,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
@@ -24734,10 +24743,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27762,6 +27771,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bqU" = (
@@ -28404,6 +28416,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bsK" = (
@@ -28648,6 +28663,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "btH" = (
@@ -29137,6 +29155,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvL" = (
@@ -29412,6 +29433,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bwI" = (
@@ -29511,6 +29535,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bxq" = (
@@ -29804,6 +29831,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "byt" = (
@@ -52277,6 +52307,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fdy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "fdz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68313,6 +68357,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"prQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "prR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -111161,7 +111214,7 @@ bjf
 bkG
 blU
 boz
-boy
+fdy
 bsU
 bsU
 bsU
@@ -111682,7 +111735,7 @@ bkn
 bvL
 bgp
 bhJ
-biA
+prQ
 bDt
 aJs
 aJy
@@ -111939,7 +111992,7 @@ bcj
 bvM
 bcj
 bBN
-biA
+prQ
 bDt
 aJs
 aJz
@@ -112196,7 +112249,7 @@ bwA
 bvR
 blE
 bcj
-biA
+prQ
 bEB
 bQG
 bVk
@@ -112453,7 +112506,7 @@ bfA
 bvR
 bfA
 byo
-biA
+prQ
 bEH
 aNs
 aAy
@@ -112967,7 +113020,7 @@ bfe
 bvZ
 bAe
 bcj
-biA
+prQ
 bDt
 aJt
 aJr
@@ -113738,7 +113791,7 @@ bfk
 bcj
 bcj
 bcj
-biA
+prQ
 bDt
 bzJ
 aJr

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -24698,9 +24698,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biP" = (
@@ -24711,9 +24708,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "biQ" = (
@@ -24722,9 +24716,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
@@ -24743,10 +24734,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27771,9 +27762,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bqU" = (
@@ -28416,9 +28404,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bsK" = (
@@ -28663,9 +28648,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "btH" = (
@@ -29155,9 +29137,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bvL" = (
@@ -29433,9 +29412,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bwI" = (
@@ -29535,9 +29511,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bxq" = (
@@ -29831,9 +29804,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "byt" = (
@@ -52307,20 +52277,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"fdy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "fdz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68357,15 +68313,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"prQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "prR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -111214,7 +111161,7 @@ bjf
 bkG
 blU
 boz
-fdy
+boy
 bsU
 bsU
 bsU
@@ -111735,7 +111682,7 @@ bkn
 bvL
 bgp
 bhJ
-prQ
+biA
 bDt
 aJs
 aJy
@@ -111992,7 +111939,7 @@ bcj
 bvM
 bcj
 bBN
-prQ
+biA
 bDt
 aJs
 aJz
@@ -112249,7 +112196,7 @@ bwA
 bvR
 blE
 bcj
-prQ
+biA
 bEB
 bQG
 bVk
@@ -112506,7 +112453,7 @@ bfA
 bvR
 bfA
 byo
-prQ
+biA
 bEH
 aNs
 aAy
@@ -113020,7 +112967,7 @@ bfe
 bvZ
 bAe
 bcj
-prQ
+biA
 bDt
 aJt
 aJr
@@ -113791,7 +113738,7 @@ bfk
 bcj
 bcj
 bcj
-prQ
+biA
 bDt
 bzJ
 aJr


### PR DESCRIPTION
Adds a disposal bin to the southeast section of yogsmeta bridge, that pipes down through the bridge hallway so that engineers don't have to go into the captain's office to reach the pipes.
Now the bridge-bound CMOs, HoSes, RDs, and CEs are not forced to litter.
![ymbd](https://user-images.githubusercontent.com/131717681/234149431-5033ac59-814d-4b9a-bfb6-54d43a59b8bd.png)

# Changelog
:cl:  
mapping: Disposals bin and associated pipes added to the yogsmeta bridge. 
/:cl:
