### PR TITLE
Nitroglycerin no longer explodes inside of bodies

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -33,6 +33,7 @@
 	results = list(/datum/reagent/nitroglycerin = 2)
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/toxin/acid = 1)
 	strengthdiv = 2
+	mob_react = FALSE
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, created_volume)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
@@ -46,6 +47,7 @@
 	required_reagents = list(/datum/reagent/nitroglycerin = 1)
 	required_temp = 474
 	strengthdiv = 2
+	mob_react = FALSE
 
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion


### PR DESCRIPTION
# Document the changes in your pull request

Nitroglycerin will no longer explode when inside a body.

# Wiki Documentation

Might be worth mentioning on the guide to chemistry.

# Changelog

:cl:  
tweak: nitroglycerin no longer explodes inside of bodies
/:cl:
