### PR TITLE
changes how EMPs drain power cells 2: this time it's actually good

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -136,7 +136,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	charge -= 1000 / severity
+	charge -= max((charge * 0.1), 500) / severity
 	if (charge < 0)
 		charge = 0
 


### PR DESCRIPTION
Drains between 10% of the CURRENT battery or 500, whichever is higher
amount is halved if only a light EMP rather than heavy

:cl:  
tweak: EMPs remove a small % of current charge rather than a flat amount
/:cl:
