### PR TITLE
plain burger needs plain patty to craft

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -73,7 +73,7 @@
 /datum/crafting_recipe/food/burger
 	name = "Burger"
 	reqs = list(
-			/obj/item/reagent_containers/food/snacks/patty = 1,
+			/obj/item/reagent_containers/food/snacks/patty/plain = 1,
 			/obj/item/reagent_containers/food/snacks/bun = 1
 	)
 


### PR DESCRIPTION
you could make a plain burger with a plain patty, corgi patty, human patty etc. seems an oversight, this fixes that.

:cl:  ktlwjec
bugfix: plain burger can only be crafted with a plain patty
/:cl: