### PR TITLE
Meteors no longer explode space turfs

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 				SSexplosions.low_mov_atom += thing
 
 	//then, ram the turf if it still exists
-	if(T)
+	if(T && !isspaceturf(T))
 		switch(hitpwr)
 			if(EXPLODE_DEVASTATE)
 				SSexplosions.highturf += T


### PR DESCRIPTION
# Document the changes in your pull request

yes, this is stupid

Tested on a private server by spawning 20 meteor events of varying levels, seemed to reduce meteor lag but I can't tell without a testmerge

# Changelog


:cl:  
experimental: meteors will no longer explode empty space tiles, which should impact nothing since the tile would be empty anyways, but may possibly reduce the amount of stress they put on everything else
/:cl:
