### PR TITLE
The dispenser update part one

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -520,30 +520,37 @@
 		/datum/reagent/consumable/icetea,
 		/datum/reagent/consumable/space_cola,
 		/datum/reagent/consumable/rootbeer,
-		/datum/reagent/consumable/spacemountainwind,
-		/datum/reagent/consumable/dr_gibb,
-		/datum/reagent/consumable/space_up,
 		/datum/reagent/consumable/tonic,
 		/datum/reagent/consumable/sodawater,
 		/datum/reagent/consumable/lemon_lime,
-		/datum/reagent/consumable/pwr_game,
 		/datum/reagent/consumable/shamblers,
 		/datum/reagent/consumable/sugar,
-		/datum/reagent/consumable/pineapplejuice,
 		/datum/reagent/consumable/orangejuice,
 		/datum/reagent/consumable/grenadine,
 		/datum/reagent/consumable/limejuice,
-		/datum/reagent/consumable/tomatojuice,
 		/datum/reagent/consumable/lemonjuice,
-		/datum/reagent/consumable/menthol,
-		/datum/reagent/consumable/berryjuice
+		/datum/reagent/consumable/menthol
+		
 	)
-	t2_upgrade_reagents = null
-	t3_upgrade_reagents = null
-	t4_upgrade_reagents = null
+	t2_upgrade_reagents = list(
+		/datum/reagent/consumable/berryjuice,
+		/datum/reagent/consumable/pineapplejuice,
+		/datum/reagent/consumable/tomatojuice
+	)
+	t3_upgrade_reagents = list(
+		/datum/reagent/consumable/sol_dry,
+		/datum/reagent/consumable/spacemountainwind,
+		/datum/reagent/consumable/dr_gibb,
+		/datum/reagent/consumable/space_up,
+		/datum/reagent/consumable/pwr_game
+	)
+	t4_upgrade_reagents = list(
+		/datum/reagent/consumable/peachjuice
+	)
 	emagged_reagents = list(
 		/datum/reagent/consumable/ethanol/thirteenloko,
-		/datum/reagent/consumable/ethanol/whiskey_cola,
+		/datum/reagent/consumable/laughter,
+		/datum/reagent/consumable/nothing,
 		/datum/reagent/toxin/mindbreaker,
 		/datum/reagent/toxin/staminatoxin
 	)
@@ -596,13 +603,16 @@
 		/datum/reagent/consumable/ethanol/amaretto
 	)
 	t2_upgrade_reagents = null
-	t3_upgrade_reagents = null
-	t4_upgrade_reagents = null
-	emagged_reagents = list(
-		/datum/reagent/consumable/ethanol,
+	t3_upgrade_reagents = list(
+		/datum/reagent/consumable/ethanol/champagne
+	)
+	t4_upgrade_reagents = list(
 		/datum/reagent/iron,
+		/datum/reagent/consumable/ethanol
+	)
+	emagged_reagents = list(
 		/datum/reagent/toxin/minttoxin,
-		/datum/reagent/consumable/ethanol/atomicbomb,
+		/datum/reagent/consumable/ethanol/syndicatebomb,
 		/datum/reagent/consumable/ethanol/fernet
 	)
 


### PR DESCRIPTION
This was made after consulting the one and only Ruthix Mox. It probably isn't completely balanced but I am willing to fiddle stuff around.

# Document the changes in your pull request

Moves some bartender dispenser stuff behind tiers. I suggest you check the code changes yourself for the best image.

## Soda dispenser
- Moves some juices to T2
- All the vendor sodas except the cola are behind T3 now (Sol Dry included).
- Peach juice is now a T4.
- Nothing and laughter added to emag
- Whiskey cola removed from emag

## Booze dispenser
- Champagne added to T3
- Iron and Ethanol moved from emag to T4
- Atomic bomb replaced with syndicate bomb in emag (Since it heals syndies now)

# Wiki Documentation
https://wiki.yogstation.net/wiki/Guide_to_Drinks will probably need an update.
Unless wiki is faster than me, I can do it.

# Changelog

:cl: Majkl-J and RandomHoboman 
tweak: Bartending dispensers received a minor upgrade to their manipulators, changing required tiers.
/:cl:
