### PR TITLE
Gives Psychiatrist Skeleton Crew (Lowpop) Chemistry Access

### DIFF
--- a/yogstation/code/modules/jobs/job_types/psychiatrist.dm
+++ b/yogstation/code/modules/jobs/job_types/psychiatrist.dm
@@ -15,7 +15,7 @@
 
 	outfit = /datum/outfit/job/psych
 
-	added_access = list()
+	added_access = list(ACCESS_CHEMISTRY)
 	base_access = list(ACCESS_MEDICAL, ACCESS_PSYCH)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED


### PR DESCRIPTION
# Document the changes in your pull request

As the title states. With no more office chem machine if, for some reason, need to restock specialty meds, they can do so if no chemists are available and the station is in Skeleton Crew (LOWPOP) mode.

# Wiki Documentation

Added Access will need to be changed.

# Changelog

:cl:  
tweak: Psych gets lowpop chem access
/:cl:
