### PR TITLE
Space Ninja nerfs

### DIFF
--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -32,7 +32,14 @@ GLOBAL_LIST_EMPTY(ninja_capture)
 	update_ninja_icons_removed(M)
 
 /datum/antagonist/ninja/proc/equip_space_ninja(mob/living/carbon/human/H = owner.current)
-	return H.equipOutfit(/datum/outfit/ninja)
+	. = H.equipOutfit(/datum/outfit/ninja)
+	if(!.)
+		return
+	if(istype(H.belt, /obj/item/energy_katana))
+		var/obj/item/energy_katana/katana = H.belt
+		for(var/datum/objective/O as anything in objectives)
+			if(istype(O, /datum/objective/debrain) || istype(O, /datum/objective/assassinate))
+				katana.people_to_kill |= O.target
 
 /datum/antagonist/ninja/proc/addMemories()
 	antag_memory += "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!<br>"

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -32,7 +32,7 @@
 	damtype = STAMINA // non-lethal except to those who attack us
 	var/killing_sound = 'sound/weapons/bladeslice.ogg'
 	var/killing_verbs = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/list/mob/living/people_to_kill
+	var/list/mob/living/people_to_kill = list()
 
 	var/datum/effect_system/spark_spread/spark_system
 	var/datum/action/innate/dash/ninja/jaunt
@@ -40,7 +40,6 @@
 
 /obj/item/energy_katana/Initialize()
 	. = ..()
-	people_to_kill = list()
 	jaunt = new(src)
 	spark_system = new /datum/effect_system/spark_spread()
 	spark_system.set_up(5, 0, src)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -45,7 +45,7 @@ They *could* go in their appropriate files, but this is supposed to be modular
 				spark_system.start()
 				playsound(loc, "sparks", 50, 1)
 				cell.use(drain)
-				S.cell.give(drain)
+				S.cell.give(drain * 3)
 				. += drain
 			else
 				break

--- a/code/modules/ninja/suit/suit_attackby.dm
+++ b/code/modules/ninja/suit/suit_attackby.dm
@@ -18,22 +18,7 @@
 
 
 	else if(istype(I, /obj/item/stock_parts/cell))
-		var/obj/item/stock_parts/cell/CELL = I
-		if(CELL.maxcharge > cell.maxcharge && n_gloves && n_gloves.candrain)
-			to_chat(U, span_notice("Higher maximum capacity detected.\nUpgrading..."))
-			if (n_gloves && n_gloves.candrain && do_after(U, s_delay, src))
-				U.transferItemToLoc(CELL, src)
-				CELL.charge = min(CELL.charge+cell.charge, CELL.maxcharge)
-				var/obj/item/stock_parts/cell/old_cell = cell
-				old_cell.charge = 0
-				U.put_in_hands(old_cell)
-				old_cell.add_fingerprint(U)
-				old_cell.corrupt()
-				old_cell.update_icon()
-				cell = CELL
-				to_chat(U, span_notice("Upgrade complete. Maximum capacity: <b>[round(cell.maxcharge/100)]</b>%"))
-			else
-				to_chat(U, span_danger("Procedure interrupted. Protocol terminated."))
+		to_chat(U, span_warning("ERROR: CELL REPLACEMENT UNAUTHORIZED AS OF TREATY#18678"))
 		return
 
 	else if(istype(I, /obj/item/disk/tech_disk))//If it's a data disk, we want to copy the research on to the suit.


### PR DESCRIPTION
# Document the changes in your pull request

Ninja sword now has a built-in "honor" clause and is completely non-lethal against anyone who has not directly attacked them 
(Doesn't stop them from picking up a toolbox, but it is 3x worse than the katana)

Kill/debrain objectives are automatically granted lethal status

#

Ninja can no longer upgrade their cell to a higher capacity

Ninja cell upgrades makes power usage absolutely trivial; You may still carry around bluespace cells for the same effect, but you will have to take an active role in recharging

To offset this, draining APCs now grants triple charge from before

# Changelog

:cl:  
tweak: Space ninjas draining APCs now do so 3x better
tweak: Energy katana is now non-lethal until you attack them directly or are an objective
tweak: Space ninjas can no longer upgrade their cell to a higher capacity
/:cl:
