### PR TITLE
Gives CE unique HUD glasses like all the other heads

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -107,6 +107,24 @@
 	flash_protect = 1
 	tint = 1
 
+/obj/item/clothing/glasses/meson/sunglasses/ce
+	name = "advanced engineering sunglasses"
+	desc = "A meson scanner, diagnostic HUD, and reactive welding shield built into a pair of sunglasses."
+	flash_protect = 2 // welding moment
+	var/hud_type = DATA_HUD_DIAGNOSTIC_BASIC
+
+/obj/item/clothing/glasses/meson/sunglasses/ce/equipped(mob/living/carbon/human/user, slot)
+	..()
+	if(slot == SLOT_GLASSES)
+		var/datum/atom_hud/H = GLOB.huds[hud_type]
+		H.show_to(user)
+
+/obj/item/clothing/glasses/meson/sunglasses/ce/dropped(mob/living/carbon/human/user)
+	. = ..()
+	if(istype(user) && user.glasses == src)
+		var/datum/atom_hud/H = GLOB.huds[hud_type]
+		H.hide_from(user)
+
 /obj/item/clothing/glasses/science
 	name = "science goggles"
 	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -64,7 +64,7 @@
 	head = /obj/item/clothing/head/hardhat/white
 	gloves = /obj/item/clothing/gloves/color/black
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1) //yogs - removes eng budget
-	glasses = /obj/item/clothing/glasses/meson/sunglasses
+	glasses = /obj/item/clothing/glasses/meson/sunglasses/ce
 
 	backpack = /obj/item/storage/backpack/industrial
 	satchel = /obj/item/storage/backpack/satchel/eng


### PR DESCRIPTION
# Document the changes in your pull request

Captain and HoP get personnel HUD, HoS gets security and medical HUD, RD gets a diagnostic and reagent HUD, CMO gets medical and reagent HUD, CE gets..... ?????

This gives the CE special HUD glasses like all the other heads do: meson sunglasses with a diagnostic HUD.

# Changelog

:cl:  
tweak: CE sunglasses have diagnostic HUD now
/:cl:
