### PR TITLE
bz drains changeling chemicals again

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2025,7 +2025,7 @@
 	if(L.mind)
 		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
-			changeling.chem_charges = max(changeling.chem_charges-2, 0)
+			changeling.chem_charges = max(changeling.chem_charges-6, 0)
 	return ..()
 
 /datum/reagent/pax/peaceborg


### PR DESCRIPTION
due to changeling powercreep, BZ (which used to drain 1 chemical from a changeling every tick, also stopping chemical regeneration) now pathetically just slows down changeling chemical generation by 2, so changelings still generate 3 chemicals every tick.

# Changelog

:cl:  
bugfix: a changeling huffing BZ will actually drain their chemicals
/:cl:
