### PR TITLE
makes worldshaker and ultrakill admin only because nobody knows how to do game balance

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -154,17 +154,6 @@
 	cost = 11
 	item = /obj/item/book/granter/martial/preternis_stealth
 	restricted_species = list("preternis")
-
-/datum/uplink_item/race_restricted/worldshaker
-	name = "Prototype worldshaker compound"
-	desc = "A foul concoction made by reverse engineering chemicals compounds found in an ancient Vxtrin military outpost.\
-	Said to cause rapid muscle and plate growth in any Preternis that consumes it. It's believed to have been used by Vxtrin to transform their workers into highly effective commando units.\
-	It is not uncommon for Preterni that have consumed it to be crushed under the weight of their own ever-growing skin. The weight will also prevent use of conventional vehicles."
-	cost = 20
-	player_minimum = 25 //basically a fuckin megafauna
-	item = /obj/item/book/granter/martial/worldshaker
-	manufacturer = /datum/corporation/traitor/vahlen
-	restricted_species = list("preternis")
 	
 /datum/uplink_item/race_restricted/explosive_fist_art
 	name = "Burned scroll"
@@ -172,15 +161,6 @@
 	cost = 14
 	item = /obj/item/book/granter/martial/explosive_fist
 	restricted_species = list("plasmaman")
-
-/datum/uplink_item/race_restricted/ultra_violence
-	name = "Version one upgrade module"
-	desc = "A module full of forbidden techniques that will make you capable of ultimate bloodshed. \
-			If you install this, it will make you incapable of pushing and pulling. \
-			There are no half-measures, either you succeed or you die."
-	cost = 16
-	item = /obj/item/book/granter/martial/ultra_violence
-	restricted_species = list("ipc")
 
 /datum/uplink_item/stealthy_weapons/camera_flash
 	name = "Camera Flash"


### PR DESCRIPTION
Krav Maga: These gloves provide a useful stun if the prisoners are getting uppity, can't be disarmed either. Can also KO them with several hits! Only useful in the brig though.

CQC: Good for stealth! You can drop someone to the ground and silence them before they can scream, be careful though, you don't have any advantage at range!

Sleeping Carp: You do plenty of damage in melee. You can deflect bullets too! However, you can't use guns, rendering you committed to your art once you've learned it.

Flying Fang: You do a lot of damage in melee, although without as many stuns. Unlike the other martial arts, you get a ranged attack! Also, you can heal a bit off of fallen enemies, this leaves you vulnerable though, so be careful! No guns or armor either.

V1: I KNOW SUMMON GUNS IS A WIZARD ITEM, BUT LET'S GIVE IT TO TRAITORS TOO. WHILE WE'RE AT IT, WE'LL DOUBLE THEIR MAX HEALTH. NEED TO BE SURE THE TRAITOR'S UNSTOPPABLE TOO, SO NO EMPS! NO STUNS EITHER! ALSO, THE TRAITOR CAN CONSTANTLY HEAL OFF OF EVERYONE BY PUNCHING THEM, AND IF THEY GET IN TROUBLE THEY CAN DASH AWAY AT A MILLION MILES PER HOUR, WHICH ALSO MAKES THEM INVINCIBLE

Worldshaker: ENOUGH BEING SUBTLE. YOU HAVE 100% DAMAGE RESISTANCE. YOU GET AOE STUNS. YOU GET MELEE STUNS. YOU GET RANGED STUNS. GO FUCKING NUTS.

Do you see the problem with the last two martial arts?

# Changelog

:cl:  
rscdel: V1 and worldshaker are admin-only
/:cl:
