### PR TITLE
Easter food tweaks

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -149,11 +149,11 @@
 /datum/crafting_recipe/food/hotcrossbun
 	name = "Hot-Cross Bun"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
+		/obj/item/reagent_containers/food/snacks/bun = 1,
 		/datum/reagent/consumable/sugar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/hotcrossbun
-	subcategory = CAT_MISCFOOD
+	subcategory = CAT_BREAD
 
 
 /obj/item/reagent_containers/food/snacks/store/cake/brioche
@@ -177,7 +177,7 @@
 		/datum/reagent/consumable/sugar = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/brioche
-	subcategory = CAT_MISCFOOD
+	subcategory = CAT_CAKE
 
 /obj/item/reagent_containers/food/snacks/scotchegg
 	name = "scotch egg"
@@ -197,7 +197,7 @@
 		/obj/item/reagent_containers/food/snacks/meatball = 1  //YOGS - Bigotry rule
 	)
 	result = /obj/item/reagent_containers/food/snacks/scotchegg
-	subcategory = CAT_MISCFOOD
+	subcategory = CAT_EGG
 
 /obj/item/reagent_containers/food/snacks/soup/mammi
 	name = "Mammi"
@@ -214,7 +214,7 @@
 		/datum/reagent/consumable/milk = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/mammi
-	subcategory = CAT_MISCFOOD
+	subcategory = CAT_SOUP
 
 /obj/item/reagent_containers/food/snacks/chocolatebunny
 	name = "chocolate bunny"


### PR DESCRIPTION
Changes hot cross bun recipe to use a bun instead of an entire loaf of bread, never made sense to me why it would need that. Also changes the categories around a bit for easter food, since things like brioche cake should be in the cake category, just makes sense.



wiki:

hot cross bun recipe needs a bun instead of bread



:cl:  Ktlwjec
tweak: Hot-Cross Bun no longer needs an entire loaf of bread to make, instead it needs a bun.
/:cl:
