### PR TITLE
Ashwalkers breathe oxygen instead of nitrogen

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -182,8 +182,7 @@
 	limbs_id = "lizard"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE,HAS_FLESH,HAS_BONE,HAS_TAIL)
 	inherent_traits = list(TRAIT_NOGUNS) //yogs start - ashwalkers have special lungs and actually breathe
-	mutantlungs = /obj/item/organ/lungs/ashwalker
-	breathid = "n2" // yogs end
+	mutantlungs = /obj/item/organ/lungs/ashwalker // yogs end
 	species_language_holder = /datum/language_holder/lizard/ash //ashwalker dum
 
 // yogs start - Ashwalkers now have ash immunity

--- a/yogstation/code/modules/surgery/organs/lungs.dm
+++ b/yogstation/code/modules/surgery/organs/lungs.dm
@@ -4,14 +4,8 @@
 	icon = 'yogstation/icons/obj/surgery.dmi'
 	icon_state = "lungs-ash"
 
-	safe_oxygen_min = 0
-	safe_nitro_min = 16
-	safe_toxins_max = 0.05
+	safe_oxygen_min = 6 // adapted to the thinner atmosphere of lavaland
 	safe_co2_max = 20
-	SA_para_min = 1
-	SA_sleep_min = 5
-	BZ_trip_balls_min = 1
-	gas_stimulation_min = 0.002
 
 /obj/item/organ/lungs/plant
 	name = "mesophyll"


### PR DESCRIPTION
# Document the changes in your pull request

Breathing nitrogen is, biologically speaking, very weird. It doesn't make sense for ashwalkers to be like this considering they evolved from a species which doesn't, so this makes them require 6kPa of oxygen to breathe instead of 17kPa of nitrogen.

# Wiki Documentation

Change "you don't need to breathe" to "you don't need as much oxygen to breathe" on the ashwalker wiki page

# Changelog

:cl:  
tweak: ashwalkers require 6kPa of oxygen to breathe instead of 17kPa of nitrogen, removed a few redundant variable definitions
/:cl:
