### PR TITLE
Allows the reviver implant to work on all limbs

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -80,10 +80,10 @@
 		owner.adjustOxyLoss(-5)
 		revive_cost += 0.5 SECONDS
 	if(owner.getBruteLoss())
-		owner.adjustBruteLoss(-2)
+		owner.adjustBruteLoss(-2, required_status = BODYPART_ANY)
 		revive_cost += 4 SECONDS
 	if(owner.getFireLoss())
-		owner.adjustFireLoss(-2)
+		owner.adjustFireLoss(-2, required_status = BODYPART_ANY)
 		revive_cost += 4 SECONDS
 	if(owner.getToxLoss())
 		owner.adjustToxLoss(-1)


### PR DESCRIPTION
# Document the changes in your pull request
I find it silly that the Reviver implant doesn't use chem AND doesn't heal mechanical limbs. 
Generally, the races who HAVE self-surgery (Preternis, IPC) cannot benefit from their racial upsides, which is a bit strange.
Additionally, organics can have mechanical limbs, which also helps a bit.
"what if this is really op!!!"
IPCs in hard crit take burn damage from "thermal regulation failures", so don't worry about them slowly rising back up like Dracula if you keep them unattended for a short bit. 
Preterni benefits from this a bit more, but I don't think it is game-breaking in essence nor really all that much of a concern. If you have somebody in crit, you've PROBABLY already won and with the way reviver implant cooldown works, they're not going to be constantly standing back up in crit. 

tested ingame.
# Changelog
:cl:  
tweak: reviver implant now works on all limbs, including mechanical ones.  
/:cl:
