### PR TITLE
lessened ethereal colour washout

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -88,11 +88,10 @@
 	if(H.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(H.health, 0) / 100
 		var/light_range = 1 + (4 * healthpercent)
-		var/light_power = 1 + healthpercent
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
 		H.set_light(light_range + 1, 0.1, current_color)//this just controls actual view range, not the overlay
-		ethereal_light.set_light_range_power_color(light_range, light_power, current_color)
+		ethereal_light.set_light_range_power_color(light_range, 1, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -91,7 +91,7 @@
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
 		H.set_light(light_range + 1, 0.1, current_color)//this just controls actual view range, not the overlay
-		ethereal_light.set_light_range_power_color(light_range, 1, current_color)
+		ethereal_light.set_light_range_power_color(light_range, healthpercent, current_color)
 		ethereal_light.set_light_on(TRUE)
 		fixed_mut_color = copytext_char(current_color, 2)
 	else


### PR DESCRIPTION
With the new lighting system power is a lot more impactful
This means an ethereal with full health having a light power of 2 kinda just overwrites the colours of everything nearby
This colour change makes it nearly impossible to wear cool clothes or have distinct body colours as the light will just wash everything out

Ethereal light range is untouched

:cl:  
tweak: Ethereal light power is lowered to reduce colour problems
/:cl:
