### PR TITLE
reviver implant bugfix for #12764

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -66,7 +66,7 @@
 
 	if(cooldown > world.time)
 		return
-	if(owner.stat != UNCONSCIOUS)
+	if(owner.stat != UNCONSCIOUS && owner.stat != SOFT_CRIT)
 		return
 	if(owner.suiciding)
 		return

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -66,7 +66,7 @@
 
 	if(cooldown > world.time)
 		return
-	if(owner.stat != UNCONSCIOUS && owner.stat != SOFT_CRIT)
+	if(!owner.stat)
 		return
 	if(owner.suiciding)
 		return

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -56,7 +56,7 @@
 
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
-		if(owner.stat == UNCONSCIOUS || owner.stat == SOFT_CRIT)
+		if(owner.stat)
 			addtimer(CALLBACK(src, PROC_REF(heal)), 2 SECONDS)
 		else
 			cooldown = revive_cost + world.time


### PR DESCRIPTION

# Document the changes in your pull request
reviver implant was supposed to heal you in soft crit as outlined in #12764, but always stopped instantly since it only cared if you were unconscious at the time. .
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: reviver implant heals in soft crit as intended
/:cl:
