### PR TITLE
limit bartender shotgun to the bar

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/service.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/service.dm
@@ -21,5 +21,5 @@
 		/obj/item/clothing/glasses/sunglasses/reagent = 1,
 		/obj/item/clothing/neck/petcollar = 1,
 		/obj/item/storage/belt/bandolier = 1,
-		/obj/item/gun/ballistic/shotgun/doublebarrel = 1) //now in closet rather than on a table
+		/obj/item/gun/ballistic/shotgun/doublebarrel/bartender = 1) //now in closet rather than on a table
 	generate_items_inside(items_inside,src)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -180,6 +180,9 @@
 	if(unique_reskin && !current_skin && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		reskin_obj(user)
 
+/obj/item/gun/ballistic/shotgun/doublebarrel/bartender
+	pin = /obj/item/firing_pin/location/bar
+
 // IMPROVISED SHOTGUN //
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -126,7 +126,19 @@
 	icon_state = "firing_pin_pindi"
 	req_implant = /obj/item/implant/weapons_auth
 
+/obj/item/firing_pin/location
+	name = "location firing pin"
+	desc = "Will only authorize if the user is within a pre-programmed area."
+	fail_message = "LOCATION CHECK FAILED"
+	var/list/enabled_areas
 
+/obj/item/firing_pin/location/pin_auth(mob/living/user)
+	for(var/location in enabled_areas)
+		if(istype(get_area(user), location))
+			return TRUE
+
+/obj/item/firing_pin/location/bar
+	enabled_areas = list(/area/crew_quarters/bar)
 
 // Honk pin, clown's joke item.
 // Can replace other pins. Replace a pin in cap's laser for extra fun!


### PR DESCRIPTION
bartender gets sunglasses, armor, and a shotgun at the start of the round which is a little weird considering they're a service role. while the cook does get cqc it's limited to the kitchen, so why wouldn't the bartender's shotgun be limited to the bar? also a lot of bartenders love to grief or validhunt with the shotgun which is a bad thing

# Changelog

:cl:  
tweak: bartender's shotgun can only be fired in the bar
/:cl:
