### PR TITLE
Wand of Resurrection used on self is no longer instant (do_after)

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -94,6 +94,9 @@
 	max_charges = 10 //10, 5, 5, 4
 
 /obj/item/gun/magic/wand/resurrection/zap_self(mob/living/user)
+	to_chat(user, span_notice("You steady the wand, ready to fire it at yourself..."))
+	if(!do_after(user, 7 SECONDS, user))
+		return
 	..()
 	charges--
 	if(user.anti_magic_check())


### PR DESCRIPTION
# Document the changes in your pull request

To fix a lot of the issues presented with the wand of resurrection, a decently inconveniencing do_after suffices.

No longer can be used in combat, or even briefly out of combat to return instantly, but is now designed as a better form of healing than having to sit in some place for a minute patching yourself up.

# Changelog

:cl:  
tweak: Wand of Resurrection now takes 7 seconds to use on yourself
/:cl:
