### PR TITLE
fixes changeling tentacle giving you grab slowdown if you are resting or knocked down when it starts trying to grab people

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -331,8 +331,9 @@
 			H.swap_hand()
 		if(H.get_active_held_item())
 			return
-		C.grabbedby(H)
-		C.grippedby(H, instant = TRUE) //instant aggro grab
+		if((user.mobility_flags & MOBILITY_STAND))
+			C.grabbedby(H)
+			C.grippedby(H, instant = TRUE) //instant aggro grab
 
 /obj/item/projectile/tentacle/proc/tentacle_stab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -331,7 +331,7 @@
 			H.swap_hand()
 		if(H.get_active_held_item())
 			return
-		if((user.mobility_flags & MOBILITY_STAND))
+		if((H.mobility_flags & MOBILITY_STAND))
 			C.grabbedby(H)
 			C.grippedby(H, instant = TRUE) //instant aggro grab
 


### PR DESCRIPTION
# Document the changes in your pull request

grabs are DUMB

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: changeling tentacle can no longer give you a semi-permanent slowdown effect if you use it on grab intent while knocked down
/:cl:
