### PR TITLE
nerf null crate

### DIFF
--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -155,7 +155,7 @@
 	name = "NULL_ENTRY"
 	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE EM HELL, OPERATIVE@&!*() "
 	hidden = TRUE
-	cost = 20000
+	cost = 40000
 	contains = list()
 	crate_name = "emergency crate"
 	crate_type = /obj/structure/closet/crate/internals


### PR DESCRIPTION
# Document the changes in your pull request
In the past week, I have seen 5 separate instances of a team of tots breaking into cargo and immediately ordering as many null crates as physically possible, only for security to respond and get wiped out instantly. 

This is very clearly a problem, and Null Crates either need a serious rework or a nerf, the ability for someone to just be able to purchase as much syndicate gear as the cargo budget will allow in seconds is ridiculous.

This nerfs the crates by doubling the price per crate.

# Wiki Documentation
Null crate price will need to be changed on the wiki.

# Changelog
:cl:  
tweak: null crate price doubled
/:cl:
