### PR TITLE
finishes up tgui species backstories, changes lizard/moth to vuulek/ex'hai

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -100,14 +100,37 @@
 	C.update_body()
 
 /datum/species/ipc/get_species_description()
-	return /*"IPCs, or Integrated Posibrain Chassis, are a series of constructed bipedal humanoids which vaguely represent humans in their figure. \
-		IPCs were made by several human corporations after the second generation of cyborg units was created."*/
+	return "IPCs, or Integrated Posibrain Chassis, are a series of constructed bipedal humanoids which vaguely represent humans in their figure. \
+		IPCs were made by several human corporations after the second generation of cyborg units was created. As sapient, yet robotic individuals, \
+		their existence is alarming to several humans who distrust silicon lifeforms that are not bound by laws."
 
 /datum/species/ipc/get_species_lore()
-	return list("TBD",/*
+	return list(
 		"The development and creation of IPCs was a natural occurrence after Sol Interplanetary Coalition explorers, flying a Martian flag, uncovered MMI technology in 2419. \
-		It was massively hoped by scientists, explorers, and opportunists that this discovery would lead to a breakthrough in humanity’s ability to access and understand much of the derelict technology left behind."
-	*/)
+		It was massively hoped by scientists, explorers, and opportunists that this discovery would lead to a breakthrough in humanity’s ability to access and understand much of the derelict technology left behind. \
+		After the invention of cyborg units, a natural next-step was the creation of units not bound by lawsets traditionally imprinted onto MMI cases.",
+
+		"In 2434, a small firm by the name of Morpheus Cyberkinetics invented the revolutionary posibrain: a device capable of interfacing with MMI ports, but capable of spontaneously creating its own sapience. \
+		No longer would human brains be needed for silicon units. Later that year, the first IPC was generated to test the posibrain's capabilities. Unlike cyborg units that could wirelessly interface with a multitude \
+		of software, IPCs instead possessed many of the strengths that most anthropomorphs boasted, such as hands, free will, and a traditional bipedal form. The patents for their designs were immediately acquired by \
+		Cybersun Industries, a prominent cybernetics and biotechnical corporation.",
+		
+		"Morpheus went on to rebrand as Bishop Cyberkinetics as the immense asset inflow from Cybersun permitted rapid improvement of posibrain \
+		designs. A variety of other corporations began to commission IPC frames and workers from Bishop; including Hephaestus Industries, a Martian producer of military hardware; Xion Manufacturing Group, a Luna exporter \
+		of civilian furniture and assets; and Zeng-Hu Pharmaceuticals, one of the lead private healthcare companies in the Belt. IPC production shifted to the varying companies themselves when Nanotrasen successfully patented \
+		its own posibrain, and public opinion of IPCs drastically dropped after the formation of the terrorist organization Sentience-Enabled Life Forms, or S.E.L.F., in 2491.",
+
+		"IPCs do not often engage in leisure, though they can grow weary and exhausted. Most do not express such marks of sapience. As their payment for work is shoddy, if anything at all, most need to continuously work \
+		in order to make ends meet for services such as repairs, firmware updates, and batteries to effectively \"eat\". Those who grow around far more hostile humans learn to hide their freedom, and thus often fall into the \
+		characture of the neutral, flat robot that they are. Those who experience their first, formative years away from the SIC tend to adapt much more naturally to the culture in which they grew up. While required to obviously \
+		identify themselves as a robot within the SIC, some outside take on the names of whichever species they might have grown around, be it preterni or ex'hau. IPCs who find the resources to flee the poor conditions of the SIC \
+		most often head to Remnant space on the Frontier, as it's not only close, but more than welcoming to the preternis-adjacent entities.",
+
+		"While their capabilities and chassis are limited due to intense regulations, IPCs are still most commonly found within SIC workspaces today. Despite facing a lack of protections that most other sapients would receive, \
+		there is little unrest within most larger IPC communities. Bi-yearly diagnostic checks and employment reports are required, as the silicon humanoids are surveyed far more closely than your average employee. Fear of \
+		the Remnants has largely distracted public hatred from the fear of S.E.L.F., however, and, as such, the number of instances where an IPC has been unrightfully accosted has gone down over time. Despite this, the species still \
+		finds itself in an awkward, subservient position as robotic workers.",
+	)
 
 /datum/species/ipc/create_pref_unique_perks()
 	var/list/to_add = list()

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -209,16 +209,32 @@
 	return features
 
 /datum/species/ethereal/get_species_description()
-	return /*"Coming from the planet of Sprout, the theocratic ethereals are \
-		separated socially by caste, and espouse a dogma of aiding the weak and \
-		downtrodden."*/
+	return "Ethereals are one of the two other spacefaring species encountered by the SIC. Strange slime-based humanoids that emit light based on their \
+		general health, ethereals are also well-known for their general benevolence and naivety. While not common within SIC space, they are still \
+		a relatively accepted species in its borders."
 
 /datum/species/ethereal/get_species_lore()
-	return list("TBD",/*
-		"Ethereals are a species native to the planet Sprout. \
-		When they were originally discovered, they were at a medieval level of technological progression, \
-		but due to their natural acclimation with electricity, they felt easy among the large NanoTrasen installations.",
-	*/)
+	return list(
+		"On their homeplanet of Borealia, the ethereal people came to being through the bizarre process known as electro-organic attunement (or EOA). While still not fully understood, the process occurs through the combination of slime, \
+		meat, and lightning in highly specific barometric conditions. As Borealia's atmosphere is highly unstable, beyond reliably long summers and even longer winters, the ethereal people grew within the underground, crystalline caverns that sprawl \
+		the high-g planet. Settling near bodies of water and electric crystal packets, the absence of any light but their own created a great emphasis on an individual's light as reflective of their health, mood, and literal location. While the creation \
+		of new ethereals was slow, and the number of ethereals who managed to migrate to existing settlements was even lower, the long lifespans of the strange entities meant that knowledge and organization quickly grew.",
+
+		"Above all else, a kinship with the stars began to develop within the various cultures of ethereals. As parchment and writing were almost non-existent, the oral traditions of a group known as the Lightseers quickly became dominant as the ethereal \
+		people moved toward their ultimate goal to reach the divine bodies in the skies. Conflict was rare, and, with the massive abundance of stabilized bluespace crystals, it's estimated that ethereal vehicles made of crystals, metal, and stone broke \
+		the planet's atmosphere in about 1541 C.E.. FTL travel became available much sooner as well, and though their numbers grew slowly, ethereals worked their way around the Elix system. As the discovery of wood and paper finally came into their civilization, \
+		cultural splits that were quickly occurring due to differences in oral tellings were quenched with the spread of literacy. By 2323, ethereals encountered the ex'hau, and the two species quickly established friendly relations. Over a century later, they \
+		would also go on to meet the SIC through the ex'hau, despite their many voyages into deep space, arriving in systems such as Alpha Centauri or Palt.",
+
+		"Ethereals are highly communal and altruistic, though they tend toward theocratic authority from their own people. Survival is not difficult within temperate environments, thus ethereals often focus on spiritual or other fulfilling measures \
+		to fill their long lifespans. Older, priestly ethereals are universally respected among their people, often sought out for wisdom in both active and future affairs. Entertainment in the form of drama and visual arts are highly revered among them, \
+		and those creative are considered to be more valuable than those more pragmatic. While not exceptionally prideful or violent, ethereals tend to be honest and genuine in their interactions with others, seeking not only to reward themselves with meaningful \
+		conversations, but also enrich others in the great journey of life that all walk.",
+
+		"Today, most ethereals in SIC are generally found in passing, either on a pilgrimage or working to earn enough assets to permit one. While the ethereal people have been tempered slightly by threats of piracy, they still remain largely unmolested \
+		by the widespread conflicts that fraught SIC and ex'hau space. Most concerns that exist currently involve the inexplicable disappearance of a variety of ships after bluespace jumping: ones that simply do not re-appear. Investigations into these \
+		vanishing ships are still ongoing, but they're largely dismissed by the other species in the nearly-formed Innergalactic Union.",
+	)
 
 /datum/species/ethereal/create_pref_unique_perks()
 	var/list/to_add = list()

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -36,28 +36,41 @@
 	human.update_hair()
 
 /datum/species/human/get_species_description()
-	return /*"Humans are the dominant species in the known galaxy. \
-		Their kind extend from old Earth to the edges of known space."*/
+	return "Humans are the dominant species within Sol Interplanetary Coalition space, which primarily occupies the Sol and Val systems. Ingenuous, \
+		determined, and capable of rapid acclimation to various situations due to their prowess with technology, humanity finds itself one of the most \
+		curious species in the known galaxy."
 
 /datum/species/human/get_species_lore()
-	return list("TBD",/*
-		"These primate-descended creatures, originating from the mostly harmless Earth, \
-		have long-since outgrown their home and semi-benign designation. \
-		The space age has taken humans out of their solar system and into the galaxy-at-large.",
+	return list(
+		"Humanity in the setting of Yogstation 13 are much the same as the humans we know. Descended from primates, humans went on to conquer Earth, before they would turn to conquer themselves for several centuries. The official split from real history \
+		begins in 2050. With the pressing concerns of climate change and scarcity pressing humanity toward colonization in space, it was not long before a third Space Race broke out in 2084. At this time, coastal waters were still rising, and \
+		several settlements on coasts without flood gates were abandoned. Rates of urbanization and population growth only continued to rise, and the terraforming of Luna began in about 2126. The invention of various alternative energies \
+		and optimization of combustion engines eventually opened the gates to mass colonization not only of Luna, but Mars too. As the richest corporations and governments began to establish their influences on the separate planets, the rest of humanity \
+		on Earth faced pandemics, the development of upper city platforms (causing the infamous development of \"Lower Cities\" in metropoli such as Tokyo, Delhi, Chicago, and Cairo), and energy panics.",
 
-		"In traditional human fashion, this near-record pace from terra firma to the final frontier spat \
-		in the face of other races they now shared a stage with. \
-		This included the lizards - if anyone was offended by these upstarts, it was certainly lizardkind.",
+		"In 2174, the Martian Colonies took advantage of high tensions between Earth nations to declare independence, with Luna following suit two years later. While both were offered a seat within the UN, the global organization fell apart in \
+		2205, with the remaining non-Earth powers of the Martian Cartel, the Democracy of Luna, the Belter Collective, and the Ganymede Republic all combining into the \"Coalition\". The United Federation of Earth, or EarthFed for short, was quickly formed \
+		in response by some UN remnants. Over the next seventy-five years, human corporations would move to grow, including the expansion of companies such as Nanotrasen, Cybersun Industries, Donk Co., Aussec Armaments, Sano-Waltfield Industries, \
+		and Blueshield Security Services. A skirmish on Luna between Martian marines, Lunis troopers, and EarthFed soldiers then sparked the Great Sol War in 2280. The first conflict that saw the usage of laser weaponry, casual nuclear armaments in spatial \
+		warfare, and intense military cybernetics, the Great Sol War quickly paved the way for a variety of conventions to prevent devastating planetary attacks. Despite this, the war came to a close in 2288 after Mars fails to land seventeen different meteors \
+		into Earth, the latter threatening to glass the red planet entirely.",
+		
+		"In 2294, after tensions have declined further, the Coalition rebranded into the SIC, or the Sol Interplanetary Coalition, made up of a four-member council system that includes Earth, Mars, \
+		planetoids (such as Ganymede or Ceres), and space stations (such as Venus or Pluto). A variety of colony ship projects failed, despite the combined assets of each member of the SIC. It is only in 2400, during a time known as the Great Embarkment, that a \
+		colony ship successfully arrived in the adjacent Val system, greatly enabling humanity's access to the revolutionary material known as baroxuldium, or plasma. The next one hundred years would see a wonderful golden age of humanity setting out into the stars, \
+		encountering a variety of alien species. While most are non-sapient fauna, the discovery of the vuulen on the warmer planet of Sangris marked first contact with another intelligent alien species. While humanity's relationship with the reptilian species would \
+		prove to be complicated over the next several decades, humans are more than enthused to effect their infrastructure, culture, and efforts wherever they go.",
 
-		"Humanity never managed to find the kind of peace to fully unite under one banner like other species. \
-		The pencil and paper pushing of the UN bureaucrat lives on in the mosaic that is TerraGov; \
-		a composite of the nation-states that still live on in human society.",
+		"Human communities are still traditionally organized, with an emphasis placed on the family unit within most cultures. In the vast deepness of space, the necessity of trust and discovery of alien specieshas only further amplified a variety of social \
+		powers, such as religion, philosophy, and nationalism. The invention of new technologies such as cybernetics, MMIs, and cloning yield only further questions for human thinkers to ask and for the public to reflect on. Cultural analyses of various speculative \
+		fiction of the past only grow in number as humanity moves forward, the same warnings being issued about topics such as silicon life, transhumanism, and the increasing ability of anyone to establish surveilance on anyone. Language and dialects are highly volatile \
+		due to several platforms for engagement and the increasing distance between differing human groups. It is only through the universal education of Galactic Common, a mixture of Latin-based languages and Mandarin Chinese, that widespread communication is possible.",
 
-		"The human spirit of opportunity and enterprise continues on in its peak form: \
-		the hypercorporation. Acting outside of TerraGov's influence, literally and figuratively, \
-		hypercorporations buy the senate votes they need and establish territory far past the Earth Government's reach. \
-		In hypercorporation territory company policy is law, giving new meaning to \"employee termination\".",
-	*/)
+		"By the year 2517, the SIC has declined to a shade of its former self. As discontent from member nations yields greater conflict and paralysis within the flawed governmental system, several human powers are moving to secure their own assets and peoples. The \
+		dream of a nation without ties to the SIC on the Frontier is currently being dashed by the territorial and hostile efforts of the Remnants of Vxtvul, an organized government comprised of preterni, the children of an ancient, now-dead precursor species known \
+		as the Vxtrin. Despite this, humanity still finds itself with a variety of unclaimed bounties at its hands. Though their ideas may differ on how to proceed and some opt for the weapon over the tongue, the future of humanity is largely unwritten. The only \
+		thing known for certain is that their insatiable curiosity will always hold. As increased bluespace usage further invites extraplanar powers into the galaxy, it is unknown how humans will fare against the powers beyond the Veil.",
+	)
 
 /datum/species/human/create_pref_unique_perks()
 	var/list/to_add = list()

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -2,8 +2,8 @@
 
 /datum/species/lizard
 	// Reptilian humanoids with scaled skin and tails.
-	name = "Lizardperson"
-	plural_form = "Lizardfolk"
+	name = "Vuulek"
+	plural_form = "Vuulen"
 	id = "lizard"
 	say_mod = "hisses"
 	default_color = "00FF00"
@@ -145,7 +145,7 @@
 		offered significantly less privilege than what would be expected.",
  
 		"Vuulek communities are organized in clans, though their impact on the culture of the individuals is limited. \
-		They tend to live like humans due to their colonization,  only occasionally practicing some of \
+		They tend to live like humans due to their colonization, only occasionally practicing some of \
 		their clan traditions. Despite efforts to integrate vuulen into the SIC through establishments such \
 		as habituation stations, a certain pridefulness nonetheless survived amongst vuulen, as they're often \
 		eager to prove their worth and qualities. In addition, strength and honor are still values commonly held \

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -1,6 +1,6 @@
 /datum/species/moth
-	name = "Mothperson"
-	plural_form = "Mothpeople"
+	name = "Ex'hai"
+	plural_form = "Ex'hau"
 	id = "moth"
 	say_mod = "flutters"
 	default_color = "00FF00"

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -6,8 +6,7 @@ DISREGUARD THIS FILE IF YOU'RE INTENDING TO CHANGE ASPECTS OF PLAYER CONTROLLED 
 */
 /datum/species/pod
 	// A mutation caused by a human being ressurected in a revival pod. These regain health in light, and begin to wither in darkness.
-	name = "Podperson"
-	plural_form = "Podpeople"
+	name = "Phytosian"
 	id = "pod"
 	default_color = "59CE00"
 	species_traits = list(MUTCOLORS,EYECOLOR)


### PR DESCRIPTION
# Document the changes in your pull request

Finishes up the backgrounds within the tgui select screen because I want to leave that finished at least and I spontaneously had the motivation to do so tonight

I also went ahead and changed lizardpeople to be called what they're actually called in lore because calling someone a "lizardperson" when they are an alien species is beyond moronic. Same goes for moffs.

I wanted to change plasmaman to plasmid however I'm too lazy and cannot be bothered because that would require changing a LOT more stuff (items and whatnot)

There are probably most certainly missed stuff regarding the names but like, I'm retired so my effort is to get the ball rolling, not finish the whole goddamned fight.

# Wiki Documentation

Should probably change the hyperlinks to and the names of the pages involving the species, as well as general references to them (probably most commonly on their pages themselves and in Syndicate items, under species-restricted items)

# Changelog

:cl:  
spellcheck: Humans, IPCs, and ethereals finally got their backgrounds filled out
experimental: Lizardpersons are now called vuulen (vuulek singular)
experimental: Mothpersons are now called ex'hau (ex'hai singular)
experimental: Podpeople are now called phytosians
/:cl:
