### PR TITLE
Gives the H.E.C.K. suit spaceproof again

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -85,7 +85,7 @@
 	desc = "Hostile Environment Cross-Kinetic Suit: A suit designed to withstand the wide variety of hazards from Lavaland. It wasn't enough for its last owner."
 	icon_state = "hostile_env"
 	item_state = "hostile_env"
-	clothing_flags = THICKMATERIAL
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	slowdown = 0


### PR DESCRIPTION
Reverts: #16534

was a heavily opposed PR
HECK suit has since been nerfed stat wise

there's no reason to it not have spaceproof anyways
Mining hardsuits are still a thing
They also have a hardsuit from tendril chests
It only comes from a megafauna, but is worse than other armour items miners have access to

The original PR didn't even remove spaceproof from the helmet
It also left the H.E.C.K suit as a varient of spacesuit despite the lack of spaceproof

:cl:  
tweak: H.E.C.K. suit has spaceproof again
/:cl:
