### PR TITLE
Adds gravitational lensing to the Ark

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -49,13 +49,9 @@
 	START_PROCESSING(SSprocessing, src)
 	if (!grav_lens)
 		grav_lens = new(src)
-		grav_lens.transform = matrix().Scale(0.5)
+		grav_lens.transform = matrix().Scale(0.15)
 		grav_lens.pixel_x = -240
 		grav_lens.pixel_y = -240
-		// Radioactive green glow messes with the displacement map
-		/*var/datum/component/radioactive/c = grav_lens.GetComponent(/datum/component/radioactive)
-		if(c)
-			c.RemoveComponent()*/
 		vis_contents += grav_lens
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
@@ -72,6 +68,19 @@
 					M.playsound_local(M, 'sound/machines/clockcult/ark_scream.ogg', 100, FALSE, pressure_affected = FALSE)
 			hierophant_message("<span class='big boldwarning'>The Ark is taking damage!</span>")
 	last_scream = world.time + ARK_SCREAM_COOLDOWN
+	if(grav_lens)
+		addtimer(CALLBACK(src, PROC_REF(grow), damage_amount), 0.01 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(shrink)), 0.69 SECONDS)
+
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/grow(damage_amount)
+		animate(grav_lens, transform = matrix().Scale(0.4 + damage_amount/125), time = 0.2)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/shrink()
+		animate(grav_lens, transform = matrix().Scale(0.15), time = 0.5)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/growEnd(end_time)
+		animate(grav_lens, transform = matrix().Scale(2), time = end_time)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/kitchen/fork))
@@ -204,6 +213,7 @@
 			countdown.stop()
 			visible_message(span_userdanger("[src] begins to pulse uncontrollably... you might want to run!"))
 			sound_to_playing_players(volume = 50, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/clockcult_gateway_disrupted.ogg'))
+			growEnd(2 SECONDS)
 			for(var/mob/M in GLOB.player_list)
 				var/turf/T = get_turf(M)
 				if((T && T.z == z) || is_servant_of_ratvar(M))
@@ -350,6 +360,7 @@
 				resistance_flags |= INDESTRUCTIBLE
 				purpose_fulfilled = TRUE
 				make_glow()
+				growEnd(14 SECONDS)
 				animate(glow, transform = matrix() * 1.5, alpha = 255, time = 12.5 SECONDS)
 				sound_to_playing_players(volume = 100, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/ratvar_rises.ogg')) //End the sounds
 				sleep(12.5 SECONDS)

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -47,7 +47,7 @@
 	START_PROCESSING(SSprocessing, src)
 	if (!grav_lens)
 		grav_lens = new(src)
-		grav_lens.transform = matrix().Scale(0.15)
+		grav_lens.transform = matrix().Scale(0.8)
 		grav_lens.pixel_x = -240
 		grav_lens.pixel_y = -240
 		vis_contents += grav_lens
@@ -75,7 +75,7 @@
 		animate(grav_lens, transform = matrix().Scale(0.1 + damage_amount/80), time = 0.2)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/shrink()
-		animate(grav_lens, transform = matrix().Scale(0.15), time = 0.3)
+		animate(grav_lens, transform = matrix().Scale(0.8), time = 0.3)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/growEnd(end_time)
 		animate(grav_lens, transform = matrix().Scale(2), time = end_time)

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -47,7 +47,7 @@
 	START_PROCESSING(SSprocessing, src)
 	if (!grav_lens)
 		grav_lens = new(src)
-		grav_lens.transform = matrix().Scale(0.8)
+		grav_lens.transform = matrix().Scale(0.08)
 		grav_lens.pixel_x = -240
 		grav_lens.pixel_y = -240
 		vis_contents += grav_lens
@@ -75,7 +75,7 @@
 		animate(grav_lens, transform = matrix().Scale(0.1 + damage_amount/80), time = 0.2)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/shrink()
-		animate(grav_lens, transform = matrix().Scale(0.8), time = 0.3)
+		animate(grav_lens, transform = matrix().Scale(0.08), time = 0.3)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/growEnd(end_time)
 		animate(grav_lens, transform = matrix().Scale(2), time = end_time)

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -39,8 +39,6 @@
 	var/spaghetti_cooldown = 50
 	var/atom/movable/gravity_lens/grav_lens
 
-
-
 /obj/structure/destructible/clockwork/massive/celestial_gateway/Initialize()
 	. = ..()
 	glow = new(get_turf(src))
@@ -70,14 +68,14 @@
 	last_scream = world.time + ARK_SCREAM_COOLDOWN
 	if(grav_lens)
 		addtimer(CALLBACK(src, PROC_REF(grow), damage_amount), 0.01 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(shrink)), 0.69 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(shrink)), 0.7 SECONDS)
 
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/grow(damage_amount)
-		animate(grav_lens, transform = matrix().Scale(0.4 + damage_amount/125), time = 0.2)
+		animate(grav_lens, transform = matrix().Scale(0.1 + damage_amount/80), time = 0.2)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/shrink()
-		animate(grav_lens, transform = matrix().Scale(0.15), time = 0.5)
+		animate(grav_lens, transform = matrix().Scale(0.15), time = 0.3)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/growEnd(end_time)
 		animate(grav_lens, transform = matrix().Scale(2), time = end_time)
@@ -360,12 +358,12 @@
 				resistance_flags |= INDESTRUCTIBLE
 				purpose_fulfilled = TRUE
 				make_glow()
-				growEnd(14 SECONDS)
 				animate(glow, transform = matrix() * 1.5, alpha = 255, time = 12.5 SECONDS)
 				sound_to_playing_players(volume = 100, channel = CHANNEL_JUSTICAR_ARK, S = sound('sound/effects/ratvar_rises.ogg')) //End the sounds
 				sleep(12.5 SECONDS)
 				make_glow()
 				animate(glow, transform = matrix() * 3, alpha = 0, time = 0.5 SECONDS)
+				growEnd(14 SECONDS)
 				QDEL_IN(src, 0.3 SECONDS)
 				sleep(0.3 SECONDS)
 				GLOB.clockwork_gateway_activated = TRUE

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -37,6 +37,9 @@
 	var/recalling
 	var/next_spaghetti = 0
 	var/spaghetti_cooldown = 50
+	var/atom/movable/gravity_lens/grav_lens
+
+
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/Initialize()
 	. = ..()
@@ -44,6 +47,16 @@
 	if(!GLOB.ark_of_the_clockwork_justiciar)
 		GLOB.ark_of_the_clockwork_justiciar = src
 	START_PROCESSING(SSprocessing, src)
+	if (!grav_lens)
+		grav_lens = new(src)
+		grav_lens.transform = matrix().Scale(0.5)
+		grav_lens.pixel_x = -240
+		grav_lens.pixel_y = -240
+		// Radioactive green glow messes with the displacement map
+		/*var/datum/component/radioactive/c = grav_lens.GetComponent(/datum/component/radioactive)
+		if(c)
+			c.RemoveComponent()*/
+		vis_contents += grav_lens
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Whenever the Ark is shot now, it will give a gravitational lensing affect based entierly on its damage, (0.1 + damage_amount/80)
It will then shrink back down as it recovers.
It also adds a lens effect to the ark once its destroyed, as well as when its completed. Currently this is unfinished, as I have yet to add a check for damaging it, meaning the lensing will get reset once you shoot it again.
Makes shooting the ark way more interesting, and has the potential to cause a little bit more chaos in the Ark room.

https://user-images.githubusercontent.com/42524344/236644511-439b1e12-4331-4181-a686-18cb10258966.mp4

# Changelog
:cl:  
rscadd: Added Gravitation Lensing to the Ark
/:cl:
