### PR TITLE
Possibly fixes dusting leaving invisible corpses

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -6,17 +6,19 @@
 			new /obj/effect/temp_visual/gib_animation(loc, "gibbed-r")
 
 /mob/living/carbon/human/dust(just_ash, drop_items, force)
+	death(TRUE)
+
 	if(drop_items)
 		unequip_everything()
 
 	if(buckled)
 		buckled.unbuckle_mob(src, force = TRUE)
 
-	Stun(100, TRUE, TRUE)//hold them still as they get deleted so they don't fuck up the animation
 	notransform = TRUE
+
 	dust_animation()
-	spawn_dust(just_ash)
-	QDEL_IN(src, 20) // since this is sometimes called in
+	QDEL_IN(src, 2 SECONDS) // since this is sometimes called in
+	addtimer(CALLBACK(src, PROC_REF(spawn_dust), just_ash), 1.5 SECONDS)//spawn the dust after the body disappears
 
 /mob/living/carbon/human/dust_animation()
 	var/obj/effect/dusting_anim/dust_effect = new(loc, ref(src))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -14,8 +14,8 @@
 
 	notransform = TRUE
 
-	dust_animation()
 	QDEL_IN(src, 2 SECONDS) // since this is sometimes called in
+	dust_animation()
 	addtimer(CALLBACK(src, PROC_REF(spawn_dust), just_ash), 1.5 SECONDS)//spawn the dust after the body disappears
 
 /mob/living/carbon/human/dust_animation()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,7 +16,7 @@
 
 	QDEL_IN(src, 2 SECONDS) // since this is sometimes called in
 	dust_animation()
-	addtimer(CALLBACK(src, PROC_REF(spawn_dust), just_ash), 1.5 SECONDS)//spawn the dust after the body disappears
+	spawn_dust(just_ash)
 
 /mob/living/carbon/human/dust_animation()
 	var/obj/effect/dusting_anim/dust_effect = new(loc, ref(src))

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -6,8 +6,6 @@
 			new /obj/effect/temp_visual/gib_animation(loc, "gibbed-r")
 
 /mob/living/carbon/human/dust(just_ash, drop_items, force)
-	death(TRUE)
-
 	if(drop_items)
 		unequip_everything()
 


### PR DESCRIPTION
fucked if i know, i couldn't re-create the bug no matter what form of dusting i used
so i tweaked it so the QDEL_IN part is called before the dust animation to hopefully fix any runtime breaking the proc and not calling QDEL_IN


:cl:  
bugfix: Dusting leaving invisible corpses might be fixed now
/:cl:
