### PR TITLE
alcohol tolerance mutation has instability

### DIFF
--- a/yogstation/code/datums/mutations/alcohol.dm
+++ b/yogstation/code/datums/mutations/alcohol.dm
@@ -4,6 +4,7 @@
 	quality = POSITIVE
 	text_gain_indication = span_notice("Your liver feels amazing.")
 	text_lose_indication = span_danger("Your liver feels sad.")
+	instability = 5
 
 /datum/mutation/human/alcohol_tolerance/on_acquiring(mob/living/carbon/human/owner)
 	if(..())


### PR DESCRIPTION
Makes alcohol tolerance cost 5 instability (same as glowy). It's a minor positive mutation but it is still a positive mutation, so I think it needs some instability. It's never made sense to me why you can just get it for free.

I'll change wiki for this.


:cl:  Ktlwjec
tweak: Alcohol Tolerance mutation instability is now 5.
/:cl:
