### PR TITLE
Deletes arrivals secpoint, replaces it with border patrol.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -79,33 +79,37 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "aak" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aal" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
-/mob/living/simple_animal/crab/kreb{
-	desc = "Here to lay down the hard claws of the law!";
-	health = 50;
-	name = "Officer Kreb";
-	real_name = "Officer Kreb"
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
+/obj/item/pen,
+/obj/item/stamp{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aam" = (
@@ -4836,7 +4840,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	icon_state = "cognacglass";
-	list_reagents = list(/datum/reagent/consumable/ethanol/cognac = 20);
+	list_reagents = list(/datum/reagent/consumable/ethanol/cognac=20);
 	pixel_x = -5;
 	pixel_y = -3
 	},
@@ -5972,23 +5976,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKX" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
+/obj/machinery/inspector_booth,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aKY" = (
@@ -6073,9 +6061,12 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aLz" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "aLD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -6551,8 +6542,9 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aOj" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
+/obj/structure/chair/comfy/beige,
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
@@ -6775,8 +6767,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aPt" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/white/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 4;
+	name = "Border turnstile"
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPu" = (
 /obj/structure/table/wood,
@@ -7809,10 +7816,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aVj" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7897,8 +7900,30 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aVX" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderexit";
+	name = "Border Exit"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aWc" = (
 /obj/machinery/status_display/evac{
@@ -13039,7 +13064,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -13843,6 +13868,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bQJ" = (
+/mob/living/simple_animal/crab/kreb{
+	desc = "Here to lay down the hard claws of the law!";
+	health = 50;
+	name = "Officer Kreb";
+	real_name = "Officer Kreb"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -14983,25 +15018,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
 /area/hallway/secondary/entry)
 "cfI" = (
-/obj/structure/table/reinforced,
-/obj/item/paper,
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "cfY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -15554,6 +15581,9 @@
 "cmN" = (
 /obj/structure/sign/map/left{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18535,18 +18565,14 @@
 /turf/open/floor/plating,
 /area/medical/psych)
 "dmu" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Lounge"
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -20758,23 +20784,24 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "egY" = (
-/obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 9
+	},
+/obj/machinery/photocopier{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "ehd" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = 4;
-	pixel_y = 21
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/papershredder,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -21685,7 +21712,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8;
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -22572,9 +22599,25 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eOj" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/entry)
+/obj/machinery/door/airlock/command{
+	name = "Border Patrol";
+	req_access_txt = "57"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "eOo" = (
 /obj/structure/table/wood,
 /obj/item/coin/silver,
@@ -24355,11 +24398,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/space/basic,
+/area/space)
 "fyM" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -24375,14 +24415,14 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "fza" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "fzb" = (
 /obj/machinery/shower{
@@ -25058,7 +25098,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 8;
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -25219,10 +25259,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fNw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -28885,26 +28925,22 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "hqu" = (
-/obj/machinery/camera{
-	c_tag = "Security Checkpoint";
-	dir = 1;
-	network = list("ss13","chpt")
-	},
-/obj/machinery/light_switch{
-	pixel_x = 6;
-	pixel_y = -25
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 8;
-	name = "Security Checkpoint APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "borderentry";
+	name = "Border Entry";
+	pixel_x = -25;
+	pixel_y = 4;
+	req_access_txt = "57;1;4"
+	},
+/obj/machinery/button/door{
+	id = "borderexit";
+	name = "Border Exit";
+	pixel_x = -25;
+	pixel_y = -6;
+	req_access_txt = "57;1;4"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -30756,14 +30792,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "iai" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/arrow_ccw{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -31284,7 +31314,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
-	sensors = list("mix_sensor" = "Tank")
+	sensors = list("mix_sensor"="Tank")
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/mix)
@@ -31576,8 +31606,29 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "ipy" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderexit";
+	name = "Border Exit"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -31603,19 +31654,16 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
 "iqm" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
+/obj/machinery/modular_computer/console/preset/command,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/machinery/modular_computer/console/preset/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -39246,17 +39294,18 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "lBX" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /obj/structure/table,
-/obj/item/crowbar,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/item/radio/off{
-	pixel_x = 9;
-	pixel_y = 1
+/obj/item/folder/blue,
+/obj/item/folder/blue{
+	pixel_x = 3;
+	pixel_y = 4
 	},
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = 4;
+	pixel_y = -28
 	},
-/obj/item/assembly/flash/handheld,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "lCM" = (
@@ -42838,9 +42887,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mVV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/arrow_ccw{
+	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mWe" = (
@@ -45867,7 +45917,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
 	name = "liquid pepper spray"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -46591,15 +46641,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
-"oyx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oyA" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -47827,13 +47868,7 @@
 /turf/open/water/safe,
 /area/hydroponics/garden)
 "oZu" = (
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/darkblue/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "oZW" = (
@@ -47933,7 +47968,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -48493,15 +48528,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "poD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Arrivals Hallway";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -49209,6 +49248,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pAL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "pBk" = (
@@ -49238,13 +49283,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "pBm" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/darkblue/warning/lower,
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "pBG" = (
@@ -50085,17 +50125,29 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "pVq" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderentry";
+	name = "Border Entry"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -50339,13 +50391,14 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "pZU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -52910,6 +52963,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rbS" = (
@@ -52925,15 +52981,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "rbV" = (
-/obj/machinery/computer/security,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -53399,9 +53452,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "rmT" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rmU" = (
@@ -54299,15 +54353,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rHV" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rIf" = (
 /obj/structure/spacepoddoor,
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
@@ -56746,7 +56791,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 8;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -56785,12 +56830,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"sJV" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "sKd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57220,7 +57259,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
@@ -57910,14 +57949,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tht" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -57953,10 +57990,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "tin" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 6
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 4
 	},
-/obj/machinery/armaments_dispenser,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "tit" = (
@@ -58572,16 +58614,27 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "twj" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderentry";
+	name = "Border Entry"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60327,8 +60380,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "ugL" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 8;
+	name = "Security Checkpoint APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -69136,11 +69198,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xQf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/pen,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "xQl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -81739,7 +81810,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+fyJ
 aaa
 aaa
 aSm
@@ -84055,11 +84126,11 @@ aBI
 pVq
 twj
 aPt
-aPt
-aPt
-aPt
-rHV
-iai
+asE
+asE
+mnb
+mnb
+asE
 czK
 czK
 czK
@@ -84308,15 +84379,15 @@ aBI
 egY
 ugL
 hqu
-aBI
-oyx
-hmO
+aHu
+tht
+qOw
+mVV
+asE
 cKI
 dmV
 dRK
 aPv
-ayl
-xQf
 czK
 lze
 gIv
@@ -84567,13 +84638,13 @@ bQJ
 pBm
 aKX
 tht
-hmO
+qOw
+iai
+mnb
 wrN
 igu
 dRN
 toE
-ayl
-xQf
 czK
 aym
 pPf
@@ -84820,17 +84891,17 @@ alU
 vZz
 aBI
 rbV
-pAL
+aLz
 oZu
-aHu
-ipy
-hmO
+xQf
+tht
+qOw
+iai
+mnb
 uiF
 aNb
 aNb
 uiF
-ayl
-fyJ
 czK
 pPf
 gIR
@@ -85077,17 +85148,17 @@ alU
 vZz
 aBI
 iqm
-pAL
-aal
 cfI
-sJV
-hmO
-wrN
+aal
+aHu
+tht
+qOw
+iai
+mnb
+uiF
 aNb
 aNb
-aPv
-ayl
-xQf
+uiF
 czK
 gws
 lze
@@ -85336,14 +85407,14 @@ aBI
 aak
 pAL
 lBX
-aHu
+aBI
 ipy
-hmO
-aPx
+aVX
+aPt
+asE
 aOj
-aOj
-aPx
-ayl
+aNb
+aNb
 fza
 czK
 pPf
@@ -85593,15 +85664,15 @@ bHn
 pZU
 poD
 tin
-aBI
+eOj
 dmu
-lYI
-asE
-asE
-asE
-asE
+qOw
 ayl
-mVV
+asE
+aPx
+uiF
+uiF
+aPx
 czK
 aUN
 gJt
@@ -85852,13 +85923,13 @@ azF
 azF
 azF
 rmT
-hmO
-aLz
-aVj
-aVX
-eOj
+lYI
+ayl
+asE
+mnb
 ayl
 ayl
+mnb
 czK
 lze
 lze
@@ -86109,7 +86180,7 @@ gTo
 xbZ
 azF
 cmN
-hmO
+qOw
 ayl
 ayl
 ayl

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6061,12 +6061,9 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aLz" = (
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "aLD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -6345,8 +6342,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "aNb" = (
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "aNc" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -6362,7 +6362,7 @@
 /area/maintenance/starboard/fore)
 "aNf" = (
 /turf/open/floor/goonplaque,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aNg" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -6547,7 +6547,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "aOl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6767,6 +6767,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aPt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
+"aPu" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/turf/open/floor/wood,
+/area/vacant_room)
+"aPv" = (
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
+"aPx" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
 	dir = 1
 	},
@@ -6784,26 +6801,7 @@
 	name = "Border turnstile"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"aPu" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/turf/open/floor/wood,
-/area/vacant_room)
-"aPv" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
-"aPx" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "aPy" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -7258,8 +7256,9 @@
 	c_tag = "Arrivals Hallway";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "aRS" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -7816,6 +7815,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aVj" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7900,31 +7903,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aVX" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/turnstile/brig{
-	dir = 8;
-	name = "Border turnstile"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "borderexit";
-	name = "Border Exit"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "aWc" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -15024,8 +15005,22 @@
 	},
 /area/hallway/secondary/entry)
 "cfI" = (
+/obj/machinery/door/airlock/command{
+	name = "Border Patrol";
+	req_one_access_txt = "57;63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 8
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -15586,7 +15581,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "cmV" = (
 /obj/structure/chair,
 /obj/item/storage/box/fancy/cigarettes,
@@ -15656,7 +15651,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "cno" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -17212,10 +17207,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cKI" = (
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/trimline/white/arrow_ccw{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "cLg" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line,
@@ -18575,7 +18572,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "dmv" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -18618,8 +18615,15 @@
 /area/medical/sleeper)
 "dmV" = (
 /obj/structure/table/wood,
+/obj/item/storage/box/fancy/cigarettes{
+	pixel_y = 2
+	},
+/obj/item/lighter/greyscale{
+	pixel_x = 4;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "dnc" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -18706,11 +18710,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dpF" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "dpM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20067,20 +20071,14 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "dRK" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/fancy/cigarettes{
-	pixel_y = 2
-	},
-/obj/item/lighter/greyscale{
-	pixel_x = 4;
-	pixel_y = 2
-	},
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "dRN" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "dSp" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -22599,23 +22597,18 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eOj" = (
-/obj/machinery/door/airlock/command{
-	name = "Border Patrol";
-	req_access_txt = "57"
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
 	},
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "eOo" = (
@@ -24394,12 +24387,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fyJ" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "fyM" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -24423,7 +24412,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "fzb" = (
 /obj/machinery/shower{
 	dir = 4
@@ -24480,7 +24469,7 @@
 "fAd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "fAs" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Science";
@@ -25266,7 +25255,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "fNQ" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/corner{
@@ -28933,14 +28922,14 @@
 	name = "Border Entry";
 	pixel_x = -25;
 	pixel_y = 4;
-	req_access_txt = "57;1;4"
+	req_one_access_txt = "57;63"
 	},
 /obj/machinery/button/door{
 	id = "borderexit";
 	name = "Border Exit";
 	pixel_x = -25;
 	pixel_y = -6;
-	req_access_txt = "57;1;4"
+	req_one_access_txt = "57;63"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -30792,11 +30781,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "iai" = (
-/obj/effect/turf_decal/trimline/white/arrow_ccw{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "iak" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -31161,11 +31148,9 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "igu" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/chips,
-/obj/item/reagent_containers/food/drinks/soda_cans/cola,
-/turf/open/floor/carpet,
-/area/hallway/secondary/entry)
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "igG" = (
 /obj/structure/table,
 /obj/item/vending_refill/medical{
@@ -31631,7 +31616,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "ipG" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
 	dir = 8
@@ -40314,12 +40299,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "lYI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "lYK" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -42208,7 +42195,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "mFW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -42887,12 +42874,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mVV" = (
-/obj/effect/turf_decal/trimline/white/arrow_ccw{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "mWe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -46641,6 +46629,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
+"oyx" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "oyA" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -48434,7 +48432,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "pmW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Teleporter Maintenance";
@@ -50150,7 +50148,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "pVC" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -53457,7 +53455,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/hallway/primary/port)
 "rmU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -54353,6 +54351,32 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rHV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderexit";
+	name = "Border Exit"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "rIf" = (
 /obj/structure/spacepoddoor,
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
@@ -56830,6 +56854,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"sJV" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/space/basic,
+/area/space)
 "sKd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57949,15 +57980,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tht" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "thv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -58281,12 +58309,11 @@
 /turf/open/floor/wood,
 /area/library)
 "toE" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/chips,
+/obj/item/reagent_containers/food/drinks/soda_cans/cola,
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
 "toV" = (
 /obj/machinery/door/poddoor{
 	id = "turbinevent";
@@ -58638,7 +58665,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/security/checkpoint/auxiliary)
 "twp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -60436,8 +60463,11 @@
 /turf/open/floor/carpet,
 /area/library)
 "uiF" = (
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/trimline/white/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "uiJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -65972,9 +66002,12 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "wrN" = (
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "wso" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -69198,20 +69231,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xQf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "xQl" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -81810,7 +81835,7 @@ aaa
 aaa
 aaa
 aaa
-fyJ
+sJV
 aaa
 aaa
 aSm
@@ -84125,12 +84150,12 @@ aBI
 aBI
 pVq
 twj
-aPt
-asE
-asE
-mnb
-mnb
-asE
+aPx
+aPH
+aPH
+aVX
+aVX
+aPH
 czK
 czK
 czK
@@ -84380,14 +84405,14 @@ egY
 ugL
 hqu
 aHu
-tht
-qOw
-mVV
-asE
+oyx
+aPt
 cKI
-dmV
+aPH
 dRK
-aPv
+aLz
+dmV
+dpF
 czK
 lze
 gIv
@@ -84637,14 +84662,14 @@ ehd
 bQJ
 pBm
 aKX
-tht
-qOw
-iai
-mnb
-wrN
-igu
+oyx
+aPt
+uiF
+aVX
 dRN
 toE
+iai
+xQf
 czK
 aym
 pPf
@@ -84891,17 +84916,17 @@ alU
 vZz
 aBI
 rbV
-aLz
-oZu
-xQf
 tht
-qOw
-iai
-mnb
+oZu
+eOj
+oyx
+aPt
 uiF
-aNb
-aNb
-uiF
+aVX
+fyJ
+aPv
+aPv
+fyJ
 czK
 pPf
 gIR
@@ -85148,17 +85173,17 @@ alU
 vZz
 aBI
 iqm
-cfI
+aNb
 aal
 aHu
-tht
-qOw
-iai
-mnb
+oyx
+aPt
 uiF
-aNb
-aNb
-uiF
+aVX
+fyJ
+aPv
+aPv
+fyJ
 czK
 gws
 lze
@@ -85409,12 +85434,12 @@ pAL
 lBX
 aBI
 ipy
-aVX
-aPt
-asE
+rHV
+aPx
+aPH
 aOj
-aNb
-aNb
+aPv
+aPv
 fza
 czK
 pPf
@@ -85664,15 +85689,15 @@ bHn
 pZU
 poD
 tin
-eOj
+cfI
 dmu
-qOw
-ayl
-asE
-aPx
-uiF
-uiF
-aPx
+lYI
+aLE
+aPH
+mVV
+fyJ
+fyJ
+mVV
 czK
 aUN
 gJt
@@ -85923,13 +85948,13 @@ azF
 azF
 azF
 rmT
-lYI
-ayl
-asE
-mnb
-ayl
-ayl
-mnb
+wrN
+aLE
+aPH
+aVX
+aLE
+aLE
+aVX
 czK
 lze
 lze
@@ -86180,12 +86205,12 @@ gTo
 xbZ
 azF
 cmN
-qOw
-ayl
-ayl
-ayl
-ayl
-ayl
+lYI
+aLE
+aLE
+aLE
+aLE
+aLE
 fAd
 czK
 pPf
@@ -86440,9 +86465,9 @@ cnn
 fNw
 pmE
 aNf
-ayl
-ayl
-ayl
+aLE
+igu
+aVj
 aRR
 czK
 czK
@@ -86696,11 +86721,11 @@ azF
 azF
 azF
 mFR
-dpF
-dpF
-asE
-asE
-asE
+cSb
+cSb
+aPH
+aPH
+aPH
 nxy
 ioi
 aUR
@@ -86955,7 +86980,7 @@ aNl
 tLt
 aNg
 aNg
-asE
+aPH
 fmF
 ioi
 ioi
@@ -87212,7 +87237,7 @@ qhL
 qtS
 ijG
 kcZ
-asE
+aPH
 nxy
 nxy
 ioi

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6061,9 +6061,31 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aLz" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/grimy,
-/area/hallway/primary/port)
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/turnstile/brig{
+	dir = 8;
+	name = "Border turnstile"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "borderexit";
+	name = "Border Exit"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "aLD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -6341,12 +6363,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"aNb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "aNc" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -6767,23 +6783,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aPt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
-"aPu" = (
-/obj/structure/table/wood,
-/obj/item/camera_film,
-/turf/open/floor/wood,
-/area/vacant_room)
-"aPv" = (
-/turf/open/floor/carpet,
-/area/hallway/primary/port)
-"aPx" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
 	dir = 1
 	},
@@ -6799,6 +6798,23 @@
 /obj/machinery/turnstile/brig{
 	dir = 4;
 	name = "Border turnstile"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
+"aPu" = (
+/obj/structure/table/wood,
+/obj/item/camera_film,
+/turf/open/floor/wood,
+/area/vacant_room)
+"aPv" = (
+/turf/open/floor/carpet,
+/area/hallway/primary/port)
+"aPx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -7816,8 +7832,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aVj" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/grimy,
 /area/hallway/primary/port)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -7903,8 +7922,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aVX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/storage/box/fancy/cigarettes{
+	pixel_y = 2
+	},
+/obj/item/lighter/greyscale{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/grimy,
 /area/hallway/primary/port)
 "aWc" = (
 /obj/machinery/status_display/evac{
@@ -15005,22 +15031,8 @@
 	},
 /area/hallway/secondary/entry)
 "cfI" = (
-/obj/machinery/door/airlock/command{
-	name = "Border Patrol";
-	req_one_access_txt = "57;63"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -18614,15 +18626,8 @@
 /turf/open/floor/plating,
 /area/medical/sleeper)
 "dmV" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/fancy/cigarettes{
-	pixel_y = 2
-	},
-/obj/item/lighter/greyscale{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "dnc" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -18710,10 +18715,8 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dpF" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/structure/table/wood,
+/turf/open/floor/carpet,
 /area/hallway/primary/port)
 "dpM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -22597,20 +22600,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eOj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westright{
-	dir = 1;
-	name = "Security Checkpoint";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "eOo" = (
 /obj/structure/table/wood,
 /obj/item/coin/silver,
@@ -30781,8 +30773,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "iai" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "iak" = (
 /obj/machinery/firealarm{
@@ -31148,9 +31143,20 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "igu" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westright{
+	dir = 1;
+	name = "Security Checkpoint";
+	req_access_txt = "1"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "igG" = (
 /obj/structure/table,
 /obj/item/vending_refill/medical{
@@ -46630,15 +46636,9 @@
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
 "oyx" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/arrow_ccw,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/grimy,
+/area/hallway/primary/port)
 "oyA" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -49246,11 +49246,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pAL" = (
+/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -54352,31 +54350,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rHV" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/turnstile/brig{
-	dir = 8;
-	name = "Border turnstile"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "borderexit";
-	name = "Border Exit"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "rIf" = (
 /obj/structure/spacepoddoor,
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver{
@@ -56855,12 +56831,15 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "sJV" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/trimline/white/arrow_ccw,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "sKd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57980,9 +57959,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "tht" = (
-/obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -66002,12 +65983,25 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "wrN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/airlock/command{
+	name = "Border Patrol";
+	req_one_access_txt = "57;63"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/area/security/checkpoint/auxiliary)
 "wso" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -69234,7 +69228,6 @@
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/port)
 "xQl" = (
@@ -81835,7 +81828,7 @@ aaa
 aaa
 aaa
 aaa
-sJV
+aaa
 aaa
 aaa
 aSm
@@ -84150,11 +84143,11 @@ aBI
 aBI
 pVq
 twj
-aPx
+aPt
 aPH
 aPH
-aVX
-aVX
+rHV
+rHV
 aPH
 czK
 czK
@@ -84405,14 +84398,14 @@ egY
 ugL
 hqu
 aHu
-oyx
-aPt
+sJV
+tht
 cKI
 aPH
 dRK
-aLz
-dmV
-dpF
+oyx
+aVX
+xQf
 czK
 lze
 gIv
@@ -84662,14 +84655,14 @@ ehd
 bQJ
 pBm
 aKX
-oyx
-aPt
+sJV
+tht
 uiF
-aVX
+rHV
 dRN
 toE
-iai
-xQf
+dpF
+aVj
 czK
 aym
 pPf
@@ -84916,13 +84909,13 @@ alU
 vZz
 aBI
 rbV
-tht
+pAL
 oZu
-eOj
-oyx
-aPt
+igu
+sJV
+tht
 uiF
-aVX
+rHV
 fyJ
 aPv
 aPv
@@ -85173,13 +85166,13 @@ alU
 vZz
 aBI
 iqm
-aNb
+cfI
 aal
 aHu
-oyx
-aPt
+sJV
+tht
 uiF
-aVX
+rHV
 fyJ
 aPv
 aPv
@@ -85430,12 +85423,12 @@ alU
 nWn
 aBI
 aak
-pAL
+aPx
 lBX
 aBI
 ipy
-rHV
-aPx
+aLz
+aPt
 aPH
 aOj
 aPv
@@ -85689,7 +85682,7 @@ bHn
 pZU
 poD
 tin
-cfI
+wrN
 dmu
 lYI
 aLE
@@ -85948,13 +85941,13 @@ azF
 azF
 azF
 rmT
-wrN
+iai
 aLE
 aPH
-aVX
+rHV
 aLE
 aLE
-aVX
+rHV
 czK
 lze
 lze
@@ -86466,8 +86459,8 @@ fNw
 pmE
 aNf
 aLE
-igu
-aVj
+dmV
+eOj
 aRR
 czK
 czK


### PR DESCRIPTION
# Document the changes in your pull request
Since we have a new inspector booth, I thought I would add a proper use for it by changing the sec checkpoint to border patrol.
This is a completely optional feature, for hops or secoffs that want to larp as if theyre in papers please, the shutters are off by default and can only be enabled with secoff or HoP access.
It also now acts as pretty much a secondary HoP office.

![image](https://github.com/yogstation13/Yogstation/assets/42524344/76358990-b702-417e-b830-c6db1d8e5b44)

# Changelog
:cl:  
mapping: Arrivals checkpoint is no longer, embrace border patrol.
/:cl:
