### PR TITLE
Deletes male polysmorphs

### DIFF
--- a/code/modules/client/preferences/gender.dm
+++ b/code/modules/client/preferences/gender.dm
@@ -8,6 +8,15 @@
 	return list(MALE, FEMALE, PLURAL)
 
 /datum/preference/choiced/gender/apply_to_human(mob/living/carbon/human/target, value)
-	if(!target.dna.species.sexes)
+	var/datum/species/S = target.dna.species
+
+	if(!S.sexes || (AGENDER in S.species_traits))
 		value = PLURAL //disregard gender preferences on this species
+
+	if(S)
+		if(FGENDER in S.species_traits)
+			value = FEMALE
+		else if(MGENDER in S.species_traits)
+			value = MALE
+			
 	target.gender = value


### PR DESCRIPTION
Polysmorphs are now even more forced to be female (and other forced gender races are fixed probably, not that they exist) because I CANNOT for the life of me figure out the cursed fucking tgui character preferences menu to fix it but this works well enough. It no longer matters what gender you select roundstart.

Also I could have made some questionable jokes with this pr but had to hold myself back, so just think of them yourself.

# Changelog

:cl:  

bugfix: Forced-gender species (polys) no longer can spawn as the wrong gender

/:cl:
