### PR TITLE
Fixes mapmerge2 not working under python 3.11

### DIFF
--- a/tools/mapmerge2/requirements.txt
+++ b/tools/mapmerge2/requirements.txt
@@ -1,3 +1,3 @@
-pygit2==1.10.0
+pygit2==1.11.1
 bidict==0.22.0
 Pillow==9.3.0


### PR DESCRIPTION
im not filling out this essay of a template, close the pr if you care

makes mapmerge compatible with python 3.11 without having to build from source

there's a pygit2 1.12.0 but it has more breakage potential than 1.11.1 so 1.11.1 it is