### PR TITLE
Some Battleroyale mode tweaks

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -205,7 +205,7 @@
 /obj/item/antag_spawner/nuke_ops/borg_tele/spawn_antag(client/C, turf/T, kind, datum/mind/user)
 	var/mob/living/silicon/robot/R
 	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop,TRUE)
-	var/royaler = is_battleroyale(user)
+	var/royaler = user.has_antag_datum(/datum/antagonist/battleroyale, TRUE)
 	if(!creator_op && !royaler)
 		return
 

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -205,7 +205,8 @@
 /obj/item/antag_spawner/nuke_ops/borg_tele/spawn_antag(client/C, turf/T, kind, datum/mind/user)
 	var/mob/living/silicon/robot/R
 	var/datum/antagonist/nukeop/creator_op = user.has_antag_datum(/datum/antagonist/nukeop,TRUE)
-	if(!creator_op)
+	var/royaler = is_battleroyale(user)
+	if(!creator_op && !royaler)
 		return
 
 	switch(borg_to_spawn)
@@ -220,7 +221,7 @@
 	if(prob(50))
 		brainfirstname = pick(GLOB.first_names_female)
 	var/brainopslastname = pick(GLOB.last_names)
-	if(creator_op.nuke_team.syndicate_name)  //the brain inside the syndiborg has the same last name as the other ops.
+	if(!royaler && creator_op.nuke_team.syndicate_name)  //the brain inside the syndiborg has the same last name as the other ops.
 		brainopslastname = creator_op.nuke_team.syndicate_name
 	var/brainopsname = "[brainfirstname] [brainopslastname]"
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -212,7 +212,7 @@
 		playsound(user, 'sound/weapons/saberoff.ogg', 5, 1)
 		to_chat(user, span_warning("[src] can now be concealed."))
 	else
-		if(!is_syndicate(user)) // this is just a normal pen to non syndicates as they don't know how to switch it on.
+		if(!is_syndicate(user) && !is_battleroyale(user)) // this is just a normal pen to non syndicates as they don't know how to switch it on.
 			. = ..()
 			return
 		on = TRUE

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -28,7 +28,7 @@ GLOBAL_VAR(stormdamage)
 
 /datum/game_mode/fortnite/pre_setup()
 	var/area/hallway/secondary/A = locate(/area/hallway/secondary) in GLOB.areas //Assuming we've gotten this far, let's spawn the battle bus.
-	GLOB.stormdamage = 5
+	GLOB.stormdamage = 3
 	if(A)
 		var/turf/T = safepick(get_area_turfs(A)) //Move to a random turf in arrivals. Please ensure there are no space turfs in arrivals!!!
 		new /obj/structure/battle_bus(T)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -178,7 +178,7 @@ GLOBAL_VAR(stormdamage)
 /datum/game_mode/fortnite/proc/loot_drop()
 	loot_spawn(1)
 
-/datum/game_mode/fortnite/proc/loot_spawn(amount = 2)
+/datum/game_mode/fortnite/proc/loot_spawn(amount = 3)
 	for(var/obj/effect/landmark/event_spawn/es in GLOB.landmarks_list)
 		var/area/AR = get_area(es)
 		for(var/I = 0, I < amount, I++)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -208,6 +208,8 @@ GLOBAL_VAR(stormdamage)
 	O.owner = owner
 	objectives += O
 	var/mob/living/carbon/human/tfue = owner.current
+	for(var/obj/item/I in tfue.get_equipped_items(TRUE))//remove all clothes before giving the antag clothes
+		qdel(I)
 	tfue.equipOutfit(/datum/outfit/battleroyale, visualsOnly = FALSE)
 
 /mob/living/carbon/human/Life()

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -67,6 +67,7 @@ GLOBAL_VAR(stormdamage)
 	for(var/obj/machinery/door/W in GLOB.machines)//set all doors to all access
 		W.req_access = list()
 		W.req_one_access = list()
+		W.locked = FALSE //no bolted either
 	addtimer(CALLBACK(src, PROC_REF(check_win)), 30 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(loot_spawn)), 0.5 SECONDS)//make sure this happens before shrinkborders
 	addtimer(CALLBACK(src, PROC_REF(shrinkborders)), 1 SECONDS)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -19,7 +19,8 @@ GLOBAL_VAR(stormdamage)
 	var/list/queued = list() //Who is queued to enter?
 	var/list/randomweathers = list("royale science", "royale medbay", "royale service", "royale cargo", "royale security", "royale engineering")
 	var/stage_interval = 2 MINUTES //Copied from Nich's homework. Storm shrinks every 2 minutes (changed for testing, don't forget to change back)
-	var/loot_interval = 1 MINUTES
+	var/loot_interval = 90 SECONDS //roughly the time between loot drops
+	var/loot_deviation = 30 SECONDS //how much plus or minus around the interval
 	var/borderstage = 0
 	var/weightcull = 5 //anything above this gets culled
 	var/finished = FALSE
@@ -71,7 +72,7 @@ GLOBAL_VAR(stormdamage)
 	addtimer(CALLBACK(src, PROC_REF(check_win)), 30 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(loot_spawn)), 0.5 SECONDS)//make sure this happens before shrinkborders
 	addtimer(CALLBACK(src, PROC_REF(shrinkborders)), 1 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(loot_drop)), loot_interval, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_LOOP)//literally just keep calling it
+	addtimer(CALLBACK(src, PROC_REF(loot_drop)), loot_interval)//literally just keep calling it
 	return ..()
 
 /datum/game_mode/fortnite/check_win()
@@ -179,6 +180,8 @@ GLOBAL_VAR(stormdamage)
 
 /datum/game_mode/fortnite/proc/loot_drop()
 	loot_spawn(1)
+	var/nextdelay = loot_interval + (rand(1, loot_deviation * 2) - loot_deviation)
+	addtimer(CALLBACK(src, PROC_REF(loot_drop)), nextdelay)//literally just keep calling it
 
 /datum/game_mode/fortnite/proc/loot_spawn(amount = 3)
 	for(var/obj/effect/landmark/event_spawn/es in GLOB.landmarks_list)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -29,7 +29,7 @@ GLOBAL_VAR(stormdamage)
 
 /datum/game_mode/fortnite/pre_setup()
 	var/area/hallway/secondary/A = locate(/area/hallway/secondary) in GLOB.areas //Assuming we've gotten this far, let's spawn the battle bus.
-	GLOB.stormdamage = 3
+	GLOB.stormdamage = 2
 	if(A)
 		var/turf/T = safepick(get_area_turfs(A)) //Move to a random turf in arrivals. Please ensure there are no space turfs in arrivals!!!
 		new /obj/structure/battle_bus(T)
@@ -147,13 +147,15 @@ GLOBAL_VAR(stormdamage)
 		if(9)//finish it
 			SSweather.run_weather("royale centre", 2)
 
-	GLOB.stormdamage += 1
 
 	if(borderstage)//doesn't cull during round start
 		ItemCull()
 
 	borderstage++
 
+	if(borderstage % 2 == 0) //so it scales, but not too hard
+		GLOB.stormdamage *= 1.5
+		
 	if(borderstage <= 9)
 		addtimer(CALLBACK(src, PROC_REF(shrinkborders)), stage_interval)
 
@@ -179,7 +181,7 @@ GLOBAL_VAR(stormdamage)
 		message_admins("battle royale loot drop lists have been depleted somehow, PANIC")
 
 /datum/game_mode/fortnite/proc/loot_drop()
-	loot_spawn(rand(1,2))
+	loot_spawn(1)
 	var/nextdelay = loot_interval + (rand(1, loot_deviation * 2) - loot_deviation)
 	addtimer(CALLBACK(src, PROC_REF(loot_drop)), nextdelay)//literally just keep calling it
 

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR(stormdamage)
 	var/list/queued = list() //Who is queued to enter?
 	var/list/randomweathers = list("royale science", "royale medbay", "royale service", "royale cargo", "royale security", "royale engineering")
 	var/stage_interval = 2 MINUTES //Copied from Nich's homework. Storm shrinks every 2 minutes (changed for testing, don't forget to change back)
-	var/loot_interval = 90 SECONDS //roughly the time between loot drops
+	var/loot_interval = 75 SECONDS //roughly the time between loot drops
 	var/loot_deviation = 30 SECONDS //how much plus or minus around the interval
 	var/borderstage = 0
 	var/weightcull = 5 //anything above this gets culled
@@ -155,7 +155,7 @@ GLOBAL_VAR(stormdamage)
 
 	if(borderstage % 2 == 0) //so it scales, but not too hard
 		GLOB.stormdamage *= 1.5
-		
+
 	if(borderstage <= 9)
 		addtimer(CALLBACK(src, PROC_REF(shrinkborders)), stage_interval)
 

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -64,8 +64,9 @@ GLOBAL_VAR(stormdamage)
 	if(!GLOB.battleroyale_players.len)
 		message_admins("Somehow no one has been properly signed up to battle royale despite the round just starting, please contact someone to fix it.")
 
-	for(var/obj/machinery/door/airlock/W in GLOB.machines)//set all doors to all access
+	for(var/obj/machinery/door/W in GLOB.machines)//set all doors to all access
 		W.req_access = list()
+		W.req_one_access = list()
 	addtimer(CALLBACK(src, PROC_REF(check_win)), 30 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(loot_spawn)), 0.5 SECONDS)//make sure this happens before shrinkborders
 	addtimer(CALLBACK(src, PROC_REF(shrinkborders)), 1 SECONDS)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -221,7 +221,7 @@ GLOBAL_VAR(stormdamage)
 /datum/antagonist/battleroyale/proc/gamer_life()
 	var/mob/living/carbon/human/tfue = owner.current
 	if(tfue && isspaceturf(tfue.loc))
-		tfue.adjustFireLoss(GLOB.stormdamage * 2, TRUE, TRUE) //no hiding in space
+		tfue.adjustFireLoss(GLOB.stormdamage, TRUE, TRUE) //no hiding in space
 
 /datum/antagonist/battleroyale/greet()
 	SEND_SOUND(owner.current, 'yogstation/sound/effects/battleroyale/greet_br.ogg')

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -179,7 +179,7 @@ GLOBAL_VAR(stormdamage)
 		message_admins("battle royale loot drop lists have been depleted somehow, PANIC")
 
 /datum/game_mode/fortnite/proc/loot_drop()
-	loot_spawn(1)
+	loot_spawn(rand(1,2))
 	var/nextdelay = loot_interval + (rand(1, loot_deviation * 2) - loot_deviation)
 	addtimer(CALLBACK(src, PROC_REF(loot_drop)), nextdelay)//literally just keep calling it
 

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -259,7 +259,7 @@ GLOBAL_VAR(stormdamage)
 	START_PROCESSING(SSfastprocess, src)
 	GLOB.thebattlebus = src //So the GM code knows where to move people to!
 	starter_z = z
-	addtimer(CALLBACK(src, PROC_REF(cleanup)), 1 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(cleanup)), 2 MINUTES)
 
 /obj/structure/battle_bus/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -206,16 +206,10 @@ GLOBAL_VAR(stormdamage)
 	objectives += O
 	var/mob/living/carbon/human/tfue = owner.current
 	tfue.equipOutfit(/datum/outfit/battleroyale, visualsOnly = FALSE)
-	START_PROCESSING(SSprocessing, src)
 
-/datum/antagonist/battleroyale/on_removal()
-	. = ..()
-	STOP_PROCESSING(SSprocessing, src)
-
-/datum/antagonist/battleroyale/process(delta_time)
-	. = ..()
+/datum/antagonist/battleroyale/proc/gamer_life()
 	var/mob/living/carbon/human/tfue = owner.current
-	if(tfue && isspaceturf(get_turf(tfue)))//to account for not being able to put the storm on space turf tiles (if someone reviewing this knows how, please tell me)
+	if(tfue && isspaceturf(tfue.loc))//to account for not being able to put the storm on space turf tiles (if someone reviewing this knows how, please tell me)
 		tfue.adjustFireLoss(GLOB.stormdamage * 2, TRUE, TRUE) //no hiding in space
 
 /datum/antagonist/battleroyale/greet()

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -259,6 +259,7 @@ GLOBAL_VAR(stormdamage)
 	START_PROCESSING(SSfastprocess, src)
 	GLOB.thebattlebus = src //So the GM code knows where to move people to!
 	starter_z = z
+	addtimer(CALLBACK(src, PROC_REF(cleanup)), 1 MINUTES)
 
 /obj/structure/battle_bus/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)
@@ -282,8 +283,10 @@ GLOBAL_VAR(stormdamage)
 			var/obj/effect/landmark/observer_start/L = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 			M.forceMove(get_turf(L))
 		qdel(src) // Thank you for your service
-	if(!contents)//in case Z-level loops
-		QDEL_IN(src, 10 SECONDS)
+
+/obj/structure/battle_bus/proc/cleanup()
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/structure/battle_bus/CanPass(atom/movable/mover, turf/target)
 	SHOULD_CALL_PARENT(FALSE)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -207,6 +207,12 @@ GLOBAL_VAR(stormdamage)
 	var/mob/living/carbon/human/tfue = owner.current
 	tfue.equipOutfit(/datum/outfit/battleroyale, visualsOnly = FALSE)
 
+/mob/living/carbon/human/Life()
+	. = ..()
+	if(is_battleroyale(src))
+		var/datum/antagonist/battleroyale/gamer = mind.has_antag_datum(/datum/antagonist/battleroyale)
+		gamer.gamer_life()
+		
 /datum/antagonist/battleroyale/proc/gamer_life()
 	var/mob/living/carbon/human/tfue = owner.current
 	if(tfue && isspaceturf(tfue.loc))//to account for not being able to put the storm on space turf tiles (if someone reviewing this knows how, please tell me)

--- a/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/battleroyale.dm
@@ -212,10 +212,10 @@ GLOBAL_VAR(stormdamage)
 	if(is_battleroyale(src))
 		var/datum/antagonist/battleroyale/gamer = mind.has_antag_datum(/datum/antagonist/battleroyale)
 		gamer.gamer_life()
-		
+
 /datum/antagonist/battleroyale/proc/gamer_life()
 	var/mob/living/carbon/human/tfue = owner.current
-	if(tfue && isspaceturf(tfue.loc))//to account for not being able to put the storm on space turf tiles (if someone reviewing this knows how, please tell me)
+	if(tfue && isspaceturf(tfue.loc))
 		tfue.adjustFireLoss(GLOB.stormdamage * 2, TRUE, TRUE) //no hiding in space
 
 /datum/antagonist/battleroyale/greet()

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -324,18 +324,16 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 	var/selected
 	switch(type)
 		if(1)//weapon focus (to fuel the fight)
-			for(var/i in 1 to rand(2,4))
+			for(var/i in 1 to rand(2,3))
 				selected = pickweightAllowZero(GLOB.battleroyale_weapon)
 				new selected(src)
 			selected = pickweightAllowZero(GLOB.battleroyale_utility)
 			new selected(src)
 
 		if(2)//armour focus (so people can select what they want)
-			for(var/i in 1 to 2)//less than weapons because guns can run out
+			for(var/i in 1 to 3)//less than weapons because guns can run out
 				selected = pickweightAllowZero(GLOB.battleroyale_armour)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_weapon)
-			new selected(src)
 			selected = pickweightAllowZero(GLOB.battleroyale_healing)
 			new selected(src)
 
@@ -350,7 +348,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 			new selected(src)
 
 		if(4)//KABOOOM AHAHAHAHAHA
-			for(var/i in 1 to rand(2,5))
+			for(var/i in 1 to rand(2,4))
 				selected = pickweightAllowZero(GLOB.battleroyale_utility)
 				new selected(src)
 
@@ -358,8 +356,6 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 			for(var/i in 1 to rand(2,4))
 				selected = pickweightAllowZero(GLOB.battleroyale_healing)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_armour)
-			new selected(src)
 
 /obj/structure/closet/crate/battleroyale/open(mob/living/user)
 	. = ..()

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -261,6 +261,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/storage/box/syndie_kit/augmentation = -2,
 		/obj/item/grenade/syndieminibomb = -2,
 		/obj/item/dragons_blood = -2,
+		/obj/item/desynchronizer = -2,
 		/obj/item/book/granter/martial/cqc = -2,
 		/obj/item/book/granter/spell/smoke = -2,
 

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -152,10 +152,8 @@ GLOBAL_LIST_INIT(battleroyale_weapon, list(
 		/obj/item/nullrod/hammer = 2,
 		/obj/item/nullrod/tribal_knife = 2,
 		/obj/item/nullrod/vibro = 2,
-		/obj/item/nullrod/talking = 2,
 
 		/obj/item/flamethrower/full/tank = 1,
-		/obj/item/twohanded/required/baseball_bat/metal_bat = 1,
 		/obj/item/twohanded/required/chainsaw = 1,
 		/obj/item/twohanded/fireaxe/metal_h2_axe = 1,
 		/obj/item/nullrod/whip = 1,
@@ -166,12 +164,14 @@ GLOBAL_LIST_INIT(battleroyale_weapon, list(
 		/obj/item/gun/ballistic/revolver/detective = 0,
 		/obj/item/twohanded/required/baseball_bat/homerun = 0,
 		/obj/item/twohanded/fireaxe = 0,
+		/obj/item/nullrod/talking = 0,
 
 		/obj/item/melee/powerfist = -1,
 		/obj/item/gun/ballistic/automatic/pistol = -1,
 		/obj/item/gun/ballistic/shotgun/doublebarrel = -1,
 		/obj/item/melee/transforming/energy/sword = -1,
 		/obj/item/gun/energy/laser/retro/old = -1,
+		/obj/item/twohanded/required/baseball_bat/metal_bat = -1,
 
 		/obj/item/gun/ballistic/shotgun/automatic/combat = -2,
 		/obj/item/gun/ballistic/shotgun/automatic/combat/compact = -2,
@@ -236,16 +236,15 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/grenade/plastic/c4 = 4,
 		/obj/item/storage/toolbox/mechanical = 4,
 
-		/obj/item/book/granter/spell/smoke/lesser = 3,
 		/obj/item/gun/energy/wormhole_projector/upgraded = 3,
 
 		/obj/item/autosurgeon/cmo = 2,
-		/obj/item/nullrod/hermes = 2,
+		/obj/item/book/granter/spell/smoke/lesser = 2,
 
 		/obj/item/reagent_containers/glass/bottle/potion/flight = 1,
-		/obj/item/book/granter/spell/smoke = 1,
 		/obj/item/autosurgeon/reviver = 1,
 		/obj/item/nullrod/servoskull = 1,
+		/obj/item/nullrod/staff = 1,
 
 		/obj/item/storage/backpack/duffelbag/syndie/c4 = 0,
 		/obj/item/teleportation_scroll/apprentice = 0,
@@ -257,13 +256,13 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/autosurgeon/thermal_eyes = -1,
 		/obj/item/autosurgeon/xray_eyes = -1,
 		/obj/item/multisurgeon/airshoes = -1,
-		/obj/item/nullrod/staff = -1,
+		/obj/item/nullrod/hermes = -1,
 
 		/obj/item/storage/box/syndie_kit/augmentation = -2,
 		/obj/item/grenade/syndieminibomb = -2,
-		/obj/item/desynchronizer = -2,
 		/obj/item/dragons_blood = -2,
 		/obj/item/book/granter/martial/cqc = -2,
+		/obj/item/book/granter/spell/smoke = -2,
 
 		/obj/item/antag_spawner/nuke_ops/borg_tele/medical = -3,
 		/obj/item/antag_spawner/nuke_ops/borg_tele/assault = -3,

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -324,7 +324,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 	var/selected
 	switch(type)
 		if(1)//weapon focus (to fuel the fight)
-			for(var/i in 1 to rand(2,3))
+			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_weapon)
 				new selected(src)
 			selected = pickweightAllowZero(GLOB.battleroyale_utility)
@@ -348,14 +348,18 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 			new selected(src)
 
 		if(4)//KABOOOM AHAHAHAHAHA
-			for(var/i in 1 to rand(2,4))
+			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_utility)
 				new selected(src)
+			selected = pickweightAllowZero(GLOB.battleroyale_weapon)
+			new selected(src)
 
 		if(5)//https://www.youtube.com/watch?v=Z0Uh3OJCx3o
-			for(var/i in 1 to rand(2,4))
+			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_healing)
 				new selected(src)
+			selected = pickweightAllowZero(GLOB.battleroyale_armour)
+			new selected(src)
 
 /obj/structure/closet/crate/battleroyale/open(mob/living/user)
 	. = ..()
@@ -363,7 +367,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		new /obj/structure/healingfountain(get_turf(src))
 		qdel(src)
 		return
-	QDEL_IN(src, 30 SECONDS)//to remove clutter after a bit
+	QDEL_IN(src, 15 SECONDS)//to remove clutter after a bit
 
 /obj/item/battleroyale
 	name = "This item is created and used by the battle royale gamemode"

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -329,17 +329,13 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_weapon)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_utility)
-			new selected(src)
 
 		if(2)//armour focus (so people can select what they want)
 			for(var/i in 1 to 3)//less than weapons because guns can run out
 				selected = pickweightAllowZero(GLOB.battleroyale_armour)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_healing)
-			new selected(src)
 
-		if(3)//allrounder
+		if(3)//allrounder, technically has more items than the others
 			selected = pickweightAllowZero(GLOB.battleroyale_weapon)
 			new selected(src)
 			selected = pickweightAllowZero(GLOB.battleroyale_armour)
@@ -353,15 +349,11 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_utility)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_weapon)
-			new selected(src)
 
 		if(5)//https://www.youtube.com/watch?v=Z0Uh3OJCx3o
 			for(var/i in 1 to 3)
 				selected = pickweightAllowZero(GLOB.battleroyale_healing)
 				new selected(src)
-			selected = pickweightAllowZero(GLOB.battleroyale_armour)
-			new selected(src)
 
 /obj/structure/closet/crate/battleroyale/open(mob/living/user)
 	. = ..()

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -361,7 +361,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		new /obj/structure/healingfountain(get_turf(src))
 		qdel(src)
 		return
-	QDEL_IN(src, 15 SECONDS)//to remove clutter after a bit
+	QDEL_IN(src, 10 SECONDS)//to remove clutter after a bit
 
 /obj/item/battleroyale
 	name = "This item is created and used by the battle royale gamemode"

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -36,6 +36,7 @@ GLOBAL_LIST_INIT(battleroyale_armour, list(
 		/obj/item/clothing/suit/space/fragile = 5,
 		/obj/item/clothing/head/helmet/space/fragile = 5,
 		/obj/item/clothing/suit/hooded/wintercoat = 5,
+		/obj/item/clothing/suit/hooded/wintercoat/northern = 5, //it's a donator item, but it's my donator item so i'm adding it
 		//Weight of 4 - mostly minor stats, space suits with slowdown
 		/obj/item/shield/riot/buckler = 4,
 		/obj/item/clothing/head/helmet/space/nasavoid = 4,

--- a/yogstation/code/game/gamemodes/battle_royale/storm.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/storm.dm
@@ -19,7 +19,7 @@
 	var/list/areaIgnore = list()//if you want areaTypesToWeather to ignore something specific, because mappers can't be consistent with that type of area the thing should be
 
 /datum/weather/royale/weather_act(mob/living/L)
-	L.adjustFireLoss(3, TRUE, TRUE)
+	L.adjustFireLoss(GLOB.stormdamage, TRUE, TRUE)
 
 /datum/weather/royale/New()
 	.=..()

--- a/yogstation/code/game/gamemodes/battle_royale/storm.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/storm.dm
@@ -6,7 +6,7 @@
 	weather_overlay = "ash_storm"
 	telegraph_overlay = "light_ash"
 	end_message = null
-	telegraph_duration = 3 SECONDS //actually give them a brief moment to react
+	telegraph_duration = 10 SECONDS //actually give them a brief moment to react
 	end_duration = 1
 	immunity_type = "fuckno"
 	telegraph_sound = 'yogstation/sound/effects/battleroyale/stormclosing.ogg'

--- a/yogstation/code/game/gamemodes/battle_royale/storm.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/storm.dm
@@ -19,7 +19,7 @@
 	var/list/areaIgnore = list()//if you want areaTypesToWeather to ignore something specific, because mappers can't be consistent with that type of area the thing should be
 
 /datum/weather/royale/weather_act(mob/living/L)
-	L.adjustFireLoss(3)
+	L.adjustFireLoss(3, TRUE, TRUE)
 
 /datum/weather/royale/New()
 	.=..()

--- a/yogstation/code/game/gamemodes/vampire/vampire.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire.dm
@@ -13,9 +13,6 @@
 	if(is_vampire(src))
 		var/datum/antagonist/vampire/vamp = mind.has_antag_datum(/datum/antagonist/vampire)
 		vamp.vampire_life()
-	if(is_battleroyale(src))
-		var/datum/antagonist/battleroyale/gamer = mind.has_antag_datum(/datum/antagonist/battleroyale)
-		gamer.gamer_life()
 
 /datum/game_mode/vampire
 	name = "vampire"

--- a/yogstation/code/game/gamemodes/vampire/vampire.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire.dm
@@ -13,7 +13,9 @@
 	if(is_vampire(src))
 		var/datum/antagonist/vampire/vamp = mind.has_antag_datum(/datum/antagonist/vampire)
 		vamp.vampire_life()
-
+	if(is_battleroyale(src))
+		var/datum/antagonist/battleroyale/gamer = mind.has_antag_datum(/datum/antagonist/battleroyale)
+		gamer.gamer_life()
 
 /datum/game_mode/vampire
 	name = "vampire"


### PR DESCRIPTION
Hisa did two rounds of it, some tweaks 

metal baseball bat is rarer (-2 weight)
fairy boots are rarer (-3 weight)
smoke spells are slightly rarer (lesser -1 weight and greater -3 weight)
less loot boxes
boxes only hold what the name talks about and hold less
loot drops have random varience drop delays
boxes disappear faster once opened
make syndie borg callers work probably
godmode in the bus is now 10 seconds rather than until you leave (so dcs aren't permanently godmode)
properly spawn with default gear
more time to react to a zone closing
makes the edagger usable

storm scales damage over time
starts at 2 and is multiplied by 1.5 for every 2 zones that close

if you have any other suggestions let me know

:cl:  
tweak: some "balance" tweaks to the battleroyale meme mode
/:cl:
