### PR TITLE
buster blocking some interacts

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -613,12 +613,12 @@
 			walk_towards(s_such_strength, H)
 			animate(s_such_strength, alpha = 100, color = "#d40a0a", transform = matrix()*1.25, time = 0.25 SECONDS)
 			H.ignore_slowdown(type)
-			H.physiology.brute_mod *= 0.25
-			H.physiology.burn_mod *= 0.25
-			H.physiology.tox_mod *= 0.25
-			H.physiology.oxy_mod *= 0.25
-			H.physiology.clone_mod *= 0.25
-			H.physiology.stamina_mod *= 0.25
+			H.physiology.brute_mod *= 0.75
+			H.physiology.burn_mod *= 0.75
+			H.physiology.tox_mod *= 0.75
+			H.physiology.oxy_mod *= 0.75
+			H.physiology.clone_mod *= 0.75
+			H.physiology.stamina_mod *= 0.75
 		owner.log_message("gained buster damage reduction", LOG_ATTACK)
 
 /datum/status_effect/doubledown/on_remove()
@@ -626,10 +626,10 @@
 		qdel(s_such_strength)
 		var/mob/living/carbon/human/H = owner
 		H.unignore_slowdown(type)
-		H.physiology.brute_mod /= 0.25
-		H.physiology.burn_mod /= 0.25
-		H.physiology.tox_mod /= 0.25
-		H.physiology.oxy_mod /= 0.25
-		H.physiology.clone_mod /= 0.25
-		H.physiology.stamina_mod /= 0.25
+		H.physiology.brute_mod /= 0.75
+		H.physiology.burn_mod /= 0.75
+		H.physiology.tox_mod /= 0.75
+		H.physiology.oxy_mod /= 0.75
+		H.physiology.clone_mod /= 0.75
+		H.physiology.stamina_mod /= 0.75
 	owner.log_message("lost buster damage reduction", LOG_ATTACK)//yogs end

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -377,7 +377,7 @@ Class Procs:
 /obj/machinery/_try_interact(mob/user)
 	if((interaction_flags_machine & INTERACT_MACHINE_WIRES_IF_OPEN) && panel_open && (attempt_wire_interaction(user) == WIRE_INTERACTION_BLOCK))
 		return TRUE
-	if((user.mind?.martial_art) && istype(user.mind.martial_art, /datum/martial_art/buster_style) && (user.a_intent == INTENT_GRAB)) //buster arm shit since it can throw vendors
+	if((user.mind?.has_martialart(MARTIALART_BUSTERSTYLE)) && (user.a_intent == INTENT_GRAB)) //buster arm shit since it can throw vendors
 		return	
 	return ..()
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -377,6 +377,8 @@ Class Procs:
 /obj/machinery/_try_interact(mob/user)
 	if((interaction_flags_machine & INTERACT_MACHINE_WIRES_IF_OPEN) && panel_open && (attempt_wire_interaction(user) == WIRE_INTERACTION_BLOCK))
 		return TRUE
+	if((user.mind?.martial_art) && istype(user.mind.martial_art, /datum/martial_art/buster_style) && (user.a_intent == INTENT_GRAB)) //buster arm shit since it can throw vendors
+		return	
 	return ..()
 
 /obj/machinery/CheckParts(list/parts_list)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -418,7 +418,7 @@ GLOBAL_LIST_EMPTY(lockers)
 		return
 	if(!(user.mobility_flags & MOBILITY_STAND) && get_dist(src, user) > 0)
 		return
-	if((user.mind?.martial_art) && istype(user.mind.martial_art, /datum/martial_art/buster_style) && (user.a_intent == INTENT_GRAB))
+	if((user.mind?.has_martialart(MARTIALART_BUSTERSTYLE)) && (user.a_intent == INTENT_GRAB))
 		return //buster arm shit since trying to pick up an open locker just stuffs you in it
 	if(!toggle(user))
 		togglelock(user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -418,7 +418,8 @@ GLOBAL_LIST_EMPTY(lockers)
 		return
 	if(!(user.mobility_flags & MOBILITY_STAND) && get_dist(src, user) > 0)
 		return
-
+	if((user.mind?.martial_art) && istype(user.mind.martial_art, /datum/martial_art/buster_style) && (user.a_intent == INTENT_GRAB))
+		return //buster arm shit since trying to pick up an open locker just stuffs you in it
 	if(!toggle(user))
 		togglelock(user)
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -664,9 +664,6 @@ GLOBAL_LIST_EMPTY(vending_products)
 	to_chat(user, span_notice("You short out the product lock on [src]."))
 
 /obj/machinery/vending/_try_interact(mob/user)
-	if((user.mind?.martial_art) && istype(user.mind.martial_art, /datum/martial_art/buster_style) && (user.a_intent == INTENT_GRAB)) //buster arm shit since it can throw vendors
-		return
-	
 	if(seconds_electrified && !(stat & NOPOWER))
 		if(shock(user, 100))
 			return


### PR DESCRIPTION
# Document the changes in your pull request

heard buster arm kept opening ui when grabbing stuff but idk what exactly so i'm hoping this handles whatever
also makes it so grabbing doesnt open/close lockers and crates

# Changelog

:cl:  
bugfix: fixed buster arm grab opening ui's on stuff and toggling lockers
/:cl:
