### PR TITLE
Update easter.dm - no more changeling haste

### DIFF
--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -90,7 +90,7 @@
 	icon_state = "bunnyhead"
 	item_state = "bunnyhead"
 	desc = "Considerably more cute than 'Frank'."
-	slowdown = -1
+	slowdown = -0.3
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
 /obj/item/clothing/suit/bunnysuit
@@ -98,7 +98,7 @@
 	desc = "Hop Hop Hop!"
 	icon_state = "bunnysuit"
 	item_state = "bunnysuit"
-	slowdown = -1
+	slowdown = -0.3
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 


### PR DESCRIPTION


# Document the changes in your pull request

Easter bunny outfit doesn't give you changeling haste speed at all times. Instead, it will make you faster than the average humanoid, so the very niche and rare gamer outfit can still game, just not you know, the fastest speed the game can give. 

Negative slowdown on clothes gives speed instead, changed from -1 slowdown to -0.3 slowdown. Tested in-game, it is still very much a gamer fit. 

# Changelog

:cl:  
tweak: Easter Bunny outfit has its changeling speed inducers removed and replaced with a more moderate speed inducer instead.
/:cl:
