### PR TITLE
the ultrakill martial art is now not as hot garbagio

### DIFF
--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -1,7 +1,8 @@
 #define IPCMARTIAL "ipcmartialtrait"
-#define GUN_HAND "HG"
+#define GUN_HAND "GH"
 #define POCKET_PISTOL "GG"
-#define BLOOD_BURST "HH"
+#define SUPERKILL "HHHH"
+#define HOOK "PP" //the P is for graPPle
 #define MAX_DASH_DIST 4
 #define DASH_SPEED 2
 
@@ -12,11 +13,34 @@
 	deflection_chance = 0
 	reroute_deflection = TRUE
 	help_verb = /mob/living/carbon/human/proc/ultra_violence_help
+	var/datum/action/cooldown/ultrakill_clearstuns/button = new /datum/action/cooldown/ultrakill_clearstuns()
 	///used to keep track of the dash stuff
 	var/recalibration = /mob/living/carbon/human/proc/violence_recalibration
 	var/dashing = FALSE
 	var/dashes = 3
 	var/dash_timer = null
+
+/datum/action/cooldown/ultrakill_clearstuns
+	name = "Clear Stuns"
+	desc = "Spend a dash charge to clear all stuns."
+	cooldown_time = 10 SECONDS
+	button_icon_state = "adrenal"
+	var/mob/living/carbon/human/user
+
+/datum/action/cooldown/ultrakill_clearstuns/Activate()
+	var/datum/martial_art/ultra_violence/martial_art = user.mind.martial_art
+	if(martial_art.dashes < 1)
+		return
+	user.SetStun(0)
+	user.SetKnockdown(0)
+	user.SetUnconscious(0)
+	user.SetParalyzed(0)
+	user.SetImmobilized(0)
+	user.adjustStaminaLoss(-75)
+	user.set_resting(FALSE)
+	user.update_mobility()
+	martial_art.dashes -= 1
+	user.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, martial_art.dashes)
 
 /datum/martial_art/ultra_violence/can_use(mob/living/carbon/human/H)
 	return isipc(H)
@@ -31,12 +55,17 @@
 		speed_boost(A, -0.2, "pocketpistol")
 		return TRUE
 
-	if(A == D) //you can pull your gun out by "grabbing" yourself
+	if(findtext(streak, HOOK) && A == D) //to prevent accidents
+		streak = ""
+		grapple_hook(A)
+		return TRUE
+
+	if(A == D) //you can pull your gun out by "grabbing" yourself, or your hook
 		return FALSE
 
-	if(findtext(streak, BLOOD_BURST))
+	if(findtext(streak, SUPERKILL))
 		streak = ""
-		blood_burst(A,D)
+		superkill(A,D)
 		speed_boost(A, -0.5, "bloodburst")
 		return TRUE
 
@@ -47,6 +76,10 @@
 		return TRUE
 
 /datum/martial_art/ultra_violence/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	add_to_streak("P",D)
+	check_streak(A,D)
+	if(D.stat != DEAD)
+		playsound(A, 'sound/effects/snap.ogg', 20, FALSE)
 	return TRUE  //no disarming
 
 /datum/martial_art/ultra_violence/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -73,12 +106,16 @@
 	start of blood burst section 
 
 ---------------------------------------------------------------*/
-/datum/martial_art/ultra_violence/proc/blood_burst(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/ultra_violence/proc/superkill(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	var/obj/item/ammo_casing/shotgun/buckshot/syndie/ammo = new /obj/item/ammo_casing/shotgun/buckshot/syndie()
+	A.put_in_active_hand(ammo)
+	ammo.fire_casing(D, A)
+	if(!QDELETED(ammo))
+		ammo.moveToNullspace()//get rid of the spent casing
+		QDEL_NULL(ammo)
 
-	A.add_mob_blood(D)
-	D.apply_damage(16, BRUTE, A.zone_selected, wound_bonus = 5, bare_wound_bonus = 5, sharpness = SHARP_EDGED)//between 21 and 30 brute damage, 16 of which is sharp and can wound
-	D.bleed(20)
-	D.add_splatter_floor(D.loc, TRUE)
+	playsound(A, "sound/weapons/shotgunshot.ogg", 90, FALSE)
+	to_chat(A, span_notice("You blast [D] with your gun hand."))
 
 	new /obj/effect/gibspawner/generic(D.loc)
 
@@ -92,6 +129,7 @@
 		heal_amt -= max(brute_before - A.getBruteLoss(), 0)
 		A.adjustFireLoss(-heal_amt, FALSE, FALSE, BODYPART_ANY)
 		new /obj/effect/gibspawner/generic(D.loc)
+	regen_dash() //Fully recharges stamina
 
 /*---------------------------------------------------------------
 
@@ -104,6 +142,14 @@
 
 ---------------------------------------------------------------*/
 /datum/martial_art/ultra_violence/proc/pocket_pistol(mob/living/carbon/human/A)
+	if(dashes < 1)
+		to_chat(A, span_notice("You're out of stamina!"))
+		return
+	if(A.is_holding_item_of_type(/obj/item/gun/ballistic/revolver/ipcmartial))
+		to_chat(A, span_notice("You already have a revolver out!"))
+		return
+	dashes -= 1
+	A.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 	var/obj/item/gun/ballistic/revolver/ipcmartial/gun = new /obj/item/gun/ballistic/revolver/ipcmartial (A)   ///I don't check does the user have an item in a hand, because it is a martial art action, and to use it... you need to have a empty hand
 	gun.gun_owner = A
 	A.put_in_hands(gun)
@@ -129,13 +175,12 @@
 	desc = "A .357 piercer bullet casing."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/ipcmartial
-	click_cooldown_override = 0.1 //this gun shoots faster
 
-/obj/item/projectile/bullet/ipcmartial //literally just default 357 with mob piercing
+/obj/item/projectile/bullet/ipcmartial
 	name = ".357 piercer bullet"
-	damage = 40
-	armour_penetration = 15
-	wound_bonus = -45
+	damage = 30 //no dumbass the ultrakill revolver doesn't do a fuck ton of damage
+	armour_penetration = 0 //to disincentivize spamming from range against tough enemies (maurice reference)
+	wound_bonus = -40
 	wound_falloff_tile = -2.5
 	penetrating = TRUE
 
@@ -187,6 +232,8 @@
 	playsound(A, "sound/weapons/shotgunshot.ogg", 90, FALSE)
 	to_chat(A, span_notice("You shoot [D] with your gun hand."))
 	D.add_splatter_floor(D.loc, TRUE)
+	dashes += 1
+	A.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes + 1)
 	streak = ""
 
 /*---------------------------------------------------------------
@@ -201,14 +248,11 @@
 ---------------------------------------------------------------*/
 
 /datum/martial_art/ultra_violence/proc/regen_dash(mob/living/carbon/human/H)
-	dashes += 1
-	dashes = clamp(dashes, 0, 3)
-	if(dashes == 3)
-		deltimer(dash_timer)//stop regen when full
-	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
+	dashes=3
+	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dash+1)
 
 /datum/martial_art/ultra_violence/proc/InterceptClickOn(mob/living/carbon/human/H, params, atom/A)
-	if(H.a_intent != INTENT_DISARM || H.stat == DEAD || H.IsUnconscious() || H.IsFrozen())
+	if(H.a_intent != INTENT_DISARM || H.stat == DEAD || H.IsUnconscious() || H.IsFrozen() || H.get_active_held_item() || A == H)
 		return
 	dash(H, A)
 
@@ -223,7 +267,6 @@
 	else
 		H.apply_status_effect(STATUS_EFFECT_DODGING)
 		playsound(H, 'sound/effects/dodge.ogg', 50)
-		dash_timer = addtimer(CALLBACK(src, PROC_REF(regen_dash), H), 4 SECONDS, TIMER_LOOP|TIMER_UNIQUE|TIMER_STOPPABLE)//start regen
 		H.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the dash
 		dashing = TRUE
 		H.throw_at(A, MAX_DASH_DIST, DASH_SPEED, H, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(dash_end), H))
@@ -244,6 +287,56 @@
 	end of dash section
 
 ---------------------------------------------------------------*/
+
+//GRAPPLE HOOK, uses a subtype of nut buster wiresnatcher
+/obj/item/gun/magic/wire/ultrakiller
+	name = "whiplash"
+	desc = "A grappling hook built into your arm."
+	max_charges = 1
+	ammo_type = /obj/item/ammo_casing/magic/wire/ultrakiller
+	var/mob/gun_owner
+
+/obj/item/ammo_casing/magic/wire/ultrakiller
+	name = "hook"
+	desc = "A hook."
+	projectile_type = /obj/item/projectile/wire/ultrakiller
+	caliber = "hook"
+	icon_state = "hook"
+
+/obj/item/projectile/wire/ultrakiller/on_hit(atom/target)
+	var/mob/living/carbon/human/H = firer
+	if(!H)
+		return
+	if(isobj(target)) // If it's an object
+		var/obj/item/I = target
+		if(!I?.anchored) // Give it to us if it's not anchored
+			I.throw_at(get_step_towards(H,I), 8, 2)
+			H.visible_message(span_danger("[I] is pulled by [H]'s wire!"))
+			if(istype(I, /obj/item/clothing/head))
+				H.equip_to_slot_if_possible(I, SLOT_HEAD)
+				H.visible_message(span_danger("[H] pulls [I] onto [H.p_their()] head!"))
+			else
+				H.put_in_hands(I)
+			return
+		zip(H, target) // Pull us towards it if it's anchored
+	if(isliving(target)) // If it's somebody
+		var/mob/living/victim = target
+		victim.Immobilize(2 SECONDS) //can get some combo going on them
+		zip(H, victim)
+	if(iswallturf(target)) // If we hit a wall, pull us to it
+		var/turf/W = target
+		zip(H, W)
+
+/datum/martial_art/ultra_violence/proc/grapple_hook(mob/living/carbon/human/A)
+	if(dashes < 1)
+		to_chat(A, span_notice("You're out of stamina!"))
+		return
+	dashes -= 1
+	var/obj/item/gun/magic/wire/ultrakiller/gun = new()
+	gun.gun_owner = A
+	to_chat(A, span_notice("You prepare to use the whiplash."))
+	A.put_in_active_hand(gun)
+
 /*---------------------------------------------------------------
 
 	training related section
@@ -256,17 +349,17 @@
 	to_chat(usr, "<b><i>You search your data banks for techniques of Ultra Violence.</i></b>")
 
 	to_chat(usr, span_notice("This module has made you a hell-bound killing machine."))
-	to_chat(usr, span_notice("You are immune to stuns and cannot be slowed by damage."))
-	to_chat(usr, span_notice("You will deflect emps while throwmode is enabled, releases the energy into anyone nearby."))
-	to_chat(usr, span_notice("After deflecting, or getting hit by an emp you will be immune to more for 5 seconds."))
+	to_chat(usr, span_notice("You cannot be slowed by damage."))
+	to_chat(usr, span_notice("You will deflect emps while throwmode is enabled, releasing the energy into anyone nearby."))
 	to_chat(usr, span_warning("Your disarm has been replaced with a charged-based dash system."))
 	to_chat(usr, span_warning("You cannot grab either, JUST KILL THEM!")) //seriously, no pushing or clinching, that's boring, just kill
 	to_chat(usr, span_notice("<b>Getting covered in blood will heal you.</b>"))
 	
 	to_chat(usr, "[span_notice("Disarm Intent")]: Dash in a direction granting brief invulnerability.")
-	to_chat(usr, "[span_notice("Pocket Revolver")]: Grab Grab. Puts a loaded revolver in your hand for three shots. Target must be living, but can be yourself.")
-	to_chat(usr, "[span_notice("Gun Hand")]: Harm Grab. Shoots the target with the shotgun in your hand.")
-	to_chat(usr, "[span_notice("Blood Burst")]: Harm Harm. Explodes blood from the target, covering you in blood and healing for a bit. Executes people in hardcrit exploding more blood everywhere.")
+	to_chat(usr, "[span_notice("Whiplash")]")
+	to_chat(usr, "[span_notice("Pocket Revolver")]: Grab Grab. Puts a loaded revolver in your hand for three shots. Target must be living, but can be yourself. Consumes one dash charge.")
+	to_chat(usr, "[span_notice("Gun Hand")]: Harm Grab. Shoots the target with a weak shotgun shell. Restores one dash charge.")
+	to_chat(usr, "[span_notice("Ultrakill")]: Harm Harm Harm Harm. Blasts the target with a strong shotgun shell, and explodes blood from the target, covering you in blood and healing for a bit. Executes people in hardcrit exploding more blood everywhere. Fully recharges stamina.")
 	to_chat(usr, span_notice("Completing any combo will give a speed buff with the strength of the Pocket Revolver speed boost being weaker."))
 	to_chat(usr, span_notice("Should your dash cease functioning, use the 'Reinitialize Module' function."))
 
@@ -286,18 +379,17 @@
 	H.dna.species.punchdamagelow += 4
 	H.dna.species.punchdamagehigh += 4 //no fancy comboes, just punches
 	H.dna.species.punchstunthreshold += 50 //disables punch stuns
-	H.dna.species.staminamod = 0 //my god, why must you make me add all these additional things, stop trying to disable them, just kill them
-	ADD_TRAIT(H, TRAIT_NOSOFTCRIT, IPCMARTIAL)
-	ADD_TRAIT(H, TRAIT_NOHARDCRIT, IPCMARTIAL)//instead of giving them more health, just remove crit entirely, fits better thematically too
+	ADD_TRAIT(H, TRAIT_NOSOFTCRIT, IPCMARTIAL) //so it's sorta possible to be arrested, counterracts the damage modifiers
 	ADD_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN, IPCMARTIAL)
 	ADD_TRAIT(H, TRAIT_NOLIMBDISABLE, IPCMARTIAL)
 	ADD_TRAIT(H, TRAIT_NO_STUN_WEAPONS, IPCMARTIAL)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, IPCMARTIAL)
-	ADD_TRAIT(H, TRAIT_STUNIMMUNE, IPCMARTIAL)///mainly so emps don't end you instantly, they still do damage though
 	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 	add_verb(H, recalibration)
 	usr.click_intercept = src //probably breaks something, don't know what though
 	H.dna.species.GiveSpeciesFlight(H)//because... c'mon
+	button.Grant(H)
+	button.user = H
 
 /datum/martial_art/ultra_violence/on_remove(mob/living/carbon/human/H)
 	..()
@@ -317,6 +409,7 @@
 	H.clear_alert("dash_charge")
 	remove_verb(H, recalibration)
 	usr.click_intercept = null //un-breaks the thing that i don't know is broken
+	button.Remove(H)
 	//not likely they'll lose the martial art i guess, so i guess they can keep the wings since i don't know how to remove them
 
 #undef GUN_HAND

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -249,7 +249,7 @@
 
 /datum/martial_art/ultra_violence/proc/regen_dash(mob/living/carbon/human/H)
 	dashes=3
-	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dash+1)
+	H.throw_alert("dash_charge", /atom/movable/screen/alert/ipcmartial, dashes+1)
 
 /datum/martial_art/ultra_violence/proc/InterceptClickOn(mob/living/carbon/human/H, params, atom/A)
 	if(H.a_intent != INTENT_DISARM || H.stat == DEAD || H.IsUnconscious() || H.IsFrozen() || H.get_active_held_item() || A == H)

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -356,9 +356,9 @@
 	to_chat(usr, span_notice("<b>Getting covered in blood will heal you.</b>"))
 	
 	to_chat(usr, "[span_notice("Disarm Intent")]: Dash in a direction granting brief invulnerability.")
-	to_chat(usr, "[span_notice("Whiplash")]")
+	to_chat(usr, "[span_notice("Whiplash")]: Disarm Disarm. Extends a grappling hook from your arm that pulls you to targets. Whoever you hit will be immobilized for two seconds. Consumes one dash charge.")
 	to_chat(usr, "[span_notice("Pocket Revolver")]: Grab Grab. Puts a loaded revolver in your hand for three shots. Target must be living, but can be yourself. Consumes one dash charge.")
-	to_chat(usr, "[span_notice("Gun Hand")]: Harm Grab. Shoots the target with a weak shotgun shell. Restores one dash charge.")
+	to_chat(usr, "[span_notice("Gun Hand")]: Grab Harm. Shoots the target with a weak shotgun shell. Restores one dash charge.")
 	to_chat(usr, "[span_notice("Ultrakill")]: Harm Harm Harm Harm. Blasts the target with a strong shotgun shell, and explodes blood from the target, covering you in blood and healing for a bit. Executes people in hardcrit exploding more blood everywhere. Fully recharges stamina.")
 	to_chat(usr, span_notice("Completing any combo will give a speed buff with the strength of the Pocket Revolver speed boost being weaker."))
 	to_chat(usr, span_notice("Should your dash cease functioning, use the 'Reinitialize Module' function."))
@@ -414,7 +414,7 @@
 
 #undef GUN_HAND
 #undef POCKET_PISTOL
-#undef BLOOD_BURST
+#undef SUPERKILL
 #undef MAX_DASH_DIST
 #undef DASH_SPEED
 #undef IPCMARTIAL

--- a/code/game/objects/items/devices/busterarm/wire_snatch.dm
+++ b/code/game/objects/items/devices/busterarm/wire_snatch.dm
@@ -82,7 +82,7 @@
 	. = ..()
 	ADD_TRAIT(src, HAND_REPLACEMENT_TRAIT, NOBLUDGEON)
 	if(ismob(loc))
-		loc.visible_message(span_warning("A long cable comes out from [loc.name]'s arm!"), span_warning("You extend the buster's wire from your arm."))
+		loc.visible_message(span_warning("A long cable comes out from [loc.name]'s arm!"), span_warning("You extend a wire from your arm."))
 
 /// Deletes the wire once it has no more shots left
 /obj/item/gun/magic/wire/process_chamber()

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -149,7 +149,7 @@
 		if(!istype(mind.martial_art, /datum/martial_art/ultra_violence))
 			to_chat(src, span_warning("Use of ranged weaponry would bring dishonor to the clan."))
 			return FALSE
-		else if(!istype(G, /obj/item/gun/ballistic/revolver/ipcmartial))//more snowflake shit
+		else if((!istype(G, /obj/item/gun/ballistic/revolver/ipcmartial)) && (!istype(G, /obj/item/gun/magic/wire/ultrakiller)))//more snowflake shit
 			to_chat(src, span_warning("This gun is not compliant with Ultra Violence standards."))
 			return FALSE
 	return .


### PR DESCRIPTION
currently it's boring and overpowered, you can pull infinite revolvers out of your ass and spam them from range, if you ever get in trouble you can just warp away at light speed, but all the other moves are borderline worthless for actual combat so the only thing you can do is spam infinite 357s.

Changes:
Revolver damage reduced to 30, AP removed.

Spawning a revolver will take 1 dash charge, and cannot spawn if you have no dash charges.

Dash charges no longer recover by themselves, and require combos to recharge.

The shotgun combo will restore 1 dash charge

Blood burst renamed, now requires 4 harm hits again, fully recharges dash and will also shoot the target with a syndicate shotgun shell.

Stun immunity removed

Button to remove stuns and heal 75 stamina damage added, costs 1 dash charge to use

Whiplash added. Can pull you to targets, will immobilize whoever you hit for two seconds, giving you the opportunity to start comboing them. Costs 1 dash charge.

Hard crit immunity removed



# Changelog

:cl:  
tweak: slightly adjusted the ultrakill martial art
/:cl:
