### PR TITLE
Fixes modular computers having inconsistent damage examines

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -50,6 +50,17 @@
 /obj/machinery/modular_computer/examine(mob/user)
 	. = ..()
 	. += get_modular_computer_parts_examine(user)
+	if(cpu && !(cpu.resistance_flags & INDESTRUCTIBLE))
+		if(cpu.resistance_flags & ON_FIRE)
+			. += span_warning("It's on fire!")
+		var/healthpercent = (cpu.obj_integrity/cpu.max_integrity) * 100
+		switch(healthpercent)
+			if(50 to 99)
+				. += "It looks slightly damaged."
+			if(25 to 50)
+				. += "It appears heavily damaged."
+			if(0 to 25)
+				. += span_warning("It's falling apart!")
 
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
 	. = ..()
@@ -141,4 +152,3 @@
 /obj/machinery/modular_computer/bullet_act(obj/item/projectile/Proj)
 	if(cpu)
 		cpu.bullet_act(Proj)
-	. = ..()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -52,15 +52,15 @@
 	. += get_modular_computer_parts_examine(user)
 	if(cpu && !(cpu.resistance_flags & INDESTRUCTIBLE))
 		if(cpu.resistance_flags & ON_FIRE)
-			. += span_warning("It's on fire!")
+			. += span_warning("The CPU is on fire!")
 		var/healthpercent = (cpu.obj_integrity/cpu.max_integrity) * 100
 		switch(healthpercent)
 			if(50 to 99)
-				. += "It looks slightly damaged."
+				. += "The CPU looks slightly damaged."
 			if(25 to 50)
-				. += "It appears heavily damaged."
+				. += "The CPU appears heavily damaged."
 			if(0 to 25)
-				. += span_warning("It's falling apart!")
+				. += span_warning("The CPU is falling apart!")
 
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)
 	. = ..()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -19,13 +19,13 @@
 	var/icon_state_powered = null						// Icon state when the computer is turned on.
 	var/screen_icon_state_menu = "menu"					// Icon state overlay when the computer is turned on, but no program is loaded that would override the screen.
 	var/screen_icon_screensaver = "standby"				// Icon state overlay when the computer is powered, but not 'switched on'.
-	var/overlay_skin = null		
+	var/overlay_skin = null
 	var/max_hardware_size = 0							// Maximal hardware size. Currently, tablets have 1, laptops 2 and consoles 3. Limits what hardware types can be installed.
 	var/steel_sheet_cost = 10							// Amount of steel sheets refunded when disassembling an empty frame of this computer.
 	var/light_strength = 0								// Light luminosity when turned on
 	var/base_active_power_usage = 100					// Power usage when the computer is open (screen is active) and can be interacted with. Remember hardware can use power too.
 	var/base_idle_power_usage = 10						// Power usage when the computer is idle and screen is off (currently only applies to laptops)
-	
+
 	// Stuff for presets
 	var/list/starting_components = list()
 	var/list/starting_files = list()
@@ -141,3 +141,4 @@
 /obj/machinery/modular_computer/bullet_act(obj/item/projectile/Proj)
 	if(cpu)
 		cpu.bullet_act(Proj)
+	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Projectiles are coded to attack the "CPU" (real computer inside) directly, but this leads you to "shooting" the "computer" and not getting any damage examines, leading to confusing and inconsistent gameplay. This gives damage examines for the CPU, clearing it up.

# Changelog

:cl:  
bugfix: Modular computers will now have proper damage examines whether you attack it directly or with bullets
/:cl:
