### PR TITLE
Hypospray QoL fixes

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -463,6 +463,7 @@
 						"black vial" = "vial_black"
 						)
 	possible_transfer_amounts = list(5, 10, 15)
+	spillable = FALSE
 	volume = 15
 	disease_amount = 15
 	/// Name that used as the base for pen renaming, so subtypes can have different names without having to worry about messing with it

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -84,7 +84,7 @@
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
 	else if(reagents.total_volume)
-		if(user.a_intent == INTENT_HARM)
+		if(user.a_intent == INTENT_HARM && !istype(target, /obj/item/hypospray))
 			user.visible_message(span_danger("[user] splashes the contents of [src] onto [target]!"), \
 								span_notice("You splash the contents of [src] onto [target]."))
 			reagents.reaction(target, TOUCH)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -84,7 +84,7 @@
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
 	else if(reagents.total_volume)
-		if(user.a_intent == INTENT_HARM && !istype(target, /obj/item/hypospray))
+		if(user.a_intent == INTENT_HARM)
 			user.visible_message(span_danger("[user] splashes the contents of [src] onto [target]!"), \
 								span_notice("You splash the contents of [src] onto [target]."))
 			reagents.reaction(target, TOUCH)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -362,11 +362,12 @@
 		return
 
 /obj/item/hypospray/attackby(obj/item/I, mob/living/user)
+	var/quickloading = FALSE
 	if((istype(I, /obj/item/reagent_containers/glass/bottle/vial) && container != null))
 		if(!quickload)
 			to_chat(user, span_warning("[src] can not hold more than one container!"))
 			return FALSE
-		unload_hypo(user)
+		quickloading = TRUE
 	if(I.w_class <= max_container_size)
 		var/obj/item/reagent_containers/glass/bottle/vial/V = I
 		if(!is_type_in_list(V, allowed_containers))
@@ -374,6 +375,8 @@
 			return FALSE
 		if(!user.transferItemToLoc(V,src))
 			return FALSE
+		if(quickloading)
+			unload_hypo(user)
 		container = V
 		user.visible_message(span_notice("[user] has loaded [container] into [src]."),span_notice("You have loaded [container] into [src]."))
 		update_icon()


### PR DESCRIPTION
# Document the changes in your pull request

Hypospray quickload actually swaps the vials properly instead of dropping to the ground, and trying to load one on harm intent no longer deletes the reagents in the vial

# Changelog

:cl:  
bugfix: hypospray quickload actually swaps the vials instead of dropping one onto the floor
bugfix: trying to load a hypospray on harm intent no longer deletes the vial's contents
/:cl:
