### PR TITLE
very microscopically updates the Listening Post

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -525,7 +525,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 10
+	dir = 10;
+	density = 0
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -676,7 +677,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 5
+	dir = 5;
+	density = 0
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -1265,7 +1267,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/window/reinforced/survival_pod{
-	dir = 6
+	dir = 6;
+	density = 0
 	},
 /obj/item/phone,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -2416,7 +2419,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 9
+	dir = 9;
+	density = 0
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -4,8 +4,8 @@
 /area/template_noop)
 "ab" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav)
 "ac" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
@@ -82,7 +82,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ak" = (
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -130,7 +130,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "az" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -196,7 +196,7 @@
 /area/ruin/space/has_grav/listeningstation/engineering)
 "aJ" = (
 /turf/open/floor/plating/asteroid,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "aK" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -358,7 +358,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -505,7 +505,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "bG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -664,7 +664,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "eu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/sink{
@@ -826,7 +826,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hb" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -842,7 +842,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "hk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1144,7 +1144,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "kv" = (
 /obj/structure/closet/syndicate{
 	req_access_txt = "150"
@@ -1238,7 +1238,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "lG" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -1306,6 +1306,10 @@
 /obj/item/storage/firstaid/emergency,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
+"nv" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
 "nG" = (
 /obj/machinery/vending/hydronutrients{
 	default_price = 0;
@@ -1339,7 +1343,7 @@
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "oq" = (
 /turf/closed/mineral/gibtonite,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "ou" = (
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -1616,7 +1620,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "uP" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -1660,7 +1664,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "vx" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -1836,7 +1840,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "yQ" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/listeningstation/telecomms)
@@ -1927,13 +1931,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "AE" = (
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "By" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2389,7 +2393,7 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Mw" = (
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "MF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -2486,7 +2490,7 @@
 /area/ruin/space/has_grav/listeningstation/hallway)
 "NO" = (
 /turf/closed/mineral/random,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "NS" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small{
@@ -3242,11 +3246,7 @@
 "YH" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid,
-/area/ruin/unpowered)
-"Zg" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
+/area/ruin/space/has_grav)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 8
@@ -3560,7 +3560,7 @@ NO
 aJ
 aJ
 aJ
-Zg
+ab
 aJ
 aJ
 NO
@@ -3600,9 +3600,9 @@ aJ
 aJ
 aJ
 aJ
-Zg
-Zg
-Zg
+ab
+ab
+ab
 NO
 NO
 "}
@@ -4160,9 +4160,9 @@ Oa
 uQ
 az
 Mw
-ab
-ab
-ab
+nv
+nv
+nv
 NO
 NO
 "}
@@ -4201,7 +4201,7 @@ Tv
 as
 Mw
 Mw
-ab
+nv
 ay
 bF
 AE

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1513,6 +1513,7 @@
 /obj/item/stack/arcadeticket,
 /obj/effect/turf_decal/delivery,
 /obj/item/computer_hardware/hard_drive/portable/super,
+/obj/item/reagent_containers/glass/bottle/mannitol,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "sR" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -194,9 +194,6 @@
 "aI" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation/engineering)
-"aJ" = (
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation/warehouse)
 "aK" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -405,6 +402,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "bv" = (
@@ -1222,6 +1220,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "lm" = (
@@ -3846,7 +3845,7 @@ qP
 qP
 vx
 na
-aJ
+fp
 tz
 im
 ak

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -892,6 +892,9 @@
 /obj/item/twohanded/required/kirbyplants,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"hv" = (
+/turf/closed/wall/explosive,
+/area/ruin/space/has_grav/listeningstation/warehouse)
 "hA" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -1128,7 +1131,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "jB" = (
 /obj/effect/baseturf_helper/asteroid/airless,
-/turf/closed/wall/rust,
+/turf/closed/wall/explosive,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "jK" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -1889,6 +1892,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/listeningstation/engineering)
+"yV" = (
+/turf/closed/wall/explosive,
 /area/ruin/space/has_grav/listeningstation/engineering)
 "zc" = (
 /obj/structure/cable{
@@ -3074,6 +3080,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/airlock)
+"VT" = (
+/turf/closed/wall/explosive,
+/area/ruin/space/has_grav/listeningstation/telecomms)
 "Wg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3086,6 +3095,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/airlock)
+"Wp" = (
+/turf/closed/wall/explosive,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "WK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -3716,7 +3728,7 @@ kw
 ak
 bg
 pZ
-pZ
+VT
 WO
 pZ
 bg
@@ -3793,7 +3805,7 @@ FS
 bu
 Oi
 OF
-Cy
+hv
 Uw
 UV
 zV
@@ -3855,7 +3867,7 @@ aY
 MU
 wW
 wW
-wW
+Wp
 az
 az
 NO
@@ -3891,7 +3903,7 @@ aa
 tg
 Qq
 Fq
-wW
+Wp
 Da
 wW
 Cw
@@ -3921,7 +3933,7 @@ ae
 KJ
 ss
 at
-wW
+Wp
 cd
 wo
 lm
@@ -4013,7 +4025,7 @@ aF
 Mo
 wW
 Iv
-wW
+Wp
 aY
 aY
 az
@@ -4119,7 +4131,7 @@ Dk
 Dk
 aT
 aI
-aI
+yV
 Dk
 bn
 as

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -732,12 +732,31 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "fi" = (
-/obj/item/pickaxe{
-	pixel_y = 6;
-	pixel_x = -4
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/shutters{
+	id = "lpost_privacy_left"
 	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav/listeningstation)
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation/quarters)
+"fl" = (
+/obj/structure/closet/crate/hydroponics{
+	name = "janitorial crate";
+	desc = "All you need to make the station clean."
+	},
+/obj/item/mop,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/soap/syndie,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/c20r{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "fn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -828,13 +847,6 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation)
-"gM" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
 "hb" = (
@@ -963,12 +975,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/telecomms)
 "is" = (
-/obj/effect/turf_decal/stripes/asteroid/corner{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/door/poddoor/shutters{
+	id = "lpost_privacy_left"
 	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -1990,6 +2003,9 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/mineral/ore_redemption{
+	req_access = list(150)
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Cy" = (
@@ -2019,16 +2035,12 @@
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/listeningstation/engineering)
 "DC" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters{
-	id = "lpost_privacy_left"
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation/quarters)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "Ef" = (
 /obj/structure/closet/crate,
 /obj/machinery/firealarm{
@@ -2091,13 +2103,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"Fz" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
 "FB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2294,13 +2299,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
 "Jr" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters{
-	id = "lpost_privacy_left"
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation/quarters)
+/area/ruin/space/has_grav/listeningstation)
 "JQ" = (
 /obj/machinery/power/apc/auto_name/north{
 	req_access = list(150)
@@ -2395,6 +2399,11 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
+"Mc" = (
+/obj/effect/turf_decal/stripes/asteroid/corner,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
 "Mo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2409,17 +2418,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Mv" = (
-/obj/structure/closet/crate/hydroponics{
-	name = "janitorial crate"
-	},
-/obj/item/mop,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/soap/syndie,
-/obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/c20r{
-	pixel_y = -32
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Mw" = (
@@ -2653,6 +2652,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"OY" = (
+/obj/item/pickaxe{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/turf/open/floor/plating/asteroid,
+/area/ruin/space/has_grav/listeningstation)
 "OZ" = (
 /obj/machinery/power/apc/auto_name/north{
 	req_access = list(150)
@@ -2677,10 +2683,8 @@
 	dir = 9
 	},
 /obj/structure/closet/crate/engineering,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/rods/twentyfive,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
@@ -2957,6 +2961,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
+"TO" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "TS" = (
 /obj/machinery/computer/camera_advanced/syndie{
 	dir = 4
@@ -3281,9 +3292,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "YH" = (
-/obj/effect/turf_decal/stripes/asteroid/corner,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -3561,7 +3571,7 @@ NO
 NO
 NO
 NO
-uy
+YH
 uy
 uy
 uy
@@ -3601,7 +3611,7 @@ NO
 NO
 NO
 NO
-fi
+OY
 uy
 uy
 aJ
@@ -3643,10 +3653,10 @@ NO
 uy
 uy
 uy
-YH
-Fz
-Fz
-Fz
+Mc
+Jr
+Jr
+Jr
 NO
 NO
 "}
@@ -3684,9 +3694,9 @@ NO
 uy
 uy
 as
-DC
+fi
 FD
-Jr
+is
 az
 NO
 "}
@@ -3885,9 +3895,9 @@ wW
 Da
 wW
 Cw
+Mv
 hb
 az
-NO
 NO
 "}
 (15,1,1) = {"
@@ -3925,9 +3935,9 @@ XG
 md
 uR
 FV
+Mv
 hA
 as
-oq
 NO
 "}
 (16,1,1) = {"
@@ -3966,8 +3976,8 @@ ai
 wW
 tw
 Mv
+fl
 as
-NO
 NO
 "}
 (17,1,1) = {"
@@ -4164,9 +4174,9 @@ il
 tG
 az
 az
-DC
+fi
 Yt
-Jr
+is
 az
 NO
 "}
@@ -4203,10 +4213,10 @@ js
 Oa
 uQ
 az
-is
-gM
-gM
-gM
+DC
+TO
+TO
+TO
 NO
 NO
 "}

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1268,13 +1268,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
-"ma" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
 "md" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1631,6 +1624,11 @@
 "uy" = (
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
+"uB" = (
+/obj/effect/turf_decal/stripes/asteroid/corner,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
 "uH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable{
@@ -1784,12 +1782,6 @@
 "wW" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"wY" = (
-/obj/effect/turf_decal/stripes/asteroid/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav/listeningstation)
 "xp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2221,13 +2213,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
-"HX" = (
-/obj/item/pickaxe{
-	pixel_y = 6;
-	pixel_x = -4
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav/listeningstation)
 "Ir" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 9
@@ -2609,6 +2594,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"OB" = (
+/obj/item/pickaxe{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/turf/open/floor/plating/asteroid,
+/area/ruin/space/has_grav/listeningstation)
 "OF" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/rationpack,
@@ -3017,6 +3009,13 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
+"Va" = (
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "Vb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
@@ -3230,6 +3229,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"XT" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "Yt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3292,8 +3298,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "YH" = (
-/obj/effect/turf_decal/stripes/asteroid/corner,
-/turf/open/floor/plating/asteroid,
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -3611,7 +3620,7 @@ NO
 NO
 NO
 NO
-HX
+OB
 uy
 uy
 aJ
@@ -3653,10 +3662,10 @@ NO
 uy
 uy
 uy
+uB
 YH
-ma
-ma
-ma
+YH
+YH
 NO
 NO
 "}
@@ -4213,10 +4222,10 @@ js
 Oa
 uQ
 az
-wY
-ab
-ab
-ab
+Va
+XT
+XT
+XT
 NO
 NO
 "}

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1157,6 +1157,7 @@
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/clothing/under/syndicate/camo,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/suppressor,
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "kw" = (
@@ -4303,7 +4304,7 @@ NO
 lq
 NO
 vw
-vw
+aj
 aj
 er
 NO

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -4,8 +4,8 @@
 /area/template_noop)
 "ab" = (
 /obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav)
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "ac" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
@@ -82,7 +82,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "ak" = (
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -130,7 +130,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "az" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -195,8 +195,9 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation/engineering)
 "aJ" = (
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
 "aK" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -358,7 +359,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -505,7 +506,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "bG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -664,7 +665,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "eu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/sink{
@@ -826,7 +827,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "hb" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -842,7 +843,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "hk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1101,6 +1102,9 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"jw" = (
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/listeningstation)
 "jB" = (
 /obj/effect/baseturf_helper/asteroid/airless,
 /turf/closed/wall/rust,
@@ -1144,7 +1148,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "kv" = (
 /obj/structure/closet/syndicate{
 	req_access_txt = "150"
@@ -1238,7 +1242,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "lG" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -1306,10 +1310,6 @@
 /obj/item/storage/firstaid/emergency,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
-"nv" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
 "nG" = (
 /obj/machinery/vending/hydronutrients{
 	default_price = 0;
@@ -1343,7 +1343,7 @@
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "oq" = (
 /turf/closed/mineral/gibtonite,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "ou" = (
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -1614,13 +1614,16 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"uy" = (
+/turf/open/floor/plating/asteroid,
+/area/ruin/space/has_grav/listeningstation)
 "uH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "uP" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -1664,7 +1667,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "vx" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -1831,6 +1834,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/listeningstation/hallway)
+"yI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north{
+	req_access = list(150)
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav/listeningstation)
 "yN" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/telecomms)
@@ -1840,7 +1855,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "yQ" = (
 /turf/closed/wall/r_wall/rust,
 /area/ruin/space/has_grav/listeningstation/telecomms)
@@ -1931,13 +1946,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "AE" = (
 /obj/structure/grille,
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "By" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2129,7 +2144,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation/engineering)
+/area/ruin/space/has_grav/listeningstation)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 9
@@ -2393,7 +2408,7 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Mw" = (
 /turf/open/floor/plating/asteroid/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "MF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -2490,7 +2505,7 @@
 /area/ruin/space/has_grav/listeningstation/hallway)
 "NO" = (
 /turf/closed/mineral/random,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "NS" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small{
@@ -3246,7 +3261,7 @@
 "YH" = (
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav)
+/area/ruin/space/has_grav/listeningstation)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 8
@@ -3478,9 +3493,9 @@ NO
 NO
 NO
 NO
-aJ
-aJ
-aJ
+uy
+uy
+uy
 NO
 NO
 aa
@@ -3518,10 +3533,10 @@ NO
 NO
 NO
 YH
-aJ
-aJ
-aJ
-aJ
+uy
+uy
+uy
+uy
 NO
 NO
 aa
@@ -3557,12 +3572,12 @@ NO
 NO
 NO
 NO
+uy
+uy
+uy
 aJ
-aJ
-aJ
-ab
-aJ
-aJ
+uy
+uy
 NO
 aa
 "}
@@ -3596,13 +3611,13 @@ NO
 NO
 NO
 NO
+uy
+uy
+uy
+uy
 aJ
 aJ
 aJ
-aJ
-ab
-ab
-ab
 NO
 NO
 "}
@@ -3637,8 +3652,8 @@ as
 as
 oq
 NO
-aJ
-aJ
+uy
+uy
 as
 fi
 FD
@@ -4160,9 +4175,9 @@ Oa
 uQ
 az
 Mw
-nv
-nv
-nv
+ab
+ab
+ab
 NO
 NO
 "}
@@ -4201,7 +4216,7 @@ Tv
 as
 Mw
 Mw
-nv
+ab
 ay
 bF
 AE
@@ -4428,8 +4443,8 @@ Mw
 NO
 NO
 NO
-NO
-lq
+jw
+yI
 NO
 NO
 NO

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -646,6 +646,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "ed" = (
@@ -1262,6 +1268,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
+"ma" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
 "md" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1771,6 +1784,12 @@
 "wW" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"wY" = (
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav/listeningstation)
 "xp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2202,6 +2221,13 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
+"HX" = (
+/obj/item/pickaxe{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/turf/open/floor/plating/asteroid,
+/area/ruin/space/has_grav/listeningstation)
 "Ir" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 9
@@ -3250,6 +3276,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "YD" = (
@@ -3260,7 +3292,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "YH" = (
-/obj/item/pickaxe,
+/obj/effect/turf_decal/stripes/asteroid/corner,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
 "Zh" = (
@@ -3298,6 +3330,12 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "lpost_warehouse"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/warehouse)
@@ -3533,7 +3571,7 @@ NO
 NO
 NO
 NO
-YH
+uy
 uy
 uy
 uy
@@ -3573,7 +3611,7 @@ NO
 NO
 NO
 NO
-uy
+HX
 uy
 uy
 aJ
@@ -3615,10 +3653,10 @@ NO
 uy
 uy
 uy
-uy
-aJ
-aJ
-aJ
+YH
+ma
+ma
+ma
 NO
 NO
 "}
@@ -4175,7 +4213,7 @@ js
 Oa
 uQ
 az
-Mw
+wY
 ab
 ab
 ab

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -732,16 +732,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "fi" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lpost_privacy_left"
+/obj/item/pickaxe{
+	pixel_y = 6;
+	pixel_x = -4
 	},
-/obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation/quarters)
+/turf/open/floor/plating/asteroid,
+/area/ruin/space/has_grav/listeningstation)
 "fn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -832,6 +828,13 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
+"gM" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
 "hb" = (
@@ -960,13 +963,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/telecomms)
 "is" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lpost_privacy_right"
+/obj/effect/turf_decal/stripes/asteroid/corner{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation/quarters)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/listeningstation)
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -1624,11 +1626,6 @@
 "uy" = (
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
-"uB" = (
-/obj/effect/turf_decal/stripes/asteroid/corner,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
 "uH" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable{
@@ -2023,8 +2020,8 @@
 /area/ruin/space/has_grav/listeningstation/engineering)
 "DC" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lpost_privacy_right"
+/obj/machinery/door/poddoor/shutters{
+	id = "lpost_privacy_left"
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -2094,6 +2091,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"Fz" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation)
 "FB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2105,7 +2109,7 @@
 /area/ruin/space/has_grav/listeningstation/hallway)
 "FD" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/door/poddoor/shutters{
 	id = "lpost_privacy_left"
 	},
 /obj/structure/cable{
@@ -2291,7 +2295,7 @@
 /area/ruin/space/has_grav/listeningstation/engineering)
 "Jr" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
+/obj/machinery/door/poddoor/shutters{
 	id = "lpost_privacy_left"
 	},
 /obj/structure/cable,
@@ -2594,13 +2598,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"OB" = (
-/obj/item/pickaxe{
-	pixel_y = 6;
-	pixel_x = -4
-	},
-/turf/open/floor/plating/asteroid,
-/area/ruin/space/has_grav/listeningstation)
 "OF" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/rationpack,
@@ -3009,13 +3006,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
-"Va" = (
-/obj/effect/turf_decal/stripes/asteroid/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation)
 "Vb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donkpockets,
@@ -3229,17 +3219,10 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"XT" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/listeningstation)
 "Yt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lpost_privacy_right"
+/obj/machinery/door/poddoor/shutters{
+	id = "lpost_privacy_left"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3298,10 +3281,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "YH" = (
+/obj/effect/turf_decal/stripes/asteroid/corner,
 /obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "Zh" = (
@@ -3620,7 +3601,7 @@ NO
 NO
 NO
 NO
-OB
+fi
 uy
 uy
 aJ
@@ -3662,10 +3643,10 @@ NO
 uy
 uy
 uy
-uB
 YH
-YH
-YH
+Fz
+Fz
+Fz
 NO
 NO
 "}
@@ -3703,7 +3684,7 @@ NO
 uy
 uy
 as
-fi
+DC
 FD
 Jr
 az
@@ -4185,7 +4166,7 @@ az
 az
 DC
 Yt
-is
+Jr
 az
 NO
 "}
@@ -4222,10 +4203,10 @@ js
 Oa
 uQ
 az
-Va
-XT
-XT
-XT
+is
+gM
+gM
+gM
 NO
 NO
 "}

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -194,6 +194,9 @@
 "aI" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/listeningstation/engineering)
+"aJ" = (
+/turf/open/floor/plating/asteroid,
+/area/ruin/unpowered)
 "aK" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -3238,7 +3241,11 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "YH" = (
 /obj/item/pickaxe,
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/asteroid,
+/area/ruin/unpowered)
+"Zg" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "Zh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -3471,9 +3478,9 @@ NO
 NO
 NO
 NO
-Mw
-Mw
-Mw
+aJ
+aJ
+aJ
 NO
 NO
 aa
@@ -3511,10 +3518,10 @@ NO
 NO
 NO
 YH
-Mw
-Mw
-Mw
-Mw
+aJ
+aJ
+aJ
+aJ
 NO
 NO
 aa
@@ -3550,12 +3557,12 @@ NO
 NO
 NO
 NO
-Mw
-Mw
-Mw
-ab
-Mw
-Mw
+aJ
+aJ
+aJ
+Zg
+aJ
+aJ
 NO
 aa
 "}
@@ -3589,13 +3596,13 @@ NO
 NO
 NO
 NO
-Mw
-Mw
-Mw
-Mw
-ab
-ab
-ab
+aJ
+aJ
+aJ
+aJ
+Zg
+Zg
+Zg
 NO
 NO
 "}
@@ -3630,8 +3637,8 @@ as
 as
 oq
 NO
-Mw
-Mw
+aJ
+aJ
 as
 fi
 FD

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -424,7 +424,7 @@
 //SYNDICATE LISTENING POST STATION
 
 /area/ruin/space/has_grav/listeningstation
-	name = "Listening Post"
+	name = "Unidentified Asteroid"
 	icon_state = "yellow"
 
 /area/ruin/space/has_grav/listeningstation/telecomms

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -179,3 +179,11 @@
 	sheet_type = /obj/item/stack/tile/bronze
 	sheet_amount = 2
 	girder_type = /obj/structure/girder/bronze
+
+/turf/closed/wall/explosive
+	desc = "A huge chunk of metal used to seperate rooms. This one smells of gunpowder."
+
+/turf/closed/wall/explosive/ex_act(severity)
+	var/obj/item/bombcore/large/bombcore = new(get_turf(src))
+	bombcore.detonate()
+	..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -28,6 +28,7 @@
 	/obj/structure/falsewall,
 	/obj/structure/falsewall/brass,
 	/obj/structure/falsewall/reinforced,
+	/turf/closed/wall/explosive
 	/turf/closed/wall/rust,
 	/turf/closed/wall/r_wall/rust,
 	/turf/closed/wall/clockwork)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -28,7 +28,7 @@
 	/obj/structure/falsewall,
 	/obj/structure/falsewall/brass,
 	/obj/structure/falsewall/reinforced,
-	/turf/closed/wall/explosive
+	/turf/closed/wall/explosive,
 	/turf/closed/wall/rust,
 	/turf/closed/wall/r_wall/rust,
 	/turf/closed/wall/clockwork)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

fixes a wire, suppressors are no longer lost in shipping
mannitol bottle for interrogating people after killing them (a use for the MMI)
warning lines on the windows
the asteroid has a new area (just the original base Listening Post area with an APC)
the left comms agent's cave is an air pocket and has a pickaxe embedded in the wall instead of not
warehouse shutters have warning lines
waste injector is now powered by roid APC
the roid APC is meant specifically for building 'gimmick' areas in the left side of the roid
adds ORM to crew quarters maint
adds explosive regular walls, which explode
crew quarters shutters are closed by default
they now get some mesons as well in a tool closet in engi, as well as their toolboxes being moved there


:cl:  
rscadd: the listening post has managed to successfully order its suppressors this time also a few other things
rscadd: in fact a lot of changes
rscadd: there are now 'regular' explosive walls instead of just plastitanium, for mappers to use when they need to give a self-destruct bomb more oomph without plastitanium walls everywhere _**(these can be identified by examine text as they will smell of gunpowder)**_
/:cl:
