### PR TITLE
All Heads of Staff can set Blue/Green Alert and Emergency Maint Access

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -136,9 +136,6 @@
 			SSshuttle.requestEvac(usr, reason)
 			post_status("shuttle")
 		if ("changeSecurityLevel")
-			if (!authenticated_as_silicon_or_captain(usr))
-				return
-
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				to_chat(usr, span_warning("The system is not able to change the security alert level more than once per minute, please wait."))
 				return
@@ -345,8 +342,6 @@
 			state = STATE_MAIN
 			playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
 		if ("toggleEmergencyAccess")
-			if (!authenticated_as_silicon_or_captain(usr))
-				return
 			if (GLOB.emergency_access)
 				if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 					to_chat(usr, span_alert("Maintenance airlock communications relays recharging. Please stand by."))
@@ -405,8 +400,8 @@
 				data["canRecallShuttles"] = !issilicon(user)
 				data["canRequestNuke"] = FALSE
 				data["canSendToSectors"] = FALSE
-				data["canSetAlertLevel"] = FALSE
-				data["canToggleEmergencyAccess"] = FALSE
+				data["canSetAlertLevel"] = TRUE
+				data["canToggleEmergencyAccess"] = TRUE
 				data["importantActionReady"] = COOLDOWN_FINISHED(src, important_action_cooldown)
 				data["shuttleCalled"] = FALSE
 				data["shuttleLastCalled"] = FALSE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -140,6 +140,7 @@
 				return
 
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
+				to_chat(usr, span_warning("The system is not able to change the security alert level more than once per minute, please wait."))
 				return
 
 			// Check if they have
@@ -150,7 +151,7 @@
 					to_chat(usr, span_warning("You need to swipe your ID!"))
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 					return
-				if (!(ACCESS_CAPTAIN in id_card.access))
+				if (!(ACCESS_HEADS in id_card.access))
 					to_chat(usr, span_warning("You are not authorized to do this!"))
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 					return


### PR DESCRIPTION
# Document the changes in your pull request

As stated in title. Also added an error text for if someone attempts to change the alert level while it's on cooldown.

Reason for this is for the no auto-blue at round start, it's needed for rounds without Captains. Emergency Maint is just QoL if no AI or Cap for rad storm/blob/etc.

# Changelog

:cl:  
tweak: Heads of Staff can use Communications Console to change security level and emergency maint access.
/:cl:
