### PR TITLE
Morphine heals in crit and when asleep now

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -757,6 +757,10 @@
 		if(24 to INFINITY)
 			M.Sleeping(40, 0)
 			. = 1
+	if(M.stat > CONSCIOUS)
+		M.adjustBruteLoss(-1*REM)
+		M.adjustFireLoss(-1*REM)
+		M.adjustOxyLoss(-1*REM)
 	..()
 
 /datum/reagent/medicine/morphine/overdose_process(mob/living/M)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Morphine will heal 1 brute, burn and oxy damage per tick now, either when the patient is asleep or in critical condition, largely negating its use for combat and generally being a bit more practical for stuff like surgery.

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Morphine heals in crit or when you're asleep 

/:cl:
