### PR TITLE
You can now alt click ammo boxes/magazines to combine/take bullets

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -113,6 +113,9 @@
 	return TRUE
 
 /obj/item/ammo_box/attackby(obj/item/A, mob/user, params, silent = FALSE, replace_spent = 0)
+	attempt_load(A, user, silent, replace_spent)
+
+/obj/item/ammo_box/proc/attempt_load(obj/item/A, mob/user, silent = FALSE, replace_spent = 0) //user attempts to put a into this box
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
@@ -148,6 +151,21 @@
 		playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
 		to_chat(user, span_notice("You remove a round from [src]!"))
 		update_icon()
+
+/obj/item/ammo_box/AltClick(mob/user)
+	. = ..()
+	if(!user.canUseTopic(src, TRUE))
+		return
+	var/obj/item/held_item = user.get_active_held_item()
+	if(held_item && held_item != src)
+		attempt_load(held_item, user)
+	else
+		var/obj/item/ammo_casing/A = get_round()
+		if(A)
+			user.put_in_hands(A)
+			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
+			to_chat(user, span_notice("You remove a round from [src]!"))
+			update_icon()
 
 /obj/item/ammo_box/update_icon()
 	var/shells_left = stored_ammo.len

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -162,7 +162,9 @@
 	else
 		var/obj/item/ammo_casing/A = get_round()
 		if(A)
-			user.put_in_hands(A)
+			if(!user.put_in_hands(A))
+				A.forceMove(drop_location())
+				A.bounce_away(FALSE, NONE)
 			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
 			to_chat(user, span_notice("You remove a round from [src]!"))
 			update_icon()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -113,9 +113,6 @@
 	return TRUE
 
 /obj/item/ammo_box/attackby(obj/item/A, mob/user, params, silent = FALSE, replace_spent = 0)
-	attempt_load(A, user, silent, replace_spent)
-
-/obj/item/ammo_box/proc/attempt_load(obj/item/A, mob/user, silent = FALSE, replace_spent = 0) //user attempts to put a into this box
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
@@ -151,21 +148,6 @@
 		playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
 		to_chat(user, span_notice("You remove a round from [src]!"))
 		update_icon()
-
-/obj/item/ammo_box/AltClick(mob/user)
-	. = ..()
-	if(!user.canUseTopic(src, TRUE))
-		return
-	var/obj/item/held_item = user.get_active_held_item()
-	if(held_item && held_item != src)
-		attempt_load(held_item, user)
-	else
-		var/obj/item/ammo_casing/A = get_round()
-		if(A)
-			user.put_in_hands(A)
-			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
-			to_chat(user, span_notice("You remove a round from [src]!"))
-			update_icon()
 
 /obj/item/ammo_box/update_icon()
 	var/shells_left = stored_ammo.len


### PR DESCRIPTION
# Document the changes in your pull request

alt clicking a thing with things in it on yogs -> open up/dispense one

this does not match ammo boxes and now it does. will make interacting with them slightly less CBT

# Changelog

:cl:  
tweak: ammo boxes and magazines can be interacted with by alt clicking
/:cl:
