### PR TITLE
Moves mining medic labcoat underneath other items in locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -129,6 +129,7 @@
 	new /obj/item/clothing/suit/toggle/labcoat/emt/explorer(src)
 	new /obj/item/clothing/head/beret/emt/mining(src)
 	new /obj/item/clothing/under/yogs/rank/miner/medic(src)
+	new /obj/item/clothing/suit/toggle/labcoat/explorer(src)
 	new /obj/item/storage/belt/medical/mining(src)
 	new /obj/item/clothing/glasses/hud/health/meson(src)
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
@@ -141,7 +142,6 @@
 	new /obj/item/bodybag/environmental(src)
 	new /obj/item/extinguisher/mini(src)
 	new /obj/item/reagent_containers/medspray/synthflesh(src)
-	new /obj/item/clothing/suit/toggle/labcoat/explorer(src)
 	var/obj/item/key/K = new(src)
 	K.name = "ATV key"
 	K.desc = "It's a small grey key. Don't let those goddamn ashwalkers or plantpeople get it."


### PR DESCRIPTION
This is 100% self serving, it being ontop of everything else messes with my roundstart process

:cl:  
tweak: Moves mining medic labcoat underneath other items in locker
/:cl:
