### PR TITLE
Rebrands .357 Nutcracker rounds to FRAG-13

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -13,10 +13,10 @@
 	pellets = 6
 	variance = 20 //Same spread and pellets as buckshot
 
-/obj/item/ammo_casing/a357/nutcracker
-	name = ".357 Nutcracker bullet casing"
-	desc = "A .357 Nutcracker bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/nutcracker
+/obj/item/ammo_casing/a357/frag13
+	name = ".357 FRAG-13 bullet casing"
+	desc = "A .357 FRAG-13 bullet casing."
+	projectile_type = /obj/item/projectile/bullet/a357/frag13
 
 /obj/item/ammo_casing/a357/metalshock
 	name = ".357 Metalshock bullet casing"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -16,12 +16,12 @@
 	icon_state = "357feather"
 	ammo_type = /obj/item/ammo_casing/a357/ironfeather
 
-/obj/item/ammo_box/a357/nutcracker
-	name = "speed loader (.357 Nutcracker)"
+/obj/item/ammo_box/a357/frag13
+	name = "speed loader (.357 FRAG-13)"
 	desc = "A seven-shot speed loader designed for .357 revolver. \
 			These rounds lose moderate stopping power but are capable of destroying doors and windows quickly."
 	icon_state = "357cracker"
-	ammo_type = /obj/item/ammo_casing/a357/nutcracker
+	ammo_type = /obj/item/ammo_casing/a357/frag13
 
 /obj/item/ammo_box/a357/metalshock
 	name = "speed loader (.357 Metalshock)"
@@ -166,9 +166,9 @@
 	name = "ammo box (.357 Ironfeather)"
 	ammo_type = /obj/item/ammo_casing/a357/ironfeather
 
-/obj/item/ammo_box/no_direct/a357/nutcracker
-	name = "ammo box (.357 Nutcracker)"
-	ammo_type = /obj/item/ammo_casing/a357/nutcracker
+/obj/item/ammo_box/no_direct/a357/frag13
+	name = "ammo box (.357 FRAG-13)"
+	ammo_type = /obj/item/ammo_casing/a357/frag13
 
 /obj/item/ammo_box/no_direct/a357/metalshock
 	name = "ammo box (.357 Metalshock)"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -113,8 +113,8 @@
 /obj/item/projectile/bullet/a357/frag13/on_hit(atom/target) //Basically breaching slug with 1.5x damage
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 750 //One shot to break a window, two shots for a door, three if reinforced
-	playsound(loc, get_sfx("explosion"), vol_by_damage(), TRUE, -1, null, get_rand_frequency()) // it explodes guys trust me
-	var/turf/T = get_turf()
+	playsound(loc, get_sfx("explosion"), vol_by_damage(), 1, frequency = get_rand_frequency()) // it explodes guys trust me
+	var/turf/T = get_turf(src)
 	if(T && istype(T))
 		new /obj/effect/hotspot(T)
 	..()

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -106,13 +106,17 @@
 	tile_dropoff = 0.35 //Loses 0.05 damage less per tile than standard damaging pellets
 	wound_falloff_tile = -1.5 //Still probably won't cause wounds at range
 
-/obj/item/projectile/bullet/a357/nutcracker
-	name = ".357 Nutcracker bullet"
+/obj/item/projectile/bullet/a357/frag13
+	name = ".357 FRAG-13 bullet"
 	damage = 30
 
-/obj/item/projectile/bullet/a357/nutcracker/on_hit(atom/target) //Basically breaching slug with 1.5x damage
+/obj/item/projectile/bullet/a357/frag13/on_hit(atom/target) //Basically breaching slug with 1.5x damage
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 750 //One shot to break a window, two shots for a door, three if reinforced
+	playsound(loc, get_sfx("explosion"), vol_by_damage(), 1, frequency = get_rand_frequency()) // it explodes guys trust me
+	var/turf/T = get_turf()
+	if(T && istype(T))
+		new /obj/effect/hotspot(T)
 	..()
 
 /obj/item/projectile/bullet/a357/metalshock

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -113,7 +113,7 @@
 /obj/item/projectile/bullet/a357/frag13/on_hit(atom/target) //Basically breaching slug with 1.5x damage
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 750 //One shot to break a window, two shots for a door, three if reinforced
-	playsound(loc, get_sfx("explosion"), vol_by_damage(), 1, frequency = get_rand_frequency()) // it explodes guys trust me
+	playsound(loc, get_sfx("explosion"), vol_by_damage(), TRUE, -1, null, get_rand_frequency()) // it explodes guys trust me
 	var/turf/T = get_turf()
 	if(T && istype(T))
 		new /obj/effect/hotspot(T)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -969,7 +969,7 @@
 	desc = "A disk containing designs for both standard and non-standard 10mm and .357 bullet designs."
 	icon_state = "datadisk1"
 	var/list/ammo_types = list(/datum/design/c10mm/disk, /datum/design/c10mm/cs/disk, /datum/design/c10mm/sp/disk, /datum/design/c10mm/ap, /datum/design/c10mm/hp, /datum/design/c10mm/inc, /datum/design/c10mm/emp,
-								/datum/design/box_a357/disk, /datum/design/box_a357/ironfeather/disk, /datum/design/box_a357/nutcracker, /datum/design/box_a357/metalshock, /datum/design/box_a357/heartpiercer, /datum/design/box_a357/wallstake)
+								/datum/design/box_a357/disk, /datum/design/box_a357/ironfeather/disk, /datum/design/box_a357/frag13, /datum/design/box_a357/metalshock, /datum/design/box_a357/heartpiercer, /datum/design/box_a357/wallstake)
 
 /obj/item/disk/design_disk/illegal_ammo/Initialize()
 	. = ..()
@@ -1043,11 +1043,11 @@
 	id = "box_a357_ironfeather_disk"
 	category = list("Security")
 
-/datum/design/box_a357/nutcracker
-	name = "Ammo Box (.357 Nutcracker)"
-	id = "box_a357_nutcracker"
+/datum/design/box_a357/frag13
+	name = "Ammo Box (.357 FRAG-13)"
+	id = "box_a357_frag13"
 	materials = list (/datum/material/iron = 60000)
-	build_path = /obj/item/ammo_box/no_direct/a357/nutcracker
+	build_path = /obj/item/ammo_box/no_direct/a357/frag13
 	category = list ("Security")
 
 /datum/design/box_a357/metalshock

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -874,11 +874,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Ironfeather shells contain six pellets which are less damaging than buckshot but mildly better over range."
 	item = /obj/item/storage/box/syndie_kit/revolvershotgunammo
 
-/datum/uplink_item/ammo/revolver/nutcracker
-	name = ".357 Nutcracker Speed Loader"
-	desc = "A speed loader that contains seven .357 Nutcracker rounds; usable with the Syndicate revolver. \
-			These rounds lose moderate stopping power in exchange for being able to rapidly destroy doors and windows."
-	item = /obj/item/ammo_box/a357/nutcracker
+/datum/uplink_item/ammo/revolver/frag13
+	name = ".357 FRAG-13 Speed Loader" // the revolver used to cost 13TC
+	desc = "A speed loader that contains seven explosive .357 FRAG-13 rounds; usable with the Syndicate revolver. \
+			These rounds lose moderate stopping power in exchange for being able to rapidly destroy doors and windows, as well as igniting targets."
+	item = /obj/item/ammo_box/a357/frag13
 
 /datum/uplink_item/ammo/revolver/metalshock
 	name = ".357 Metalshock Speed Loader"


### PR DESCRIPTION
# Document the changes in your pull request

Nutcracker == LAME

FRAG-13 = EXPLOSION = WOOAHH BOOM COOL

The mechanical differences are that it makes an explosion sound and ignites targets now so you can consider it 357's incendiary round now

# Changelog

:cl:  
rscdel: Removed .357 Nutcracker rounds.
rscadd: Added .357 FRAG-13 rounds to replace .357 Nutcracker rounds. They are like Nutcracker rounds but they explode.
/:cl:
