### PR TITLE
neuro toxin on a mech as a xenomorph will now emp it

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -7,6 +7,8 @@
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
 		nodamage = TRUE
+	else if (istype(target, /obj/mecha))
+		empulse(target, 2,3)
 	else if(iscarbon(target))
 		var/mob/living/carbon/H = target
 		H.reagents.add_reagent(/datum/reagent/toxin/staminatoxin/neurotoxin_alien, 10 * H.get_permeability_protection())


### PR DESCRIPTION
xenomorphs have literally zero ability to fight mechs at all because of their insane melee armor and unbearable cuck buttons (looking at you, flaming chainsaw sword that does an ass load of damage and lights xenomorphs on fire) and now neurotoxin is ass so it should at least do something instead of just mildly slowing whoever you shot.

# Wiki Documentation

xenomorph neurotoxin will cause a 2,3 emp if it hits a mech

# Changelog

:cl:  
rscadd: xenomorph neurotoxin causes a small emp if it hits a mech
/:cl:
