### PR TITLE
Adds Lavaland EMT as a mining medic title

### DIFF
--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -17,7 +17,7 @@
 
 	outfit = /datum/outfit/job/miningmedic
 
-	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer", "Land Search & Rescue", "Mining EMT")
+	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Planetside Health Officer", "Land Search & Rescue", "Lavaland EMT")
 
 	minimal_character_age = 26 //Matches MD
 

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -17,7 +17,7 @@
 
 	outfit = /datum/outfit/job/miningmedic
 
-	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer", "Land Search & Rescue")
+	alt_titles = list("Mining Medical Support", "Lavaland Medical Care Unit", "Junior Mining Medic", "Planetside Health Officer", "Land Search & Rescue", "Mining EMT")
 
 	minimal_character_age = 26 //Matches MD
 

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -1,6 +1,6 @@
 /datum/job/miningmedic
 	title = "Mining Medic"
-	description = "Watch over the Shaft Miners and they all inevitably die in Lavaland."
+	description = "Watch over the Shaft Miners as they all inevitably die on Lavaland."
 	flag = MMEDIC
 	orbit_icon = "kit-medical"
 	department_head = list("Chief Medical Officer")


### PR DESCRIPTION
I like short title names

Removes the junior mining medic title as the role was given time requirements
so no mining medic should be considered a "junior"

:cl:  
rscadd: Lavaland EMT as a mining medic title
rscdel: Junior mining medic as a mining medic title
spellcheck: fixes grammar in mining medic description
/:cl:
