### PR TITLE
Updates in-game maintainer list

### DIFF
--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -35,7 +35,7 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<font size='2'><b>Current Head Developers:</b> baiomu, JamieD12<br></font>
+			<font size='2'><b>Current Head Developers:</b> JamieD12, baiomu <br></font>
 			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/yogstation13/Yogstation/graphs/contributors'>-Click Here-</a><br></font>
 			<font size='2'><b>Code Maintainers:</b> adamsogm, AshCorr, Bibby, Cuackles, Djiq, Ling, Manatee, Molti, monster860, TheReddDragon, Wejengin2, ynot01<br></font>
 			<font size='2'><b>Sprite Maintainers:</b> Anerisa, Cuackles, Halcyon<br></font>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -35,11 +35,11 @@
 <table align='center' class="top">
 	<tr>
 		<td valign='top'>
-			<font size='2'><b>Current Head Developers:</b> JamieD12<br></font>
+			<font size='2'><b>Current Head Developers:</b> baiomu, JamieD12<br></font>
 			<font size='2'><b>Currently Active GitHub contributor list:</b> <a href='https://github.com/yogstation13/Yogstation/graphs/contributors'>-Click Here-</a><br></font>
-			<font size='2'><b>Maintainers:</b> adamsogm, AshCorr, baiomu, Bibby, Cuackles, Djiq, Ling, Manatee, Molti, monster860, OrcaCora, Partheo, Wejengin2, ynot01, Anerisa, Halcyon, TheReddDragon<br></font>
-			<font size='2'><b>Spriters:</b> Alagoinha, Cuackles, Halcyon, Missatessatessy, Mqiib, OrcaCora, Tipy1802, Xoxeyos<br></font>
-			<font size='2'><b>Mappers:</b> Vaelophis, baiomu, Ezhan, MenacingManatee, N3D6, GravelyAnonymous, Wejengin2, Xoxeyos<br></font>
+			<font size='2'><b>Code Maintainers:</b> adamsogm, AshCorr, Bibby, Cuackles, Djiq, Ling, Manatee, Molti, monster860, TheReddDragon, Wejengin2, ynot01<br></font>
+			<font size='2'><b>Sprite Maintainers:</b> Anerisa, Cuackles, Halcyon<br></font>
+			<font size='2'><b>Map Maintainers:</b> Aquizit, Ezhan, Wejengin2<br></font>
 			<font size='2'><b>Thanks to:</b> /tg/station, FTL13 devs, Baystation 12, /vg/station, NTstation, CDK Station devs, FacepunchStation, GoonStation devs, the original SpaceStation developers, Invisty for the title image and Hippiestation for dissapointed.ogg and other assets.<br> Also a thanks to anybody who has contributed who is not listed here :( Ask to be added here on our discord.</font>
 			<font size='2' color='red'><b><br>Have a bug to report?</b> Visit our <a href="https://github.com/yogstation13/Yogstation/issues/new?template=bug_report.md">Issue Tracker</a>.<br></font>
 			<font size='2'>Please ensure that the bug has not already been reported and <u><a href="https://github.com/yogstation13/Yogstation/issues"><b>use the template provided here</b></a></u>.<br></font>


### PR DESCRIPTION
a number of people gone
a number of new people
new head dev too
time for an update

changed the groups to specifically say maintainers for each section since sprite maintainers are a bit above regular spriters (god bless our lord and saviour cuackles)

:cl:  
tweak: Updates in-game maintainer list
/:cl:
