### PR TITLE
replaces the spellbook in the lavaland wizard den with 3 construct shells

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
@@ -112,6 +112,7 @@
 /area/ruin/powered)
 "r" = (
 /obj/structure/table/wood,
+/obj/structure/constructshell,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "s" = (
@@ -125,11 +126,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/ruin/powered)
-"u" = (
-/obj/structure/table/wood,
-/obj/item/book/granter/spell/random,
 /turf/open/floor/wood,
 /area/ruin/powered)
 "v" = (
@@ -363,7 +359,7 @@ a
 a
 a
 x
-u
+r
 h
 g
 h


### PR DESCRIPTION
# Document the changes in your pull request

Spellbook only has grief/validhunt spells in it, all of which are robeless because of course they are
Instead I will replace it with construct shells (soulstone not included)

FOR REFERENCE, the spells the book can give are
fireball
sacred flame
smoke
blind
mindswap
forcewall
knock
barnyard
charge
summon item
lightningbolt

# Wiki Documentation

update wizard den map if it's present, 3 tables in the wizard room have construct shells instead of a random spellbook

# Changelog

:cl:  
rscdel: no more spellbook in the wizard den on lavaland because I hate miners
rscadd: construct shells in the wizard den on lavaland
/:cl:
