### PR TITLE
toy hammer

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -147,7 +147,7 @@
 				/obj/item/stack/rods = 6)
 	time = 10 SECONDS
 	category = CAT_MISC
-	
+
 /datum/crafting_recipe/motorized_wheelchair
 	name = "Motorized Wheelchair"
 	result = /obj/vehicle/ridden/wheelchair/motorized
@@ -227,6 +227,12 @@
 	name = "Toy Sword"
 	reqs = list(/obj/item/light/bulb = 1, /obj/item/stack/cable_coil = 1, /obj/item/stack/sheet/plastic = 4)
 	result = /obj/item/toy/sword
+	category = CAT_MISC
+
+/datum/crafting_recipe/toysword
+	name = "Toy Sledgehammer"
+	reqs = list(/obj/item/light/bulb = 2, /obj/item/stack/cable_coil = 1, /obj/item/stack/sheet/plastic = 4)
+	result = /obj/item/twohanded/vxtvulhammer/toy/pirate // not authentic!!!!
 	category = CAT_MISC
 
 /datum/crafting_recipe/toybat

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/talking/codex_gigas = 2,
 		/obj/item/clothing/under/syndicate/tacticool = 2,
 		/obj/item/toy/sword = 2,
+		/obj/item/twohanded/vxtvulhammer/toy = 2,
 		/obj/item/toy/gun = 2,
 		/obj/item/gun/ballistic/shotgun/toy/crossbow = 2,
 		/obj/item/storage/box/fakesyndiesuit = 2,
@@ -78,7 +79,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		var/obj/item/circuitboard/CB = new thegame()
 		var/atom/newgame = new CB.build_path(loc, CB)
 		newgame.dir = dir
-		
+
 		return INITIALIZE_HINT_QDEL
 	Reset()
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -382,6 +382,40 @@
 /obj/item/twohanded/dualsaber/toy/IsReflect()//Stops Toy Dualsabers from reflecting energy projectiles
 	return 0
 
+/*
+ * Subtype of Vxtvul Hammer
+ */
+/obj/item/twohanded/vxtvulhammer/toy
+	name = "toy sledgehammer"
+	desc = "A Donksoft motorized hammer with realistic flashing lights and speakers."
+	force = 0
+	force_wielded = 0 // after recreating the dozen procs this thing has I decided it should be a subtype
+	throwforce = 0
+	resistance_flags = NONE
+	armour_penetration = 0
+	block_chance = 0
+	w_class = WEIGHT_CLASS_NORMAL
+	toy = TRUE
+	var/pirated = FALSE // knockoff brand!
+
+/obj/item/twohanded/vxtvulhammer/toy/Initialize()
+	. = ..()
+	if(pirated || prob(10)) // man i got scammed!
+		pirated = TRUE
+		name = "toy pirate sledgehammer"
+		desc += " This one looks different from the ones you see on commercials..."
+		icon_state = "vxtvul_hammer_pirate0-0"
+		update_icon()
+
+/obj/item/twohanded/vxtvulhammer/toy/update_icon()
+	if(!pirated)
+		icon_state = "vxtvul_hammer_pirate[wielded]-[supercharged]"
+	else
+		icon_state = "vxtvul_hammer[wielded]-[supercharged]"
+
+/obj/item/twohanded/vxtvulhammer/toy/pirate
+	pirated = TRUE
+
 /obj/item/toy/katana
 	name = "replica katana"
 	desc = "Woefully underpowered in D20."

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1226,13 +1226,17 @@
 			var/atom/throw_target = get_edge_target_turf(target, user.dir)
 			var/mob/living/victim = target
 			if(toy)
-				victim.safe_throw_at(throw_target, 1, 1)
+				ADD_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
+				victim.safe_throw_at(throw_target, rand(1,2), 3, callback = CALLBACK(src, PROC_REF(afterimpact), victim))
 			else
 				victim.throw_at(throw_target, 15, 5) //Same distance as maxed out power fist with three extra force
 				victim.Paralyze(2 SECONDS)
 				user.visible_message(span_danger("The hammer thunders as it viscerally strikes [target.name]!"))
 				to_chat(victim, span_userdanger("Agony sears through you as [user]'s blow cracks your body off its feet!"))
 				victim.emote("scream")
+
+/obj/item/twohanded/vxtvulhammer/proc/afterimpact(mob/living/victim)
+	REMOVE_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
 
 /obj/item/twohanded/vxtvulhammer/pirate //Exact same but different text and sprites
 	icon_state = "vxtvul_hammer_pirate0-0"

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1063,7 +1063,7 @@
 	desc = "A relic sledgehammer with charge packs wired to two blast pads on its head. \
 			While wielded in two hands, the user can charge a massive blow that will shatter construction and hurl bodies."
 	force = 4 //It's heavy as hell
-	force_wielded = 24 
+	force_wielded = 24
 	armour_penetration = 50 //Designed for shattering walls in a single blow, I don't think it cares much about armor
 	throwforce = 18
 	attack_verb = list("attacked", "hit", "struck", "bludgeoned", "bashed", "smashed")
@@ -1083,6 +1083,7 @@
 	var/datum/effect_system/spark_spread/spark_system //It's a surprise tool that'll help us later
 	var/charging = FALSE
 	var/supercharged = FALSE
+	var/toy = FALSE
 
 /obj/item/twohanded/vxtvulhammer/Initialize() //For the sparks when you begin to charge it
 	. = ..()
@@ -1133,8 +1134,9 @@
 	supercharged = !supercharged
 	if(supercharged)
 		set_light_on(TRUE) //Glows when charged
-		force = initial(force) + (wielded ? force_wielded : 0) + 12 //12 additional damage for a total of 40 has to be a massively irritating check because of how force_wielded works
-		armour_penetration = 100
+		if(!toy)
+			force = initial(force) + (wielded ? force_wielded : 0) + 12 //12 additional damage for a total of 40 has to be a massively irritating check because of how force_wielded works
+			armour_penetration = 100
 	else
 		set_light_on(FALSE)
 		force = initial(force) + (wielded ? force_wielded : 0)
@@ -1188,7 +1190,7 @@
 		playsound(loc, 'sound/effects/explosion3.ogg', 20, TRUE) //Bit of a reverb
 		supercharge() //At start so it doesn't give an unintentional message if you hit yourself
 
-		if(ismachinery(target))
+		if(ismachinery(target) && !toy)
 			var/obj/machinery/machine = target
 			machine.take_damage(machine.max_integrity * 2) //Should destroy machines in one hit
 			if(istype(target, /obj/machinery/door))
@@ -1201,7 +1203,7 @@
 					light.take_damage(light.max_integrity * 2)
 			user.visible_message(span_danger("The hammer thunders against the [target.name], demolishing it!"))
 
-		else if(isstructure(target))
+		else if(isstructure(target) && !toy)
 			var/obj/structure/struct = target
 			struct.take_damage(struct.max_integrity * 2) //Destroy structures in one hit too
 			if(istype(target, /obj/structure/table))
@@ -1209,13 +1211,13 @@
 					platform.take_damage(platform.max_integrity * 2) //Destroys table frames left behind
 			user.visible_message(span_danger("The hammer thunders against the [target.name], destroying it!"))
 
-		else if(iswallturf(target))
+		else if(iswallturf(target) && !toy)
 			var/turf/closed/wall/fort = target
 			fort.dismantle_wall(1) //Deletes the wall but drop the materials, just like destroying a machine above
 			user.visible_message(span_danger("The hammer thunders against the [target.name], shattering it!"))
 			playsound(loc, 'sound/effects/meteorimpact.ogg', 50, TRUE) //Otherwise there's no sound for hitting the wall, since it's just dismantled
 
-		else if(ismecha(target))
+		else if(ismecha(target) && !toy)
 			var/obj/mecha/mech = target
 			mech.take_damage(mech.max_integrity/3) //A third of its max health is dealt as an untyped damage, in addition to the normal damage of the weapon (which has high AP)
 			user.visible_message(span_danger("The hammer thunders as it massively dents the plating of the [target.name]!"))
@@ -1223,11 +1225,14 @@
 		else if(isliving(target))
 			var/atom/throw_target = get_edge_target_turf(target, user.dir)
 			var/mob/living/victim = target
-			victim.throw_at(throw_target, 15, 5) //Same distance as maxed out power fist with three extra force
-			victim.Paralyze(2 SECONDS)
-			user.visible_message(span_danger("The hammer thunders as it viscerally strikes [target.name]!"))
-			to_chat(victim, span_userdanger("Agony sears through you as [user]'s blow cracks your body off its feet!"))
-			victim.emote("scream")
+			if(toy)
+				victim.safe_throw_at(throw_target, 1, 1)
+			else
+				victim.throw_at(throw_target, 15, 5) //Same distance as maxed out power fist with three extra force
+				victim.Paralyze(2 SECONDS)
+				user.visible_message(span_danger("The hammer thunders as it viscerally strikes [target.name]!"))
+				to_chat(victim, span_userdanger("Agony sears through you as [user]'s blow cracks your body off its feet!"))
+				victim.emote("scream")
 
 /obj/item/twohanded/vxtvulhammer/pirate //Exact same but different text and sprites
 	icon_state = "vxtvul_hammer_pirate0-0"

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -122,6 +122,7 @@
 	/obj/item/toy/balloon,
 	/obj/item/toy/gun,
 	/obj/item/toy/sword,
+	/obj/item/twohanded/vxtvulhammer/toy,
 	/obj/item/toy/foamblade,
 	/obj/item/toy/prize/ripley,
 	/obj/item/toy/prize/honk,

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -11,6 +11,7 @@
 					/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted = 10,
 					/obj/item/gun/ballistic/shotgun/toy/unrestricted = 10,
 					/obj/item/toy/sword = 10,
+					/obj/item/twohanded/vxtvulhammer/toy = 7,
 					/obj/item/ammo_box/foambox = 20,
 					/obj/item/toy/foamblade = 10,
 					/obj/item/toy/syndicateballoon = 10,

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -11,6 +11,7 @@
 		/obj/item/gun/ballistic/automatic/toy/pistol/unrestricted = 10,
 		/obj/item/gun/ballistic/shotgun/toy/unrestricted = 10,
 		/obj/item/toy/sword = 10,
+		/obj/item/twohanded/vxtvulhammer/toy = 7,
 		/obj/item/ammo_box/foambox = 20,
 		/obj/item/toy/foamblade = 10,
 		/obj/item/toy/foamblade/baseball = 10,

--- a/yogstation/code/_globalvars/lists/maintenance_loot.dm
+++ b/yogstation/code/_globalvars/lists/maintenance_loot.dm
@@ -424,6 +424,7 @@ GLOBAL_LIST_INIT(maintenance_loot_traditional,list(
 	/obj/item/toy/snappop/phoenix = W_LEGENDARY,
 	/obj/item/toy/spinningtoy = W_RARE,
 	/obj/item/toy/sword = W_RARE,
+	/obj/item/twohanded/vxtvulhammer/toy = W_RARE,
 	/obj/item/toy/syndicateballoon = W_RARE,
 	/obj/item/toy/talking/AI = W_RARE,
 	/obj/item/toy/talking/codex_gigas = W_RARE,

--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -590,6 +590,9 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 /datum/donator_gear/sword0
 	name = "toy sword"
 	unlock_path = /obj/item/toy/sword
+/datum/donator_gear/hammer
+	name = "toy sledgehammer"
+	unlock_path = /obj/item/twohanded/vxtvulhammer/toy
 
 //plushies - kill me, for fuck sake
 /datum/donator_gear/plushvar


### PR DESCRIPTION
# Document the changes in your pull request

Like Vxtvul Hammer but toy

When charged, will (safely) move a player back one or two tiles. Just like the real thing!

# Wiki Documentation

- On spawn, has a 10% chance to use the pirate (knockoff brand) skin
- Can craft with 2 bulbs, cable coil, and 4 plastic
- Available as donator gear
- Available as an arcade prize
- Available as easter egg toy
- Available in Donksoft Toy Vendors
- Available in maint loot

# Changelog

:cl:  
rscadd: Added the toy sledgehammer, available to craft, purchase at vendor, or donator gear
/:cl:
