### PR TITLE
glasses color toggle text is now correct

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -525,7 +525,7 @@
 	if(!isliving(exposed) || exposed == owner)
 		owner.balloon_alert(owner, "invalid exposed!")
 		return FALSE
-	
+
 	var/mob/living/living_exposed = exposed
 	living_exposed.apply_status_effect(STATUS_EFFECT_EXPOSED)
 	living_exposed.adjust_jitter(5 SECONDS)
@@ -548,10 +548,10 @@
 
 		if (HAS_TRAIT_FROM(human_user, TRAIT_SEE_GLASS_COLORS, GLASSES_TRAIT))
 			REMOVE_TRAIT(human_user, TRAIT_SEE_GLASS_COLORS, GLASSES_TRAIT)
-			to_chat(human_user, span_notice("You will now see glasses colors."))
+			to_chat(human_user, span_notice("You will no longer see glasses colors."))
 		else
 			ADD_TRAIT(human_user, TRAIT_SEE_GLASS_COLORS, GLASSES_TRAIT)
-			to_chat(human_user, span_notice("You will no longer see glasses colors."))
+			to_chat(human_user, span_notice("You will now see glasses colors."))
 		human_user.update_glasses_color(src, TRUE)
 	else
 		return ..()


### PR DESCRIPTION
the text was switched around, so it would say "You will no longer see glasses colors." when you toggle it on and "You will now see glasses colors." when you toggle it off.


:cl:  
bugfix: glasses color toggle text is now correct
/:cl: