### PR TITLE
Fixes misleading donor item poster text

### DIFF
--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -563,10 +563,10 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 	name = "lime lipstick"
 	unlock_path = /obj/item/lipstick/random
 /datum/donator_gear/rolled_poster
-	name = "contraband poster - Lusty Xenomorph"
+	name = "random contraband poster"
 	unlock_path = /obj/item/poster/random_contraband
 /datum/donator_gear/rolled_legit
-	name = "motivational poster - Help Others"
+	name = "random motivational poster"
 	unlock_path = /obj/item/poster/random_official
 /datum/donator_gear/razor
 	name = "electric razor"


### PR DESCRIPTION
# Document the changes in your pull request

# Changelog

:cl:  
bugfix: Fixed donator posters being labeled as specific posters when they aren't
/:cl:
