### PR TITLE
His grace does triple damage to airlocks

### DIFF
--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -52,8 +52,12 @@
 	if(!proximity)
 		return
 	if(!QDELETED(A) && (istype(A, /obj/machinery/door) || istype(A, /obj/structure/door_assembly)))
-		var/obj/O = A // Do triple damage to airlocks
-		O.take_damage(force*2, BRUTE, MELEE, FALSE, null, armour_penetration)
+		var/obj/O = A
+		// If the initial hit didn't count and we're pretending to have triple damage, make up for it
+		if(O.damage_deflection > force)
+			O.take_damage(force*3, BRUTE, MELEE, FALSE, null, armour_penetration)
+		else
+			O.take_damage(force*2, BRUTE, MELEE, FALSE, null, armour_penetration)
 
 /obj/item/his_grace/CtrlClick(mob/user) //you can't pull his grace
 	return

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -47,6 +47,14 @@
 	else
 		..()
 
+/obj/item/his_grace/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	if(!QDELETED(A) && (istype(A, /obj/machinery/door) || istype(A, /obj/structure/door_assembly)))
+		var/obj/O = A
+		O.take_damage(force*2, BRUTE, MELEE, FALSE, null, armour_penetration)
+
 /obj/item/his_grace/CtrlClick(mob/user) //you can't pull his grace
 	return
 

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -52,7 +52,7 @@
 	if(!proximity)
 		return
 	if(!QDELETED(A) && (istype(A, /obj/machinery/door) || istype(A, /obj/structure/door_assembly)))
-		var/obj/O = A
+		var/obj/O = A // Do triple damage to airlocks
 		O.take_damage(force*2, BRUTE, MELEE, FALSE, null, armour_penetration)
 
 /obj/item/his_grace/CtrlClick(mob/user) //you can't pull his grace


### PR DESCRIPTION
# Document the changes in your pull request

This item is non-existent in present day yogs and in theory a large counter is the AI bolting doors or people hiding behind areas the user simply has no access to while the user has their timer run out and eventually die. Lessening this counter should make the 20TC purchase a bit more smooth.

# Changelog
:cl:  
tweak: His Grace now deals triple damage to airlocks
/:cl:
