### PR TITLE
another buster arm pr (nerf)

### DIFF
--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -490,7 +490,7 @@
 
 	combined_msg +=  span_warning("Should your moves cease to function altogether, utilize the 'Recalibrate Arm' function.")
 
-	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 50% for 2 seconds.</b>")
+	combined_msg += span_notice("<b>After landing an attack, you become resistant to damage slowdown and all incoming damage by 25% for 2 seconds.</b>")
 
 	to_chat(usr, examine_block(combined_msg.Join("\n")))
 

--- a/code/datums/martial/buster_style.dm
+++ b/code/datums/martial/buster_style.dm
@@ -44,11 +44,24 @@
 /datum/martial_art/buster_style/can_use(mob/living/carbon/human/H)
 	var/obj/item/bodypart/r_arm/robot/buster/R = H.get_bodypart(BODY_ZONE_R_ARM)
 	var/obj/item/bodypart/l_arm/robot/buster/L = H.get_bodypart(BODY_ZONE_L_ARM)
-	var/obj/item/bodypart/l_arm/robot/buster/left
-	var/obj/item/bodypart/r_arm/robot/buster/right 
-	if(!((right && left) in H.bodyparts))
-		src.remove(H)
-		return
+	if(L)
+		if(!istype(L, /obj/item/bodypart/l_arm/robot/buster))
+			if(R && !istype(R, /obj/item/bodypart/r_arm/robot/buster))
+				src.remove(H)
+				return FALSE
+		else
+			if(R && !istype(R, /obj/item/bodypart/r_arm/robot/buster))
+				if((L?.bodypart_disabled))
+					return FALSE
+	if(R)
+		if(!istype(R, /obj/item/bodypart/r_arm/robot/buster))
+			if(L && !istype(L, /obj/item/bodypart/l_arm/robot/buster))
+				src.remove(H)
+				return FALSE
+		else
+			if(L && !istype(L, /obj/item/bodypart/l_arm/robot/buster))
+				if((R?.bodypart_disabled))
+					return FALSE
 	if(H.restrained() || H.get_active_held_item() || HAS_TRAIT(H, TRAIT_PACIFISM) || !(H.mobility_flags & MOBILITY_MOVE) || H.stat != CONSCIOUS)
 		for(var/atom/movable/K in thrown)
 			thrown.Remove(K)
@@ -61,11 +74,6 @@
 	if(L && R)
 		if((L?.bodypart_disabled) && (R?.bodypart_disabled))
 			to_chat(H, span_warning("The arms aren't in a functional state right now!"))
-			return FALSE
-		return TRUE //still got the other arm to pop off with
-	if(R || L)
-		if(R?.bodypart_disabled || L?.bodypart_disabled)
-			to_chat(H, span_warning("The [L ? "left" : "right"] buster arm isn't in a functional state right now!"))
 			return FALSE
 	return ..()
 

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -600,7 +600,7 @@
 
 /atom/movable/screen/alert/status_effect/doubledown
 	name = "Doubling Down"
-	desc = "Taking 50% less damage, go all in!"
+	desc = "Taking 25% less damage, go all in!"
 	icon_state = "aura"
 
 /datum/status_effect/doubledown/on_apply()
@@ -612,12 +612,12 @@
 			walk_towards(s_such_strength, H)
 			animate(s_such_strength, alpha = 100, color = "#d40a0a", transform = matrix()*1.25, time = 0.25 SECONDS)
 			H.ignore_slowdown(type)
-			H.physiology.brute_mod *= 0.5
-			H.physiology.burn_mod *= 0.5
-			H.physiology.tox_mod *= 0.5
-			H.physiology.oxy_mod *= 0.5
-			H.physiology.clone_mod *= 0.5
-			H.physiology.stamina_mod *= 0.5
+			H.physiology.brute_mod *= 0.25
+			H.physiology.burn_mod *= 0.25
+			H.physiology.tox_mod *= 0.25
+			H.physiology.oxy_mod *= 0.25
+			H.physiology.clone_mod *= 0.25
+			H.physiology.stamina_mod *= 0.25
 		owner.log_message("gained buster damage reduction", LOG_ATTACK)
 
 /datum/status_effect/doubledown/on_remove()
@@ -625,10 +625,10 @@
 		qdel(s_such_strength)
 		var/mob/living/carbon/human/H = owner
 		H.unignore_slowdown(type)
-		H.physiology.brute_mod /= 0.5
-		H.physiology.burn_mod /= 0.5
-		H.physiology.tox_mod /= 0.5
-		H.physiology.oxy_mod /= 0.5
-		H.physiology.clone_mod /= 0.5
-		H.physiology.stamina_mod /= 0.5
+		H.physiology.brute_mod /= 0.25
+		H.physiology.burn_mod /= 0.25
+		H.physiology.tox_mod /= 0.25
+		H.physiology.oxy_mod /= 0.25
+		H.physiology.clone_mod /= 0.25
+		H.physiology.stamina_mod /= 0.25
 	owner.log_message("lost buster damage reduction", LOG_ATTACK)//yogs end

--- a/code/game/objects/items/devices/busterarm/buster_limb.dm
+++ b/code/game/objects/items/devices/busterarm/buster_limb.dm
@@ -30,10 +30,12 @@
 /// Remove our actions, re-enable gloves
 /obj/item/bodypart/l_arm/robot/buster/drop_limb(special)
 	var/mob/living/carbon/N = owner
+	var/obj/item/bodypart/r_arm = N.get_bodypart(BODY_ZONE_R_ARM)
 	megabuster_action.Remove(N)
-	buster_style.remove(N)
-	N.click_intercept = null
-	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
+	if(!istype(r_arm, /obj/item/bodypart/r_arm/robot/buster))
+		buster_style.remove(N)
+		N.click_intercept = null
+		to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
 	..()
 
 /// Attacking a human mob with the arm causes it to instantly replace their arm
@@ -80,10 +82,12 @@
 /// Remove our actions, re-enable gloves
 /obj/item/bodypart/r_arm/robot/buster/drop_limb(special)
 	var/mob/living/carbon/N = owner
+	var/obj/item/bodypart/l_arm = N.get_bodypart(BODY_ZONE_L_ARM)
 	megabuster_action.Remove(N)
-	buster_style.remove(N)
-	N.click_intercept = null
-	to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
+	if(!istype(l_arm, /obj/item/bodypart/l_arm/robot/buster))
+		buster_style.remove(N)
+		N.click_intercept = null
+		to_chat(owner, "[span_boldannounce("You've lost the ability to use Buster Style...")]")
 	..()
 
 /// Attacking a human mob with the arm causes it to instantly replace their arm

--- a/code/game/objects/items/devices/busterarm/wire_snatch.dm
+++ b/code/game/objects/items/devices/busterarm/wire_snatch.dm
@@ -144,6 +144,7 @@
 		zip(H, target) // Pull us towards it if it's anchored
 	if(isliving(target)) // If it's somebody
 		H.apply_status_effect(STATUS_EFFECT_DOUBLEDOWN)
+		H.swap_hand(0) //for the sake of throttling people you catch
 		var/mob/living/L = target
 		var/turf/T = get_step(get_turf(H), H.dir)
 		var/turf/Q = get_turf(H)


### PR DESCRIPTION
# Document the changes in your pull request
-buster style works again
-damage reduction on double down is reduced to 25% from 50%
-you dont lose buster style if you have a second arm on you
-buster style being disabled on breaking the limb works now
-wire snatch now switches your active hand when you hit a mob or person
 reasoning for winding down the damage reduction is so the martial art is a bit closer to the league of the normal ones, plus it still has the slowdown ignoring which fulfills the purpose of the status effect, which is to not die immediately if someone sees you coming

# Wiki Documentation

https://wiki.yogstation.net/wiki/Syndicate_Items
change the 50% bit in the buster arm section to 25%

# Changelog

:cl:  
bugfix: fixed buster style not working
tweak: tweaked buster arm buff & disabling
/:cl:
