### PR TITLE
Update .gitignore to not include .dmm-pal files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.mdme.*
 *.m.dme
 *.test.dme
+*.dmm-pal
 ### https://raw.github.com/github/gitignore/cc542de017c606138a87ee4880e5f06b3a306def/Global/Linux.gitignore
 
 *~


### PR DESCRIPTION
# Document the changes in your pull request

Does yogstation a favor by adding the .dmm palette file that is created when editing maps with the built in editor with 515 to the gitignore list.

# Changelog

:cl:  BurgerBB
rscadd: Updates .gitignore to not include .dmm-pal files. Is a changelog even needed?
/:cl:
