### PR TITLE
Revert sterilizier sprays having the "25 uit but no refill" because when do you need 25 units of sterilizer

### DIFF
--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -109,7 +109,4 @@
 /obj/item/reagent_containers/medspray/sterilizine
 	name = "sterilizer spray"
 	desc = "Spray bottle loaded with non-toxic sterilizer. Useful in preparation for surgery."
-	list_reagents = list(/datum/reagent/space_cleaner/sterilizine = 100)
-	can_fill_from_container = FALSE
-	amount_per_transfer_from_this = 25
-	volume = 100
+	list_reagents = list(/datum/reagent/space_cleaner/sterilizine = 30)


### PR DESCRIPTION
# Document the changes in your pull request
Sterilizer got hit with the "temporary hypo" niche for medsprays except i disagree that you will ever need to inject someone with 25 units of sterilizer and that they shouldnt be refillable since its the purpose made "surgery thing"
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: sterilizer sprays now hold 30 units down from 100, and inject 5 or 10 units down from 5 or 25, but can be refilled again
/:cl:
