### PR TITLE
Shuttle Ain't Free

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -52,6 +52,8 @@ SUBSYSTEM_DEF(shuttle)
 	var/shuttle_purchased = SHUTTLEPURCHASE_PURCHASABLE //If the station has purchased a replacement escape shuttle this round
 	var/emag_shuttle_purchased = FALSE //If the traitors have purchased a replacement escape shuttle this round
 
+	var/freebie = TRUE // The first shuttle call is free, for emergencies of course.
+
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
 	var/datum/map_template/shuttle/selected

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -384,7 +384,16 @@
 		return
 
 	if(trim(reason))
+		var/datum/bank_account/bank_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+		if (!SSshuttle.freebie)
+			if (bank_account.account_balance < 1000)
+				to_chat(src, span_warning("Your station cannot afford to call the emergency shuttle!"))
+				return
+			bank_account.adjust_money(-1000)
 		SSshuttle.requestEvac(src, reason)
+		if (!SSshuttle.freebie) // we want to tell them AFTER the gigantic message to ensure that they see it
+			to_chat(src, span_info("NOTICE: 1000 credits has been deducted from your station's funds as penalty for \
+									repeatedly calling the shuttle. 500 credits will be refunded in the event of a shuttle recall."))
 
 	// hack to display shuttle timer
 	if(!EMERGENCY_IDLE_OR_RECALLED)


### PR DESCRIPTION
# Document the changes in your pull request

Interesting dynamic to the shuttle calls, if the shuttle is called frivolously then the station is punished; if the station somehow ran out of money by end shift then they might have to scrap together credits to leave! An antagonist can also use this to delay shuttle call by controlling the vault funds if the free shuttle call was used up.

# Wiki Documentation

First call is free
Every call after that costs 1000 credits
Recalls refund half of call cost
Only calls/recalls made from AI or communications consoles will cost/refund money
If the first call is recalled by an admin or otherwise, you will keep your one free call

# Changelog

:cl:  
tweak: Every shuttle call past the first one will cost the station money! Make sure you leave for a good reason!
/:cl:
