### PR TITLE
gorlex exile should hopefully pop up on roundend now

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -242,6 +242,7 @@
 		//Lower chance of someone needing to do an additional objective, but getting hijack instead of DaGD
 		if(prob(PROB_ACTUAL_TRAITOR)) //20%
 			company = /datum/corporation/gorlex //Should not double wammy the corporate introduction, I hope
+			name = "Gorlex Marauders Exile"
 			owner.special_role = TRAITOR_AGENT_ROLE
 			special_role = TRAITOR_AGENT_SROLE
 			marauder = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

this should work

for some reason the way i want hijack to work on this mode doesn't?? but i don't want to fix it/look into it rn

# Wiki Documentation

# Changelog

:cl:  
tweak: gorlex maurader now has a new name in roundend report
/:cl:
