### PR TITLE
Fixes nanites bypassing EMP protection

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -180,6 +180,9 @@
 	holder.icon_state = "nanites[nanite_percent]"
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
+	var/datum/component/empprotection/empproof = host_mob.GetExactComponent(/datum/component/empprotection)
+	if(empproof)
+		return // don't do EMP effects if they're protected from EMPs
 	nanite_volume *= (rand(0.75, 0.90))		//Lose 10-25% of nanites
 	adjust_nanites(null, -(rand(5, 30)))		//Lose 5-30 flat nanite volume
 	for(var/X in programs)

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -181,7 +181,7 @@
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
 	var/datum/component/empprotection/empproof = host_mob.GetExactComponent(/datum/component/empprotection)
-	if(empproof)
+	if(empproof && (empproof.flags & EMP_PROTECT_SELF))
 		return // don't do EMP effects if they're protected from EMPs
 	nanite_volume *= (rand(0.75, 0.90))		//Lose 10-25% of nanites
 	adjust_nanites(null, -(rand(5, 30)))		//Lose 5-30 flat nanite volume

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -181,7 +181,7 @@
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
 	var/datum/component/empprotection/empproof = host_mob.GetExactComponent(/datum/component/empprotection)
-	if(empproof && (empproof.flags & EMP_PROTECT_SELF))
+	if(empproof && (empproof.getEmpFlags() & EMP_PROTECT_SELF))
 		return // don't do EMP effects if they're protected from EMPs
 	nanite_volume *= (rand(0.75, 0.90))		//Lose 10-25% of nanites
 	adjust_nanites(null, -(rand(5, 30)))		//Lose 5-30 flat nanite volume


### PR DESCRIPTION
# Document the changes in your pull request

Exactly what the title says, makes nanites actually care whether the host mob has protection against EMPs or not.

# Changelog

:cl:  
bugfix: fixes nanites bypassing EMP protection
/:cl:
