### PR TITLE
Beepsky does stamina damage instead of instant stun

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -5,9 +5,8 @@
 	icon_state = "secbot"
 	density = FALSE
 	anchored = FALSE
-	health = 40
-	maxHealth = 40
-	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	health = 75
+	maxHealth = 75
 	pass_flags = PASSMOB
 
 	radio_key = /obj/item/encryptionkey/secbot //AI Priv + Security
@@ -266,20 +265,23 @@ Auto Patrol: []"},
 	icon_state = "secbot-c"
 	addtimer(CALLBACK(src, .proc/update_icon), 2)
 	var/threat = 5
-	C.stuttering = max(5, C.stuttering)
-	C.apply_damage(70, STAMINA) // basically a baton mounted on a little robot, so it shouldn't be any stronger than an actual baton
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
+		if(H.check_shields(src, 54, "[src]'s baton"))
+			return
 	else
 		threat = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
-
+	C.stuttering = max(5, C.stuttering)
+	C.apply_damage(54, STAMINA, BODY_ZONE_CHEST, C.run_armor_check(BODY_ZONE_CHEST, ENERGY)) // baton runs off of the tiny bot's power instead of an actual cell, not enough to work at full capacity
 	log_combat(src,C,"stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
-	C.visible_message(span_danger("[src] has stunned [C]!"),\
-							span_userdanger("[src] has stunned you!"))
+	C.visible_message(
+		span_danger("[src] has stunned [C]!"),
+		span_userdanger("[src] has stunned you!")
+	)
 
 /mob/living/simple_animal/bot/secbot/handle_automated_action()
 	if(!..())

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -5,8 +5,8 @@
 	icon_state = "secbot"
 	density = FALSE
 	anchored = FALSE
-	health = 25
-	maxHealth = 25
+	health = 40
+	maxHealth = 40
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	pass_flags = PASSMOB
 
@@ -267,7 +267,7 @@ Auto Patrol: []"},
 	addtimer(CALLBACK(src, .proc/update_icon), 2)
 	var/threat = 5
 	C.stuttering = max(5, C.stuttering)
-	C.apply_damage(40, STAMINA)
+	C.apply_damage(70, STAMINA) // basically a baton mounted on a little robot, so it shouldn't be any stronger than an actual baton
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -223,7 +223,7 @@ Auto Patrol: []"},
 		return
 	if(iscarbon(A))
 		var/mob/living/carbon/C = A
-		if((!C.IsParalyzed() || arrest_type) && stuncount < 30)
+		if((C.getStaminaLoss() < C.maxHealth || arrest_type) && stuncount < 30)
 			stun_attack(A)
 			if(lastStunned && lastStunned == A)
 				stuncount++
@@ -266,14 +266,12 @@ Auto Patrol: []"},
 	icon_state = "secbot-c"
 	addtimer(CALLBACK(src, .proc/update_icon), 2)
 	var/threat = 5
+	C.stuttering = max(5, C.stuttering)
+	C.apply_damage(40, STAMINA)
 	if(ishuman(C))
-		C.stuttering = 5
-		C.Paralyze(100)
 		var/mob/living/carbon/human/H = C
 		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 	else
-		C.Paralyze(100)
-		C.stuttering = 5
 		threat = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, .proc/check_for_weapons))
 
 	log_combat(src,C,"stunned")
@@ -326,7 +324,7 @@ Auto Patrol: []"},
 		if(BOT_PREP_ARREST)		// preparing to arrest target
 
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
-			if( !Adjacent(target) || !isturf(target.loc) ||  target.AmountParalyzed() < 40)
+			if( !Adjacent(target) || !isturf(target.loc) ||  target.getStaminaLoss() < target.maxHealth)
 				back_to_hunt()
 				return
 
@@ -353,7 +351,7 @@ Auto Patrol: []"},
 				back_to_idle()
 				return
 
-			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.AmountParalyzed() < 40)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
+			if(!Adjacent(target) || !isturf(target.loc) || (target.loc != target_lastloc && target.getStaminaLoss() < target.maxHealth)) //if he's changed loc and about to get up or not adjacent or got into a closet, we prep arrest again.
 				back_to_hunt()
 				return
 			else //Try arresting again if the target escapes.


### PR DESCRIPTION
# Document the changes in your pull request

Beepsky now does 54 stamina damage instead of 10 seconds of instant paralysis

# Changelog

:cl:  
tweak: beepsky does 54 stamina damage to you instead of 10 seconds of instant paralysis
tweak: increased beepsky's health to compensate and removes its damage coefficients
/:cl:
