### PR TITLE
Suit sensors update slower.

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -1,4 +1,4 @@
-#define SENSORS_UPDATE_PERIOD 100 //How often the sensor data updates.
+#define SENSORS_UPDATE_PERIOD 150 //How often the sensor data updates.
 
 /obj/machinery/computer/crew
 	name = "crew monitoring console"


### PR DESCRIPTION
# Document the changes in your pull request
Suit sensors have been the talk of a slowdown for quite a while now, so this is not coming from an ided perspective. 
WHICH IT IS! However, it's coming from many ideds and not a spur-of-the-moment rage ided, but I'm not going to lie; I've certainly had experience with the main issues of suit sensors.

**Keep in mind that I don't see 15 seconds as the final value, and I'd like both medical and non-medical players to have input on duration.**

![glort](https://github.com/yogstation13/Yogstation/assets/44381232/8e8c8923-7f78-41c8-bac3-7be71771daac)
In the image, you have
- 2 Paramedics
- 1 Brig Phys
- 2 Security
- 1 random artist (???)

However, the issue isn't going to be sucking job slots from medbay; the issue is that mainly this situation happened within 10 seconds of me doing anything that wasn't EMP -> High damage/STUN combo. 
Mainly suit sensors have become problematic due to Yogstation's active medbay player base. It'd be silly to balance antags around dealing with 5+ sec ganks, paramedics, 1-2 valid hunters, and any medical staff that's bored enough, so generally, it's best to slow down suit sensors.
That being said, too high of duration would make suit sensors useless, which I wish to avoid.
__It takes around 30 seconds to navigate from escape to arrivals__; additionally, since medbay is a bit closer to the "center" of most maps, like the most played map(box), response times are quicker. 
I believe this creates an antag loop where you must instantly or nigh instantly round remove someone or be locked to a boring playstyle of dropping an EMP into a slowdown.

While *YES* you could argue that "just get emps bro; everybody has a department lathe,"  this goes back to a boring gameplay loop of huge dmg dumps before you get detected and trigger three paramedics spawning eight tiles away. 

On an ided level, I want this to give a bit more breathing room to antags.
On a gameplay level, I want this to allow antags to do things other than boring combos by at least slowing down the rate paramedics/sec will fly to your location.
ON **all.** levels I want this to be discussed to ensure suit sensors don't become useless while still preventing silent round-removals.


# Wiki Documentation
Suit sensors update every 15 seconds if we even note that. We probably don't.
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: suit sensors update every 15 seconds instead of 10.
/:cl:
