### PR TITLE
Fixes the hand teleporter gettign a little quirky when failing to dispel portals, further proving the theory that yogsdev debugging is "let theos use it"

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -167,27 +167,22 @@
 			. += "<span class='notice'>A tier <b>[manipulator.rating]</b> micro manipulator is installed. It is <i>screwed</i> in place.<span>"
 
 /obj/item/hand_tele/pre_attack(atom/target, mob/user, params)
-	if(try_dispel_portal(target, user))
+	if(is_parent_of_portal(target))
+		try_dispel_portal(target, user)
 		return FALSE
 	return ..()
 
 /obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user)
-	if(is_parent_of_portal(target))
+	if(is_parent_of_portal(target)) //dispel me from this horrid realm
 		var/dispel_time = 5 - manipulator.rating
 		if(dispel_time == 0)
 			qdel(target)
 			to_chat(user, span_notice("You dispel [target] with \the [src]!"))
-			return TRUE
+			return
 		balloon_alert(user, "Dispelling portal...")
 		if(do_after(user, dispel_time SECONDS, target))
 			qdel(target)
 			to_chat(user, span_notice("You dispel [target] with \the [src]!"))
-			return TRUE
-	return FALSE
-
-/obj/item/hand_tele/afterattack(atom/target, mob/user)
-	try_dispel_portal(target, user)
-	. = ..()
 
 /obj/item/hand_tele/attack_self(mob/user)
 	var/turf/current_location = get_turf(user)//What turf is the user on?


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Removes extra dispel on afterattack since dispel gets called both on pre attack and after attack for... some reason. Thid would allow a second attempt at dispelling a portal if you moved away from it during the first one, rather than;
Failing to dispel a portal no longer forces you to teleport through it, since for some reason we decided to pass whether the dispel was successful as whether or not we should hit the portal normally
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: the hand teleporter no longer acts quirky when failing to dispel portals, which would result in attempting to dispel it a second time or teleporting you through it
/:cl:
