### PR TITLE
Jellypeople squoosh easier

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -17,6 +17,7 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 1 // = regular burn damage unlike other slimes
+	armor = -10	//Squishy
 	payday_modifier = 0.6 //literally a pile of toxic ooze walking around, definitely a health hazard
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -14,8 +14,8 @@
 	damage_overlay_type = ""
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	liked_food = MEAT
-	coldmod = 6   // = 3x cold damage
-	heatmod = 0.5 // = 1/4x heat damage
+	coldmod = 6
+	heatmod = 0.5
 	burnmod = 1 // = regular burn damage unlike other slimes
 	armor = -10	//Squishy
 	payday_modifier = 0.6 //literally a pile of toxic ooze walking around, definitely a health hazard


### PR DESCRIPTION
Jellypeople are secretly an incredibly gamer race with the downside of being cold hurts you a lot except you can just carry coffee to completely nullify that. Now they have an ACTUAL downside.



# Wiki Documentation

Jellypeople now are more prone to being injured by basically everything because they're held together by ???? and not bone and muscle like everyone else.

# Changelog

:cl:  

tweak: Jellypeople now have -10 armor by default
/:cl:
