### PR TITLE
replaces nullies with a more interactive mechanic

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -102,10 +102,7 @@
 				M.IgniteMob()
 				to_chat(user, span_danger("The card shorts out and catches fire in your hands!"))
 			log_combat(user, target, "attempted to emag")
-			if (!istype(target, /obj/machinery/computer/cargo))
-				target.emag_act(user)
-			else
-				to_chat(user, span_notice("The cheap circuitry isn't strong enough to subvert this!"))
+			target.emag_act(user)
 		emagging = FALSE
 
 /obj/item/card/emag/improvised/attackby(obj/item/W, mob/user, params)

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -23,12 +23,12 @@
 	reward = 4
 
 /datum/bounty/item/syndicate/aicore
-	name = "!&@#AI CORE BOARD CONSOLE!#@*$"
+	name = "!&@#AI CORE CONSOLE BOARD!#@*$"
 	description = "!&@#WE'RE INTERESTED IN LEARNING MORE ABOUT NANOTRASEN AIS. SEND US AN AI DATA CORE BOARD TO BE REWARDED!#@*$"
 	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
 	reward = 2
 /datum/bounty/item/syndicate/aicontrol
-	name = "!&@#AI CONTROL BOARD CONSOLE!#@*$"
+	name = "!&@#AI CONTROL CONSOLE BOARD!#@*$"
 	description = "!&@#A CONSOLE TO REMOTELY DISABLE AI UNITS WOULD BE QUITE HELPFUL FOR US, SO GET US ONE!#@*$"
 	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
 	reward = 6
@@ -37,3 +37,35 @@
 	description = "!&@#WE'RE INTERESTED IN DEVELOPING ARMOR THAT CAN RESIST EXPLOSIVES BETTER. THE PROTOTYPE HARDSUIT WOULD BE HELPFUL FOR THIS GOAL!#@*$"
 	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
 	reward = 3
+/datum/bounty/item/syndicate/boh
+	name = "!&@#BAG OF HOLDING!#@*$"
+	description = "!&@#EXPERIMENTAL BLUESPACE TECHNOLOGY LIKE A BAG OF HOLDING WOULD BE APPRECIATED BY THE LAB BOYS. THEY'RE WILLING TO PAY HANDSOMELY, TOO#@*$"
+	wanted_types = list(/obj/item/storage/backpack/holding,/obj/item/storage/backpack/holding/rd)
+	reward = 7
+/datum/bounty/item/syndicate/aeg
+	name = "!&@#ADVANCED ENERGY GUN!#@*$"
+	description = "!&@#WE'RE LOOKING FOR FLAWS IN NANOTRASEN WEAPONS TECHNOLOGY TO EXPLOIT. SEND US SOME EXAMPLES OF THEIR TECHNOLOGY, AND WE'LL REWARD YOU#@*$"
+	wanted_types = list(/obj/item/gun/energy/e_gun/nuclear)
+	required_count = 3
+	reward = 4
+/datum/bounty/item/syndicate/aiupload
+	name = "!&@#AI UPLOAD CONSOLE BOARD!#@*$"
+	description = "!&@#WE'RE PROBING NANOTRASEN AIS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOAL#@*$"
+	wanted_types = list(/obj/item/circuitboard/computer/aiupload)
+	reward = 5
+/datum/bounty/item/syndicate/borgupload
+	name = "!&@#CYBORG UPLOAD CONSOLE BOARD!#@*$"
+	description = "!&@#WE'RE PROBING NANOTRASEN CYBORGS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOA.#@*$"
+	wanted_types = list(/obj/item/circuitboard/computer/borgupload)
+	reward = 3
+/datum/bounty/item/syndicate/gygaxboards
+	name = "!&@#GYGAX EXOSUIT BOARDS!#@*$"
+	description = "!&@#AFTER A RECENT OPERATION, SEVERAL OF OUR DARK GYGAX UNITS HAVE BEEN LEFT INOPERABLE. SEND SOME REPLACEMENT BOARDS TO US FOR A REWARD#@*$"
+	wanted_types = list(/obj/item/circuitboard/mecha/gygax/peripherals,/obj/item/circuitboard/mecha/gygax/targeting,/obj/item/circuitboard/mecha/gygax/main)
+	reward = 5
+	required_count = 3
+/datum/bounty/item/syndicate/phazon
+	name = "!&@#PHAZON EXOSUIT!#@*$"
+	description = "!&@#WE'D LOVE TO GET OUR HANDS ON ONE OF THESE. IT MAY BE HARD TO SOURCE, BUT WE WILL REWARD YOU GENEROUSLY IF YOU SUCCEED.#@*$"
+	wanted_types = list(/obj/mecha/combat/phazon)
+	reward = 12 //you need an anomaly core and robotics for this one broski, it's gotta be worth a lot

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -58,12 +58,16 @@
 	description = "!&@#WE'RE PROBING NANOTRASEN CYBORGS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOAL#@*$"
 	wanted_types = list(/obj/item/circuitboard/computer/borgupload)
 	reward = 3
-/datum/bounty/item/syndicate/gygaxboards
-	name = "!&@#GYGAX EXOSUIT BOARDS!#@*$"
-	description = "!&@#AFTER A RECENT OPERATION, SEVERAL OF OUR DARK GYGAX UNITS HAVE BEEN LEFT INOPERABLE. SEND SOME REPLACEMENT BOARDS TO US FOR A REWARD#@*$"
-	wanted_types = list(/obj/item/circuitboard/mecha/gygax/peripherals,/obj/item/circuitboard/mecha/gygax/targeting,/obj/item/circuitboard/mecha/gygax/main)
+/datum/bounty/item/syndicate/wardenshotgun
+	name = "!&@#COMPACT COMBAT SHOTGUN!#@*$"
+	description = "!&@#WHILE INFERIOR TO OUR BULLDOG SHOTGUNS, COMPACT COMBAT SHOTGUNS CONTAIN AN EXPENSIVE PART THAT'S REQUIRED TO MANUFACTURE BULLDOG SHOTGUNS. YOU'LL SAVE US A PRETTY PENNY BY GIVING US ONE, AND WE'LL PAY YOU IN RETURN#@*$"
+	wanted_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat/compact)
+	reward = 8 //you gotta kill the warden
+/datum/bounty/item/syndicate/wardenshotgun
+	name = "!&@#ADVANCED HARDSUIT!#@*$"
+	description = "!&@#THE RADIATION SHIELDING BUILT INTO THE ADVANCED HARDSUIT IS SERIOUSLY HIGH-TECH, AND WE WANT A GOOD LOOK AT IT. BRING IT TO US AND WE'LL GIVE YOU A REWARD.#@*$"
+	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/engine/elite)
 	reward = 5
-	required_count = 3
 /datum/bounty/item/syndicate/phazon
 	name = "!&@#PHAZON EXOSUIT!#@*$"
 	description = "!&@#WE'D LOVE TO GET OUR HANDS ON ONE OF THESE. IT MAY BE HARD TO SOURCE, BUT WE WILL REWARD YOU GENEROUSLY IF YOU SUCCEED.#@*$"

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -55,7 +55,7 @@
 	reward = 5
 /datum/bounty/item/syndicate/borgupload
 	name = "!&@#CYBORG UPLOAD CONSOLE BOARD!#@*$"
-	description = "!&@#WE'RE PROBING NANOTRASEN CYBORGS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOA.#@*$"
+	description = "!&@#WE'RE PROBING NANOTRASEN CYBORGS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOAL#@*$"
 	wanted_types = list(/obj/item/circuitboard/computer/borgupload)
 	reward = 3
 /datum/bounty/item/syndicate/gygaxboards

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -30,12 +30,12 @@
 /datum/bounty/item/syndicate/aicontrol
 	name = "!&@#AI CONTROL CONSOLE BOARD!#@*$"
 	description = "!&@#A CONSOLE TO REMOTELY DISABLE AI UNITS WOULD BE QUITE HELPFUL FOR US, SO GET US ONE!#@*$"
-	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
+	wanted_types = list(/obj/item/circuitboard/computer/ai_upload_download)
 	reward = 6
 /datum/bounty/item/syndicate/rdsuit
 	name = "!&@#PROTOTYPE HARDSUIT!#@*$"
 	description = "!&@#WE'RE INTERESTED IN DEVELOPING ARMOR THAT CAN RESIST EXPLOSIVES BETTER. THE PROTOTYPE HARDSUIT WOULD BE HELPFUL FOR THIS GOAL!#@*$"
-	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
+	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/rd)
 	reward = 3
 /datum/bounty/item/syndicate/boh
 	name = "!&@#BAG OF HOLDING!#@*$"

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -1,0 +1,39 @@
+/datum/bounty/item/syndicate
+
+/datum/bounty/item/syndicate/claim(mob/user) //Syndicate bounties add TCs to your uplink
+	if(can_claim())
+		var/datum/mind/claimer = user.mind
+		if(claimer.find_syndicate_uplink())
+			var/datum/component/uplink/U = claimer.find_syndicate_uplink()
+			U.telecrystals += reward
+			claimed = TRUE //to prevent deleting the TCs if you claim it with no uplink
+
+/datum/bounty/item/syndicate/reward_string()
+	return "!&@#WE'LL GIVE YOU [reward] TELECRYSTALS IF YOU DO THIS FOR US!#@*$"
+
+/datum/bounty/item/syndicate/saber
+	name = "!&@#THE CAPTAIN'S SABRE!#@*$"
+	description = "!&@#WE'RE TESTING OUT OUR ARMOR'S PROTECTIVE ABILITY, BUT WE NEED SOMETHING SHARP! PROVIDE IT TO US FOR A REWARD!#@*$"
+	wanted_types = list(/obj/item/melee/sabre)
+	reward = 5
+/datum/bounty/item/syndicate/capsuit
+	name = "!&@#THE CAPTAIN'S SWAT SUIT!#@*$"
+	description = "!&@#OUR NEW BATCH OF ARMOR-PIERCING ROUNDS HAVE JUST COME OFF THE PRODUCTION LINE, AND WE NEED SOMETHING TO TEST THEM ON! HELP US OUT AND YOU'LL BE REWARDED!#@*$"
+	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/swat/captain)
+	reward = 4
+
+/datum/bounty/item/syndicate/aicore
+	name = "!&@#AI CORE BOARD CONSOLE!#@*$"
+	description = "!&@#WE'RE INTERESTED IN LEARNING MORE ABOUT NANOTRASEN AIS. SEND US AN AI DATA CORE BOARD TO BE REWARDED!#@*$"
+	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
+	reward = 2
+/datum/bounty/item/syndicate/aicontrol
+	name = "!&@#AI CONTROL BOARD CONSOLE!#@*$"
+	description = "!&@#A CONSOLE TO REMOTELY DISABLE AI UNITS WOULD BE QUITE HELPFUL FOR US, SO GET US ONE!#@*$"
+	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
+	reward = 6
+/datum/bounty/item/syndicate/rdsuit
+	name = "!&@#PROTOTYPE HARDSUIT!#@*$"
+	description = "!&@#WE'RE INTERESTED IN DEVELOPING ARMOR THAT CAN RESIST EXPLOSIVES BETTER. THE PROTOTYPE HARDSUIT WOULD BE HELPFUL FOR THIS GOAL!#@*$"
+	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
+	reward = 3

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -63,7 +63,7 @@
 	description = "!&@#WHILE INFERIOR TO OUR BULLDOG SHOTGUNS, COMPACT COMBAT SHOTGUNS CONTAIN AN EXPENSIVE PART THAT'S REQUIRED TO MANUFACTURE BULLDOG SHOTGUNS. YOU'LL SAVE US A PRETTY PENNY BY GIVING US ONE, AND WE'LL PAY YOU IN RETURN#@*$"
 	wanted_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat/compact)
 	reward = 8 //you gotta kill the warden
-/datum/bounty/item/syndicate/wardenshotgun
+/datum/bounty/item/syndicate/advancedhardsuit
 	name = "!&@#ADVANCED HARDSUIT!#@*$"
 	description = "!&@#THE RADIATION SHIELDING BUILT INTO THE ADVANCED HARDSUIT IS SERIOUSLY HIGH-TECH, AND WE WANT A GOOD LOOK AT IT. BRING IT TO US AND WE'LL GIVE YOU A REWARD.#@*$"
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/engine/elite)

--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -21,12 +21,6 @@
 	description = "!&@#OUR NEW BATCH OF ARMOR-PIERCING ROUNDS HAVE JUST COME OFF THE PRODUCTION LINE, AND WE NEED SOMETHING TO TEST THEM ON! HELP US OUT AND YOU'LL BE REWARDED!#@*$"
 	wanted_types = list(/obj/item/clothing/suit/space/hardsuit/swat/captain)
 	reward = 4
-
-/datum/bounty/item/syndicate/aicore
-	name = "!&@#AI CORE CONSOLE BOARD!#@*$"
-	description = "!&@#WE'RE INTERESTED IN LEARNING MORE ABOUT NANOTRASEN AIS. SEND US AN AI DATA CORE BOARD TO BE REWARDED!#@*$"
-	wanted_types = list(/obj/item/circuitboard/machine/ai_data_core)
-	reward = 2
 /datum/bounty/item/syndicate/aicontrol
 	name = "!&@#AI CONTROL CONSOLE BOARD!#@*$"
 	description = "!&@#A CONSOLE TO REMOTELY DISABLE AI UNITS WOULD BE QUITE HELPFUL FOR US, SO GET US ONE!#@*$"

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -205,11 +205,10 @@ GLOBAL_LIST_EMPTY(bounties_list_syndicate)
 		try_add_bounty(new low_priority_bounty)
 
 /proc/setup_syndicate_bounties() //Much simpler as we're only picking from one pool of bounties
-	var/i = 1
-	for(i to 5)
+	for(var/i in 1 to 5)
 		var/pick = pick(subtypesof(/datum/bounty/item/syndicate))
-		if(try_add_syndie_bounty(new pick))
-			i += 1
+		if(!(try_add_syndie_bounty(new pick)))
+			i -= 1
 		
 
 /proc/try_add_syndie_bounty(datum/bounty/new_bounty)

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -1,4 +1,5 @@
 GLOBAL_LIST_EMPTY(bounties_list)
+GLOBAL_LIST_EMPTY(bounties_list_syndicate)
 
 /datum/bounty
 	var/name
@@ -6,6 +7,10 @@ GLOBAL_LIST_EMPTY(bounties_list)
 	var/reward = 1000 // In credits.
 	var/claimed = FALSE
 	var/high_priority = FALSE
+
+//SYNDICATE BOUNTY
+/datum/bounty/syndicate
+
 
 // Displayed on bounty UI screen.
 /datum/bounty/proc/completion_string()
@@ -53,16 +58,19 @@ GLOBAL_LIST_EMPTY(bounties_list)
 /proc/bounty_ship_item_and_contents(atom/movable/AM, dry_run=FALSE)
 	if(!GLOB.bounties_list.len)
 		setup_bounties()
+	if(!GLOB.bounties_list_syndicate.len)
+		setup_syndicate_bounties()
 
 	var/list/matched_one = FALSE
 	for(var/thing in reverseRange(AM.GetAllContents()))
 		var/matched_this = FALSE
-		for(var/datum/bounty/B in GLOB.bounties_list)
-			if(B.applies_to(thing))
-				matched_one = TRUE
-				matched_this = TRUE
-				if(!dry_run)
-					B.ship(thing)
+		for(var/list/i in list(GLOB.bounties_list,GLOB.bounties_list_syndicate))
+			for(var/datum/bounty/B in i)
+				if(B.applies_to(thing))
+					matched_one = TRUE
+					matched_this = TRUE
+					if(!dry_run)
+						B.ship(thing)
 		if(!dry_run && matched_this)
 			qdel(thing)
 	return matched_one
@@ -195,6 +203,24 @@ GLOBAL_LIST_EMPTY(bounties_list)
 
 	for(var/low_priority_bounty in low_priority_strict_type_list)
 		try_add_bounty(new low_priority_bounty)
+
+/proc/setup_syndicate_bounties() //Much simpler as we're only picking from one pool of bounties
+	var/i = 1
+	for(i to 5)
+		var/pick = pick(subtypesof(/datum/bounty/item/syndicate))
+		if(try_add_syndie_bounty(new pick))
+			i += 1
+		
+
+/proc/try_add_syndie_bounty(datum/bounty/new_bounty)
+	if(!new_bounty || !new_bounty.name || !new_bounty.description)
+		return FALSE
+	for(var/i in GLOB.bounties_list_syndicate)
+		var/datum/bounty/B = i
+		if(!B.compatible_with(new_bounty) || !new_bounty.compatible_with(B))
+			return FALSE
+	GLOB.bounties_list_syndicate += new_bounty
+	return TRUE
 
 /proc/completed_bounty_count()
 	var/count = 0

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -205,7 +205,7 @@ GLOBAL_LIST_EMPTY(bounties_list_syndicate)
 		try_add_bounty(new low_priority_bounty)
 
 /proc/setup_syndicate_bounties() //Much simpler as we're only picking from one pool of bounties
-	for(var/i in 1 to 5)
+	for(var/i in 0 to 5)
 		var/pick = pick(subtypesof(/datum/bounty/item/syndicate))
 		if(!(try_add_syndie_bounty(new pick)))
 			i -= 1

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -24,7 +24,6 @@
 	. = ..()
 	info = "<h2>Nanotrasen Cargo Bounties</h2></br>"
 	update_icon()
-
 	for(var/datum/bounty/B in GLOB.bounties_list)
 		if(B.claimed)
 			continue
@@ -32,8 +31,22 @@
 		<ul><li>Reward: [B.reward_string()]</li>
 		<li>Completed: [B.completion_string()]</li></ul>"}
 
+/obj/machinery/computer/bounty/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	to_chat(user, span_warning("You adjust the antenna on \The [src], tuning it to a syndicate frequency."))
+	obj_flags |= EMAGGED
+	do_sparks(8, FALSE, loc)
+
+/obj/machinery/computer/bounty/proc/get_list_to_use()
+	if(obj_flags & EMAGGED)
+		return GLOB.bounties_list_syndicate
+	return GLOB.bounties_list
+
 /obj/machinery/computer/bounty/ui_interact(mob/user, datum/tgui/ui)
-	if(!GLOB.bounties_list.len)
+	if(!get_list_to_use().len)
+		if(get_list_to_use() == GLOB.bounties_list_syndicate)
+			setup_syndicate_bounties()
 		setup_bounties()
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
@@ -43,10 +56,11 @@
 /obj/machinery/computer/bounty/ui_data(mob/user)
 	var/list/data = list()
 	var/list/bountyinfo = list()
-	for(var/datum/bounty/B in GLOB.bounties_list)
+	for(var/datum/bounty/B in get_list_to_use())
 		bountyinfo += list(list("name" = B.name, "description" = B.description, "reward_string" = B.reward_string(), "completion_string" = B.completion_string() , "claimed" = B.claimed, "can_claim" = B.can_claim(), "priority" = B.high_priority, "bounty_ref" = REF(B)))
 	data["stored_cash"] = cargocash.account_balance
 	data["bountydata"] = bountyinfo
+	data["emagged"] = (obj_flags & EMAGGED)
 	return data
 
 /obj/machinery/computer/bounty/ui_act(action,params)
@@ -54,7 +68,7 @@
 		return
 	switch(action)
 		if("ClaimBounty")
-			var/datum/bounty/cashmoney = locate(params["bounty"]) in GLOB.bounties_list
+			var/datum/bounty/cashmoney = locate(params["bounty"]) in get_list_to_use()
 			if(cashmoney)
 				cashmoney.claim()
 			return TRUE

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -44,7 +44,8 @@
 	return GLOB.bounties_list
 
 /obj/machinery/computer/bounty/ui_interact(mob/user, datum/tgui/ui)
-	if(!get_list_to_use().len)
+	var/list/list_to_use = get_list_to_use()
+	if(!list_to_use.len)
 		if(get_list_to_use() == GLOB.bounties_list_syndicate)
 			setup_syndicate_bounties()
 		setup_bounties()

--- a/code/modules/cargo/bounty_console.dm
+++ b/code/modules/cargo/bounty_console.dm
@@ -71,7 +71,7 @@
 		if("ClaimBounty")
 			var/datum/bounty/cashmoney = locate(params["bounty"]) in get_list_to_use()
 			if(cashmoney)
-				cashmoney.claim()
+				cashmoney.claim(usr)
 			return TRUE
 		if("Print")
 			if(printer_ready < world.time)

--- a/tgui/packages/tgui/interfaces/CargoBountyConsole.js
+++ b/tgui/packages/tgui/interfaces/CargoBountyConsole.js
@@ -7,11 +7,13 @@ export const CargoBountyConsole = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     bountydata = [],
+    emagged
   } = data;
   return (
     <Window
       width={750}
       height={600}
+      theme={emagged ? "syndicate" : undefined}
       resizable>
       <Window.Content scrollable>
         <Section

--- a/tgui/packages/tgui/interfaces/CargoBountyConsole.js
+++ b/tgui/packages/tgui/interfaces/CargoBountyConsole.js
@@ -7,7 +7,7 @@ export const CargoBountyConsole = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     bountydata = [],
-    emagged
+    emagged,
   } = data;
   return (
     <Window

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1892,6 +1892,7 @@
 #include "code\modules\cargo\bounties\security.dm"
 #include "code\modules\cargo\bounties\slime.dm"
 #include "code\modules\cargo\bounties\special.dm"
+#include "code\modules\cargo\bounties\syndicate.dm"
 #include "code\modules\cargo\bounties\virus.dm"
 #include "code\modules\cargo\exports\gear.dm"
 #include "code\modules\cargo\exports\large_objects.dm"

--- a/yogstation/code/modules/cargo/cargo_packs.dm
+++ b/yogstation/code/modules/cargo/cargo_packs.dm
@@ -151,30 +151,6 @@
 					/obj/item/skub)
 	crate_name = "skub crate"
 
-/datum/supply_pack/emergency/syndicate
-	name = "NULL_ENTRY"
-	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE EM HELL, OPERATIVE@&!*() "
-	hidden = TRUE
-	cost = 20000
-	contains = list()
-	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/internals
-	dangerous = TRUE
-
-/datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
-	var/crate_value = 30
-	var/list/uplink_items = get_uplink_items(SSticker.mode)
-	while(crate_value)
-		var/category = pick(uplink_items)
-		var/item = pick(uplink_items[category])
-		var/datum/uplink_item/I = uplink_items[category][item]
-		if(!I.surplus_nullcrates || prob(100 - I.surplus_nullcrates))
-			continue
-		if(crate_value < I.cost)
-			continue
-		crate_value -= I.cost
-		new I.item(C)
-
 /datum/supply_pack/misc/milliondollarhat
 	name = "Half Off Million Dollar Hat"
 	desc = "Contains a hat that defies both logic and fashion sense. Now half off!"


### PR DESCRIPTION
people whine about null crates every time they pop up, and with good reason. a single traitor (or every traitor on the station) can rush down cargo and, for the price of one six tc emag, can synthesize infinite numbers of traitor goods. this is very bad.

Replaces null crates with syndicate bounties. Emagging a bounty console will now give you a list of special syndicate bounties you can do in order to make some TC. These are limited, and give considerably less TC in value than null crates, however the benefit is you can pick what you want instead of getting a bunch of items you'll be banned for using.

Screenshot of a few of the bounties:
![image](https://user-images.githubusercontent.com/70169560/236335812-064ad11c-14bd-4442-aa9f-b8beec76d317.png)


# Wiki Documentation

Possible bounty items:
Cap sword, 5tc
Cap hardsuit, 4tc
AI data core board, 2tc
AI control console board, 6tc
RD hardsuit, 3tc
BOH, 7tc
3AEGs, 4tc
AI upload, 5tc
Borg upload, 3tc
CE hardsuit, 5tc
Warden shotgun, 8tc
Phazon, 12tc

Upon completing and claiming a bounty, the TC earned will be teleported directly into the claimer's uplink.
Only 5 bounties can spawn, ever.
# Changelog

:cl:  
rscadd: Syndicate Bounties
rscdel: Null crates
tweak: Makeshift emags now work on cargo consoles, if you really want the special ops crate
/:cl:
