### PR TITLE
Caps the wildly reproducing slimes at 256

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -419,6 +419,10 @@
 	config_entry_value = 64
 	min_val = 0
 
+/datum/config_entry/number/slimecap
+	config_entry_value = 256
+	min_val = 0
+
 /datum/config_entry/number/ratcap
 	default = 64
 	min_val = 0

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -9,6 +9,7 @@ SUBSYSTEM_DEF(mobs)
 	var/static/list/clients_by_zlevel[][]
 	var/static/list/dead_players_by_zlevel[][] = list(list()) // Needs to support zlevel 1 here, MaxZChanged only happens when z2 is created and new_players can login before that.
 	var/static/list/cubemonkeys = list()
+	var/static/list/slimes = list()
 	var/static/list/cheeserats = list()
 
 /datum/controller/subsystem/mobs/stat_entry(msg)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -87,6 +87,12 @@
 
 
 /mob/living/simple_animal/slime/Initialize(mapload, new_colour="grey", new_is_adult=FALSE)
+	var/cap = CONFIG_GET(number/slimecap)
+	if(LAZYLEN(SSmobs.slimes) > cap)
+		visible_message(span_warning("This sector's concentration of living slime mass consumes \the [src]!"))
+		return INITIALIZE_HINT_QDEL
+	SSmobs.slimes += src
+
 	var/datum/action/innate/slime/feed/F = new
 	F.Grant(src)
 
@@ -105,6 +111,25 @@
 	. = ..()
 	set_nutrition(700)
 
+/mob/living/simple_animal/slime/death(gibbed)
+	. = ..()
+	if(src in SSmobs.slimes)
+		SSmobs.slimes -= src
+
+/mob/living/simple_animal/slime/can_be_revived()
+	. = ..()
+	if(!.)
+		return
+	var/cap = CONFIG_GET(number/slimecap)
+	if(LAZYLEN(SSmobs.slimes) > cap)
+		visible_message(span_warning("This sector's concentration of living slime mass prevents \the [src] from being revived!"))
+		return FALSE
+
+/mob/living/simple_animal/slime/revive(full_heal, admin_revive)
+	. = ..()
+	if(.)
+		SSmobs.slimes += src
+
 /mob/living/simple_animal/slime/Destroy()
 	for (var/A in actions)
 		var/datum/action/AC = A
@@ -112,6 +137,8 @@
 	set_target(null)
 	set_leader(null)
 	clear_friends()
+	if(src in SSmobs.slimes)
+		SSmobs.slimes -= src
 	return ..()
 
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -676,6 +676,9 @@ DISABLE_HUMAN_MOOD
 ## A cap on how many monkeys may be created via monkey cubes
 #MONKEYCAP 64
 
+## A cap on how many slimes may be spawned
+#SLIMECAP 256
+
 ## Cap on how many regal rat minions there can be
 #RATCAP 64
 


### PR DESCRIPTION
# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

Dead slimes do not count towards the cap, and there is a config option (default 256)

Depicted: 4281 slimes (undetermined how many of them were alive)
![image](https://github.com/yogstation13/Yogstation/assets/28408322/73da28f4-5e64-4ddf-85ec-9105dd0ad042)

# Changelog

:cl:  
tweak: Living slimes are now capped at 256
/:cl:
