### PR TITLE
let you actually get the ammo for the usp from the armaments dispenser

### DIFF
--- a/code/modules/vending/security_armaments.dm
+++ b/code/modules/vending/security_armaments.dm
@@ -7,7 +7,7 @@
 	layer = 2.9
 	density = TRUE
 	var/list/inventory = list()
-	var/list/allowed_types = list()
+	var/list/allowed_types = list(/obj/item/ammo_box/magazine/recharge/ntusp)
 	
 	contents = newlist(/obj/item/gun/energy/disabler, 
 					   /obj/item/gun/ballistic/automatic/pistol/ntusp)


### PR DESCRIPTION
# Document the changes in your pull request

also fixes an exploit

# Changelog

:cl:  
bugfix: the NT-USP magazine will properly dispense from the armaments dispenser  
/:cl:
