### PR TITLE
Hypodermic Prickles works again.

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -407,9 +407,7 @@
 			user.log_message("pricked [target == user ? "themselves" : target ] ([contained]).", INDIVIDUAL_ATTACK_LOG)
 			if(target != user && target.ckey && user.ckey) // injecting people with plants now creates admin logs (stolen from hypospray code)
 				log_attack("[user.name] ([user.ckey]) pricked [target.name] ([target.ckey]) with [G], which had [contained] (INTENT: [uppertext(user.a_intent)])")
-		var/injecting_amount = G.seed.potency * 0.2 // A number between 0 and 20.
-		if( target.getarmor(def_zone, BIO) > 0 )
-			injecting_amount = injecting_amount * abs( target.getarmor( def_zone, BIO )/100 - 1 ) // Essentially reduce injection value based on percentage of bioarmor.
+		var/injecting_amount = G.seed.potency * 0.2 * clamp(1 - target.getarmor(def_zone, BIO)/100, 0, 1) // A number between 0 and 20, reduced by bio armor as a percent
 		if(injecting_amount < 1)
 			return
 		var/fraction = min(injecting_amount/G.reagents.total_volume, 1)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -407,7 +407,9 @@
 			user.log_message("pricked [target == user ? "themselves" : target ] ([contained]).", INDIVIDUAL_ATTACK_LOG)
 			if(target != user && target.ckey && user.ckey) // injecting people with plants now creates admin logs (stolen from hypospray code)
 				log_attack("[user.name] ([user.ckey]) pricked [target.name] ([target.ckey]) with [G], which had [contained] (INTENT: [uppertext(user.a_intent)])")
-		var/injecting_amount = max(G.seed.potency * 0.2) / target.getarmor(def_zone, BIO) // Maximum of 20, reduced by bio protection
+		var/injecting_amount = G.seed.potency * 0.2 // A number between 0 and 20.
+		if( target.getarmor(def_zone, BIO) > 0 )
+			injecting_amount = injecting_amount * abs( target.getarmor( def_zone, BIO )/100 - 1 ) // Essentially reduce injection value based on percentage of bioarmor.
 		if(injecting_amount < 1)
 			return
 		var/fraction = min(injecting_amount/G.reagents.total_volume, 1)


### PR DESCRIPTION
# Document the changes in your pull request
Hypodermic Prickles functions properly because it now doesn't divide by zero. Aka, you can inject people with chemicals now instead of it just not working (was a bug caused by #18714)

Closes #18861 

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Hypodermic Prickles now works against targets with bioarmor of 0.
/:cl:
