### PR TITLE
Revert "Traitor: Episode III - Revenge of the Desword"

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/dualsaber
 	player_minimum = 25
 	cost = 16
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/doublesword/get_discount()
 	return pick(4;0.8,2;0.65,1;0.5)


### PR DESCRIPTION
Reverts yogstation13/Yogstation#18909

This was a bad idea in the first place, I think it would honestly be better if maybe you could craft two eswords together for a makeshift desword with flat 75 block chance and nothing else (which is still pretty goofy)
Desword lets you completely negate all energy and laser attacks and has a 75 block chance for "everything else" and generally completely destroys any semblance of balance regarding trying to pick a strategy and it being counterable with another strategy.
Which is melee and bullet, with bulletproof armor being two rwalls or one cargo order away, making bullets laughably bad and melee your only viable option against a desword user (good luck with that), and this isn't even factoring in any other TC that you can get from bounties, contractor, and other traitors. The only TRULY viable strategy is bomb but security can't go around chucking singlecaps can they?