### PR TITLE
Makes healium actually useful

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -95,10 +95,16 @@
 	if(!removed)
 		return
 
-	var/proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 12 moles at a time.
-	removed.adjust_moles(/datum/gas/water_vapor, -proportion)
-	removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
-	removed.adjust_moles(/datum/gas/hydrogen, proportion)
+	var/proportion = 0
+	if(removed.get_moles(/datum/gas/water_vapor))
+		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 12 moles at a time.
+		removed.adjust_moles(/datum/gas/water_vapor, -proportion)
+		removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
+		removed.adjust_moles(/datum/gas/hydrogen, proportion)
+	if(removed.get_moles(/datum/gas/hypernoblium))
+		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 4 moles at a time
+		removed.adjust_moles(/datum/gas/hypernoblium, -proportion)
+		removed.adjust_moles(/datum/gas/antinoblium, proportion)
 	env.merge(removed) //put back the new gases in the turf
 	air_update_turf()
 
@@ -112,7 +118,8 @@
 			working = FALSE
 	else
 		active_power_usage = (5 * proportion) / (efficiency + workingPower)
-		cell.give(charge_rate)
+		if(cell)
+			cell.give(charge_rate)
 
 	if(!working)
 		return PROCESS_KILL

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -95,16 +95,10 @@
 	if(!removed)
 		return
 
-	var/proportion = 0
-	if(removed.get_moles(/datum/gas/water_vapor))
-		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 12 moles at a time.
-		removed.adjust_moles(/datum/gas/water_vapor, -proportion)
-		removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
-		removed.adjust_moles(/datum/gas/hydrogen, proportion)
-	if(removed.get_moles(/datum/gas/hypernoblium))
-		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 4 moles at a time
-		removed.adjust_moles(/datum/gas/hypernoblium, -proportion)
-		removed.adjust_moles(/datum/gas/antinoblium, proportion)
+	var/proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 12 moles at a time.
+	removed.adjust_moles(/datum/gas/water_vapor, -proportion)
+	removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
+	removed.adjust_moles(/datum/gas/hydrogen, proportion)
 	env.merge(removed) //put back the new gases in the turf
 	air_update_turf()
 
@@ -118,8 +112,7 @@
 			working = FALSE
 	else
 		active_power_usage = (5 * proportion) / (efficiency + workingPower)
-		if(cell)
-			cell.give(charge_rate)
+		cell.give(charge_rate)
 
 	if(!working)
 		return PROCESS_KILL

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -22,6 +22,7 @@
 	name = "Healium crystal"
 	desc = "A crystal made from the Healium gas, it's cold to the touch."
 	icon_state = "healium_crystal"
+	grind_results = list(/datum/reagent/healium = 20)
 	///Amount of stamina damage mobs will take if in range
 	var/stamina_damage = 30
 	///Range of the grenade that will cool down and affect mobs

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -252,12 +252,10 @@
 			reagent_transfer += 0.5 * delta_time
 			if(reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
 				reagent_transfer = 0
-		if(air1.get_moles(/datum/gas/healium) > 5) //healium check, if theres enough we get some extra healing from our favorite pink gas.
-			mob_occupant.adjustBruteLoss(-5) //healium healing factor from lungs, occupant should be asleep.
-			mob_occupant.adjustToxLoss(-5)
-			mob_occupant.adjustFireLoss(-7)
-			air1.adjust_moles(/datum/gas/healium, -max(0,air1.get_moles(/datum/gas/oxygen) - 2 / efficiency))
-
+		if(air1.get_moles(/datum/gas/healium) > 1) //healium check, if theres enough we get some extra healing from our favorite pink gas.
+			var/existing = mob_occupant.reagents.get_reagent_amount(/datum/reagent/healium)
+			mob_occupant.reagents.add_reagent(/datum/reagent/healium, 1 - existing)
+			air1.set_moles(/datum/gas/healium, max(0, air1.get_moles(/datum/gas/healium) - 0.1 / efficiency))
 	return 1
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1439,17 +1439,33 @@
 
 /datum/reagent/healium/on_mob_metabolize(mob/living/L)
 	. = ..()
-	L.SetSleeping(1000, ignore_canstun = TRUE)
-	L.SetUnconscious(1000, ignore_canstun = TRUE)
+	L.SetSleeping(1000)
+	L.SetUnconscious(1000)
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.5, blacklisted_movetypes=(FLYING|FLOATING)) // slowdown for if you're awake
+	ADD_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
 
 /datum/reagent/healium/on_mob_life(mob/living/carbon/M)
-	M.SetSleeping(1000, ignore_canstun = TRUE)
-	M.SetUnconscious(1000, ignore_canstun = TRUE) //in case you have sleep immunity :^)
+	M.SetSleeping(100)
+	M.SetUnconscious(100)
+	var/heal_factor = 1
+	if(M.stat == CONSCIOUS) // if you're awake it gives you side effects and heals a lot less (not enough to outheal nitrium)
+		heal_factor *= 0.1
+		M.adjust_disgust((40 - M.disgust) / 10) // makes you sick
+		M.adjust_jitter_up_to(2, 10)
+		if(M.getStaminaLoss() > 0)
+			heal_factor *= (max(M.maxHealth - M.getStaminaLoss(), 0) / M.maxHealth) // having stamina damage reduces the healing
+	else if(M.bodytemperature < T0C)
+		heal_factor *= (100 + max(T0C - M.bodytemperature, 200)) / 100 // if you're asleep, you get healed faster when you're cold (up to 3x at 73 kelvin)
+	M.adjustFireLoss(-7*heal_factor*REM)
+	M.adjustToxLoss(-5*heal_factor*REM)
+	M.adjustBruteLoss(-5*heal_factor*REM)
 	..()
 
 /datum/reagent/healium/on_mob_end_metabolize(mob/living/L)
 	L.SetSleeping(10, ignore_canstun = TRUE)
 	L.SetUnconscious(10, ignore_canstun = TRUE)
+	L.remove_movespeed_modifier(type)
+	REMOVE_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
 	return ..()
 
 /datum/reagent/halon

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1462,8 +1462,8 @@
 	..()
 
 /datum/reagent/healium/on_mob_end_metabolize(mob/living/L)
-	L.SetSleeping(10, ignore_canstun = TRUE)
-	L.SetUnconscious(10, ignore_canstun = TRUE)
+	L.SetSleeping(1 SECONDS)
+	L.SetUnconscious(1 SECONDS)
 	L.remove_movespeed_modifier(type)
 	REMOVE_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1452,8 +1452,6 @@
 		heal_factor *= 0.1
 		M.adjust_disgust((40 - M.disgust) / 10) // makes you sick
 		M.adjust_jitter_up_to(2, 10)
-		if(M.getStaminaLoss() > 0)
-			heal_factor *= (max(M.maxHealth - M.getStaminaLoss(), 0) / M.maxHealth) // having stamina damage reduces the healing
 	else if(M.bodytemperature < T0C)
 		heal_factor *= (100 + max(T0C - M.bodytemperature, 200)) / 100 // if you're asleep, you get healed faster when you're cold (up to 3x at 73 kelvin)
 	M.adjustFireLoss(-7*heal_factor*REM)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -310,15 +310,10 @@
 		breath.adjust_moles(/datum/gas/freon, -gas_breathed)
 
 	// Healium
-		REMOVE_TRAIT(H, TRAIT_SURGERY_PREPARED, "healium")
 		var/healium_pp = breath.get_breath_partial_pressure(breath.get_moles(/datum/gas/healium))
 		if(healium_pp > SA_sleep_min)
 			var/existing = H.reagents.get_reagent_amount(/datum/reagent/healium)
-			ADD_TRAIT(H, TRAIT_SURGERY_PREPARED, "healium")
 			H.reagents.add_reagent(/datum/reagent/healium,max(0, 1*eff - existing))
-			H.adjustFireLoss(-7)
-			H.adjustToxLoss(-5)
-			H.adjustBruteLoss(-5)
 		gas_breathed = breath.get_moles(/datum/gas/healium)
 		if(gas_breathed > gas_stimulation_min && !helium_speech)
 			helium_speech = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Healium no longer bypasses anti-sleep effects, instead if you're awake it will heal significantly less and cause jittering, disgust, and slowdown. However if you ARE asleep, you get healed faster depending on how cold you are, making it actually worth using in cryo and giving atmos a reason to supply medbay with some. Also, grinding healium crystals will actually make healium.

# Changelog

:cl:  
tweak: healium is actually useful now
tweak: grinding healium crystals makes healium
/:cl:
