### PR TITLE
Traitor-bloodsuckers no longer always rolls 2 bloodsuckers regardless of population

### DIFF
--- a/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
+++ b/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
@@ -40,7 +40,7 @@
 	var/list/datum/mind/possible_bloodsuckers = get_players_for_role(ROLE_BLOODSUCKER)
 
 	var/num_bloodsuckers = 1
-	num_bloodsuckers = clamp(round(bloodsucker_amount/2), 1, num_players())
+	num_bloodsuckers = clamp(round(num_players()/15), 1, bloodsucker_amount)
 
 	if(possible_bloodsuckers.len>0)
 		for(var/j = 0, j < num_bloodsuckers, j++)


### PR DESCRIPTION

<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Most antags use a decaying scaling method or some nonsense, apparently bloodsuckers never got scaling and just rolled 2 all the time if alongside traitors
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: traitorsuckers now scales bloodsuckers with population
/:cl:
