### PR TITLE
Turnstiles no longer block atmos because why would they

### DIFF
--- a/code/game/machinery/doors/turnstile.dm
+++ b/code/game/machinery/doors/turnstile.dm
@@ -15,7 +15,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = OPEN_DOOR_LAYER
 	climbable = FALSE
-	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/machinery/turnstile/brig
 	name = "Brig turnstile"
@@ -23,7 +22,7 @@
 	req_one_access = list(ACCESS_SEC_DOORS)
 	max_integrity = 400 /// Made of damn good steel
 	damage_deflection = 21 /// Same as airlocks!
-	
+
 /obj/machinery/turnstile/Initialize()
 	. = ..()
 	icon_state = "turnstile"


### PR DESCRIPTION

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Turnstiles no longer block atmos
/:cl:
