### PR TITLE
A whole bunch of voice of god changes

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -225,7 +225,7 @@
 	var/static/regex/hallucinate_words = regex("see the truth|hallucinate|the truth is out there")
 	var/static/regex/wakeup_words = regex("wake up|awaken")
 	var/static/regex/heal_words = regex("live|heal|survive|mend|life|heroes never die|rest")
-	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death|kill|judgement|thy end is now") // THY END IS NOW
+	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death|kill|judgement|thy end is now|crush") // THY END IS NOW
 	var/static/regex/bleed_words = regex("bleed|blood")
 	var/static/regex/burn_words = regex("burn|ignite|fire|flame")
 	var/static/regex/hot_words = regex("heat|hot|hell")

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -216,9 +216,6 @@
 		power_multiplier *= (1 + (1/specific_listeners.len)) //2x on a single guy, 1.5x on two and so on
 		message = copytext(message, length(found_string) + 1)
 
-	var/static/regex/stun_words = regex("stop|wait|stand still|hold on|halt")
-	var/static/regex/knockdown_words = regex("drop|fall|trip|knockdown")
-	var/static/regex/sleep_words = regex("sleep|slumber|rest")
 	var/static/regex/vomit_words = regex("vomit|throw up|sick")
 	var/static/regex/silence_words = regex("shut up|silence|be silent|ssh|quiet|hush")
 	var/static/regex/hallucinate_words = regex("see the truth|hallucinate")
@@ -260,31 +257,12 @@
 	var/static/regex/multispin_words = regex("like a record baby|right round")
 
 	var/i = 0
-	//STUN
-	if(findtext(message, stun_words))
-		cooldown = COOLDOWN_STUN
-		for(var/V in listeners)
-			var/mob/living/L = V
-			L.Stun(60 * power_multiplier)
-
-	//KNOCKDOWN
-	else if(findtext(message, knockdown_words))
-		cooldown = COOLDOWN_STUN
-		for(var/V in listeners)
-			var/mob/living/L = V
-			L.Paralyze(60 * power_multiplier)
-
-	//SLEEP
-	else if((findtext(message, sleep_words)))
-		cooldown = COOLDOWN_STUN
-		for(var/mob/living/carbon/C in listeners)
-			C.Sleeping(40 * power_multiplier)
 
 	//VOMIT
-	else if((findtext(message, vomit_words)))
+	if((findtext(message, vomit_words)))
 		cooldown = COOLDOWN_STUN
 		for(var/mob/living/carbon/C in listeners)
-			C.vomit(10 * power_multiplier, distance = power_multiplier)
+			C.vomit(10 * power_multiplier, distance = power_multiplier, stun = FALSE)
 
 	//SILENCE
 	else if((findtext(message, silence_words)))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -221,7 +221,7 @@
 	var/static/regex/hallucinate_words = regex("see the truth|hallucinate")
 	var/static/regex/wakeup_words = regex("wake up|awaken")
 	var/static/regex/heal_words = regex("live|heal|survive|mend|life|heroes never die")
-	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death")
+	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death|judgement|thy end is now") // THY END IS NOW
 	var/static/regex/bleed_words = regex("bleed|there will be blood")
 	var/static/regex/burn_words = regex("burn|ignite")
 	var/static/regex/hot_words = regex("heat|hot|hell")
@@ -297,7 +297,12 @@
 		cooldown = COOLDOWN_DAMAGE
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.apply_damage(15 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)
+			if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid))
+				L.apply_damage(360 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // very long cooldown so make it really good at killing lavaland mobs
+			else if(L.mind?.martial_art && L.mind.martial_art.id == "ultra violence")
+				L.apply_damage(45 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // DIE!!
+			else
+				L.apply_damage(15 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)
 
 	//BLEED
 	else if((findtext(message, bleed_words)))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -269,7 +269,8 @@
 			var/mob/living/L = V
 			if(iscultist(L))
 				L.heal_overall_damage(10 * power_multiplier, 10 * power_multiplier)
-			if(is_servant_of_ratvar(L))
+			if(is_servant_of_ratvar(L) && ishuman(L))
+				var/mob/living/carbon/human/H = L
 				var/obj/item/bodypart/BP = pick(H.bodyparts)
 				BP.generic_bleedstacks += 5 * power_multiplier
 

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -219,7 +219,7 @@
 
 	var/static/regex/narsian_words = regex("praise narsie|praise nar-sie|praise nar'sie") //why is it spelled so many ways can you KEEP IT CONSISTENT PLEASE
 	var/static/regex/ratvarian_words = regex("hail ratvar|honor ratvar|honour ratvar|purge all untruths") //bri'ish spelling
-	var/static/regex/knockdown_words = regex("drop|fall|trip|knockdown|kneel|lie|down")
+	var/static/regex/knockdown_words = regex("drop|fall|trip|knockdown|kneel|lie|get down")
 	var/static/regex/vomit_words = regex("vomit|throw up|sick")
 	var/static/regex/silence_words = regex("shut up|silence|be silent|ssh|quiet|hush")
 	var/static/regex/hallucinate_words = regex("see the truth|hallucinate|the truth is out there")

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -166,16 +166,17 @@
 		if(user.mind.assigned_role == "Chaplain")
 			power_multiplier *= 2
 		//Command staff has authority
-		if(user.mind.assigned_role in GLOB.command_positions)
+		if(IS_COMMAND(user))
 			power_multiplier *= 1.4
+		//I AM THE LAW
+		if(IS_SECURITY(user))
+			power_multiplier *= 1.2
 		//Why are you speaking
 		if(user.mind.assigned_role == "Mime")
 			power_multiplier *= 0.5
 
 	//Cultists are closer to their gods and are more powerful, but they'll give themselves away
-	if(iscultist(user))
-		power_multiplier *= 2
-	else if (is_servant_of_ratvar(user))
+	if(iscultist(user) || is_servant_of_ratvar(user) || IS_HERETIC(user))
 		power_multiplier *= 2
 
 	//Try to check if the speaker specified a name or a job to focus on
@@ -216,19 +217,22 @@
 		power_multiplier *= (1 + (1/specific_listeners.len)) //2x on a single guy, 1.5x on two and so on
 		message = copytext(message, length(found_string) + 1)
 
+	var/static/regex/narsian_words = regex("praise narsie|praise nar-sie|praise nar'sie") //why is it spelled so many ways can you KEEP IT CONSISTENT PLEASE
+	var/static/regex/ratvarian_words = regex("hail ratvar|honor ratvar|honour ratvar|purge all untruths") //bri'ish spelling
+	var/static/regex/knockdown_words = regex("drop|fall|trip|knockdown|kneel|lie|down")
 	var/static/regex/vomit_words = regex("vomit|throw up|sick")
 	var/static/regex/silence_words = regex("shut up|silence|be silent|ssh|quiet|hush")
-	var/static/regex/hallucinate_words = regex("see the truth|hallucinate")
+	var/static/regex/hallucinate_words = regex("see the truth|hallucinate|the truth is out there")
 	var/static/regex/wakeup_words = regex("wake up|awaken")
-	var/static/regex/heal_words = regex("live|heal|survive|mend|life|heroes never die")
-	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death|judgement|thy end is now") // THY END IS NOW
-	var/static/regex/bleed_words = regex("bleed|there will be blood")
-	var/static/regex/burn_words = regex("burn|ignite")
+	var/static/regex/heal_words = regex("live|heal|survive|mend|life|heroes never die|rest")
+	var/static/regex/hurt_words = regex("die|suffer|hurt|pain|death|kill|judgement|thy end is now") // THY END IS NOW
+	var/static/regex/bleed_words = regex("bleed|blood")
+	var/static/regex/burn_words = regex("burn|ignite|fire|flame")
 	var/static/regex/hot_words = regex("heat|hot|hell")
-	var/static/regex/cold_words = regex("cold|cool down|chill|freeze")
+	var/static/regex/cold_words = regex("cold|cool|chill|freeze|ice|winter") // WHAT'S COOLER THAN BEING COOL
 	var/static/regex/repulse_words = regex("shoo|go away|leave me alone|begone|flee|fus ro dah|get away|repulse")
 	var/static/regex/attract_words = regex("come here|come to me|get over here|attract")
-	var/static/regex/whoareyou_words = regex("who are you|say your name|state your name|identify")
+	var/static/regex/whoareyou_words = regex("who are you|say your name|state your name|identify|who goes there")
 	var/static/regex/saymyname_words = regex("say my name|who am i|whoami")
 	var/static/regex/knockknock_words = regex("knock knock")
 	var/static/regex/move_words = regex("move|walk")
@@ -254,12 +258,41 @@
 	var/static/regex/deathgasp_words = regex("play dead")
 	var/static/regex/clap_words = regex("clap|applaud")
 	var/static/regex/honk_words = regex("ho+nk") //hooooooonk
-	var/static/regex/multispin_words = regex("like a record baby|right round")
+	var/static/regex/multispin_words = regex("like a record baby|right round|spin")
 
 	var/i = 0
 
+	//PRAISE NAR-SIE
+	if(findtext(message, narsian_words) && iscultist(user))
+		cooldown = COOLDOWN_DAMAGE
+		for(var/V in listeners)
+			var/mob/living/L = V
+			if(iscultist(L))
+				L.heal_overall_damage(10 * power_multiplier, 10 * power_multiplier)
+			if(is_servant_of_ratvar(L))
+				var/obj/item/bodypart/BP = pick(H.bodyparts)
+				BP.generic_bleedstacks += 5 * power_multiplier
+
+	//HAIL RATVAR
+	else if(findtext(message, narsian_words) && is_servant_of_ratvar(user))
+		cooldown = COOLDOWN_DAMAGE
+		for(var/V in listeners)
+			var/mob/living/L = V
+			if(is_servant_of_ratvar(L))
+				L.heal_overall_damage(10 * power_multiplier, 10 * power_multiplier)
+			if(iscultist(L))
+				L.adjust_fire_stacks(1 * power_multiplier)
+				L.IgniteMob()
+
+	//KNOCKDOWN
+	else if(findtext(message, knockdown_words))
+		cooldown = COOLDOWN_STUN
+		for(var/V in listeners)
+			var/mob/living/L = V
+			L.set_resting(TRUE)
+
 	//VOMIT
-	if((findtext(message, vomit_words)))
+	else if((findtext(message, vomit_words)))
 		cooldown = COOLDOWN_STUN
 		for(var/mob/living/carbon/C in listeners)
 			C.vomit(10 * power_multiplier, distance = power_multiplier, stun = FALSE)
@@ -267,9 +300,9 @@
 	//SILENCE
 	else if((findtext(message, silence_words)))
 		cooldown = COOLDOWN_STUN
+		if(user.mind && (user.mind.assigned_role == "Curator" || user.mind.assigned_role == "Mime"))
+			power_multiplier *= 3
 		for(var/mob/living/carbon/C in listeners)
-			if(user.mind && (user.mind.assigned_role == "Curator" || user.mind.assigned_role == "Mime"))
-				power_multiplier *= 3
 			C.silent += (10 * power_multiplier)
 
 	//HALLUCINATE
@@ -297,12 +330,12 @@
 		cooldown = COOLDOWN_DAMAGE
 		for(var/V in listeners)
 			var/mob/living/L = V
+			var/damage_applied = 15 * power_multiplier
 			if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid))
-				L.apply_damage(360 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // very long cooldown so make it really good at killing lavaland mobs
+				damage_applied *= 24
 			else if(L.mind?.has_martialart(MARTIALART_ULTRAVIOLENCE))
-				L.apply_damage(45 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // DIE!!
-			else
-				L.apply_damage(15 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)
+				damage_applied *= 3 // DIE!
+			L.apply_damage(damage_applied, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)
 
 	//BLEED
 	else if((findtext(message, bleed_words)))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -299,7 +299,7 @@
 			var/mob/living/L = V
 			if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid))
 				L.apply_damage(360 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // very long cooldown so make it really good at killing lavaland mobs
-			else if(L.mind?.martial_art && L.mind.martial_art.id == "ultra violence")
+			else if(L.mind?.has_martialart(MARTIALART_ULTRAVIOLENCE))
 				L.apply_damage(45 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND) // DIE!!
 			else
 				L.apply_damage(15 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -335,7 +335,7 @@
 			if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid))
 				damage_applied *= 24
 			else if(L.mind?.has_martialart(MARTIALART_ULTRAVIOLENCE))
-				damage_applied *= 3 // DIE!
+				damage_applied *= 2 // DIE!
 			L.apply_damage(damage_applied, def_zone = BODY_ZONE_CHEST, wound_bonus=CANT_WOUND)
 
 	//BLEED


### PR DESCRIPTION
# Document the changes in your pull request

Removed stuns from voice of god, changed knockdown to an actual knockdown, added more keywords, gave security a 1.2x power modifier and heretics a 2x power modifier, added more interactions with blood and clock cult, and made the damage more effective against lavaland mobs and IPCs with ultra violence.

# Wiki documentation
On the guide to megafauna in the voice of god section:

Removes stun and sleep commands
If clock cultist, heal fellow cultists and ignites blood cultists when saying: hail ratvar / honor ratvar / purge all untruths
If blood cultists, heal fellow cultists and ignites clock cultists when saying: praise nar-sie
Knockdown command knocks down instead of stunning, triggered by: drop / fall / trip / knockdown / kneel / lie / get down
Adds "the truth is out there" as a keyword for the hallucinate command
Adds "blood" as a keyword for the bleed command instead of "there will be blood"
Adds "rest" as a keyword for heal
Adds "kill", "judgement", "thy end is now", and "crush" as keywords for the hurt command
Adds "fire" and "flame" as keywords for the burn command
Adds "ice" and "winter" as keywords for the cool command
Adds "who goes there" as a keyword for the identify command
Adds "spin" as a keyword for the right round command
Adds 1.2x power modifier for security

# Changelog

:cl:  
rscadd; added more interactions between voice of god and blood/clock cultists
rscadd: added more keywords to voice of god
tweak: voice of god doesn't stun anymore
tweak: voice of god knockdown just makes you lie down instead of stunning you
tweak: voice of god does more damage to lavaland mobs and IPCs with ultra violence
tweak: increased voice of god power modifier slightly for security and significantly for heretics
/:cl:
