### PR TITLE
[Meta] Adds spraycans to art storage

### DIFF
--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -28577,6 +28577,14 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
+/obj/item/toy/crayon/spraycan{
+	step_x = 9;
+	step_y = 8
+	},
+/obj/item/toy/crayon/spraycan{
+	step_x = 10;
+	step_y = 5
+	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
 "btp" = (


### PR DESCRIPTION
There were exactly zero spraycans ANYWHERE on yogsmeta. This remedies this by adding two cans directly opposite of the artist's coven door.
![image](https://user-images.githubusercontent.com/131717681/234376289-170d0ddf-5f36-46c5-99b7-6a96fa692307.png)

# Changelog
:cl:  
mapping: Adds two spraycans to yogsmeta artist's coven.
/:cl:
