### PR TITLE
Removes the stun from the drinking teslium shock + electrocute_act tweak

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -400,9 +400,10 @@
 	do_jitter_animation(300)
 	adjust_stutter(4 SECONDS)
 	adjust_jitter(20 SECONDS)
-	var/should_stun = !tesla_shock || (tesla_shock && siemens_coeff > 0.5) && stun
-	Paralyze(4 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun), 2 SECONDS)
+	if(stun)
+		Paralyze(4 SECONDS)
+		if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
+			addtimer(CALLBACK(src, PROC_REF(secondary_shock)), 2 SECONDS)
 	if(stat == DEAD && can_defib()) //yogs: ZZAPP
 		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(80))
 			set_heartattack(FALSE)
@@ -419,8 +420,7 @@
 
 ///Called slightly after electrocute act to apply a secondary stun.
 /mob/living/carbon/proc/secondary_shock(should_stun)
-	if(should_stun)
-		Paralyze(6 SECONDS)
+	Paralyze(6 SECONDS)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
 	if(on_fire)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -419,7 +419,7 @@
 		return shock_damage
 
 ///Called slightly after electrocute act to apply a secondary stun.
-/mob/living/carbon/proc/secondary_shock(should_stun)
+/mob/living/carbon/proc/secondary_shock()
 	Paralyze(6 SECONDS)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -229,7 +229,7 @@
 	shock_timer++
 	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
 		shock_timer = 0
-		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1, stun = FALSE) //Override because it's caused from INSIDE of you
 		playsound(M, "sparks", 50, 1)
 	..()
 


### PR DESCRIPTION
It's already killing you, no reason for it to stun
had to rewrite electrocute act slightly because it's fucked

:cl:  
tweak: teslium no longer stuns on electrocute
tweak: electrocutes can now actually not stun
/:cl:
