### PR TITLE
Worldbreaker nerfs in progress

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -90,7 +90,7 @@
 		return
 	var/throwdirection = get_dir(user, victim)
 	var/atom/throw_target = get_edge_target_turf(victim, throwdirection)
-	var/throwspeed = 3
+	var/throwspeed = 2
 	if(heavy)
 		throwspeed *= 2
 		distance *= 2

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -183,7 +183,7 @@
 	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
 	to_chat(world, "plate_change is [plate_change ? plate_change : "non-existent"]")
 	if(plate_change)
-		user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
+		user.physiology.armor = user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
 	plates = clamp(plates + amount, 0, PLATE_CAP)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -181,7 +181,6 @@
 		return
 
 	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
-	to_chat(world, "plate_change is [plate_change ? plate_change : "non-existent"]")
 	if(plate_change)
 		user.physiology.armor = user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
@@ -476,8 +475,8 @@
 	charging = TRUE
 	owner.visible_message(span_danger("[owner] prepares to stomp the ground with all their might!"), span_notice("you build up power in your legs, preparing to stomp with all you have!"))
 	var/obj/effect/temp_visual/decoy/tensecond/D = new /obj/effect/temp_visual/decoy/tensecond(owner.loc, owner)
-	animate(D, alpha = 128, color = "#000000", transform = matrix()*2, time = (heavy ? STOMP_WINDUP * 2 : STOMP_WINDUP) SECONDS)
-	if(!do_after(owner, (heavy ? STOMP_WINDUP * 2 : STOMP_WINDUP) SECONDS, owner) || !IsAvailable())
+	animate(D, alpha = 128, color = "#000000", transform = matrix()*2, time = (heavy ? STOMP_WINDUP * 2 : STOMP_WINDUP))
+	if(!do_after(owner, (heavy ? STOMP_WINDUP * 2 : STOMP_WINDUP), owner) || !IsAvailable())
 		charging = FALSE
 		qdel(D)
 		return

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -180,7 +180,7 @@
 	if(amount == 0)
 		return
 
-	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - plates
+	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
 	if(plate_change)
 		user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -90,9 +90,9 @@
 		return
 	var/throwdirection = get_dir(user, victim)
 	var/atom/throw_target = get_edge_target_turf(victim, throwdirection)
-	var/throwspeed = 2
+	var/throwspeed = 1
 	if(heavy)
-		throwspeed *= 2
+		throwspeed *= 4
 		distance *= 2
 	victim.throw_at(throw_target, distance, throwspeed, user)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -181,6 +181,7 @@
 		return
 
 	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
+	to_chat(world, "plate_change is [plate_change ? plate_change : "non-existent"]")
 	if(plate_change)
 		user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
@@ -242,7 +243,7 @@
 			new /obj/effect/temp_visual/dragon_swoop/bubblegum(telegraph)
 
 	leaping = TRUE
-	var/jumpspeed = heavy ? 1 : 3
+	var/jumpspeed = heavy ? 1 : 2
 	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -243,7 +243,7 @@
 			new /obj/effect/temp_visual/dragon_swoop/bubblegum(telegraph)
 
 	leaping = TRUE
-	var/jumpspeed = heavy ? 1 : 2
+	var/jumpspeed = heavy ? 1 : 3
 	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -75,6 +75,8 @@
 	start of helpers section
 ---------------------------------------------------------*/
 /datum/martial_art/worldbreaker/proc/stagger(mob/living/victim)
+	if(HAS_TRAIT(TRAIT_STUNIMMUNE))
+		return
 	victim.add_movespeed_modifier(id, update=TRUE, priority=101, multiplicative_slowdown = 0.5)
 	addtimer(CALLBACK(src, PROC_REF(stagger_end), victim), STAGGER_DURATION, TIMER_UNIQUE | TIMER_OVERRIDE)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -529,8 +529,8 @@
 	combined_msg += span_notice("<b>All attacks apply stagger. Stagger knocks people prone and applies a brief slow.</b>")
 
 	combined_msg +=  "[span_notice("Plates")]: You will progressively grow plates every [PLATE_INTERVAL/10] seconds. \
-	Each plate provides [PLATE_REDUCTION]% damage reduction but also slows you down. The damage reduction caps at [PLATE_REDUCTION * MAX_PLATES]% but the slowdown can continue scaling. \
-	While at maximum damage reduction you are considered \"heavy\" and most of your attacks will be slower, but do more damage in a larger area. \
+	Each plate provides [PLATE_REDUCTION]% armour but also slows you down. The armour caps at [PLATE_REDUCTION * MAX_PLATES]% but the slowdown can continue scaling. \
+	While at maximum armour you are considered \"heavy\" and most of your attacks will be slower, but do more damage in a larger area. \
 	Taking brute or burn damage will wear away at your plates until they fall off on their own."
 
 	combined_msg +=  "[span_notice("Rip Plate")]: Help intent yourself to rip off a plate. The plate can be thrown at people to stagger them and knock them back. \

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -537,7 +537,7 @@
 	var/list/combined_msg = list()
 	combined_msg +=  "<b><i>You imagine all the things you would be capable of with this power.</i></b>"
 
-	combined_msg += span_notice("<b>All attacks apply stagger. Stagger knocks people prone and applies a brief slow.</b>")
+	combined_msg += span_notice("<b>All attacks apply stagger. Stagger applies a brief slow.</b>")
 
 	combined_msg +=  "[span_notice("Plates")]: You will progressively grow plates every [PLATE_INTERVAL/10] seconds. \
 	Each plate provides [PLATE_REDUCTION]% armour but also slows you down. The armour caps at [PLATE_REDUCTION * MAX_PLATES]% but the slowdown can continue scaling. \

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -111,7 +111,7 @@
 	if(plates >= PLATE_CAP || user.stat == DEAD || !can_use(user))//no quaking the entire station
 		return
 	user.balloon_alert(user, span_notice("your plates grow thicker!"))
-	adjust_plates(1)
+	adjust_plates(user, 1)
 	update_platespeed(user)
 
 /datum/martial_art/worldbreaker/proc/rip_plate(mob/living/carbon/human/user)
@@ -121,7 +121,7 @@
 	user.balloon_alert(user, span_notice("you tear off a loose plate!"))
 
 	currentplate = 0
-	adjust_plates(-1)
+	adjust_plates(user, -1)
 	update_platespeed(user)
 	var/obj/item/worldplate/plate = new()
 	plate.linked_martial = src
@@ -144,7 +144,7 @@
 	user.visible_message(span_notice("one of [user]'s plates falls to the ground!"), span_userdanger("one of your loose plates falls off from excessive wear!"))
 	while(currentplate >= PLATE_BREAK)
 		currentplate -= PLATE_BREAK
-		adjust_plates(-1)
+		adjust_plates(user, -1)
 		update_platespeed(user)
 		var/obj/item/worldplate/plate = new(get_turf(user))//dropped to the ground
 		plate.linked_martial = src
@@ -174,12 +174,13 @@
 			REMOVE_TRAIT(user, TRAIT_RESISTHIGHPRESSURE, type)
 			REMOVE_TRAIT(user, TRAIT_RESISTLOWPRESSURE, type)
 
-/datum/martial_art/worldbreaker/proc/adjust_plates(amount = 0)
+/datum/martial_art/worldbreaker/proc/adjust_plates(mob/living/carbon/human/user, amount = 0)
 	if(amount == 0)
 		return
 
-	var/armour = clamp(amount, -plates, max(0, min(amount, MAX_PLATES - plates)))
-	user.physiology.armor.modifyAllRatings(armour * PLATE_REDUCTION)
+	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - plates
+	if(plate_change)
+		user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
 	plates += amount
 	plates = clamp(plates, 0, PLATE_CAP)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -75,7 +75,7 @@
 	start of helpers section
 ---------------------------------------------------------*/
 /datum/martial_art/worldbreaker/proc/stagger(mob/living/victim)
-	if(HAS_TRAIT(TRAIT_STUNIMMUNE))
+	if(HAS_TRAIT(victim, TRAIT_STUNIMMUNE))
 		return
 	victim.add_movespeed_modifier(id, update=TRUE, priority=101, multiplicative_slowdown = 0.5)
 	addtimer(CALLBACK(src, PROC_REF(stagger_end), victim), STAGGER_DURATION, TIMER_UNIQUE | TIMER_OVERRIDE)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -179,7 +179,7 @@
 		return
 
 	var/armour = clamp(amount, -plates, max(0, min(amount, MAX_PLATES - plates)))
-	user.physiology.armor.modifyAllRatings(amount * PLATE_REDUCTION)
+	user.physiology.armor.modifyAllRatings(armour * PLATE_REDUCTION)
 
 	plates += amount
 	plates = clamp(plates, 0, PLATE_CAP)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -159,6 +159,7 @@
 	user.add_movespeed_modifier(type, update=TRUE, priority=101, multiplicative_slowdown = platespeed, blacklisted_movetypes=(FLOATING))
 	user.physiology.damage_resistance = min(plates, MAX_PLATES) * PLATE_REDUCTION
 	user.physiology.stamina_mod = plates/PLATE_CAP
+	user.physiology.stun_mod = plates/PLATE_CAP
 	var/datum/species/preternis/S = user.dna.species
 	if(istype(S))
 		if(heavy)//sort of a sound indicator that you're in "heavy mode"

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -184,8 +184,7 @@
 	if(plate_change)
 		user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
-	plates += amount
-	plates = clamp(plates, 0, PLATE_CAP)
+	plates = clamp(plates + amount, 0, PLATE_CAP)
 
 //the plates in question
 /obj/item/worldplate

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -233,7 +233,7 @@
 			new /obj/effect/temp_visual/dragon_swoop/bubblegum(telegraph)
 
 	leaping = TRUE
-	var/jumpspeed = heavy ? 1 : 3
+	var/jumpspeed = heavy ? 1 : 2
 	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -157,9 +157,8 @@
 	var/platespeed = (plates * 0.2) - 0.5 //faster than normal if either no or few plates
 	user.remove_movespeed_modifier(type)
 	user.add_movespeed_modifier(type, update=TRUE, priority=101, multiplicative_slowdown = platespeed, blacklisted_movetypes=(FLOATING))
-	user.physiology.damage_resistance = min(plates, MAX_PLATES) * PLATE_REDUCTION
-	user.physiology.stamina_mod = plates/PLATE_CAP
-	user.physiology.stun_mod = plates/PLATE_CAP
+	var/armour = min(plates, MAX_PLATES) * PLATE_REDUCTION
+	user.physiology.armor.setRating(armour, armour, armour, armour, armour, armour, armour, armour, armour, armour, armour)
 	var/datum/species/preternis/S = user.dna.species
 	if(istype(S))
 		if(heavy)//sort of a sound indicator that you're in "heavy mode"
@@ -584,6 +583,7 @@
 	update_platespeed(H)
 	ADD_TRAIT(H, TRAIT_RESISTHEAT, type) //walk through that fire all you like, hope you don't care about your clothes
 	ADD_TRAIT(H, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	ADD_TRAIT(H, TRAIT_STUNIMMUNE, type)
 	ADD_TRAIT(H, TRAIT_NOVEHICLE, type)
 	RegisterSignal(H, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(lose_plate))
 	if(!linked_stomp)
@@ -606,6 +606,7 @@
 	update_platespeed(H)
 	REMOVE_TRAIT(H, TRAIT_RESISTHEAT, type)
 	REMOVE_TRAIT(H, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	REMOVE_TRAIT(H, TRAIT_STUNIMMUNE, type)
 	REMOVE_TRAIT(H, TRAIT_NOVEHICLE, type)
 	UnregisterSignal(H, COMSIG_MOB_APPLY_DAMAGE)
 	if(linked_stomp)


### PR DESCRIPTION
issa lil bit strong

should help to make a low plate playstyle still somewhat decent while kinda turbo stomping the full plate playstyle

:cl:  
tweak: Worldbreaker nerfs
tweak: worldbreaker stagger no longer toggles rest (only applies a temp slowdown now)
tweak: fast leap is slightly slower
tweak: push away is notably slower when not heavy
tweak: plates only have 15hp instead of 30
tweak: plate damage reduction scales up to 80% instead of 100%
tweak: damage reduction is now armour instead (ap affects it)
tweak: pummel does 18/12 instead of 21/15
tweak: worldstomp takes 2x the time to go off
tweak: worldstomp does no damage unless in closer range rather than small amounts
/:cl:
