### PR TITLE
Fixes double barrel shotguns not being reloadable

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -180,6 +180,20 @@
 	if(unique_reskin && !current_skin && user.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		reskin_obj(user)
 
+/obj/item/gun/ballistic/shotgun/doublebarrel/attackby(obj/item/A, mob/user, params)	//Parent proc is being lazy so we'll do it here
+	if((get_ammo(FALSE, FALSE) == magazine.max_ammo))
+		to_chat(user, span_notice("You can't load any more shells into into \the [src]!"))
+		return
+	.=..()
+	if(istype(A, /obj/item/ammo_casing/shotgun))
+		var/can_reload_say = !get_ammo(FALSE, FALSE)
+		to_chat(user, span_notice("You load [A] into \the [src]."))
+		playsound(src, load_sound, load_sound_volume, load_sound_vary)
+		if(can_reload_say)
+			user.say(reload_say, forced = "reloading")
+		if (chambered == null)
+			chamber_round()
+
 // IMPROVISED SHOTGUN //
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised


### PR DESCRIPTION
This is a kind of hacky fix to this because for SOME REASON the parent attackby proc isn't running properly for shotguns and I spent like two hours trying to find out why to no avail. If someone else can fix it to solve this issue be my guest, but now here we have a fix for the guns that have actually stopped working in the meantime.

# Changelog

:cl:  
 
bugfix: Loading double barrel and improvised shotguns now actually works

/:cl:
