### PR TITLE
Plasmamen heal slightly from drinking plasma instead of it poisoning them

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -64,6 +64,13 @@
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
 		holder.remove_reagent(/datum/reagent/medicine/epinephrine, 2*REM)
 	C.adjustPlasma(20)
+	if(isplasmaman(C))
+		toxpwr = 0
+		C.adjustBruteLoss(-0.5*REM, FALSE)
+		C.adjustFireLoss(-0.5*REM, FALSE)
+		C.adjustToxLoss(-1*REM, FALSE)
+	else
+		toxpwr = initial(toxpwr)
 	return ..()
 
 /datum/reagent/toxin/plasma/reaction_obj(obj/O, reac_volume)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -66,9 +66,9 @@
 	C.adjustPlasma(20)
 	if(isplasmaman(C))
 		toxpwr = 0
-		C.adjustBruteLoss(-0.5*REM, FALSE)
-		C.adjustFireLoss(-0.5*REM, FALSE)
-		C.adjustToxLoss(-1*REM, FALSE)
+		C.adjustBruteLoss(-0.25*REM, FALSE)
+		C.adjustFireLoss(-0.25*REM, FALSE)
+		C.adjustToxLoss(-0.5*REM, FALSE)
 	else
 		toxpwr = initial(toxpwr)
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

Doesn't make sense that it would poison them, so it now heals 1 toxin damage, 0.5 brute damage, and 0.5 burn damage each reagent processing tick.

# Changelog

:cl:  
tweak: liquid plasma heals plasmamen instead of poisoning them
/:cl:
