### PR TITLE
Fixes Space Dragon Rifts not Progressing Whatsoever

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -445,7 +445,7 @@ mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/T)
 /obj/structure/carp_rift/Initialize(mapload)
 	. = ..()
 	carp_stored = 1
-	time_charged = 1
+	time_charged = 0
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/carp_rift/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)


### PR DESCRIPTION
# Document the changes in your pull request

As it turns out, every check a space dragon's rift does hinges on time_charged being an even number, which can never happen if delta_time is always 2 and it starts at 1. This one-line change makes the space dragon midround function exactly as intended.

I tested the event after making this change, and can assure you that no other bugs appear to be present related to the rift mechanics.

It should be noted that space dragons actually end the round if they're allowed to succeed, so this may have a large impact on people's playstyles when the event is called, and that may warrant adjusting its weight in the future, at your discretion.

# Changelog

:cl:  
bugfix: space dragon can again place more than one rift, rifts again alert the crew when they're about to finish charging, and carps again can enter through the rift more than once during charging
/:cl:
