### PR TITLE
rounds != shells

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -133,7 +133,7 @@
 
 	if(num_loaded)
 		if(!silent)
-			to_chat(user, span_notice("You load [num_loaded] shell\s into \the [src]!"))
+			to_chat(user, span_notice("You load [num_loaded] round\s into \the [src]!"))
 			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
 		A.update_icon()
 		update_icon()
@@ -150,13 +150,13 @@
 		update_icon()
 
 /obj/item/ammo_box/update_icon()
-	var/shells_left = stored_ammo.len
+	var/rounds_left = stored_ammo.len
 	switch(multiple_sprites)
 		if(AMMO_BOX_PER_BULLET)
-			icon_state = "[initial(icon_state)]-[shells_left]"
+			icon_state = "[initial(icon_state)]-[rounds_left]"
 		if(AMMO_BOX_FULL_EMPTY)
-			icon_state = "[initial(icon_state)]-[shells_left ? "[max_ammo]" : "0"]"
-	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] shell\s left!"
+			icon_state = "[initial(icon_state)]-[rounds_left ? "[max_ammo]" : "0"]"
+	desc = "[initial(desc)] There [(rounds_left == 1) ? "is" : "are"] [rounds_left] round\s left!"
 	for (var/material in bullet_cost)
 		var/material_amount = bullet_cost[material]
 		material_amount = (material_amount*stored_ammo.len) + base_cost[material]

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -1,7 +1,7 @@
 //Surplus Carbine
 
 /obj/item/ammo_box/magazine/m10mm/rifle
-	name = "rifle magazine (.45)"
+	name = "carbine magazine (.45)"
 	desc = "A well-worn magazine fitted for the surplus carbine."
 	icon_state = "75-8"
 	ammo_type = /obj/item/ammo_casing/c45


### PR DESCRIPTION
# Document the changes in your pull request

- A round is a single [cartridge](https://en.wikipedia.org/wiki/Cartridge_(firearms)) containing a [projectile](https://en.wikipedia.org/wiki/Projectile), [propellant](https://en.wikipedia.org/wiki/Propellant), [primer](https://en.wikipedia.org/wiki/Blasting_cap) and [casing](https://en.wikipedia.org/wiki/Cartridge_(firearms)).
- A shell is a form of ammunition that is fired by a large [caliber](https://en.wikipedia.org/wiki/Caliber) [cannon](https://en.wikipedia.org/wiki/Cannon) or artillery piece. Before the mid-19th century, these shells were usually made of solid materials and relied on kinetic energy to have an effect. However, since that time, they are more often filled with [high explosives](https://en.wikipedia.org/wiki/High_explosive) (see [artillery](https://en.wikipedia.org/wiki/Artillery)).
- A shot refers to a single release of a weapons system. This may involve firing just one round or piece of ammunition (e.g., from a [semi-automatic firearm](https://en.wikipedia.org/wiki/Semi-automatic_firearm)), but can also refer to ammunition types that release a large number of projectiles at the same time (e.g., [cluster munitions](https://en.wikipedia.org/wiki/Cluster_munition) or [shotgun shells).](https://en.wikipedia.org/wiki/Shotgun)
- A [dud](https://en.wikipedia.org/wiki/Dud) refers to loaded ammunition that fails to function as intended, typically failing to detonate on landing. However, it can also refer to ammunition that fails to fire inside the weapon, known as a misfire, or when the ammunition only partially functions, known as a [hang fire](https://en.wikipedia.org/wiki/Hang_fire). Dud ammunition, which is classified as an [unexploded ordnance](https://en.wikipedia.org/wiki/Unexploded_ordnance) (UXO), is regarded as highly dangerous. In former conflict zones, it is not uncommon for dud ammunition to remain buried in the ground for many years. Large quantities of ammunition from [World War I](https://en.wikipedia.org/wiki/World_War_I) continue to be regularly found in fields throughout France and Belgium and occasionally[[citation needed](https://en.wikipedia.org/wiki/Wikipedia:Citation_needed)] still claim lives. Although classified as a UXO, landmines that have been left behind after conflict are not considered duds as they have not failed to work and may still be fully functioning.
- A bomb or, more specifically, a [guided](https://en.wikipedia.org/wiki/Guided_bomb) or [unguided bomb](https://en.wikipedia.org/wiki/Unguided_bomb) (also called an aircraft bomb or [aerial bomb](https://en.wikipedia.org/wiki/Aerial_bomb)), is typically an airdropped, unpowered explosive weapon. Mines and the warheads used in guided missiles and rockets are also referred to as bomb-type ammunition.

# Changelog

:cl:  
spellcheck: ammo boxes contain rounds not shells now
spellcheck: changes surplus carbine magazine name to a carbine magazine (not a rifle)
/:cl:
