### PR TITLE
Mime drinks aren't the same v2.0 no more stacks

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1216,9 +1216,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1)
+		M.heal_bodypart_damage(1.5,1.5)
 		. = 1
 	return ..() || .
 
@@ -1931,9 +1931,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A fizzy cocktail for those looking to start fresh."
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1)
+		M.heal_bodypart_damage(2.5,2.5)
 		. = 1
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1217,8 +1217,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1.5,1.5)
+		if(holder.has_reagent(/datum/reagent/consumable/nothing))
+			holder.remove_reagent(/datum/reagent/consumable/nothing, 5)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_paper))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/blank_paper, 5)
+		else
+			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+			M.heal_bodypart_damage(1.5,1.5)
 		. = 1
 	return ..() || .
 
@@ -1932,8 +1937,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(2.5,2.5)
+		if(holder.has_reagent(/datum/reagent/consumable/nothing))
+			holder.remove_reagent(/datum/reagent/consumable/nothing, 5)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5)
+		else
+			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+			M.heal_bodypart_damage(2.5,2.5)
 		. = 1
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1216,7 +1216,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1.5,1.5)
 		. = 1
@@ -1931,7 +1931,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A fizzy cocktail for those looking to start fresh."
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(2.5,2.5)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -143,8 +143,10 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer || /datum/reagent/consumable/ethanol/blank_paper))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer)
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_page)
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/blank_page, 5)
 		else
 			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 			M.heal_bodypart_damage(1,1, 0)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -145,8 +145,8 @@
 	if(ishuman(M) && M.job == "Mime")
 		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer))
 			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5)
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_page))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/blank_page, 5)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_paper))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/blank_paper, 5)
 		else
 			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 			M.heal_bodypart_damage(1,1, 0)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -142,7 +142,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && M.job == "Mime")
+	if(M.mind?.assigned_role == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -143,6 +143,9 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer || /datum/reagent/consumable/ethanol/blank_paper))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5))
+	else
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -144,7 +144,7 @@
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
 		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer) || (/datum/reagent/consumable/ethanol/blank_paper))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5) || /datum/reagent/consumable/ethanol/blank_paper, 5))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5) || (/datum/reagent/consumable/ethanol/blank_paper, 5))
 		else
 			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 			M.heal_bodypart_damage(1,1, 0)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -143,11 +143,11 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer || /datum/reagent/consumable/ethanol/blank_paper))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5)
-	else
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1, 0)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer) || (/datum/reagent/consumable/ethanol/blank_paper))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5) || /datum/reagent/consumable/ethanol/blank_paper, 5))
+		else
+			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
+			M.heal_bodypart_damage(1,1, 0)
 		. = 1
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -142,7 +142,7 @@
 	shot_glass_icon_state = "shotglass"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
-	if(M.mind?.assigned_role == "Mime")
+	if(ishuman(M) && M.job == "Mime")
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)
 		. = 1

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -144,7 +144,7 @@
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
 		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer || /datum/reagent/consumable/ethanol/blank_paper))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5)
 	else
 		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1, 0)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -143,9 +143,9 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer))
 			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5)
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_page)
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/blank_page))
 			holder.remove_reagent(/datum/reagent/consumable/ethanol/blank_page, 5)
 		else
 			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -143,8 +143,8 @@
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M) && M.job == "Mime")
-		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer) || (/datum/reagent/consumable/ethanol/blank_paper))
-			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5) || (/datum/reagent/consumable/ethanol/blank_paper, 5))
+		if(holder.has_reagent(/datum/reagent/consumable/ethanol/silencer || /datum/reagent/consumable/ethanol/blank_paper))
+			holder.remove_reagent(/datum/reagent/consumable/ethanol/silencer, 5 || /datum/reagent/consumable/ethanol/blank_paper, 5)
 		else
 			M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 			M.heal_bodypart_damage(1,1, 0)


### PR DESCRIPTION
# Document the changes in your pull request

Essentially, all mime drinks give the same heal. I've tweaked it so that each drink tier heals more
Nothing = 1.0 heal
Silencer = 1.5 heal
Blank Paper = 2.5 heal
The reasoning behind this is that Silencer needs Nothing to make, and Blank paper requires both Nothing & Silencer to make.
As suggested too, I've put in a way to prevent mimes from stacking heals, therefore only one drink may be in the mime system at all times. 

I.E, if they drank Nothing first and then blank paper & silencer, the nothing will cancel out blank paper & silencer till Nothing reaches 0u's. The same apply for the rest.

# Changelog

:cl:  
rscadd: Mimes can't stack their job drinks now and only one will be in their system at any time  
tweak: Silencer heals for 1.5, and blank paper heals for 2.5
/:cl:
