### PR TITLE
Removes the desword from the traitor uplink (again)

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -412,7 +412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/twohanded/dualsaber
 	player_minimum = 25
 	cost = 16
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/doublesword/get_discount()
 	return pick(4;0.8,2;0.65,1;0.5)


### PR DESCRIPTION
Desword is now nukie-only because it was REMOVED FOR A REASON and we had to let it reappear to reinforce this idea.

# Changelog

:cl:  

rscdel: Desword removed from the traitor uplink (again)
experimental: Told you so.

/:cl:
