### PR TITLE
Blood brothers now only need ONE surviving member to escape, if they can drag the soulless corpses of their team to a method of escape, as well.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -535,7 +535,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/list/datum/mind/owners = get_owners()
 	for(var/O in owners)
 		var/datum/mind/M = O
-		if(!considered_escaped(M, requires_being_alive = FALSE)) //NO MAN LEFT BEHIND
+		if(!considered_escaped(M, FALSE)) //NO MAN LEFT BEHIND
 			return FALSE
 		if(considered_alive(M))
 			has_survivor = TRUE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -513,7 +513,6 @@ GLOBAL_LIST_EMPTY(objectives)
 	name = "escape"
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
 	team_explanation_text = "Have all members of your team escape on a shuttle or pod alive, without being in custody."
-	var/requires_being_alive = TRUE
 
 /datum/objective/escape/check_completion()
 	if(..())
@@ -521,7 +520,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	// Require all owners escape safely.
 	var/list/datum/mind/owners = get_owners()
 	for(var/datum/mind/M in owners)
-		if(!considered_escaped(M, requires_being_alive))
+		if(!considered_escaped(M))
 			return FALSE
 	return TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -63,8 +63,8 @@ GLOBAL_LIST_EMPTY(objectives)
 
 	update_explanation_text()
 
-/datum/objective/proc/considered_escaped(datum/mind/M)
-	if(!considered_alive(M))
+/datum/objective/proc/considered_escaped(datum/mind/M, needs_living = TRUE)
+	if((needs_living && !considered_alive(M)))
 		return FALSE
 	if(M.force_escaped)
 		return TRUE
@@ -513,6 +513,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	name = "escape"
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
 	team_explanation_text = "Have all members of your team escape on a shuttle or pod alive, without being in custody."
+	var/requires_being_alive = TRUE
 
 /datum/objective/escape/check_completion()
 	if(..())
@@ -520,9 +521,26 @@ GLOBAL_LIST_EMPTY(objectives)
 	// Require all owners escape safely.
 	var/list/datum/mind/owners = get_owners()
 	for(var/datum/mind/M in owners)
-		if(!considered_escaped(M))
+		if(!considered_escaped(M, requires_being_alive))
 			return FALSE
 	return TRUE
+
+/datum/objective/escape/onesurvivor
+	name = "escape team can die"
+	team_explanation_text = "Have all members of your team escape outside custody on a shuttle or pod, with at least one surviving member."
+
+/datum/objective/escape/onesurvivor/check_completion()
+	if(completed)
+		return TRUE
+	var/has_survivor = FALSE	//is there a surviving member of the team?
+	var/list/datum/mind/owners = get_owners()
+	for(var/O in owners)
+		var/datum/mind/M = O
+		if(!considered_escaped(M, requires_being_alive = FALSE)) //NO MAN LEFT BEHIND
+			return FALSE
+		if(considered_alive(M))
+			has_survivor = TRUE
+	return has_survivor
 
 /datum/objective/escape/escape_with_identity/is_valid_target(possible_target)
 	var/list/datum/mind/owners = get_owners()

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -216,8 +216,8 @@
 	if(is_hijacker)
 		if(!locate(/datum/objective/hijack) in objectives)
 			add_objective(new/datum/objective/hijack)
-	else if(!locate(/datum/objective/escape) in objectives)
-		add_objective(new/datum/objective/escape)
+	else if(!locate(/datum/objective/escape/onesurvivor) in objectives)
+		add_objective(new/datum/objective/escape/onesurvivor)
 
 /datum/team/brother_team/proc/forge_single_objective()
 	if(prob(50))


### PR DESCRIPTION
# Document the changes in your pull request

>bb runs into security
>gets brigged for 2 minutes
>immediate suicide

>bb miner walks into lava
>dies
>dnr instantly

>everything going smoothly
>teammate dies to dumb idiot bullshit 1 minute from shuttle departure
>unable to revive them DESPITE the recovery shuttle having a defib on it

HAS THIS EVER HAPPENED TO YOU?
well, WORRY NO MORE, as long as you can drag their dumbass to the shuttle you will STILL RETAIN your BELOVED GREEN TEXT

# Wiki Documentation

blood brother teams now only need all of their members to escape, regardless of how dead they are, as long as at least one is alive

# Changelog
:cl:  
tweak: blood brother teams have a new escape objective; as long as one member is alive, and the whole team (including dead people) successfully escaped, they succeed.
/:cl:
