### PR TITLE
Memory loss upon death now can occur after the brain has decayed for a period of time

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -21,6 +21,8 @@
 	var/decoy_override = FALSE	//if it's a fake brain with no brainmob assigned. Feedback messages will be faked as if it does have a brainmob. See changelings & dullahans.
 	//two variables necessary for calculating whether we get a brain trauma or not
 	var/damage_delta = 0
+	//increments
+	var/decay_progress = 0
 
 	var/list/datum/brain_trauma/traumas = list()
 
@@ -214,8 +216,10 @@
 		owner.death()
 		brain_death = TRUE
 
-/obj/item/organ/brain/process()	//needs to run in life AND death
+/obj/item/organ/brain/process(delta_time)	//needs to run in life AND death
 	..()
+	if(!(owner && (owner.stat < DEAD || HAS_TRAIT(owner, TRAIT_PRESERVED_ORGANS))))
+		decay_progress += delta_time
 	//if we're not more injured than before, return without gambling for a trauma
 	if(damage <= prev_damage)
 		prev_damage = damage

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -218,7 +218,7 @@
 
 /obj/item/organ/brain/process(delta_time)	//needs to run in life AND death
 	..()
-	if(!(owner && (owner.stat < DEAD || HAS_TRAIT(owner, TRAIT_PRESERVED_ORGANS))))
+	if(!((organ_flags & ORGAN_SYNTHETIC) || (owner && (owner.stat < DEAD || HAS_TRAIT(owner, TRAIT_PRESERVED_ORGANS)))))
 		decay_progress += delta_time
 	//if we're not more injured than before, return without gambling for a trauma
 	if(damage <= prev_damage)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -575,7 +575,7 @@
 		var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
 		if(B)
 			if(B && B.decay_progress > 5 MINUTES && !admin_revive)
-				to_chat(src, span_notice("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
+				to_chat(src, span_userdanger("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
 				log_combat(src, "was revived with memory loss")
 			B.decay_progress = 0
 		if(IS_BLOODSUCKER(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -572,6 +572,12 @@
 		reload_fullscreen()
 		revive_guardian()
 		. = 1
+		var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
+		if(B)
+			if(B && B.decay_progress > 5 MINUTES && !admin_revive)
+				to_chat(src, span_notice("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
+				log_combat(src, "was revived with memory loss")
+			B.decay_progress = 0
 		if(IS_BLOODSUCKER(src))
 			var/datum/antagonist/bloodsucker/bloodsuckerdatum = src.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 			bloodsuckerdatum.heal_vampire_organs()


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Makes it so that if someone is dead for (currently) 5 minutes, upon revival a message will play telling the player that they have memory loss, either 5 or 10 minutes would likely be good, I'll let council decide that.
Message is tied to brain decay, so switching brains wouldn't work, and it should let you preserve the brain in order to preserve someone's "memories".

This will need a council vote.

# Why this is good for the game
This makes hiding targets a lot more viable, especially witnesses, while not removing the risk entirely of someone yelling your name. In theory this will mean that less people will get round removed if they don't need to be

# Wiki Documentation

Likely will need to be mentioned in any sort of rule guidelines on the wiki if there are any.
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: being dead for a while will make your memory of said death go bye bye 

/:cl:
