### PR TITLE
EMPs do reduced damage to already damaged positronic brains

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -262,7 +262,11 @@
 	if(prob(25))
 		return
 
-	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 50/severity)
+	var/obj/item/clothing/head/foilhat/hat = owner.get_item_by_slot(SLOT_HEAD)
+	if(hat && istype(hat))
+		return
+
+	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, (50/severity) * (maxHealth - damage) / maxHealth)
 	owner.adjust_drugginess(40/severity)
 	switch(severity)
 		if(1)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -262,8 +262,8 @@
 	if(prob(25))
 		return
 
-	var/obj/item/clothing/head/foilhat/hat = owner.get_item_by_slot(SLOT_HEAD)
-	if(hat && istype(hat))
+	var/obj/item/clothing/head/hat = owner.get_item_by_slot(SLOT_HEAD)
+	if(hat && istype(hat, /obj/item/clothing/head/foilhat))
 		return
 
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, (50/severity) * (maxHealth - damage) / maxHealth)


### PR DESCRIPTION
# Document the changes in your pull request

IPCs will take less brain damage from EMPs if they already have a lot of brain damage already. Also wearing a tin foil hat can prevent the damage now.

# Changelog


:cl:  
tweak: EMPs do reduced damage to already damaged IPC brains
tweak: tinfoil hat protects brain from EMP
/:cl:
