### PR TITLE
lowers amount of medical doctors that can join by default.

### DIFF
--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -7,8 +7,8 @@
 	department_head = list("Chief Medical Officer")
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 3
+	total_positions = 3
+	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
 	exp_requirements = 180

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -30,7 +30,7 @@ Chaplain=1,1
 Station Engineer=5,5
 Atmospheric Technician=3,2
 
-Medical Doctor=5,3
+Medical Doctor=3,2
 Chemist=2,2
 Geneticist=2,2
 Virologist=1,1


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request
Lowers the amount of roundstart medical doctors to 2 and the total that can join to 3
Oftentimes in medical there are 5 MDs lurking around which either makes it extremely boring as two of them can and do handle everything, or it is a complete clusterfuck of 5 medical doctors shoving into each other, on top of injured and loiterers, whenever medbay is crowded.

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: 2 roundstart MDs, 3 total 

/:cl:
