### PR TITLE
Fix spelling in of the grand mining medic cape

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
@@ -277,7 +277,7 @@
 	id = "minemeic"
 
 /datum/skillcape/trimmed/minemedic
-	name = "cape of the grand minic medic"
+	name = "cape of the grand mining medic"
 	job = "Mining Medic"
 	path = /obj/item/clothing/neck/skillcape/trimmed/minemedic
 	id = "minemeic_trimmed"


### PR DESCRIPTION
# Document the changes in your pull request
Spelling fix

# Changelog

:cl:  
spellcheck: fixed a typo in the grand mining medic cape
/:cl:
