### PR TITLE
fixes internal magazine guns being unable to reload

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -364,7 +364,7 @@
 				chambered.forceMove(drop_location())
 				chambered = null
 			var/can_reload_say = !get_ammo(FALSE, FALSE)
-			var/num_loaded = magazine.attackby(A, user, params, TRUE)
+			var/num_loaded = magazine.attempt_load(A, user, params, TRUE)
 			if (num_loaded)
 				to_chat(user, span_notice("You load [num_loaded] [cartridge_wording]\s into \the [src]."))
 				playsound(src, load_sound, load_sound_volume, load_sound_vary)


### PR DESCRIPTION
# Document the changes in your pull request

ummmm this is why we don't handle snowflake logic in item interaction procs

# Changelog

:cl:  Mqiib
bugfix: fixes internal magazine guns being unable to reload
/:cl:
