### PR TITLE
gives liquid electricity blood packs a name

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -63,6 +63,8 @@
 		var/datum/reagent/blood/B = reagents.has_reagent(/datum/reagent/blood)
 		if(B && B.data && B.data["blood_type"])
 			blood_type = B.data["blood_type"]
+		else if(reagents.has_reagent(/datum/reagent/consumable/liquidelectricity))
+			blood_type = "LE"
 		else
 			blood_type = null
 	update_pack_name()


### PR DESCRIPTION
I've tested as much as I can, works. Instead of it just being named blood pack it's named blood pack - LE. No more reaching for an empty blood pack and screaming when it's just a prank as it's full of ethereal blood.


:cl:  Ktlwjec
rscadd: Liquid Electricity blood packs are named with the blood type now.
/:cl:
