### PR TITLE
No longer drop dualsword nullrods to the ground when crit

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -557,17 +557,16 @@
 
 /obj/item/nullrod/handedsword/dropped(mob/user, silent = TRUE)
 	. = ..()
-	if(QDELETED(src))
-		return
-	if(sheath && !sheath.swords)
+	if(sheath)
+		if(sheath.swordright)
+			sheath.swordright.forceMove(sheath)
+		if(sheath.swordleft)
+			sheath.swordleft.forceMove(sheath)
+		if(!sheath.swords)
+			user.balloon_alert(user, "you sheathe \the [sheath].")
+			sheath.update_icon()
+			playsound(user, 'sound/items/sheath.ogg', 25, TRUE)
 		sheath.swords = TRUE
-		var/obj/item/otherhand = user.get_inactive_held_item()
-		if(istype(otherhand, /obj/item/nullrod/handedsword))
-			otherhand.forceMove(sheath)
-		forceMove(sheath)
-		user.balloon_alert(user, "you sheathe \the [sheath].")
-		sheath.update_icon()
-		playsound(user, 'sound/items/sheath.ogg', 25, TRUE)
 	
 
 /*---------------------------------------------------------------------------


### PR DESCRIPTION
Only did this if both swords were dropped literally at the exact same time
wouldn't you know it, this was every time they got crit with the swords in hand

:cl:  
bugfix: No longer drop dualsword nullrods to the ground when crit
/:cl:
