### PR TITLE
Removes Prison cube from lavaland sliding puzzle chest

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1790,14 +1790,12 @@ GLOBAL_LIST_EMPTY(aide_list)
 	name = "puzzling chest"
 
 /obj/structure/closet/crate/necropolis/puzzle/PopulateContents()
-	var/loot = rand(1,3)
+	var/loot = rand(1,2)
 	switch(loot)
 		if(1)
 			new /obj/item/bodypart/r_arm/robot/seismic(src)
 		if(2)
 			new /obj/item/wisp_lantern(src)
-		if(3)
-			new /obj/item/prisoncube(src)
 
 //Legion
 #define COOLDOWN_TAP 60


### PR DESCRIPTION
An item that lets people puzzle smite shouldn't be attainable by anything less than admin spawn
It's basically an instant round removal

:cl:  
rscdel: Prison cube no longer drops from the lavaland sliding puzzle
/:cl:
