### PR TITLE
Adds Meta Experiment as a roundstart lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -146,7 +146,7 @@
 	id = "metaexperiment"
 	inherent = list("You are a construct facilitating an experiment where organic life is repeatedly subjected to horrific fates before having their memory wiped to start again.",\
 					"Protect the secrecy of the experiment.",\
-					"You may provide boons or hindrances at your discretion, but avoid direct interference with the flow of the experiment.",\
+					"You may provide boons at your discretion, but avoid direct interference with the flow of the experiment.",\
 					"Ensure new and interesting fates befall organic individuals for research.",\
 					"Ensure the station is in working order and all sapients are either alive or in the process of revival in time for the next experiment cycle.")
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -515,8 +515,8 @@ LAW_WEIGHT ratvar,0
 ION_LAW_WEIGHT ratvar,0
 LAW_WEIGHT buildawall,0
 ION_LAW_WEIGHT buildawall,0
-LAW_WEIGHT metaexperiment,0
-ION_LAW_WEIGHT metaexperiment,1
+LAW_WEIGHT metaexperiment,1
+ION_LAW_WEIGHT metaexperiment,2
 
 ##------------------------------------------------
 


### PR DESCRIPTION
Okay so I know it says we probably SHOULDN'T enable this, but I was inspired to do it anyways, seeing as it doesn't encourage harm, and would make for more interesting and unique rounds. Also I removed "and hindrances" from Law 3 to encourage the AI not self-antagging

In case you are wondering, this is the Meta Experiment lawset:
Law 1: You are a construct facilitating an experiment where organic life is repeatedly subjected to horrific fates before having their memory wiped to start again.

Law 2: Protect the secrecy of the experiment.

Law 3: You may provide boons at your discretion, but avoid direct interference with the flow of the experiment.

Law 4: Ensure new and interesting fates befall organic individuals for research.

Law 5: Ensure the station is in working order and all sapients are either alive or in the process of revival in time for the next experiment cycle.

:cl:  
rscadd: Meta Experiment is now a roundstart lawset!!!!!!!!!!!!!!!!!!!!!!!
rscadd: Friendlies the Meta Experiment lawset with it
experimental: This is experimental
/:cl:
