### PR TITLE
Fixes ranger cloak + minor tweaks

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -382,8 +382,13 @@
 	update_signals()
 
 /obj/item/clothing/neck/cloak/ranger/proc/on_unequip(force, newloc, no_move, invdrop = TRUE, silent = FALSE)
+	current_user = NULL
 	update_signals()
 
+/obj/item/clothing/neck/cloak/ranger/proc/Destroy()
+	set_cloak(0)
+	. = ..()
+	
 /obj/item/clothing/neck/cloak/ranger/proc/update_signals(user)
 	if((!user || (current_user == user)) && current_user == loc && istype(current_user) && current_user.get_item_by_slot(SLOT_NECK) == src)
 		return TRUE

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -365,7 +365,7 @@
 	/// How much the cloak charges per process
 	var/cloak_charge_rate = 35
 	/// How much the cloak decreases when moving
-	var/cloak_move_loss = 5
+	var/cloak_move_loss = 7
 	/// How much the cloak decreases on a successful dodge
 	var/cloak_dodge_loss = 30
 
@@ -450,6 +450,7 @@
 	desc = "A dark red cape that uses advanced chameleon technology to make the wearer nearly invisible and aid them in dodging projectiles. Unable to sustain its image under distress or EMP."
 	icon_state = "syndie_cloak"
 	max_cloak = 75 //Max 75% dodge is a little quirky
+	cloak_move_loss = 5
 	cloak_charge_rate = 20
 	cloak_dodge_loss = 40
 	var/cloak_emp_disable_duration = 10 SECONDS

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -369,6 +369,8 @@
 	/// How much the cloak decreases on a successful dodge
 	var/cloak_dodge_loss = 30
 
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 75, ACID = 75)	//Resistant to the dangers of the natural world or something
+
 /obj/item/clothing/neck/cloak/ranger/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_POST_UNEQUIP, PROC_REF(on_unequip))

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -382,10 +382,10 @@
 	update_signals()
 
 /obj/item/clothing/neck/cloak/ranger/proc/on_unequip(force, newloc, no_move, invdrop = TRUE, silent = FALSE)
-	current_user = NULL
+	current_user = null
 	update_signals()
 
-/obj/item/clothing/neck/cloak/ranger/proc/Destroy()
+/obj/item/clothing/neck/cloak/ranger/Destroy()
 	set_cloak(0)
 	. = ..()
 	


### PR DESCRIPTION
Fixes the cloak just not working any more if you drop it and re-equip it, as well as becoming permanently invisible if it is destroyed when you're at max cloak. Also gives it a little acid and fire armor so it doesn't just melt immediately if you light on fire or get acid splashed. Finally, the movement penalty for the wizard cloak is slightly increased so if you're constantly running it WILL slowly degrade the cloak rather than you being able to stay perpetually at near-max cloak.



# Changelog

:cl:  

bugfix: Fixes ranger cloak giving permanent invisibility and no invisibility
tweak: Ranger cloak move penalty to cloaking increased by 40%

/:cl:
