### PR TITLE
Why is Kortara under Beer and Milk when it's a nut? Not anymore

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -899,11 +899,11 @@
 
 /datum/chemical_reaction/drink/sea_breeze
 	results = list(/datum/reagent/consumable/ethanol/sea_breeze = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol/bilk/kortara = 3, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/consumable/ethanol/creme_de_cacao = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/kortara = 3, /datum/reagent/consumable/ethanol/creme_de_menthe = 1, /datum/reagent/consumable/ethanol/creme_de_cacao = 1)
 
 /datum/chemical_reaction/drink/white_tiziran
 	results = list(/datum/reagent/consumable/ethanol/white_tiziran = 8)
-	required_reagents = list(/datum/reagent/consumable/ethanol/black_russian = 5, /datum/reagent/consumable/ethanol/bilk/kortara = 3)
+	required_reagents = list(/datum/reagent/consumable/ethanol/black_russian = 5, /datum/reagent/consumable/ethanol/kortara = 3)
 
 /datum/chemical_reaction/drink/drunken_espatier
 	results = list(/datum/reagent/consumable/ethanol/drunken_espatier = 5)

--- a/code/modules/hydroponics/grown/korta_nut.dm
+++ b/code/modules/hydroponics/grown/korta_nut.dm
@@ -24,7 +24,7 @@
 	grind_results = list(/datum/reagent/consumable/korta_flour = 0)
 	juice_results = list(/datum/reagent/consumable/korta_milk = 0)
 	tastes = list("peppery heat" = 1)
-	distill_reagent = /datum/reagent/consumable/ethanol/bilk/kortara
+	distill_reagent = /datum/reagent/consumable/ethanol/kortara
 
 //Sweet Korta Nut
 /obj/item/seeds/korta_nut/sweet
@@ -48,4 +48,4 @@
 	grind_results = list(/datum/reagent/consumable/korta_flour = 0)
 	juice_results = list(/datum/reagent/consumable/korta_milk = 0, /datum/reagent/consumable/korta_nectar = 0)
 	tastes = list("peppery sweet" = 1)
-	distill_reagent = /datum/reagent/consumable/ethanol/bilk/kortara
+	distill_reagent = /datum/reagent/consumable/ethanol/kortara

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2495,7 +2495,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A strange cocktail with a cracked egg believed to treat hangovers."
 	shot_glass_icon_state = "ambermoonshotglass"
 
-/datum/reagent/consumable/ethanol/bilk/kortara
+/datum/reagent/consumable/ethanol/kortara
 	name = "Kortara"
 	description = "A sweet, milky nut-based drink traditional in vuulek cuisine. Frequently mixed with fruit juices and cocoa for extra refreshment."
 	boozepwr = 25


### PR DESCRIPTION
# Document the changes in your pull request

Don't know if its intentional or not, but for some reason Kortara has the line /bilk/kortara which interferes with mixing drinks. 

It happened to me one time, and I didn't like it so I'm fixing it.

# Changelog

:cl:  

bugfix: Kortara no longer is part of the Bilk family (Beer & Milk?)

/:cl:
