### PR TITLE
Hypodermic prickles now injects on melee attack instead of when thrown

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -111,6 +111,12 @@
 		squash(user)
 	..()
 
+/obj/item/reagent_containers/food/snacks/grown/attack(mob/living/M, mob/living/user, def_zone)
+	if(!..()) // didn't get overridden
+		if(seed)
+			for(var/datum/plant_gene/trait/T in seed.genes)
+				T.on_attack(src, M, user, def_zone)
+
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!..()) //was it caught by a mob?
 		if(seed)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -397,14 +397,6 @@
 
 /datum/plant_gene/trait/stinging/on_slip(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	if(isliving(target))
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.shoes && istype(H.shoes, /obj/item/clothing))
-				if(H.shoes.clothing_flags & THICKMATERIAL)
-					return
-			if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing) && (H.wear_suit.body_parts_covered & FEET))
-				if(H.wear_suit.clothing_flags & THICKMATERIAL)
-					return
 		on_attack(G, target, null, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 
 /datum/plant_gene/trait/stinging/on_attack(obj/item/reagent_containers/food/snacks/grown/G, mob/living/target, mob/living/user, def_zone)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -415,13 +415,13 @@
 			user.log_message("pricked [target == user ? "themselves" : target ] ([contained]).", INDIVIDUAL_ATTACK_LOG)
 			if(target != user && target.ckey && user.ckey) // injecting people with plants now creates admin logs (stolen from hypospray code)
 				log_attack("[user.name] ([user.ckey]) pricked [target.name] ([target.ckey]) with [G], which had [contained] (INTENT: [uppertext(user.a_intent)])")
-		to_chat(target, span_danger("You are pricked by [G]!"))
 		var/injecting_amount = max(G.seed.potency * 0.2) / target.getarmor(def_zone, BIO) // Maximum of 20, reduced by bio protection
 		if(injecting_amount < 1)
 			return
 		var/fraction = min(injecting_amount/G.reagents.total_volume, 1)
 		G.reagents.reaction(target, INJECT, fraction)
 		G.reagents.trans_to(target, injecting_amount)
+		to_chat(target, span_danger("You are pricked by [G]!"))
 
 /datum/plant_gene/trait/smoke
 	name = "gaseous decomposition"


### PR DESCRIPTION
# Document the changes in your pull request

Hypodermic prickles injects on melee attack instead of when thrown and can no longer inject through robotic limbs or thick clothes like space suits. Also bio armor reduces the amount it injects you with.

# Wiki Documentation

Update description of hypodermic prickles on the guide to hydroponics

# Changelog

:cl:  
tweak: hypodermic prickles injects on melee attack instead of when thrown, can't inject through thick clothes or robotic limbs, and injection amount is reduced by bio armor
/:cl:
