### PR TITLE
IPC unique cult eyes message

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -98,7 +98,10 @@
 		if(glasses)
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
 		else if(eye_color == BLOODCULT_EYE && HAS_TRAIT(src, CULT_EYES))
-			. += span_warning("<B>[t_His] eyes are glowing an unnatural red!</B>")
+			if(isipc(src))
+				. += span_warning("<B>Their monitor hums quietly, with an underlying collection of blood-red pixels swirling faintly.</B>")
+			else
+				. += span_warning("<B>[t_His] eyes are glowing an unnatural red!</B>")
 
 	//ears
 	if(ears && !(SLOT_EARS in obscured))
@@ -584,8 +587,10 @@
 		if(glasses)
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
 		else if(eye_color == BLOODCULT_EYE && HAS_TRAIT(src, CULT_EYES))
-			. += span_warning("<B>[t_His] eyes are glowing an unnatural red!</B>")
-
+			if(isipc(src))
+				. += span_warning("<B>Their monitor hums quietly, with an underlying collection of blood-red pixels swirling faintly.</B>")
+			else
+				. += span_warning("<B>[t_His] eyes are glowing an unnatural red!</B>")
 	//ears
 	if(ears && !(SLOT_EARS in obscured))
 		. += "[t_He] [t_has] [ears.get_examine_string(user)] on [t_his] ears."


### PR DESCRIPTION
# Document the changes in your pull request
 IPCs now have a unique cult_eyes flavor text to compensate for having a big screen instead of eyes.
![image](https://github.com/yogstation13/Yogstation/assets/44381232/1064eff2-a711-47d1-a2bd-94c6adfc3f00)

# Wiki Documentation
IPC's should be noted to have the new blood-swirl flavortext instead of normal cult eyes. 
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: IPC's cult "eyes" now detail a monitor as opposed to eyes.
/:cl:
