### PR TITLE
removes craftable pneumatic cannons

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -327,17 +327,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
-	name = "Pneumatic Cannon"
-	result = /obj/item/pneumatic_cannon/ghetto
-	tools = list(TOOL_WELDER, TOOL_WRENCH)
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/packageWrap = 8,
-				/obj/item/pipe = 2)
-	time = 5 SECONDS
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
 // Shank - Makeshift weapon that can embed on throw
 /datum/crafting_recipe/shank
 	name = "Shank"


### PR DESCRIPTION
Pneumatic cannon is never used except for making instakill shotguns. Nerfing it would make it useless, so it is being removed instead.

# Changelog

:cl:  
rscdel: you can't make pneumatic cannons anymore
/:cl:
