### PR TITLE
makes it much less likely for changelings to team up

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -450,7 +450,7 @@
 			ac.owner = owner
 			objectives += ac
 	*/
-		if(2 || 3 || 4) //only give the murder other changelings goal if they're not in a team.
+		if(2 to 4) //only give the murder other changelings goal if they're not in a team.
 			var/datum/objective/absorb_changeling/ac = new
 			ac.owner = owner
 			objectives += ac

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -438,18 +438,19 @@
 			other_changelings_exist = TRUE
 			break
 
-	var/changeling_objective = other_changelings_exist ? pick(1,3) : 1 //yogs - fuck absorb most
+	var/changeling_objective = other_changelings_exist ? pick(1,2,3,4) : 1 //yogs - fuck absorb most
 	switch(changeling_objective) //yogs - see above
 		if(1)
 			var/datum/objective/absorb/absorb_objective = new
 			absorb_objective.owner = owner
 			absorb_objective.gen_amount_goal(3, 5) //yogs, 6-8 -> 3-5
 			objectives += absorb_objective
-		if(2)
+	/*	if(2)
 			var/datum/objective/absorb_most/ac = new
 			ac.owner = owner
 			objectives += ac
-		if(3) //only give the murder other changelings goal if they're not in a team.
+	*/
+		if(2 || 3 || 4) //only give the murder other changelings goal if they're not in a team.
 			var/datum/objective/absorb_changeling/ac = new
 			ac.owner = owner
 			objectives += ac


### PR DESCRIPTION
# Document the changes in your pull request

sick and tired of seeing 5+ ling rounds where only one rare ling has to kill another, meaning that the changelings can use their metacomm channel to utilize their unhinged abilities to permakill everyone

it's okay because they have to absorb genomes guys (it's just a murderbone antag that's not really fun for other people)

# Changelog

:cl:  
tweak: Clings now have a 75% chance to need to murk another cling, instead of 50%
/:cl:
