### PR TITLE
Reworks hydrogen and tritium fires to actually make sense

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -44,15 +44,11 @@
 #define NITRO_BALL_HEAT_SCALE 100000
 
 //tritium reaction
-#define TRITIUM_BURN_OXY_FACTOR				100
 #define TRITIUM_BURN_TRIT_FACTOR			10
 #define TRITIUM_BURN_RADIOACTIVITY_FACTOR	50000 	//The neutrons gotta go somewhere. Completely arbitrary number.
 #define TRITIUM_MINIMUM_RADIATION_ENERGY	0.1  	//minimum 0.01 moles trit or 10 moles oxygen to start producing rads
-#define MINIMUM_TRIT_OXYBURN_ENERGY 		2000000	//This is calculated to help prevent singlecap bombs(Overpowered tritium/oxygen single tank bombs)
 //hydrogen reaction
-#define HYDROGEN_BURN_OXY_FACTOR			100
-#define HYDROGEN_BURN_H2_FACTOR				5		//Burns faster and with half the energy of tritium
-#define MINIMUM_H2_OXYBURN_ENERGY 			2000000	//This is calculated to help prevent singlecap bombs(Overpowered hydrogen/oxygen single tank bombs)
+#define HYDROGEN_BURN_H2_FACTOR				5		//Burns faster and with less energy
 //ammonia reaction
 #define AMMONIA_FORMATION_FACTOR			250
 #define AMMONIA_FORMATION_ENERGY			1000

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -138,33 +138,31 @@ nobliumformation = 1001
 	)
 
 /datum/gas_reaction/tritfire/react(datum/gas_mixture/air, datum/holder)
-	var/energy_released = 0
 	var/old_heat_capacity = air.heat_capacity()
 	var/temperature = air.return_temperature()
 	var/list/cached_results = air.reaction_results
 	cached_results["fire"] = 0
-	var/turf/open/location = isturf(holder) ? holder : null
-	var/burned_fuel = 0
-	var/initial_trit = air.get_moles(/datum/gas/tritium)// Yogs
-	if(air.get_moles(/datum/gas/oxygen) < initial_trit || MINIMUM_TRIT_OXYBURN_ENERGY > (temperature * old_heat_capacity))// Yogs -- Maybe a tiny performance boost? I'unno
-		burned_fuel = min(air.get_moles(/datum/gas/oxygen) / TRITIUM_BURN_OXY_FACTOR, initial_trit) //Yogs -- prevents negative moles of Tritium
-		air.adjust_moles(/datum/gas/tritium, -burned_fuel)
-		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)	//Yogs - now consumes oxygen as intended
+	var/turf/open/location = null
+	if(isturf(holder))
+		location = holder
+	if(istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
+		var/datum/pipeline/combustion_pipenet = holder
+		location = get_turf(pick(combustion_pipenet.members))
 	else
-		burned_fuel = initial_trit / TRITIUM_BURN_TRIT_FACTOR // Yogs -- Conservation of Mass fix
-		air.adjust_moles(/datum/gas/tritium, -burned_fuel) // Yogs -- Maybe a tiny performance boost? I'unno
-		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
-		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * (TRITIUM_BURN_TRIT_FACTOR - 1)) // Yogs -- Fixes low-energy tritium fires
+		location = get_turf(holder)
+	var/burned_fuel = min(air.get_moles(/datum/gas/tritium), air.get_moles(/datum/gas/oxygen)) / TRITIUM_BURN_TRIT_FACTOR
+	if(burned_fuel <= 0)
+		return NO_REACTION
 
-	if(burned_fuel)
-		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)
-		if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
-			radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
+	air.adjust_moles(/datum/gas/tritium, -burned_fuel) // Yogs -- Maybe a tiny performance boost? I'unno
+	air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
+	air.adjust_moles(/datum/gas/water_vapor, burned_fuel)// Yogs -- Conservation of Mass
+	var/energy_released = (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * TRITIUM_BURN_TRIT_FACTOR) // Yogs -- Fixes low-energy tritium fires
 
-		//oxygen+more-or-less hydrogen=H2O
-		air.adjust_moles(/datum/gas/water_vapor, burned_fuel )// Yogs -- Conservation of Mass
+	if(location && prob(10) && burned_fuel > TRITIUM_MINIMUM_RADIATION_ENERGY) //woah there let's not crash the server
+		radiation_pulse(location, energy_released/TRITIUM_BURN_RADIOACTIVITY_FACTOR)
 
-		cached_results["fire"] += burned_fuel
+	cached_results["fire"] += burned_fuel
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -607,30 +605,22 @@ nobliumformation = 1001
 	)
 
 /datum/gas_reaction/h2fire/react(datum/gas_mixture/air, datum/holder)
-	var/energy_released = 0
 	var/old_heat_capacity = air.heat_capacity()
  //this speeds things up because accessing datum vars is slow
 	var/temperature = air.return_temperature()
 	var/list/cached_results = air.reaction_results
 	cached_results["fire"] = 0
 	var/turf/open/location = isturf(holder) ? holder : null
-	var/burned_fuel = 0
-	var/initial_hydrogen = air.get_moles(/datum/gas/hydrogen)	//Yogs
-	if(air.get_moles(/datum/gas/oxygen) < air.get_moles(/datum/gas/hydrogen) || MINIMUM_H2_OXYBURN_ENERGY > air.thermal_energy())
-		burned_fuel = min(air.get_moles(/datum/gas/oxygen)/HYDROGEN_BURN_OXY_FACTOR, initial_hydrogen) //Yogs - prevents negative mols of h2
-		air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)
-		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2) 	//Yogs - only takes half a mol of O2 for a mol of H2O
-	else
-		burned_fuel = initial_hydrogen / HYDROGEN_BURN_H2_FACTOR	//Yogs - conservation of mass fix 
-		air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)	// Yogs - see trit burn
-		air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
-		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * (HYDROGEN_BURN_H2_FACTOR - 1)) // Yogs -- burns twice as fast with half the energy
+	var/burned_fuel = min(air.get_moles(/datum/gas/hydrogen), air.get_moles(/datum/gas/oxygen)) / HYDROGEN_BURN_H2_FACTOR
+	if(burned_fuel <= 0)
+		return NO_REACTION
+	
+	air.adjust_moles(/datum/gas/hydrogen, -burned_fuel)	// Yogs - see trit burn
+	air.adjust_moles(/datum/gas/oxygen, -burned_fuel / 2)
+	air.adjust_moles(/datum/gas/water_vapor, burned_fuel)
+	var/energy_released = (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel * HYDROGEN_BURN_H2_FACTOR) // Yogs -- burns twice as fast with half the energy
 
-	if(burned_fuel)
-		energy_released += (FIRE_HYDROGEN_ENERGY_RELEASED * burned_fuel)
-		air.adjust_moles(/datum/gas/water_vapor, burned_fuel)
-
-		cached_results["fire"] += burned_fuel
+	cached_results["fire"] += burned_fuel
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()


### PR DESCRIPTION
# Document the changes in your pull request

Hydrogen and tritium fire burn rate is now dependent on both fuel and oxygen concentration instead of just the fuel amount and a binary "is the oxygen above 50% concentration" check.

This will make single tank bombs unable to reach the bomb cap without adding unnecessary checks or removals.

# Changelog

:cl:  
tweak: hydrogen/tritium fires make sense now, no more making timed singletanks with them
/:cl:
