### PR TITLE
Wing potion costs 2tc instead of 5

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2243,9 +2243,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/race_restricted/angelcoolboy
 	name = "Angel Potion"
 	desc = "We mixed a bird and a human and we somehow made a potion that turns you into a holy creature."
-	cost = 5
+	cost = 2
 	item = /obj/item/reagent_containers/glass/bottle/potion/flight/syndicate
-	restricted_species = list("human", "lizard", "moth", "skeleton", "preternis", "ipc")
+	restricted_species = list("human", "lizard", "moth", "skeleton", "preternis", "ipc", "pod")
 
 /datum/uplink_item/race_restricted/hammerimplant
 	name = "Vxtvul Hammer Implant"


### PR DESCRIPTION
# Document the changes in your pull request

Rarely used item that you can get from lavaland or xenobio anyway, so I made it cheaper (5tc->2tc) to justify actually getting it. Also phytosians can get it because they have wings now.

# Wiki Documentation

If there's a list of syndicate items, update the wing potion price to 2tc

# Changelog

:cl:  
tweak: wing potion in uplink costs 2tc and phytosians can have it now
/:cl:
