### PR TITLE
Makes "disabled" limbs more likely to get wounded

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -82,7 +82,7 @@
 	/// This number is subtracted from all wound rolls on this bodypart, higher numbers mean more defense, negative means easier to wound
 	var/wound_resistance = 0
 	/// When this bodypart hits max damage, this number is added to all wound rolls. Obviously only relevant for bodyparts that have damage caps.
-	var/disabled_wound_penalty = 15
+	var/disabled_wound_penalty = 30
 
 	/// A hat won't cover your face, but a shirt covering your chest will cover your... you know, chest
 	var/scars_covered_by_clothes = TRUE

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -14,7 +14,7 @@
 	stam_damage_coeff = 1
 	max_stamina_damage = 100
 	wound_resistance = 5
-	disabled_wound_penalty = 25
+	disabled_wound_penalty = 50
 	scars_covered_by_clothes = FALSE
 
 	var/mob/living/brain/brainmob = null //The current occupant.


### PR DESCRIPTION
Since apparently #16594 is "fixing" something that isn't a bug
This just makes wounds more likely when a limb should otherwise be disabled

:cl:  
tweak: Heavily damaged limbs are more likely to get wounds
/:cl:
