### PR TITLE
changes how EMPs drain power cells

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -168,6 +168,7 @@
 	diag_hud_set_mechhealth()
 	diag_hud_set_mechcell()
 	diag_hud_set_mechstat()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_CONTENTS)
 
 /obj/mecha/update_icon()
 	if (silicon_pilot && silicon_icon_state)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -139,7 +139,7 @@
 	if (severity == 1)
 		charge -= maxcharge * 0.5
 	else if (severity == 2)
-		charge -= maxcharge * 0.75
+		charge -= maxcharge * 0.25
 	if (charge < 0)
 		charge = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -136,6 +136,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
+	charge -= 1000 / severity
 	if (severity == 1)
 		charge -= maxcharge * 0.5
 	else if (severity == 2)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -136,7 +136,10 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	charge -= 1000 / severity
+	if (severity == 1)
+		charge = charge * 0.5
+	else if (severity == 2)
+		charge = charge * 0.75
 	if (charge < 0)
 		charge = 0
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -137,9 +137,9 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if (severity == 1)
-		charge = charge * 0.5
+		charge -= maxcharge * 0.5
 	else if (severity == 2)
-		charge = charge * 0.75
+		charge -= maxcharge * 0.75
 	if (charge < 0)
 		charge = 0
 


### PR DESCRIPTION
emps versus batteries probably hasn't been touched in a decade or so, that was fine when power cells maxed out at like 5000 but our max powercell now is literally 10x that, so this is a bit problematic

it is currently nearly impossible to drain a power cell with EMPs, the basic 'high-capacity cell' that spawns everywhere roundstart takes TEN EMPS to drain. on the flip side, energy guns are instantly rendered useless upon emp, which many people whine about.

# Changelog

:cl:  
tweak: emps will now drain a percentage of the power cell instead of a flat number, 50% drained on heavy EMPs, 25% on light EMPs
tweak: mech batteries are immune to emp drainage
/:cl:
