### PR TITLE
[box] replaces arrivals checker tiles with white decals

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -10011,13 +10011,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bkZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "blb" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -10815,10 +10808,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"bsq" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "bsF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -12501,21 +12490,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bEx" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals North";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "bEC" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -14100,6 +14074,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"bUk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bUs" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
@@ -14974,19 +14959,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cfH" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/hallway/secondary/entry)
 "cfI" = (
 /obj/structure/table/reinforced,
 /obj/item/paper,
@@ -15289,18 +15261,6 @@
 /obj/machinery/bounty_board,
 /turf/closed/wall,
 /area/engine/engineering)
-"ckO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "ckQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/bar";
@@ -20445,6 +20405,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"dZi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eaw" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -25518,6 +25485,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fXm" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fXq" = (
 /obj/structure/closet/wardrobe/green,
 /obj/machinery/light{
@@ -29262,6 +29241,10 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hxl" = (
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hxu" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -33492,11 +33475,6 @@
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
 /area/maintenance/fore)
-"jda" = (
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "jdk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -34105,14 +34083,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jrS" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "jrX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -36199,17 +36169,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"knS" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "kou" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Stbd";
@@ -37473,17 +37432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"kQg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "kQr" = (
 /obj/machinery/light{
 	dir = 4
@@ -38438,14 +38386,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lkF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "lld" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -38504,6 +38444,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"llv" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals North";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "llx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -39221,6 +39177,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lAk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lAB" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -39462,6 +39425,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lGB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lGF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42662,6 +42632,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"mSx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mSL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -44385,6 +44362,18 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/atmos/mix)
+"nDd" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nDj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -44667,12 +44656,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"nJw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "nJB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -46873,18 +46856,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oDv" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "oDy" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/window/reinforced{
@@ -48862,12 +48833,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"puZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
 "pvf" = (
 /obj/machinery/status_display/ai{
 	pixel_x = -32
@@ -49541,6 +49506,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pHd" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "pHL" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
@@ -50190,11 +50168,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"pWW" = (
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
-/area/hallway/secondary/entry)
 "pXe" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -50971,6 +50944,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qms" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qnm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -53503,16 +53486,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rpY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "rqi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -54401,12 +54374,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"rJm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "rJo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -54744,9 +54711,6 @@
 "rPO" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/hallway)
-"rPT" = (
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "rRe" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -55035,6 +54999,15 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rWr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rWs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -57736,6 +57709,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"tea" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "teq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57880,6 +57858,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tha" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -59010,6 +58994,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tEZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tFM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -59401,12 +59394,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"tNQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "tNU" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -63701,6 +63688,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vzJ" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vAd" = (
 /obj/structure/chair{
 	dir = 8;
@@ -64639,6 +64640,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"vSy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "vTi" = (
 /obj/item/shard,
 /obj/structure/disposalpipe/segment{
@@ -65552,15 +65561,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"wkt" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/entry)
 "wkE" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -66326,6 +66326,12 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"wBN" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wCs" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -66503,6 +66509,19 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai)
+"wHe" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wHf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80445,7 +80464,7 @@ apN
 apN
 apN
 apJ
-jrS
+rWr
 ieh
 mnb
 bgi
@@ -80461,7 +80480,7 @@ aSm
 aSm
 mnb
 hlb
-bsq
+tea
 beq
 aaa
 aaa
@@ -80469,7 +80488,7 @@ aaa
 aaa
 aaa
 beq
-jrS
+rWr
 qwF
 mnb
 bgi
@@ -80702,7 +80721,7 @@ apN
 apN
 apN
 apJ
-jda
+tha
 gEt
 bAX
 arB
@@ -80718,7 +80737,7 @@ eiX
 dMJ
 nGg
 qCq
-rPT
+hxl
 aSm
 aaa
 aaa
@@ -80726,7 +80745,7 @@ aaa
 aaa
 aaa
 aSm
-jda
+tha
 jWz
 kzb
 arB
@@ -80959,7 +80978,7 @@ apN
 apN
 apN
 apJ
-nJw
+lGB
 rRe
 mnb
 asE
@@ -80975,7 +80994,7 @@ aSm
 asE
 mnb
 fkk
-tNQ
+mSx
 aSm
 aaa
 aaa
@@ -80983,7 +81002,7 @@ aaa
 aaa
 aaa
 aSm
-nJw
+lGB
 rRe
 mnb
 asE
@@ -81216,7 +81235,7 @@ apN
 apN
 apN
 apJ
-jda
+tha
 sjg
 buZ
 bBI
@@ -81232,7 +81251,7 @@ aSm
 dOh
 buZ
 toz
-rPT
+hxl
 aSm
 aaa
 aaa
@@ -81240,7 +81259,7 @@ aaa
 aaa
 aaa
 aSm
-jda
+tha
 iBD
 buZ
 bBI
@@ -81473,7 +81492,7 @@ apN
 apN
 apN
 apJ
-jda
+tha
 qOw
 ayl
 aEa
@@ -81489,7 +81508,7 @@ aSm
 dOS
 ayl
 hmO
-rPT
+hxl
 aSm
 aaa
 aaa
@@ -81497,7 +81516,7 @@ aaa
 aaa
 aaa
 aSm
-jda
+tha
 hmO
 ayl
 aEa
@@ -81730,7 +81749,7 @@ apN
 apN
 apN
 apJ
-jda
+tha
 qOw
 ayl
 dsT
@@ -81746,7 +81765,7 @@ aSm
 qOB
 ayl
 hmO
-rPT
+hxl
 aSm
 aaa
 aaa
@@ -81754,7 +81773,7 @@ aaa
 aaa
 aaa
 aSm
-jda
+tha
 hmO
 ayl
 ygp
@@ -81987,7 +82006,7 @@ apN
 apN
 apN
 apJ
-puZ
+lAk
 bqi
 bvB
 bBJ
@@ -82003,7 +82022,7 @@ aSm
 dQG
 eGB
 upt
-rJm
+dZi
 aSm
 aaa
 aaa
@@ -82011,7 +82030,7 @@ aaa
 aaa
 aaa
 aSm
-puZ
+lAk
 bqi
 bvB
 liu
@@ -82244,7 +82263,7 @@ apN
 apN
 apN
 apJ
-knS
+fXm
 gce
 mnb
 asE
@@ -82260,7 +82279,7 @@ aSm
 asE
 mnb
 cVx
-wkt
+qms
 aSm
 aaa
 aaa
@@ -82268,7 +82287,7 @@ aaa
 aaa
 aaa
 aSm
-knS
+fXm
 dau
 mnb
 asE
@@ -82501,7 +82520,7 @@ asF
 asF
 asF
 apJ
-jrS
+rWr
 gEt
 bAX
 eUi
@@ -82517,7 +82536,7 @@ eiX
 aOe
 nGg
 qCq
-rPT
+hxl
 aSm
 aaa
 aaa
@@ -82525,7 +82544,7 @@ hef
 aaa
 aaa
 aSm
-jda
+tha
 gEt
 kBu
 eUi
@@ -82758,7 +82777,7 @@ eiR
 ndl
 bBv
 vEv
-bkZ
+vSy
 kIl
 mnb
 bgi
@@ -82774,7 +82793,7 @@ aSm
 aSm
 mnb
 hlb
-bsq
+tea
 beq
 aaa
 gIj
@@ -82782,7 +82801,7 @@ hgK
 aSm
 aaa
 beq
-jrS
+rWr
 ieh
 mnb
 bgi
@@ -83031,7 +83050,7 @@ aaa
 aSm
 tqk
 rWA
-tNQ
+mSx
 beq
 aSm
 aSm
@@ -83039,7 +83058,7 @@ hhC
 asE
 aSm
 beq
-jda
+tha
 iBD
 azA
 aSm
@@ -83288,7 +83307,7 @@ beq
 beq
 eHU
 hmO
-pWW
+wBN
 asE
 bBI
 mnb
@@ -83787,14 +83806,14 @@ bay
 bbS
 kBR
 dPr
-ckO
-lkF
-oDv
-kQg
-bEx
-rpY
-lkF
-cfH
+wHe
+tEZ
+pHd
+nDd
+llv
+bUk
+tEZ
+vzJ
 rbR
 tMO
 cZT


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://github.com/yogstation13/Yogstation/assets/5091394/21cae654-29d7-4121-99f9-6a9d2459a9d1)

replaces these with decals so those floor sprites can eventually be removed with the new floor additions

# Wiki Documentation

# Changelog

:cl:  
mapping: box arrivals checkerboard floors now use decals
/:cl:
