### PR TITLE
energy arrows do half damage to blobs

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -223,6 +223,8 @@
 	var/obj/item/embed_type = /obj/item/ammo_casing/reusable/arrow/energy
 	
 /obj/item/projectile/energy/arrow/on_hit(atom/target, blocked = FALSE)
+	if(istype(target, /obj/structure/blob))
+		damage = damage / 2
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/embede = target
 		var/obj/item/bodypart/part = embede.get_bodypart(def_zone)


### PR DESCRIPTION
remember how the ammo on the beam rifle was reduced because it could instantly destroy blob tiles? yeah so this is identically that except the arrows don't have limited ammo so you can just spam them forever, these destroy normal blobs of any strain (except blazing oil because that's blazing oil's whole gimmick) in literally one hit which doesn't seem fair to blob players.

normal arrows aren't affected because they're actually limited

# Changelog

:cl:  
tweak: energy arrows do 1/2 damage to blobs
/:cl:
