### PR TITLE
Replaces the stechkin APS in a space ruin with a government-sanctioned M1911

### DIFF
--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -943,7 +943,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/gun/ballistic/automatic/pistol/APS,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},


### PR DESCRIPTION

# Document the changes in your pull request

The n=on antag with a nukie weapon what will he do

# Changelog

:cl:  
tweak: Space ruin stechkin APS replaced with an M1911
/:cl:
