### PR TITLE
Fixes implanted flashes not making any light when you use them

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -293,6 +293,8 @@
 			to_chat(I.owner, span_warning("Your photon projector is running too hot to be used again so quickly!"))
 		return FALSE
 	overheat = TRUE
+	set_light_on(TRUE)
+	addtimer(CALLBACK(src, PROC_REF(flash_end)), FLASH_LIGHT_DURATION, TIMER_OVERRIDE|TIMER_UNIQUE)
 	addtimer(CALLBACK(src, PROC_REF(cooldown)), flashcd)
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 	update_icon(1)


### PR DESCRIPTION
# Document the changes in your pull request

Normal flashes light up the area for a moment when you use them but the implanted version doesn't inherit the code for that due to having a special try_use_flash() so this adds it there.

# Changelog

:cl:  
bugfix: fixed implanted flashes not having light when you use them
/:cl:
