### PR TITLE
Makes preternis lungs and eyes actually robotic as intended

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -4,6 +4,7 @@
 	see_in_dark = PRETERNIS_NV_ON
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	//preternis eyes need to be powered by a preternis to function, in a non preternis they slowly power down to blindness
+	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
 
 	low_threshold_passed = span_info("Your Preternis eyes switch to battery saver mode.")

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -79,6 +79,8 @@
 	name = "preternis lungs"
 	desc = "A specialized set of lungs. Due to the cybernetic nature of these lungs, they are far less resistant to cold but are more heat resistant and more efficent at filtering oxygen."
 	icon_state = "lungs-c"
+	status = ORGAN_ROBOTIC
+	organ_flags = ORGAN_SYNTHETIC
 	safe_oxygen_min = 12
 	safe_toxins_max = 10
 	gas_stimulation_min = 0.01 //fucking filters removing my stimulants


### PR DESCRIPTION
# Document the changes in your pull request

Whoever made these forgot to do this

# Changelog

:cl:  
bugfix: fixed preternis lungs and eyes not having the correct flags (they are actually robotic as intended now)
/:cl:
