### PR TITLE
Makes the experimentor and secondary data core of Asteroid not utterly braindead

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -1244,9 +1244,8 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "akg" = (
-/obj/machinery/computer/ai_resource_distribution{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "akh" = (
@@ -3807,6 +3806,16 @@
 "aDP" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
+"aDR" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "aDU" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -4187,9 +4196,6 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "aGP" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "aGS" = (
@@ -4406,14 +4412,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"aIn" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aIu" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4445,6 +4443,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aIQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/maintenance/central/secondary)
 "aIT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -5186,7 +5190,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQh" = (
-/turf/closed/wall,
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
 /area/science/explab)
 "aQj" = (
 /obj/machinery/camera{
@@ -6483,6 +6490,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bds" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/maintenance/central/secondary)
 "bdu" = (
 /obj/structure/chair/sofa/corner,
 /obj/effect/turf_decal/siding/wood{
@@ -12317,12 +12330,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cZb" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "cZB" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -12864,6 +12871,16 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"dis" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "dix" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -13412,6 +13429,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"dvk" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "dvm" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -17717,14 +17740,8 @@
 /turf/open/floor/carpet,
 /area/library)
 "eTo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/dark,
 /area/science/server)
 "eTC" = (
 /obj/machinery/camera{
@@ -18115,10 +18132,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "fbZ" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
 /area/science/server)
 "fcm" = (
 /obj/structure/cable/yellow{
@@ -18408,12 +18427,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ffG" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "fgb" = (
 /obj/structure/table,
 /obj/item/storage/box/fancy/donut_box{
@@ -18862,12 +18875,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fne" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/science/server)
 "fnA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -19218,18 +19225,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"fuB" = (
-/obj/structure/table,
-/obj/item/hand_labeler{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "fuC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20764,6 +20759,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"fUv" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/maintenance/central/secondary)
 "fUA" = (
 /obj/item/clothing/mask/cigarette/rollie/trippy,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -23078,14 +23079,15 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gGV" = (
@@ -23197,6 +23199,16 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
+"gJH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/central/secondary)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
@@ -26649,6 +26661,9 @@
 "hNQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "hNV" = (
@@ -27109,6 +27124,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
@@ -30044,6 +30063,9 @@
 	pixel_x = -30;
 	pixel_y = -4
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "iZN" = (
@@ -30624,17 +30646,10 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "jgP" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/computer/rdservercontrol{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/science/server)
 "jgT" = (
 /obj/machinery/light{
@@ -31581,17 +31596,12 @@
 	},
 /area/science/xenobiology)
 "jwx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "jwC" = (
@@ -33703,6 +33713,15 @@
 	pixel_x = 1;
 	pixel_y = -28
 	},
+/obj/structure/table,
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/hand_labeler{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "kka" = (
@@ -35424,6 +35443,18 @@
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"kNO" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Secondary AI Core";
+	normalspeed = 0;
+	req_access_txt = "47"
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "kNP" = (
 /obj/effect/overlay/palmtree_l{
 	pixel_x = 15;
@@ -39168,11 +39199,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"meO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "meQ" = (
 /obj/structure/cable{
 	icon_state = "1-2";
@@ -41703,6 +41729,25 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"mVH" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/central/secondary)
 "mVI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42994,6 +43039,10 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ruin/space/has_grav/listeningstation)
+"noy" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/maintenance/central/secondary)
 "noR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -44063,6 +44112,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"nGd" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "nGs" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -49050,16 +49107,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "pnq" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/computer/ai_resource_distribution{
+	dir = 1
 	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/central/secondary)
 "pns" = (
 /obj/machinery/door/airlock/research{
@@ -49675,6 +49726,24 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pvV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "pvW" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -54133,15 +54202,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "qOJ" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -55718,6 +55787,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"rnR" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "rnZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -55755,6 +55836,21 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ron" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "row" = (
 /obj/item/banhammer,
 /obj/item/bedsheet/centcom,
@@ -56873,6 +56969,9 @@
 	normalspeed = 0;
 	req_access_txt = "47"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "rFi" = (
@@ -57471,21 +57570,6 @@
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/storage/tech)
-"rPV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/research/research{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rQi" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -58843,11 +58927,11 @@
 /turf/open/floor/fakespace,
 /area/maintenance/starboard/fore)
 "smv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "smG" = (
@@ -59257,13 +59341,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "suh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
+/obj/item/toy/talking/AI,
+/turf/open/floor/plasteel/dark,
 /area/science/server)
 "sun" = (
 /obj/structure/rack,
@@ -66243,19 +66326,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "uKg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/sign/departments/minsky/research/research{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67012,7 +67089,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uZm" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/open/floor/plasteel/white,
 /area/science/server)
 "uZp" = (
@@ -67928,6 +68004,13 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"vsD" = (
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "vsN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67974,6 +68057,9 @@
 	pixel_x = -10;
 	pixel_y = 24;
 	req_one_access_txt = "30;70"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -69550,12 +69636,9 @@
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
 "vUM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "vUU" = (
@@ -75469,6 +75552,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xRx" = (
+/turf/open/floor/plasteel/white,
+/area/maintenance/central/secondary)
 "xRz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -110377,9 +110463,9 @@ afm
 uSU
 uSU
 uSU
-fjL
-gGH
 uSU
+gGH
+pvV
 uSU
 uSU
 bki
@@ -110634,9 +110720,9 @@ vaY
 aiM
 aiM
 aiM
-rPV
-uKg
 aiM
+uKg
+ron
 aiM
 aiM
 odp
@@ -110887,13 +110973,13 @@ tRa
 xLp
 hsb
 hsb
-hsb
-hsb
-hsb
-hsb
-aQh
+aPQ
+aPQ
+pos
+pos
+aPQ
+asx
 gez
-qHC
 qHC
 qHC
 aUC
@@ -111142,15 +111228,15 @@ axg
 wks
 aZv
 eEl
+akl
 nJQ
 aDt
 aPQ
 aHZ
 aHZ
 aTj
-aQh
+asx
 bqm
-meO
 rYB
 tah
 sTo
@@ -111399,15 +111485,15 @@ akl
 qso
 rxH
 eEl
+akl
 aZQ
 aZP
 pos
-cZb
+aHZ
 aXg
 gHi
-aQh
+asx
 jao
-waQ
 hgr
 iHJ
 iUo
@@ -111657,13 +111743,13 @@ akl
 rxH
 xnf
 xUo
+akl
 atv
 aPQ
 aHZ
 aHZ
-aHZ
 aQh
-fuB
+asx
 apZ
 gMO
 ePs
@@ -111916,16 +112002,16 @@ iVb
 aoG
 pEF
 iZJ
+kNO
 cAE
 aHZ
 aHZ
-aPQ
-fGL
-boj
+asx
+apZ
 qCg
 apZ
 nUp
-apZ
+vsD
 hXH
 qKj
 asx
@@ -112441,7 +112527,7 @@ uZw
 fkF
 apZ
 edA
-apZ
+fGL
 asx
 bZW
 itn
@@ -112698,7 +112784,7 @@ asx
 asx
 lJB
 edA
-apZ
+boj
 asx
 dJo
 itn
@@ -113201,10 +113287,10 @@ vGH
 bBq
 jBI
 qbb
-aCb
-ffG
-fne
-aCb
+rnR
+uZm
+uZm
+dvk
 aCb
 aKl
 gPp
@@ -113459,8 +113545,8 @@ aDY
 aDY
 aDY
 aDY
-aDY
-aDY
+noy
+xRx
 pnq
 aDY
 wNN
@@ -113715,10 +113801,10 @@ oqX
 oqX
 pDe
 pDe
-poL
-kzz
-kzz
-qls
+aDY
+bds
+fUv
+aIQ
 aDY
 sRJ
 rZn
@@ -113972,10 +114058,10 @@ jOQ
 jOQ
 mLA
 jOQ
-aIn
-kzz
-kzz
-kzz
+aDY
+gJH
+mVH
+gJH
 aDY
 aKl
 aKl
@@ -114229,10 +114315,10 @@ eBL
 xUe
 lPV
 cuk
-poL
-kzz
-kzz
-kzz
+aDY
+nGd
+aDR
+dis
 aDY
 asx
 asx

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -8003,14 +8003,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"bDq" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "bDH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8140,16 +8132,6 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"bFm" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "bFn" = (
 /obj/structure/table,
 /obj/item/nanite_remote{
@@ -10832,19 +10814,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cAE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/server";
-	dir = 4;
-	name = "Server Room APC";
-	pixel_x = 24
+/obj/machinery/door/airlock/research/glass{
+	name = "Secondary AI Core";
+	normalspeed = 0;
+	req_access_txt = "47"
 	},
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/explab)
 "cAN" = (
@@ -11620,6 +11594,19 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cNL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "cNM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12605,12 +12592,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ddO" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "den" = (
 /obj/structure/chair{
 	dir = 4
@@ -14998,21 +14979,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eaa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "eab" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -19036,18 +19002,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"fqw" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Secondary AI Core";
-	normalspeed = 0;
-	req_access_txt = "47"
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "fqz" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -26073,6 +26027,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hEw" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "hEy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27446,18 +27410,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"icW" = (
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "ida" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28682,6 +28634,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"iyt" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "iyy" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -30063,9 +30025,6 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "iZJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
@@ -31151,24 +31110,6 @@
 "jnp" = (
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
-"jnL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "jnN" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
@@ -31635,6 +31576,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "jwC" = (
@@ -31718,6 +31662,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"jya" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "jyg" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -32450,6 +32398,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"jKK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "jKV" = (
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
@@ -34859,25 +34817,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kBY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "kCn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -37382,13 +37321,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"lyA" = (
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "lyK" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -41717,6 +41649,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mUY" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "mUZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44280,6 +44224,12 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
+"nJb" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "nJl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -44418,12 +44368,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"nMw" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "nMz" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -47121,6 +47065,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oHd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "oHj" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -53257,12 +53219,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/storage)
-"qzk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "qzn" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -54221,6 +54177,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -55461,6 +55421,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -62108,10 +62072,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"tnc" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "tnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -67547,6 +67507,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vjr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vju" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69619,6 +69594,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "vUU" = (
@@ -70537,6 +70515,25 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/exoticpurple,
 /area/maintenance/port/aft)
+"wkg" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "wks" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -73628,6 +73625,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xjn" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "xjU" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -73828,6 +73834,14 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
+"xnd" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "xnf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74454,16 +74468,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
-"xyM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "xyO" = (
 /obj/machinery/light{
 	dir = 4
@@ -75180,16 +75184,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"xLm" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "xLp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76565,6 +76559,13 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall,
 /area/maintenance/disposal)
+"yjW" = (
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "ykr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -110462,7 +110463,7 @@ uSU
 uSU
 uSU
 gGH
-jnL
+oHd
 uSU
 uSU
 bki
@@ -110719,7 +110720,7 @@ aiM
 aiM
 aiM
 uKg
-eaa
+vjr
 aiM
 aiM
 odp
@@ -111999,8 +112000,8 @@ iVb
 aoG
 pEF
 iZJ
-fqw
 cAE
+aHZ
 aHZ
 aHZ
 aPQ
@@ -112008,7 +112009,7 @@ apZ
 qCg
 apZ
 nUp
-lyA
+yjW
 hXH
 qKj
 asx
@@ -113284,10 +113285,10 @@ vGH
 bBq
 jBI
 qbb
-icW
+mUY
 uZm
-uZm
-nMw
+jgP
+nJb
 aCb
 aKl
 gPp
@@ -113542,8 +113543,8 @@ aDY
 aDY
 aDY
 aCb
-tnc
-uZm
+jya
+jgP
 pnq
 aCb
 wNN
@@ -113800,8 +113801,8 @@ pDe
 pDe
 aCb
 ffG
-ddO
-qzk
+xjn
+cNL
 aCb
 sRJ
 rZn
@@ -114056,9 +114057,9 @@ jOQ
 mLA
 jOQ
 aCb
-xyM
-kBY
-xyM
+jKK
+wkg
+jKK
 aCb
 aKl
 aKl
@@ -114313,9 +114314,9 @@ xUe
 lPV
 cuk
 aCb
-bDq
-xLm
-bFm
+xnd
+iyt
+hEw
 aCb
 asx
 asx

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -381,6 +381,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
+"acB" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "acD" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -4186,6 +4190,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "aGP" = (
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "aGS" = (
@@ -9532,16 +9537,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"ced" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "cev" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -12532,6 +12527,18 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"ddm" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "ddn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -17785,6 +17792,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/listeningstation)
+"eVq" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "eVW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -19014,6 +19029,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fqI" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "fqO" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -22584,19 +22605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
-"gAq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "gAA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -26416,25 +26424,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"hKJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "hKS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -27110,10 +27099,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
@@ -29720,6 +29705,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"iUu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "iUz" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
@@ -31085,6 +31080,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"jmy" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "jmC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -32946,13 +32951,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/ruin/powered)
-"jVz" = (
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "jVA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33784,15 +33782,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"klG" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "klT" = (
 /obj/machinery/light{
 	dir = 8
@@ -35223,6 +35212,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"kIl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "kIn" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -36115,10 +36122,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"laP" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "laV" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -38565,6 +38568,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"lUB" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "lUD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39270,6 +39282,25 @@
 /obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/plasteel/white/side,
 /area/crew_quarters/heads/chief)
+"mgg" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "mgv" = (
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 4
@@ -45192,6 +45223,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"oaj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "oao" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -49865,21 +49909,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"pyx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "pyC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -53697,6 +53726,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"qGL" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "qGQ" = (
 /obj/effect/spawner/lootdrop/techstorage/AI,
 /obj/structure/rack,
@@ -56216,16 +56255,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"ruQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "ruT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -61927,14 +61956,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"tjL" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "tkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -67392,24 +67413,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vgl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "vgn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67613,18 +67616,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vkw" = (
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "vky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -69303,16 +69294,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"vOQ" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "vOS" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/camera{
@@ -71723,6 +71704,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wDX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "wEd" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -72270,12 +72266,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wNx" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "wNB" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -110463,7 +110453,7 @@ uSU
 uSU
 uSU
 gGH
-vgl
+kIl
 uSU
 uSU
 bki
@@ -110720,7 +110710,7 @@ aiM
 aiM
 aiM
 uKg
-pyx
+wDX
 aiM
 aiM
 odp
@@ -112009,7 +111999,7 @@ apZ
 qCg
 apZ
 nUp
-jVz
+apZ
 hXH
 qKj
 asx
@@ -113285,10 +113275,10 @@ vGH
 bBq
 jBI
 qbb
-vkw
+ddm
 uZm
 jgP
-wNx
+fqI
 aCb
 aKl
 gPp
@@ -113536,14 +113526,14 @@ kPp
 sPG
 tnu
 lMr
-aDY
-aDY
-aDY
-aDY
-aDY
-aDY
+amR
+amR
+amR
+amR
+amR
 aCb
-laP
+aCb
+acB
 jgP
 pnq
 aCb
@@ -113801,8 +113791,8 @@ pDe
 pDe
 aCb
 ffG
-klG
-gAq
+lUB
+oaj
 aCb
 sRJ
 rZn
@@ -114057,9 +114047,9 @@ jOQ
 mLA
 jOQ
 aCb
-ced
-hKJ
-ced
+iUu
+mgg
+iUu
 aCb
 aKl
 aKl
@@ -114314,9 +114304,9 @@ xUe
 lPV
 cuk
 aCb
-tjL
-ruQ
-vOQ
+eVq
+jmy
+qGL
 aCb
 asx
 asx

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -9532,6 +9532,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"ced" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "cev" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
@@ -11594,19 +11604,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"cNL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "cNM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22587,6 +22584,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
+"gAq" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "gAA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -26027,16 +26037,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hEw" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "hEy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26416,6 +26416,25 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"hKJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "hKS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -28634,16 +28653,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"iyt" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "iyy" = (
 /obj/structure/table,
 /obj/item/wirecutters,
@@ -31662,10 +31671,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"jya" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "jyg" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Holding Area";
@@ -32398,16 +32403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"jKK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "jKV" = (
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
@@ -32951,6 +32946,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/ruin/powered)
+"jVz" = (
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "jVA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33782,6 +33784,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"klG" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "klT" = (
 /obj/machinery/light{
 	dir = 8
@@ -36104,6 +36115,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"laP" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "laV" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -41649,18 +41664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mUY" = (
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "mUZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44224,12 +44227,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
-"nJb" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "nJl" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -47065,24 +47062,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oHd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "oHj" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -49886,6 +49865,21 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"pyx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "pyC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -51803,7 +51797,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/ai_monitored/secondarydatacore)
+/area/science/server)
 "qbj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53028,7 +53022,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/ai_monitored/secondarydatacore)
+/area/science/server)
 "qvg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -56222,6 +56216,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"ruQ" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "ruT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -61923,6 +61927,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"tjL" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "tkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -67380,6 +67392,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vgl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vgn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67507,21 +67537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"vjr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "vju" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -67598,6 +67613,18 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"vkw" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "vky" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -69276,6 +69303,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"vOQ" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "vOS" = (
 /obj/machinery/door/window/southleft,
 /obj/machinery/camera{
@@ -70515,25 +70552,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/exoticpurple,
 /area/maintenance/port/aft)
-"wkg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "wks" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -72252,6 +72270,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wNx" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "wNB" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor/border_only,
@@ -73625,15 +73649,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"xjn" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "xjU" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -73834,14 +73849,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
-"xnd" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "xnf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76559,13 +76566,6 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall,
 /area/maintenance/disposal)
-"yjW" = (
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "ykr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -110463,7 +110463,7 @@ uSU
 uSU
 uSU
 gGH
-oHd
+vgl
 uSU
 uSU
 bki
@@ -110720,7 +110720,7 @@ aiM
 aiM
 aiM
 uKg
-vjr
+pyx
 aiM
 aiM
 odp
@@ -112009,7 +112009,7 @@ apZ
 qCg
 apZ
 nUp
-yjW
+jVz
 hXH
 qKj
 asx
@@ -113285,10 +113285,10 @@ vGH
 bBq
 jBI
 qbb
-mUY
+vkw
 uZm
 jgP
-nJb
+wNx
 aCb
 aKl
 gPp
@@ -113543,7 +113543,7 @@ aDY
 aDY
 aDY
 aCb
-jya
+laP
 jgP
 pnq
 aCb
@@ -113801,8 +113801,8 @@ pDe
 pDe
 aCb
 ffG
-xjn
-cNL
+klG
+gAq
 aCb
 sRJ
 rZn
@@ -114057,9 +114057,9 @@ jOQ
 mLA
 jOQ
 aCb
-jKK
-wkg
-jKK
+ced
+hKJ
+ced
 aCb
 aKl
 aKl
@@ -114314,9 +114314,9 @@ xUe
 lPV
 cuk
 aCb
-xnd
-iyt
-hEw
+tjL
+ruQ
+vOQ
 aCb
 asx
 asx

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -381,10 +381,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"acB" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "acD" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -2398,13 +2394,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"atv" = (
-/obj/structure/closet/radiation,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
 "atx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -6127,6 +6116,14 @@
 	},
 /turf/open/floor/circuit,
 /area/maintenance/department/electrical)
+"aYO" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "aYV" = (
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
@@ -9843,6 +9840,18 @@
 "cin" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"cis" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "Server Room APC";
+	pixel_y = -23;
+	areastring = "/area/science/server"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "cit" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -10250,6 +10259,12 @@
 /obj/item/reagent_containers/glass/bottle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
+"cqm" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "cqB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -11835,6 +11850,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
+"cSl" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "cSt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/stand_clear/white,
@@ -12527,18 +12554,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
-"ddm" = (
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "ddn" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -15602,6 +15617,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ejx" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "ejI" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -16916,6 +16935,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"eGh" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "eGn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17792,14 +17830,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/listeningstation)
-"eVq" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "eVW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -19029,12 +19059,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"fqI" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "fqO" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -27016,6 +27040,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
+"hVD" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "hVP" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -29705,16 +29738,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"iUu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "iUz" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
@@ -30034,12 +30057,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = -4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -31080,16 +31097,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"jmy" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "jmC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -31968,6 +31975,24 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jDh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jDi" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/cardhand{
@@ -35212,24 +35237,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"kIl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "kIn" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -38072,6 +38079,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
+"lML" = (
+/obj/structure/closet/radiation,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "lMM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38568,15 +38587,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"lUB" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "lUD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39282,25 +39292,6 @@
 /obj/structure/closet/secure_closet/engineering_chief,
 /turf/open/floor/plasteel/white/side,
 /area/crew_quarters/heads/chief)
-"mgg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/server)
 "mgv" = (
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 4
@@ -45223,19 +45214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"oaj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "oao" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -53726,16 +53704,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"qGL" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
 "qGQ" = (
 /obj/effect/spawner/lootdrop/techstorage/AI,
 /obj/structure/rack,
@@ -55996,6 +55964,21 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"rrk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rrP" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -65367,6 +65350,16 @@
 "uwM" = (
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"uwR" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "uxc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -67674,6 +67667,16 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vlr" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "vlY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -70801,6 +70804,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"wnV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "wnY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -71704,21 +71717,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wDX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "wEd" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -110453,7 +110451,7 @@ uSU
 uSU
 uSU
 gGH
-kIl
+jDh
 uSU
 uSU
 bki
@@ -110710,7 +110708,7 @@ aiM
 aiM
 aiM
 uKg
-wDX
+rrk
 aiM
 aiM
 odp
@@ -111732,7 +111730,7 @@ rxH
 xnf
 xUo
 akl
-atv
+lML
 aPQ
 aHZ
 aHZ
@@ -113275,10 +113273,10 @@ vGH
 bBq
 jBI
 qbb
-ddm
+cSl
 uZm
 jgP
-fqI
+cqm
 aCb
 aKl
 gPp
@@ -113533,7 +113531,7 @@ amR
 amR
 aCb
 aCb
-acB
+ejx
 jgP
 pnq
 aCb
@@ -113791,8 +113789,8 @@ pDe
 pDe
 aCb
 ffG
-lUB
-oaj
+hVD
+cis
 aCb
 sRJ
 rZn
@@ -114047,9 +114045,9 @@ jOQ
 mLA
 jOQ
 aCb
-iUu
-mgg
-iUu
+wnV
+eGh
+wnV
 aCb
 aKl
 aKl
@@ -114304,9 +114302,9 @@ xUe
 lPV
 cuk
 aCb
-eVq
-jmy
-qGL
+aYO
+uwR
+vlr
 aCb
 asx
 asx

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -3806,16 +3806,6 @@
 "aDP" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
-"aDR" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "aDU" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -4443,12 +4433,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"aIQ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
 "aIT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -6490,12 +6474,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bds" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
 "bdu" = (
 /obj/structure/chair/sofa/corner,
 /obj/effect/turf_decal/siding/wood{
@@ -8025,6 +8003,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
+"bDq" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "bDH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8154,6 +8140,16 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"bFm" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "bFn" = (
 /obj/structure/table,
 /obj/item/nanite_remote{
@@ -12609,6 +12605,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ddO" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "den" = (
 /obj/structure/chair{
 	dir = 4
@@ -12871,16 +12873,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"dis" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "dix" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -13429,12 +13421,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"dvk" = (
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "dvm" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -15012,6 +14998,21 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eaa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "eab" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -18427,6 +18428,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ffG" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "fgb" = (
 /obj/structure/table,
 /obj/item/storage/box/fancy/donut_box{
@@ -19029,6 +19036,18 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"fqw" = (
+/obj/structure/cable{
+	icon_state = "1-2";
+	tag = ""
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Secondary AI Core";
+	normalspeed = 0;
+	req_access_txt = "47"
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "fqz" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
@@ -20759,12 +20778,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"fUv" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
 "fUA" = (
 /obj/item/clothing/mask/cigarette/rollie/trippy,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -23199,16 +23212,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
-"gJH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/central/secondary)
 "gJK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
@@ -27443,6 +27446,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"icW" = (
+/obj/machinery/power/apc/highcap{
+	areastring = "/area/ai_monitored/secondarydatacore";
+	dir = 4;
+	name = "AI Secondary Datacore";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "ida" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31136,6 +31151,24 @@
 "jnp" = (
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"jnL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jnN" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
@@ -34826,6 +34859,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kBY" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "kCn" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -35443,18 +35495,6 @@
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"kNO" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	tag = ""
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "Secondary AI Core";
-	normalspeed = 0;
-	req_access_txt = "47"
-	},
-/turf/open/floor/engine,
-/area/science/explab)
 "kNP" = (
 /obj/effect/overlay/palmtree_l{
 	pixel_x = 15;
@@ -37342,6 +37382,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"lyA" = (
+/obj/item/hand_labeler{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "lyK" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -41729,25 +41776,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
-"mVH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/central/secondary)
 "mVI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -43039,10 +43067,6 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ruin/space/has_grav/listeningstation)
-"noy" = (
-/obj/machinery/computer/rdservercontrol,
-/turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
 "noR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -44112,14 +44136,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"nGd" = (
-/obj/machinery/rnd/server,
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/maintenance/central/secondary)
 "nGs" = (
 /obj/structure/sign/painting{
 	persistence_id = "public";
@@ -44402,6 +44418,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"nMw" = (
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "nMz" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -49111,7 +49133,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
+/area/science/server)
 "pns" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -49726,24 +49748,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"pvV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "pvW" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -53253,6 +53257,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/storage)
+"qzk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "qzn" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -55787,18 +55797,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"rnR" = (
-/obj/machinery/power/apc/highcap{
-	areastring = "/area/ai_monitored/secondarydatacore";
-	dir = 4;
-	name = "AI Secondary Datacore";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/server)
 "rnZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -55836,21 +55834,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"ron" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "row" = (
 /obj/item/banhammer,
 /obj/item/bedsheet/centcom,
@@ -62125,6 +62108,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"tnc" = (
+/obj/machinery/computer/rdservercontrol,
+/turf/open/floor/plasteel/white,
+/area/science/server)
 "tnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -68004,13 +67991,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"vsD" = (
-/obj/item/hand_labeler{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab)
 "vsN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -74474,6 +74454,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
+"xyM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/server)
 "xyO" = (
 /obj/machinery/light{
 	dir = 4
@@ -75190,6 +75180,16 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"xLm" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/circuit/telecomms/server,
+/area/maintenance/central/secondary)
 "xLp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -75552,9 +75552,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"xRx" = (
-/turf/open/floor/plasteel/white,
-/area/maintenance/central/secondary)
 "xRz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -110465,7 +110462,7 @@ uSU
 uSU
 uSU
 gGH
-pvV
+jnL
 uSU
 uSU
 bki
@@ -110722,7 +110719,7 @@ aiM
 aiM
 aiM
 uKg
-ron
+eaa
 aiM
 aiM
 odp
@@ -110978,7 +110975,7 @@ aPQ
 pos
 pos
 aPQ
-asx
+aPQ
 gez
 qHC
 qHC
@@ -111235,7 +111232,7 @@ aPQ
 aHZ
 aHZ
 aTj
-asx
+aPQ
 bqm
 rYB
 tah
@@ -111492,7 +111489,7 @@ pos
 aHZ
 aXg
 gHi
-asx
+aPQ
 jao
 hgr
 iHJ
@@ -111749,7 +111746,7 @@ aPQ
 aHZ
 aHZ
 aQh
-asx
+aPQ
 apZ
 gMO
 ePs
@@ -112002,16 +111999,16 @@ iVb
 aoG
 pEF
 iZJ
-kNO
+fqw
 cAE
 aHZ
 aHZ
-asx
+aPQ
 apZ
 qCg
 apZ
 nUp
-vsD
+lyA
 hXH
 qKj
 asx
@@ -113287,10 +113284,10 @@ vGH
 bBq
 jBI
 qbb
-rnR
+icW
 uZm
 uZm
-dvk
+nMw
 aCb
 aKl
 gPp
@@ -113544,11 +113541,11 @@ aDY
 aDY
 aDY
 aDY
-aDY
-noy
-xRx
+aCb
+tnc
+uZm
 pnq
-aDY
+aCb
 wNN
 tZd
 aKl
@@ -113801,11 +113798,11 @@ oqX
 oqX
 pDe
 pDe
-aDY
-bds
-fUv
-aIQ
-aDY
+aCb
+ffG
+ddO
+qzk
+aCb
 sRJ
 rZn
 aKl
@@ -114058,11 +114055,11 @@ jOQ
 jOQ
 mLA
 jOQ
-aDY
-gJH
-mVH
-gJH
-aDY
+aCb
+xyM
+kBY
+xyM
+aCb
 aKl
 aKl
 aKl
@@ -114315,11 +114312,11 @@ eBL
 xUe
 lPV
 cuk
-aDY
-nGd
-aDR
-dis
-aDY
+aCb
+bDq
+xLm
+bFm
+aCb
 asx
 asx
 asx
@@ -114572,11 +114569,11 @@ aDY
 aDY
 aDY
 aDY
-aDY
-aDY
-aDY
-aDY
-aDY
+aCb
+aCb
+aCb
+aCb
+aCb
 klr
 rDi
 qBo


### PR DESCRIPTION
# Document the changes in your pull request
I seriously have no idea how any of this ever got past any eyes. It had overlapping APCS for christ sakes
Expands the experimentor room down one so that it doesnt have a weird doorway inbetween two rooms for secondary data core, also makes the tcomms admin's area bigger overall by removing a maint ruin so that the NA doesnt have to literally move the datacores N2 supply just to access a damn freezer.

![image](https://github.com/yogstation13/Yogstation/assets/42524344/21faf011-d3df-40ae-933d-a74a5dcf7aed)


# Changelog
:cl:  
mapping: Made asteroidstation secondary data core not horrific
mapping: Made asteroidstation experimentor not horrific
/:cl:
