### PR TITLE
Vampire revive no longer requires the user to be alive to activate

### DIFF
--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -323,6 +323,7 @@
 	gain_desc = "You have gained the ability to revive after death... However you can still be cremated/gibbed, and you will disintergrate if you're in the chapel!"
 	desc = "Revives you, provided you are not in the chapel!"
 	button_icon = 'yogstation/icons/mob/vampire.dmi'
+	check_flags = NONE
 	button_icon_state = "coffin"
 	background_icon_state = "bg_vampire"
 	overlay_icon_state = "bg_vampire_border"


### PR DESCRIPTION
# Document the changes in your pull request

fixes #19073
I assume, at least

caused by the spell having the default check for consciousness when it used to not have that


:cl:  
bugfix: vampires can revive while dead again
/:cl:
