### PR TITLE
Add 3rd atmos tech spawn location to AsteroidStation

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -17500,6 +17500,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eMA" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eMC" = (
 /obj/structure/chair{
 	dir = 4
@@ -118089,7 +118093,7 @@ aOl
 uzw
 jhF
 emc
-lrf
+eMA
 lrf
 kZw
 aOd


### PR DESCRIPTION
it's #18575 again! now with 100% less merge conflicts at time of recording!

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Added the 3rd atmos tech spawn location back to AsteroidStation
/:cl:
