### PR TITLE
Ignore that last PR, i'm merging adrenaline together with determination instead

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -18,6 +18,12 @@
 #define THERMAL_PROTECTION_HAND_LEFT	0.025
 #define THERMAL_PROTECTION_HAND_RIGHT	0.025
 
+#define DETERMINATION_THRESHOLD 25
+
+/mob/living/carbon/human
+	var/lasthealth
+	COOLDOWN_DECLARE(determination_cooldown)
+
 /mob/living/carbon/human/Life(times_fired)
 	set invisibility = 0
 	if (notransform)
@@ -36,6 +42,11 @@
 		if(stat != DEAD)
 			//heart attack stuff
 			handle_heart()
+
+		if(COOLDOWN_FINISHED(src, determination_cooldown) && ((health+DETERMINATION_THRESHOLD) < lasthealth))
+			reagents.add_reagent(/datum/reagent/determination, 5)
+			COOLDOWN_START(src, determination_cooldown, 10 MINUTES)
+		lasthealth = health
 
 		dna.species.spec_life(src) // for mutantraces
 	else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2161,7 +2161,12 @@
 	self_consuming = TRUE
 	/// Whether we've had at least WOUND_DETERMINATION_SEVERE (2.5u) of determination at any given time. No damage slowdown immunity or indication we're having a second wind if it's just a single moderate wound
 	var/significant = FALSE
+	can_synth = FALSE
 
+/datum/reagent/determination/on_mob_metabolize(mob/living/L)
+	. = ..()
+	ADD_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	
 // "Second wind" reagent generated when someone suffers a wound. Epinephrine, adrenaline, and stimulants are all already taken so here we are
 /datum/reagent/determination/on_mob_end_metabolize(mob/living/carbon/M)
 	if(significant)
@@ -2172,6 +2177,7 @@
 		M.adjustStaminaLoss(stam_crash)
 	M.remove_status_effect(STATUS_EFFECT_DETERMINED)
 	..()
+	REMOVE_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 
 /datum/reagent/determination/on_mob_life(mob/living/carbon/M)
 	if(!significant && volume >= WOUND_DETERMINATION_SEVERE)
@@ -2199,20 +2205,6 @@
 /datum/reagent/plaguebacteria/reaction_mob(mob/living/L, method = TOUCH, reac_volume, show_message = TRUE, permeability = 1)
 	if((method == INGEST || method == TOUCH || method == INJECT) && prob(permeability*100)) //permeability is always 1 by default except with touch and vapor
 		L.ForceContractDisease(new /datum/disease/plague(), FALSE, TRUE)
-
-/datum/reagent/adrenaline
-	name = "Adrenaline"
-	description = "Powerful chemical that termporarily makes the user immune to slowdowns"
-	color = "#d1cd9a"
-	can_synth = FALSE
-
-/datum/reagent/adrenaline/on_mob_add(mob/living/L)
-	. = ..()
-	ADD_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
-
-/datum/reagent/adrenaline/on_mob_delete(mob/living/L)
-	. = ..()
-	REMOVE_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 
 /datum/reagent/liquidsoap
 	name = "Liquid soap"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2163,7 +2163,7 @@
 	var/significant = FALSE
 	can_synth = FALSE
 
-/datum/reagent/determination/on_mob_metabolize(mob/living/L)
+/datum/reagent/determination/on_mob_metabolize(mob/living/carbon/M)
 	. = ..()
 	ADD_TRAIT(M, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 	

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2165,7 +2165,7 @@
 
 /datum/reagent/determination/on_mob_metabolize(mob/living/L)
 	. = ..()
-	ADD_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	ADD_TRAIT(M, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 	
 // "Second wind" reagent generated when someone suffers a wound. Epinephrine, adrenaline, and stimulants are all already taken so here we are
 /datum/reagent/determination/on_mob_end_metabolize(mob/living/carbon/M)
@@ -2177,7 +2177,7 @@
 		M.adjustStaminaLoss(stam_crash)
 	M.remove_status_effect(STATUS_EFFECT_DETERMINED)
 	..()
-	REMOVE_TRAIT(L, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
+	REMOVE_TRAIT(M, TRAIT_REDUCED_DAMAGE_SLOWDOWN, type)
 
 /datum/reagent/determination/on_mob_life(mob/living/carbon/M)
 	if(!significant && volume >= WOUND_DETERMINATION_SEVERE)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -22,8 +22,6 @@
 	var/beat = BEAT_NONE//is this mob having a heatbeat sound played? if so, which?
 	var/failed = FALSE		//to prevent constantly running failing code
 	var/operated = FALSE	//whether the heart's been operated on to fix some of its damages
-	var/lasthealth
-	COOLDOWN_DECLARE(adrenal_cooldown)
 
 /obj/item/organ/heart/Initialize()
 	. = ..()
@@ -75,10 +73,6 @@
 		var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
 		var/sound/fastbeat = sound('sound/health/fastbeat.ogg', repeat = TRUE)
 		var/mob/living/carbon/H = owner
-		if(COOLDOWN_FINISHED(src, adrenal_cooldown) && ((H.health+ADRENALINE_THRESHOLD) < lasthealth))
-			H.reagents.add_reagent(/datum/reagent/adrenaline, 5)
-			COOLDOWN_START(src, adrenal_cooldown, 10 MINUTES)
-		lasthealth = H.health
 
 		if(H.health <= H.crit_threshold && beat != BEAT_SLOW)
 			beat = BEAT_SLOW


### PR DESCRIPTION
# reasoning for merging the both

They're two very similar effects, an effect that kicks in while in combat in an attempt to draw the combat out longer
Problem is there's not really a visual indicator for adrenaline so you can never tell
You probably thought determination gave the damage slowdown resistance, nope, it's adrenaline

Adrenaline is the one being removed as it risks sharing it's name with adrenals (which is something else entirely)

The main balance point is that this means getting wounds will give slowdown resistance
and you'll get minor healing to your wounded limbs sometimes even if you didn't just get a new wound

# reasoning for moving "adrenaline" off of the heart
When redmoogle added adrenaline as an interesting way to make fights not end instantly upon taking enough damage to enter slowdown, they put it directly on the heart organ.
While that works, it also means any species without a heart, or someone that otherwise lost their heart without dying simply won't benefit from the mechanic

This change will allow people with vein muscle membrane + no heart to still have adrenaline
as well as plasmamen who have a different organ in place of their heart

however, as adrenaline requires organic reagent processing, IPCs will still not benefit from adrenaline

:cl:  
tweak: Adrenaline no longer requires a heart to generate
tweak: Adrenaline and determination are combined
/:cl:
