### PR TITLE
EMPing guns takes less charge but disables them for 5-10 seconds

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -80,7 +80,8 @@
 			if(!G.magazine == src)
 				return
 			G.semicd = TRUE
-			var/unjam_time = ((2/severity) + (rand(-20,20)*0.01)) SECONDS
+			// 5-10 seconds depending on severity, then give or take 0.2 seconds to prevent piercing ears
+			var/unjam_time = ((10/severity) + (rand(-20,20)*0.01)) SECONDS
 			addtimer(CALLBACK(G, TYPE_PROC_REF(/obj/item/gun, reset_semicd)), unjam_time)
 
 /obj/item/ammo_casing/caseless/c22hl

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -18,7 +18,7 @@
 			add_overlay("[icon_state]_o_full")
 		else
 			add_overlay("[icon_state]_o_mid")
-		
+
 
 /obj/item/ammo_box/magazine/recharge/attack_self() //No popping out the "bullets"
 	return
@@ -69,12 +69,19 @@
 
 /obj/item/ammo_box/magazine/recharge/ntusp/emp_act(severity) //shooting physical bullets wont stop you dying to an EMP
 	. = ..()
-	if(!(. & EMP_PROTECT_CONTENTS)) 
+	if(!(. & EMP_PROTECT_CONTENTS))
 		var/bullet_count = ammo_count()
-		var/bullets_to_remove = round(bullet_count / severity)
+		var/bullets_to_remove = round(bullet_count / (severity*2))
 		for(var/i = 0; i < bullets_to_remove, i++)
 			qdel(get_round())
 		update_icon()
+		if(isgun(loc))
+			var/obj/item/gun/ballistic/G = loc
+			if(!G.magazine == src)
+				return
+			G.semicd = TRUE
+			var/unjam_time = ((2/severity) + (rand(-20,20)*0.01)) SECONDS
+			addtimer(CALLBACK(G, TYPE_PROC_REF(/obj/item/gun, reset_semicd)), unjam_time)
 
 /obj/item/ammo_casing/caseless/c22hl
 	caliber = ENERGY

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -21,6 +21,8 @@
 	var/charge_amount = 1
 	var/use_cyborg_cell = FALSE //whether the gun's cell drains the cyborg user's cell to recharge
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
+	var/emp_jammed = FALSE
+	var/emp_jam_timer
 
 	available_attachments = list(
 		/obj/item/attachment/scope/simple,
@@ -35,10 +37,26 @@
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()
 	if(!(. & EMP_PROTECT_CONTENTS))
-		cell.use(round(cell.charge / severity))
+		cell.use(round(cell.charge / (severity*2)))
+		emp_jammed = TRUE
+		deltimer(emp_jam_timer)
+		// 1-2 seconds depending on severity, then give or take 0.2 seconds to prevent piercing ears
+		var/unjam_time = ((2/severity) + (rand(-20,20)*0.01)) SECONDS
+		emp_jam_timer = addtimer(CALLBACK(src, PROC_REF(emp_unjam)), unjam_time, TIMER_STOPPABLE)
 		chambered = null //we empty the chamber
 		recharge_newshot() //and try to charge a new shot
 		update_icon()
+
+/obj/item/gun/energy/shoot_with_empty_chamber(mob/living/user as mob|obj)
+	if(emp_jammed)
+		to_chat(user, span_danger("*EMP-JAMMED*"))
+		playsound(src, dry_fire_sound, 30, TRUE)
+	else
+		..()
+
+/obj/item/gun/energy/proc/emp_unjam()
+	emp_jammed = FALSE
+	playsound(src, "sound/machines/twobeep.ogg", 50)
 
 /obj/item/gun/energy/get_cell()
 	return cell
@@ -91,7 +109,7 @@
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
-	return !QDELETED(cell) ? (cell.charge >= shot.e_cost) : FALSE
+	return (!QDELETED(cell) ? (cell.charge >= shot.e_cost) : FALSE) && !emp_jammed
 
 /obj/item/gun/energy/recharge_newshot(no_cyborg_drain)
 	if (!ammo_type || !cell)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -40,8 +40,8 @@
 		cell.use(round(cell.charge / (severity*2)))
 		emp_jammed = TRUE
 		deltimer(emp_jam_timer)
-		// 1-2 seconds depending on severity, then give or take 0.2 seconds to prevent piercing ears
-		var/unjam_time = ((2/severity) + (rand(-20,20)*0.01)) SECONDS
+		// 5-10 seconds depending on severity, then give or take 0.2 seconds to prevent piercing ears
+		var/unjam_time = ((10/severity) + (rand(-20,20)*0.01)) SECONDS
 		emp_jam_timer = addtimer(CALLBACK(src, PROC_REF(emp_unjam)), unjam_time, TIMER_STOPPABLE)
 		chambered = null //we empty the chamber
 		recharge_newshot() //and try to charge a new shot


### PR DESCRIPTION
# Document the changes in your pull request

EMPs take 25/50% instead of 50/100% of a gun's cell now, but also disable the weapon for 5-10 seconds to retain its usefulness in combat.

Currently, laying an EMP on someone who relies on energy weapons (like a security officer) immediately puts them out of the fight unless they want to take their chances at melee stun combat.

Now, EMPs are still advantageous but not so much that it wins the fight outright by disabling your opponent's ranged options for the rest of the engagement.

Yes it works for NT-USP too

# Changelog

:cl:  
tweak: EMPing an energy gun now takes 25/50% charge instead of 50/100%
tweak: EMPing an energy gun now disables it for around 5 or 10 seconds
/:cl:
