### PR TITLE
Apparently there's two different types of grown plants

### DIFF
--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -29,6 +29,7 @@
 		if(istype(src, seed.product)) // no adding reagents if it is just a trash item
 			seed.prepare_result(src)
 		transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5
+		w_class = round((seed.potency / 100) * 2, 1) + 1 //more potent plants are larger
 		add_juice()
 
 /// Ghost attack proc


### PR DESCRIPTION
when making plants scale weight class with potency i apparently wasn't aware that there's two different types of grown items

this extends that nerf to the forgotten kind

:cl:  
bugfix: grown weapons also scale weight class with potency size like grown food
/:cl:
