### PR TITLE
Removes chem dispensers from the psychiatrist office on all maps

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -2032,6 +2032,25 @@
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/carpet,
 /area/library)
+"aqJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/assembly/flash{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/assembly/flash{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "aqK" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -13158,25 +13177,6 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dtN" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/assembly/flash{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/obj/item/assembly/flash{
-	pixel_x = -1;
-	pixel_y = 10
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "duv" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -13277,6 +13277,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/tcoms)
+"dwU" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "dwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -33244,10 +33252,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"koz" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/medical/psych)
 "koH" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -35526,6 +35530,10 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"len" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/medical/psych)
 "lep" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -51373,14 +51381,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
-"qsy" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/medical/psych)
 "qsS" = (
 /obj/machinery/light{
 	dir = 8
@@ -107342,9 +107342,9 @@ xVJ
 uut
 aVN
 kME
-qsy
-koz
-dtN
+dwU
+len
+aqJ
 aVN
 mNt
 aPk

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -13158,6 +13158,25 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"dtN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/assembly/flash{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/assembly/flash{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "duv" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -31842,10 +31861,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jOO" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/wood,
-/area/medical/psych)
 "jOQ" = (
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -33229,6 +33244,10 @@
 /obj/machinery/gibber,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"koz" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/medical/psych)
 "koH" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -51354,6 +51373,14 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
+"qsy" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "qsS" = (
 /obj/machinery/light{
 	dir = 8
@@ -56917,26 +56944,6 @@
 "ses" = (
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"sey" = (
-/obj/structure/table/wood,
-/obj/item/assembly/flash{
-	pixel_x = -1;
-	pixel_y = 10
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = -1
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/assembly/flash{
-	pixel_x = 5;
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "seA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -62929,14 +62936,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ukc" = (
-/obj/machinery/chem_master,
-/obj/item/book/manual/wiki/chemistry,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "ukq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -107343,9 +107342,9 @@ xVJ
 uut
 aVN
 kME
-sey
-jOO
-ukc
+qsy
+koz
+dtN
 aVN
 mNt
 aPk

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -13971,6 +13971,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"bUN" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "bUV" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/light,
@@ -35382,10 +35386,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kdq" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/medical/psych)
 "kdC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -60568,6 +60568,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"uwk" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -16;
+	pixel_y = 5
+	},
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "uxv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64700,26 +64720,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft)
-"way" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -16;
-	pixel_y = 5
-	},
-/obj/item/folder/white{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/folder/white{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "waB" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -108648,7 +108648,7 @@ jdO
 jdO
 xFh
 fyq
-way
+uwk
 jxu
 xpC
 hEv
@@ -108905,7 +108905,7 @@ cFP
 wfd
 qns
 bwo
-kdq
+bUN
 jxu
 bNd
 bNd
@@ -109162,7 +109162,7 @@ bDB
 gjv
 btY
 fju
-kdq
+bUN
 jxu
 qYx
 rnx

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -19870,26 +19870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dSq" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -16;
-	pixel_y = 5
-	},
-/obj/item/folder/white{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "dSz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -28258,13 +28238,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"hjl" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/psych)
 "hjz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/fore";
@@ -35409,6 +35382,10 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kdq" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "kdC" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -64186,14 +64163,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vRr" = (
-/obj/machinery/chem_master,
-/obj/item/book/manual/wiki/chemistry,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/psych)
 "vRA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -64731,6 +64700,26 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft)
+"way" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -16;
+	pixel_y = 5
+	},
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "waB" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -108402,7 +108391,7 @@ vFJ
 jdO
 wFq
 hpd
-hjl
+sUY
 jxu
 bSN
 pYm
@@ -108659,7 +108648,7 @@ jdO
 jdO
 xFh
 fyq
-vRr
+way
 jxu
 xpC
 hEv
@@ -108916,7 +108905,7 @@ cFP
 wfd
 qns
 bwo
-sUY
+kdq
 jxu
 bNd
 bNd
@@ -109173,7 +109162,7 @@ bDB
 gjv
 btY
 fju
-dSq
+kdq
 jxu
 qYx
 rnx

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -51094,6 +51094,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"epO" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/obj/item/lighter{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/laser_pointer{
+	pixel_x = 4;
+	pixel_y = -10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "eqK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54252,24 +54274,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"guf" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/suit/straight_jacket,
-/turf/open/floor/wood,
-/area/medical/psych)
 "gut" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -54728,28 +54732,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"gKZ" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/obj/item/lighter{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/laser_pointer{
-	pixel_x = 4;
-	pixel_y = -10
-	},
-/obj/item/flashlight/pen{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "gLe" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -55792,6 +55774,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hCq" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 5
+	},
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "hCE" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -56395,10 +56394,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"hXt" = (
-/obj/structure/bookcase/random/reference,
-/turf/open/floor/wood,
-/area/medical/psych)
 "hXL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -71598,6 +71593,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"rCS" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "rCZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -77083,6 +77082,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vbh" = (
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/suit/straight_jacket,
+/turf/open/floor/wood,
+/area/medical/psych)
 "vbm" = (
 /obj/structure/grille/broken,
 /obj/structure/lattice,
@@ -77305,23 +77322,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"viK" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = 5
-	},
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "viM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -106540,8 +106540,8 @@ bPc
 auQ
 gLq
 vyf
-viK
-gKZ
+hCq
+epO
 mWz
 bUs
 cLa
@@ -107054,8 +107054,8 @@ vRk
 auQ
 mTn
 bSe
-hXt
-guf
+rCS
+vbh
 mWz
 qkN
 cZr

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -48381,10 +48381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"dfW" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/wood,
-/area/medical/psych)
 "dgi" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
@@ -54256,6 +54252,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
+"guf" = (
+/obj/structure/closet/secure_closet{
+	name = "psychiatrist locker";
+	req_access_txt = "5"
+	},
+/obj/item/storage/pill_bottle/psicodine,
+/obj/item/storage/pill_bottle/lsd{
+	name = "very happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/happy{
+	name = "happy pills bottle"
+	},
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/happiness,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/suit/straight_jacket,
+/turf/open/floor/wood,
+/area/medical/psych)
 "gut" = (
 /obj/structure/closet,
 /obj/item/extinguisher,
@@ -54714,6 +54728,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"gKZ" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/obj/item/lighter{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/laser_pointer{
+	pixel_x = 4;
+	pixel_y = -10
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "gLe" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -56359,6 +56395,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"hXt" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/wood,
+/area/medical/psych)
 "hXL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56386,11 +56426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos_distro)
-"hYx" = (
-/obj/machinery/chem_master,
-/obj/item/book/manual/wiki/chemistry,
-/turf/open/floor/wood,
-/area/medical/psych)
 "hYG" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -66348,38 +66383,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"okv" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = 5
-	},
-/obj/item/lighter{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/obj/item/assembly/flash{
-	pixel_x = -5
-	},
-/obj/item/flashlight/pen{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/laser_pointer{
-	pixel_x = 4;
-	pixel_y = -10
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "okH" = (
 /obj/machinery/camera{
 	c_tag = "Interrogation room";
@@ -77302,6 +77305,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"viK" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 5
+	},
+/obj/item/assembly/flash{
+	pixel_x = -5
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "viM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -78612,27 +78632,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"wdP" = (
-/obj/structure/closet/secure_closet{
-	name = "psychiatrist locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/storage/pill_bottle/happiness,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/storage/pill_bottle/happy{
-	name = "happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/lsd{
-	name = "very happy pills bottle"
-	},
-/obj/item/storage/pill_bottle/psicodine,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "wel" = (
 /obj/item/cigbutt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -106541,8 +106540,8 @@ bPc
 auQ
 gLq
 vyf
-okv
-wdP
+viK
+gKZ
 mWz
 bUs
 cLa
@@ -107055,8 +107054,8 @@ vRk
 auQ
 mTn
 bSe
-dfW
-hYx
+hXt
+guf
 mWz
 qkN
 cZr


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Removes chem dispenser from the psychiatrist office. 
If they want chems they should have to ask chem, just like how gene has to ask chem for anti rad, and viro has to ask chem for unstable mutagen.

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
  

mapping: chem dispenser is gone from the psychiatrists office

/:cl:
