### PR TITLE
Mime drinks, Silencer + Blank Page Buff

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1216,9 +1216,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1)
+		M.heal_bodypart_damage(1.5,1.5)
 		. = 1
 	return ..() || .
 
@@ -1931,9 +1931,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A fizzy cocktail for those looking to start fresh."
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1)
+		M.heal_bodypart_damage(2.5,2.5)
 		. = 1
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1216,7 +1216,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1.5,1.5)
 		. = 1
@@ -1931,7 +1931,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A fizzy cocktail for those looking to start fresh."
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(2.5,2.5)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -142,7 +142,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -142,7 +142,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1


### PR DESCRIPTION
# Document the changes in your pull request

We care about diversity, so with that in mind. Mime drinks are no longer exclusive for those pesky human mimes. As well as Silencer and Blank page should do more healing than their previous ones because they require "Nothing" to make them both. 

[EDIT] I was wrong about the humans

# Changelog

:cl:
  
tweak: Silencer and Blank Page now do more healing than Nothing because why wouldn't it?

/:cl:
