### PR TITLE
[bounty] make destination tagger be sorted by department

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -224,6 +224,16 @@ GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals",
 	"Testing Range", "Toxins", "Dormitories", "Virology",
 	"Xenobiology", "Law Office","Detective's Office"))
 
+GLOBAL_LIST_INIT(TAGGERLOCATIONS_DEPARTMENTAL, list(
+	"Security" = list("Security", "Detective's Office", "HoS Office"),
+	"Medical" = list("Medbay", "Chemistry", "Genetics", "Virology", "CMO Office"),
+	"Science" = list("Research", "Robotics", "Xenobiology", "Toxins", "Testing Range", "RD Office"),
+	"Engineering" = list("Engineering", "Atmospherics", "CE Office"),
+	"Civilian" = list("Disposals", "Cargo Bay", "QM Office"),
+	"Service" = list("Bar", "Kitchen", "Hydroponics", "HoP Office"),
+	"Miscellaneous" = list("Dormitories", "Theatre", "Chapel", "Law Office", "Library")
+))
+
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt") + "")
 
 GLOBAL_LIST_INIT(station_names, world.file2list("strings/station_names.txt") + "")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -199,7 +199,7 @@
 /obj/item/destTagger/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user,src,ui)
 	if(!ui)
-		ui = new(user,src,"DestinationTagger")
+		ui = new(user, src, "DestinationTagger")
 		ui.open()
 
 /obj/item/destTagger/ui_act(action,list/params)
@@ -213,7 +213,7 @@
 
 /obj/item/destTagger/ui_data(mob/user)
 	var/list/data = list()
-	data["destinations"] = GLOB.TAGGERLOCATIONS
-	data["currentTag"] = currTag
+	data["destinations"] = GLOB.TAGGERLOCATIONS_DEPARTMENTAL
+	data["currentTag"] = currTag ? GLOB.TAGGERLOCATIONS[currTag] : "None"
 
 	return data

--- a/tgui/packages/tgui/interfaces/DestinationTagger.js
+++ b/tgui/packages/tgui/interfaces/DestinationTagger.js
@@ -11,25 +11,30 @@ export const DestinationTagger = (props, context) => {
     destinations,
   } = data;
 
-  const mapped_destinations = destinations.map(destination => {
-    return (
-      <Button width="144px" lineHeight={1.85} selected={destinations[currentTag - 1] === destination} key={destination} onClick={() => act('ChangeSelectedTag', { 'tag': destination })}>{destination}</Button>
-    );
-  });
-
   return (
-    <Window title="TagMaster 3.0" width={450} height={350}>
+    <Window title="TagMaster 3.0" width={462} height={750}>
       <Window.Content>
         <Section title="TagMaster 3.0 - The future, 20 years ago!">
           <LabeledList>
             <LabeledList.Item label="Current Destination">
-              {(currentTag) !== "" ? destinations[currentTag - 1] : "NONE"}
+              {currentTag}
             </LabeledList.Item>
           </LabeledList>
         </Section>
-        {mapped_destinations}
-
-
+        {
+          Object.entries(destinations).map((department, index) => {
+            let wa = department[0];
+            return(
+              <Section title={wa} key={wa}>
+                {
+                  department[1].map(destination => {
+                    return(<Button width="144px" lineHeight={1.85} selected={currentTag === destination} key={destination} onClick={() => act('ChangeSelectedTag', { 'tag': destination })}>{destination}</Button>);
+                  })
+                }
+              </Section>
+            );
+          })
+        }
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION
# Document the changes in your pull request

I removed the command one
![D50Fvz4WtQ](https://github.com/yogstation13/Yogstation/assets/5091394/5b0c40a3-c832-4e7a-8b43-4b4f77e32887)

https://forums.yogstation.net/threads/10-make-destination-taggers-not-terrible-ss13-server.26447/

# Changelog
:cl:  
tweak: destination tagger is now sorted by department
/:cl:
