### PR TITLE
Makes some EMP options more worth their "cost"

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -501,8 +501,8 @@
 /obj/item/bombcore/emp
 	name = "EMP payload"
 	desc = "A set of superconducting electromagnetic coils designed to release a powerful pulse to destroy electronics and scramble circuits"
-	range_heavy = 15
-	range_medium = 25
+	range_heavy = 30
+	range_medium = 50
 
 /obj/item/bombcore/emp/detonate()
 	if(adminlog)

--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -6,5 +6,5 @@
 
 /obj/item/grenade/empgrenade/prime()
 	update_mob()
-	empulse(src, 4, 10)
+	empulse(src, 10, 20)
 	qdel(src)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -119,9 +119,10 @@
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	// 200 created volume = 16 heavy range & 28 light range. 12 tiles larger than traitor EMP grenades. This is the maximum
-	created_volume = min(created_volume, 200)
+	// 100 created volume = 8 heavy range & 14 light range. 8 tiles smaller than traitor EMP grenades.
+	// 200 created volume = 16 heavy range & 28 light range. 14 tiles larger than traitor EMP grenades.
+	// 300 created volume = 25 heavy range & 42 light range. only attainable using bluespace beaker grenades. This is the maximum
+	created_volume = min(created_volume, 300)
 	empulse(location, round(created_volume / 12), round(created_volume / 7), 1)
 	holder.clear_reagents()
 


### PR DESCRIPTION
My problem with the emp chemical reaction is two-fold
-The traitor grenades are significantly weaker despite costing TC
-The cap is such that proper chemistry grenades aren't that much stronger than shitty beaker mixing

i tried solving both by reducing the size of the reaction emp
that was greatly disapproved so instead i'm doing the opposite

:cl:  
tweak: Maximum reagent size for EMP chemistry EMPs increased from 200u to 300u
tweak: Traitor EMP grenades are about twice the size
tweak: EMP syndiebombcore EMPs in twice the size
/:cl:
