### PR TITLE
makes r-windows slightly less frustrating to break

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -7,9 +7,9 @@
 	closingLayer = ABOVE_WINDOW_LAYER
 	resistance_flags = ACID_PROOF
 	var/base_state = "left"
-	max_integrity = 200 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
+	max_integrity = 150 //If you change this, consider changing ../door/window/brigdoor/ max_integrity at the bottom of this .dm file
 	integrity_failure = 0
-	armor = list(MELEE = 60, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 100, RAD = 100, FIRE = 70, ACID = 100)
+	armor = list(MELEE = 60, BULLET = -40, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 100, RAD = 100, FIRE = 70, ACID = 100)
 	visible = FALSE
 	flags_1 = ON_BORDER_1
 	opacity = 0
@@ -365,7 +365,7 @@
 	icon_state = "leftsecure"
 	base_state = "leftsecure"
 	var/id = null
-	max_integrity = 350 //Stronger doors for prison (regular window door health is 200)
+	max_integrity = 250 //Stronger doors for prison (regular window door health is 200)
 	reinf = 1
 	explosion_block = 1
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -10,7 +10,7 @@
 	max_integrity = 25
 	can_be_unanchored = TRUE
 	resistance_flags = ACID_PROOF
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 0, BULLET = -50, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 100)
 	CanAtmosPass = ATMOS_PASS_PROC
 	rad_insulation = RAD_VERY_LIGHT_INSULATION
 	var/ini_dir = null
@@ -390,7 +390,7 @@
 	icon_state = "rwindow"
 	reinf = TRUE
 	heat_resistance = 1600
-	armor = list(MELEE = 60, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, RAD = 100, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 60, BULLET = -50, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, RAD = 100, FIRE = 80, ACID = 100)
 	max_integrity = 75
 	explosion_block = 1
 	damage_deflection = 10
@@ -492,7 +492,7 @@
 	icon_state = "plasmawindow"
 	reinf = FALSE
 	heat_resistance = 25000
-	armor = list(MELEE = 60, BULLET = 5, LASER = 0, ENERGY = 100, BOMB = 45, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 60, BULLET = -45, LASER = 0, ENERGY = 100, BOMB = 45, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_integrity = 150
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass
@@ -531,7 +531,7 @@
 	icon_state = "plasmarwindow"
 	reinf = TRUE
 	heat_resistance = 50000
-	armor = list(MELEE = 80, BULLET = 20, LASER = 0, ENERGY = 100, BOMB = 60, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list(MELEE = 80, BULLET = 5, LASER = 0, ENERGY = 100, BOMB = 60, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
 	max_integrity = 500
 	damage_deflection = 21
 	explosion_block = 2

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -390,10 +390,10 @@
 	icon_state = "rwindow"
 	reinf = TRUE
 	heat_resistance = 1600
-	armor = list(MELEE = 80, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, RAD = 100, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 60, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, RAD = 100, FIRE = 80, ACID = 100)
 	max_integrity = 75
 	explosion_block = 1
-	damage_deflection = 11
+	damage_deflection = 10
 	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
 	rad_insulation = RAD_HEAVY_INSULATION


### PR DESCRIPTION
# Document the changes in your pull request

Yogstation history: Did you know that at one point, r-windows were the wimpiest shit ever and greytide was constant because forget hacking, why hack when you can smash a window in 6 hits  and get your gamer loot that way? Departments with windows were unsecure as fuck and it got a little ridiculous.

To compensate, window HP, armor, and damage threshhold were adjusted extremely high so  window breaking greytiding was harder. However, that took things too far and had to be nerfed. I think its been a little too much since then as well.

I also think its a bit silly that r-windows are stronger than regular plas-windows. Plasma windows only have 60 melee armor, r-windows had 80. 

Plas R-windows are neat, but are literally never built because the regular r-windows are stronger than both the nearby airlock and wall to get through. It's easier to hack through a metal wall than it is to decon a r-window, or hack an airlock.

On top of that, this change kinda fucked bullet antags who now have to shoot too many gotdang bullets to break a window. It used to be that you had a choice as a nukie between emagging an airlock, shooting/stabbing a window, or c4ing a wall to get in, but it takes too much time/bullets to do the window thing because of the previous changes.

Also fun fact, some guns would literally shoot an airlock to scraps faster and with less bullets than shooting a window.

Changes:
* R-window melee armor from 80 to 60
* R-window damage threshhold from 11 to 10
* Regular/R-window bullet armor changed to -50
* Regular plasma window bullet armor from 5 to -45
* R-Plasma Window bullet armor from 20 to 5 
* Windoors integrity from 250 to 150, bullet armor to -40
* Reinforced Windoors integrity from 350 to 250, bullet armor to -40

This way you can slightly easier beat a window to death, or shoot it. Bullets are a precious commodity, I don't think its a big deal to have a literal gun blow windows to pieces. 

If you want to stop le bullets, Reinforced Plasma Windows are still top notch because they still have a 21 damage threshhold, which means that an L6 bullet will do approximately 8? damage, and they have 500 Health. Oh no, I hope no one abuses this!! 

Last fun fact: It takes approximately 2 minutes 45 seconds for a changeling to break an r-window with an armblade, meanwhile they open airlocks instantly MOTHDROP

# Changelog

:cl:  
rscadd: Windows are weaker against bullets now
tweak: Windows will not be made out of solid indestruciblium and are in fact made of glass now. Crewmembers will have an easier time breaking them in emergency situations. 
/:cl:
