### PR TITLE
[gax gax gax] modern trims

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1,12 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aae" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aau" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 10
@@ -209,6 +201,20 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"aeA" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "aeL" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
@@ -295,14 +301,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"agA" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "agH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -325,6 +323,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ahc" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ahf" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -361,26 +380,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ahX" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	name = "Atmospherics Storage Room APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ahZ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
@@ -466,30 +465,6 @@
 "ajU" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/bridge)
-"akz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "akL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -504,35 +479,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
-"ala" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 8;
-	name = "Chemistry APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "all" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -654,6 +600,21 @@
 	},
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
+"anj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -681,6 +642,26 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"anJ" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "aoe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -911,21 +892,6 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"avt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"avQ" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "avY" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/department/bridge)
@@ -955,6 +921,19 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"awE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "axk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -998,6 +977,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ayx" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ayK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -1221,6 +1206,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"aEG" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aEH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
@@ -1261,31 +1255,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"aHQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aId" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -1354,13 +1323,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aJj" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "aJn" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -1398,6 +1360,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"aJY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aJZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -1405,13 +1376,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"aKd" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "aKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1515,6 +1479,19 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"aNU" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aOh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -1613,6 +1590,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"aPt" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "aPw" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -1692,6 +1681,15 @@
 /obj/machinery/vending/fishing,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"aQG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "aRb" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1781,15 +1779,6 @@
 	dir = 8
 	},
 /area/chapel/main)
-"aTp" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "aTw" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -1958,14 +1947,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aWJ" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "aWK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
@@ -2101,6 +2082,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bar" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bax" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -2204,6 +2198,18 @@
 /obj/machinery/holosign/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bcj" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "bco" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -2338,29 +2344,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"bem" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "bez" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -2414,13 +2397,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bgK" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "bgP" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -2449,6 +2425,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"bhE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "bhL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2512,18 +2502,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"bjZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "bkx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2541,6 +2519,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"bkK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	layer = 2.4;
+	name = "Mix Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2592,6 +2583,22 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
+"bmR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "bnk" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -2601,6 +2608,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"bnr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "bns" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -2672,6 +2685,13 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"boV" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "bpn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2707,6 +2727,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"bpQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "bpR" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -2720,6 +2746,27 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"bqd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bqk" = (
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/carpet/royalblack,
@@ -2865,12 +2912,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"btZ" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "buw" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -2903,37 +2944,6 @@
 "bvm" = (
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"bvx" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -29
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bvC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3050,28 +3060,15 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"byW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
+"byX" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	name = "Atmospheric Alert Console"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"bzz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/area/engine/atmos/storage)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -3117,13 +3114,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"bBt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "bBB" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -3234,6 +3224,13 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"bDT" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bEd" = (
 /obj/machinery/computer/apc_control{
 	dir = 1
@@ -3315,25 +3312,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bFq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bGo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3470,24 +3448,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"bJE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bJG" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/stripes/line{
@@ -3515,6 +3475,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bKq" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bKw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -3553,19 +3526,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
-"bMP" = (
-/obj/structure/chair{
-	dir = 4
+"bMo" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/storage)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3977,18 +3953,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"bUT" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/computer/station_alert{
-	name = "Station Alert Console"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bVm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4070,16 +4034,6 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"bXs" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bXA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4092,31 +4046,60 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bYj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+"bXV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/hallway/secondary/exit)
 "bYF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bZk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"bZG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bZU" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -4193,30 +4176,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"ccJ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"ccP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ccU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4285,6 +4244,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cex" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "ceS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4531,6 +4494,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"clv" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "clE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -4594,19 +4570,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"cmN" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cnh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4617,16 +4580,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"cni" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cnI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Port"
@@ -4688,17 +4641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"coV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/electrolyzer,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "cpF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -4768,13 +4710,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"cri" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "cry" = (
 /obj/machinery/light{
 	dir = 4
@@ -4806,6 +4741,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"csW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Xenobiology Lab Access";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "csY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4842,6 +4788,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ctN" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "cuo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -4943,15 +4897,6 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cwH" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "cwL" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -5162,6 +5107,22 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cAv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cAC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5315,26 +5276,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"cCC" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cCG" = (
 /obj/machinery/doppler_array/research/science,
 /obj/machinery/light/small{
@@ -5353,20 +5294,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"cDh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "cDQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -5693,17 +5620,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"cMb" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "cMn" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -5924,6 +5840,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"cRz" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "cRS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6250,12 +6172,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cZW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "cZX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -6334,23 +6250,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"dbz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+"dbN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/quartermaster/office)
 "dck" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -6393,13 +6306,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"dcO" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6792,25 +6698,6 @@
 "dll" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
-"dmK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dmV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -6857,6 +6744,19 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
+"dnK" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to distro";
+	target_pressure = 4500
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "dog" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -6960,16 +6860,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"dsg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "dsF" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -7035,6 +6925,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"dua" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "duO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -7057,13 +6957,6 @@
 /obj/effect/landmark/start/depsec/service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"dvv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dvC" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -7157,21 +7050,6 @@
 /obj/machinery/grill,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
-"dyt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dyu" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7317,33 +7195,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"dDI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dEb" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -7552,6 +7403,32 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"dHR" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7559,6 +7436,13 @@
 "dIB" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
+"dJj" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "dJF" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -7597,6 +7481,19 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"dKs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dKt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -7658,18 +7555,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"dNj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -7813,6 +7698,24 @@
 /obj/effect/spawner/lootdrop/techstorage/service,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"dRT" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dSh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8001,22 +7904,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"dVM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "dVZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -8060,6 +7947,13 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dWH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dWL" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -8091,17 +7985,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/science/mixing)
-"dYs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/broken/two,
 /area/science/mixing)
 "dYL" = (
 /turf/template_noop,
@@ -8229,10 +8112,37 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/department/eva)
+"eci" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ecv" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
+"ecy" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ecL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -8332,24 +8242,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"edJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "edS" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -8376,6 +8268,19 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"eeD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "eeG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -8386,12 +8291,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"eeW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "efb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -8602,6 +8501,23 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"ekT" = (
+/obj/machinery/camera{
+	c_tag = "Mining Dock";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "ela" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
@@ -8632,6 +8548,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"elK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "elX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -8819,23 +8745,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"epr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ept" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -8930,20 +8839,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"erF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "erK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9064,12 +8959,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"etP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "etW" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
@@ -9186,6 +9075,22 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"evJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ewm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9214,6 +9119,24 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"ewZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "exV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -9485,20 +9408,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"eDv" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eDx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -9676,6 +9585,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eGp" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eGu" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom";
@@ -9707,28 +9639,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"eHr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "eHz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"eHM" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/computer/station_alert{
+	name = "Station Alert Console"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eIf" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -9834,6 +9762,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"eJT" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eJX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -10153,24 +10091,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"ePp" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	dir = 1;
-	name = "Nanite Lab APC";
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "ePC" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10320,16 +10240,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"eVC" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/sign/departments/minsky/medical/medical1{
@@ -10430,6 +10340,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"eXU" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eYP" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -10537,12 +10457,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
-"fbd" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "fbl" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/item/radio/intercom{
@@ -10657,29 +10571,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"fdL" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "fdO" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -10724,29 +10615,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"feO" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"feP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"feV" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "ffj" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -10788,21 +10665,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"fgs" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fgB" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -10979,21 +10841,6 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"fkN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fkR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -11002,6 +10849,25 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"flc" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fli" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -11056,6 +10922,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fmf" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fmk" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -11110,6 +10985,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fmT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "fnc" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -11332,6 +11221,53 @@
 "ftY" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fun" = (
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 10
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"fur" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fuJ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
@@ -11447,6 +11383,29 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"fyk" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fyD" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
@@ -12020,6 +11979,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"fHk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "fHm" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -12361,12 +12338,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"fSh" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner,
+"fSd" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/storage)
 "fSj" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -12374,16 +12351,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fSk" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "fSF" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/firealarm{
@@ -12475,31 +12442,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"fVh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fVp" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12584,11 +12526,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"fYg" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "fYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -12801,23 +12738,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gdo" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "gdE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -12910,6 +12830,24 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"ggB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ggD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12933,6 +12871,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"ghj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ghk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -13107,13 +13054,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"glX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gmv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13135,18 +13075,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"gmR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
+"gna" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/exit)
 "gnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13161,6 +13096,13 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"gnw" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gnz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13209,19 +13151,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"gpv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "gpG" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -13256,19 +13185,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"gqx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gqK" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable{
@@ -13292,22 +13208,6 @@
 "gqR" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"gqW" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "grf" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
@@ -13439,15 +13339,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"gtV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gtZ" = (
 /obj/machinery/mass_driver{
 	id = "toxinsdriver"
@@ -13529,15 +13420,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"gve" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -13592,6 +13474,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"gwN" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gwV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -13618,6 +13513,24 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"gxL" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 1;
+	name = "Atmospherics Distribution APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "gyJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13704,17 +13617,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"gBa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light{
-	dir = 1
-	},
+"gAN" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/flashlight,
+/obj/item/assembly/igniter,
+/obj/item/book/manual/wiki/atmospherics,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
@@ -13725,6 +13640,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gBx" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gBL" = (
 /obj/machinery/light{
 	dir = 1
@@ -13785,6 +13707,20 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"gDh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gDx" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -13813,6 +13749,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gEE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "gFn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13909,16 +13855,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"gGn" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "gGK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14067,6 +14003,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"gJy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "gJz" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
@@ -14075,6 +14029,14 @@
 /area/engine/atmos/distro)
 "gJE" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"gJR" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14124,6 +14086,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"gLY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gMh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -14142,6 +14122,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"gMK" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "gMU" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -14162,16 +14159,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"gNt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "gNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -14209,6 +14196,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
+"gNN" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "gOA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14388,17 +14388,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gUr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "gUD" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
@@ -14415,6 +14404,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"gVs" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "gVy" = (
 /obj/machinery/light{
 	dir = 1
@@ -14440,10 +14436,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gWm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "gWp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gXm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "gXo" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -14494,6 +14510,41 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"gYz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
+"gYK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Dormitory South";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "gZh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -14648,20 +14699,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"hdb" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hdd" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14805,13 +14842,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"hgW" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
+"hgD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14931,6 +14978,20 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"hjR" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hjZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -15163,28 +15224,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"hnP" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/ten,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -15461,6 +15500,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"hvA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hvC" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -15851,18 +15904,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"hEr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "hED" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -15875,10 +15916,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hFD" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hFP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hGv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hGw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15964,6 +16032,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"hJt" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "hJB" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -15973,26 +16049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hKb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump";
-	target_pressure = 4500
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "hKr" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
@@ -16007,6 +16063,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"hKC" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hKH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16080,32 +16142,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"hNv" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+"hNF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hydroponics/garden)
 "hNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -16194,6 +16241,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hPF" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "hPZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
@@ -16253,6 +16307,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"hRP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"hSi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hSr" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "toxins_airlock_exterior";
@@ -16378,17 +16460,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hTW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Xenobiology Lab Access";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "hUb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16398,6 +16469,34 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"hUc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"hUj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hUI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -16444,6 +16543,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"hUW" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hVc" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16491,6 +16599,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hVH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hVM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -16562,20 +16697,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hWF" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "hXw" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
@@ -16604,41 +16725,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hZd" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "hZj" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/teleporter)
-"hZE" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hZT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16760,6 +16852,24 @@
 	icon_state = "carpetsymbol"
 	},
 /area/chapel/main)
+"ieW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ifa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17060,6 +17170,19 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
+"imZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "inC" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -17238,6 +17361,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"isx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/electrolyzer,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ite" = (
 /obj/machinery/button/door{
 	id = "escapepodbay";
@@ -17257,20 +17391,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"itj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "itk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -17474,23 +17594,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
-"iwZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste In";
-	on = 1
-	},
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ixg" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -17556,19 +17659,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ixX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "iyb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -17716,6 +17806,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"iBP" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "iCK" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mix Tank";
@@ -17762,6 +17865,15 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
+"iGo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "iGP" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -17799,17 +17911,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"iIe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "iIi" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17962,25 +18063,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"iMI" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Southeast";
-	dir = 9;
-	network = list("ss13")
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "iMK" = (
 /obj/structure/railing{
 	dir = 1
@@ -18261,19 +18343,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iSx" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "iSN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -18356,14 +18425,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"iVx" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "iVM" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/firealarm{
@@ -18492,12 +18553,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"jap" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "jaK" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -18599,17 +18654,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"jcS" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "jdr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
@@ -18668,21 +18712,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jfg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jfL" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -18692,15 +18721,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jfR" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jfX" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -18865,22 +18885,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"jlZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -18941,6 +18945,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jng" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jnk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -18990,20 +19006,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
-"joZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "jpb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -19049,6 +19051,35 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jql" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jrd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -19117,6 +19148,16 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"jtz" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jtL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -19354,6 +19395,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"jAw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks North";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19448,12 +19506,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"jCf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jCh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -19541,13 +19593,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"jDy" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "jDz" = (
 /turf/closed/wall/rust,
 /area/maintenance/solars/starboard/fore)
@@ -19602,12 +19647,6 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"jEn" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "jEp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -19634,24 +19673,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"jFL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "jGi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19698,10 +19719,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jIh" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19812,20 +19829,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jKJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jKW" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -19839,27 +19842,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"jLc" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jLo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19896,6 +19878,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jNV" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jNW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -19947,6 +19949,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jOx" = (
+/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "jOS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -20014,6 +20026,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jPL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 11
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20060,24 +20097,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"jRx" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"jRU" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "EVA East";
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "jSg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -20238,24 +20257,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"jVa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jVp" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -20269,6 +20270,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"jVq" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "jVL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20300,6 +20308,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"jWp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Waste In";
+	on = 1
+	},
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jWt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -20442,23 +20467,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/library)
-"kby" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "kbG" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
@@ -20511,15 +20519,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"kdC" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kdG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -20613,6 +20612,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"kgS" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kgT" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -20859,21 +20879,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kne" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "knf" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/distro)
@@ -20920,6 +20925,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"kou" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "kov" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -20978,28 +20992,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"kqO" = (
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/t_scanner{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/multitool{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "krf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -21082,19 +21074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ktE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "ktG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21273,19 +21252,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"kxz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "kxF" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -21372,23 +21338,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kAF" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kAM" = (
 /obj/structure/rack,
 /obj/item/gun/energy/disabler{
@@ -21433,16 +21382,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
-"kCa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "kCl" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -21825,6 +21764,22 @@
 "kKp" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
+"kKL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "kKN" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldgen,
@@ -21918,6 +21873,23 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"kOj" = (
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/chapel/office)
 "kOr" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -22086,6 +22058,34 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kUg" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"kUx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "kUA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22093,24 +22093,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kUL" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "kUU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -22128,6 +22110,20 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
+"kVD" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "kVO" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -22137,6 +22133,24 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"kVZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "kWf" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -22498,16 +22512,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"lef" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "leg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -22664,6 +22668,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"lhh" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "lhn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22972,6 +22983,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"lqA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lqS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -23008,6 +23030,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"lse" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "lsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -23033,6 +23070,21 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
+"ltg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ltm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23265,19 +23317,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"lxI" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lxW" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -23376,6 +23415,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"lzw" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "lzE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23435,22 +23503,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"lAP" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/assembly/igniter,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lAW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -23510,6 +23562,25 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"lCE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "lDa" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 2
@@ -23572,6 +23643,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"lEs" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "lEH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23670,6 +23752,14 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
+"lGw" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
@@ -23733,6 +23823,20 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lIf" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "lIh" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -23769,25 +23873,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"lJY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+"lJn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/science/mixing)
 "lKJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24020,6 +24119,20 @@
 "lQe" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
+"lQu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "lQR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -24126,24 +24239,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"lSc" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "lSj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -24201,13 +24296,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lTf" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lTB" = (
 /obj/machinery/button/door{
 	id = "evashutter";
@@ -24270,6 +24358,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lUU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lVz" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -24395,30 +24505,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lZc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "lZt" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -24455,6 +24541,23 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"mad" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "maX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -24622,6 +24725,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"mfK" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/magboots,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "mfP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only{
@@ -24674,19 +24793,6 @@
 /obj/item/multitool,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"mhr" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "mhx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -24760,12 +24866,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"miU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "mjc" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
@@ -24887,6 +24987,28 @@
 "mkA" = (
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"mkU" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/multitool{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "mlb" = (
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
@@ -25000,13 +25122,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mnR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
+"moj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "moz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25111,15 +25235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"mqo" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mqx" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
@@ -25275,6 +25390,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/warden)
+"mtl" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mtp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25283,13 +25402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"mtw" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "mtW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Nanite Laboratory Maintenance";
@@ -25301,6 +25413,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"muz" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "muA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
@@ -25403,12 +25524,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"mxh" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mxk" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -25502,29 +25617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"myJ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "myQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -25583,6 +25675,19 @@
 "mAC" = (
 /turf/closed/wall,
 /area/chapel/main)
+"mAK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mAL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25607,6 +25712,29 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
+"mBv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "mCq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -25757,19 +25885,19 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"mGz" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = 32
+"mHI" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
 	},
-/obj/structure/chair/comfy/beige{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
 	},
-/turf/open/floor/plasteel/burnt/two,
-/area/science/mixing)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mHW" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -25801,6 +25929,20 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"mIx" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge South";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "mIS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -25821,6 +25963,22 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"mKl" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mKF" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment Chamber";
@@ -25858,27 +26016,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"mLm" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"mLz" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -25933,20 +26070,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"mMJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "mMR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Disposals Access";
@@ -26024,6 +26147,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"mOZ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "mPa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -26178,13 +26318,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"mSp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "mSy" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -26404,6 +26537,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"mZl" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "mZK" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -26444,6 +26594,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"ncg" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ncC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -26462,19 +26622,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ncO" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ncW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26561,6 +26708,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"neN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "neP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26598,6 +26759,17 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ngm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/broken/two,
+/area/science/mixing)
 "ngI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -26679,6 +26851,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
+"njk" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "njp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
@@ -26760,6 +26942,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"nld" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "nlq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -26844,34 +27038,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nnE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"nnG" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "noh" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -26893,6 +27059,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"noL" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/storage";
+	name = "Atmospherics Storage Room APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "noP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -26906,6 +27092,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"npt" = (
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "npL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -27132,6 +27331,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"nuL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "nuS" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
@@ -27139,15 +27351,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nve" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
+"nvb" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -27264,13 +27474,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"nyW" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "nzc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27331,6 +27534,33 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"nzw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nzG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27351,19 +27581,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"nzK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "nzN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -27452,20 +27669,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"nAU" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nBv" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -27548,16 +27751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"nDr" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nDx" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -27632,6 +27825,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"nFd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nFm" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nFB" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -27650,13 +27866,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nFC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "nFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -27790,38 +27999,20 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"nIl" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+"nIR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = -32
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"nIy" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "nJe" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -27890,18 +28081,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"nKs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "nKu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27991,6 +28170,15 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"nKY" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nLn" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit,
@@ -28022,6 +28210,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nMQ" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "nMW" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
@@ -28055,15 +28258,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"nOe" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nOj" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -28225,19 +28419,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"nTr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nTx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -28283,16 +28464,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"nUd" = (
-/obj/structure/bookcase/random/reference,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "nUm" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -28337,6 +28508,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nVW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "nWJ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -28397,6 +28592,14 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"nYs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "nYy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -28465,12 +28668,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nZO" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"nZP" = (
 /obj/machinery/pipedispenser,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -28661,6 +28858,25 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ofi" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/exit";
+	dir = 8;
+	name = "Escape Hallway APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ofj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -28809,24 +29025,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ojL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 1;
-	name = "Atmospherics Distribution APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ojV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28858,45 +29056,6 @@
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel,
 /area/teleporter)
-"okZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"olO" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"omc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "omn" = (
 /obj/machinery/rnd/production/techfab/department/armory,
 /obj/machinery/firealarm{
@@ -29078,31 +29237,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
-"opP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 11
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -34
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "oqd" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cmo";
@@ -29121,19 +29255,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"oqn" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "oqA" = (
 /obj/machinery/light{
 	dir = 8
@@ -29193,15 +29314,6 @@
 "orF" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"orT" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ose" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -29227,21 +29339,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"osq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "osE" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet,
@@ -29390,6 +29487,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oyq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oyB" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
@@ -29402,6 +29506,12 @@
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
+"oyX" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oyZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -29511,6 +29621,17 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"oBl" = (
+/obj/structure/filingcabinet,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "oBB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29520,6 +29641,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oBO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oBV" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
@@ -29565,14 +29693,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oDl" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+"oDt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/ten,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/quartermaster/storage)
+/area/engine/atmos/storage)
 "oEt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
@@ -29604,6 +29746,20 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"oFw" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "oFK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -29615,6 +29771,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"oFV" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "oFX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
@@ -29790,6 +29954,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
+"oLk" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -29847,6 +30024,19 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
+"oOU" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/computer/atmos_control{
+	dir = 1;
+	name = "Tank Monitor"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oOX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -29869,6 +30059,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oPx" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "oPz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -29919,17 +30127,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"oQx" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Service Backroom"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "oQX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -30111,6 +30308,13 @@
 "oYc" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
+"oYd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oYi" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -30129,6 +30333,39 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"oYz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"oZp" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oZJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -30145,16 +30382,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"oZR" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pan" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -30414,17 +30641,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"pge" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pgs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -30455,18 +30671,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"pgO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pgQ" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -30476,25 +30680,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
-"phi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/structure/table,
-/obj/item/vending_refill/medical{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/hand_labeler{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/machinery/vending/wallhypo{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "php" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -30677,17 +30862,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"pkJ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pkV" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
@@ -30827,6 +31001,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"pnj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pno" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30836,19 +31027,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pnr" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/command/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pns" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -31028,6 +31206,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
+"prX" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "psc" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -31133,6 +31320,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pwq" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pwH" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -31174,6 +31371,19 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pxJ" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pxU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31235,23 +31445,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pzE" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "pAz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -31304,28 +31497,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pBx" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks South";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste to Space"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "pBD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -31388,29 +31559,6 @@
 /obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"pBX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "pCi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
@@ -31469,40 +31617,11 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pCM" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "pDd" = (
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"pDz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31690,6 +31809,21 @@
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plasteel,
 /area/janitor)
+"pJs" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Airlocks";
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pJJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/airless,
@@ -31774,6 +31908,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pLP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pLY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31898,6 +32039,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pOf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "pOz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -31913,6 +32065,29 @@
 /obj/item/storage/box/firingpins,
 /turf/open/floor/plasteel,
 /area/security/warden)
+"pOQ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pOV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -31929,20 +32104,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pPK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "pQh" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -31999,6 +32160,16 @@
 "pQR" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
+"pQY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pRc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -32107,38 +32278,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"pTG" = (
-/obj/structure/filingcabinet,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "pTI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pTV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "pTW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -32326,19 +32471,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"pXK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "pXP" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -32456,15 +32588,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"pZQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "qaG" = (
 /obj/structure/table,
 /obj/item/cultivator{
@@ -32565,24 +32688,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"qcK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -32648,19 +32753,6 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/library)
-"qeA" = (
-/obj/item/radio/intercom{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qeR" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -32951,6 +33043,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qkT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qlc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33016,6 +33126,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"qmP" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Service Backroom"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "qmZ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -33153,20 +33274,15 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"qoX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+"qpa" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks North";
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -33321,6 +33437,15 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qvR" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qwa" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -33461,6 +33586,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"qyg" = (
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "qyL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -33644,19 +33777,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qGI" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -33683,15 +33803,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qHg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qHC" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -33709,33 +33820,6 @@
 "qIk" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
-"qIK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "qIO" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -33778,18 +33862,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"qJW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"qKe" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qKg" = (
 /obj/machinery/button/door{
 	id = "Dorm2";
@@ -33877,6 +33949,16 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"qMq" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qNI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -33975,6 +34057,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"qQr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qQC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHW";
@@ -34319,19 +34416,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"qZC" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "qZW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34485,15 +34569,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"rcE" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rcK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
@@ -34781,15 +34856,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"riG" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rjf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -34798,6 +34864,30 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rjs" = (
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"rju" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "rjC" = (
@@ -34858,6 +34948,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rkZ" = (
+/obj/structure/bookcase/random/reference,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "rlg" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -34877,6 +34974,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"rlN" = (
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters";
+	pixel_x = 26;
+	pixel_y = 7;
+	req_one_access_txt = "5; 33"
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "rlY" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -34890,6 +35001,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"rmK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rmT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -35007,18 +35131,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rpv" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rpx" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -35316,17 +35428,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"ruO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "rvb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -35379,6 +35480,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"rwE" = (
+/obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
+	dir = 8;
+	name = "Chemistry APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"rwU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rxj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -35398,6 +35534,26 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"rxA" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rxG" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -35473,6 +35629,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rzw" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "rzT" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -35580,15 +35744,6 @@
 "rBC" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
-"rBQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "rBR" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -35688,6 +35843,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"rEt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rEQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -35912,6 +36076,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rJd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rJw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -35964,22 +36140,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"rMB" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/magboots,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "rMD" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -36090,22 +36250,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rPc" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rPz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -36152,6 +36296,15 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"rQO" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -36243,8 +36396,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"rTK" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+"rTH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -36401,12 +36554,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"rXf" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/burnt/two,
+/area/science/mixing)
 "rXh" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"rXs" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	layer = 2.4;
+	name = "Air to Port"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rXw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36458,6 +36638,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rXZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "rYc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -36477,24 +36664,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"rZX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"rYZ" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/hallway/primary/starboard)
 "sar" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -36513,6 +36692,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"sbf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sbk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36645,17 +36832,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sdK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "sep" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -36663,6 +36839,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"seE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "seF" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -36772,54 +36965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"shu" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"shF" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
-"sic" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "sil" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -36853,6 +36998,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"sjj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "sjm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -36888,13 +37048,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sjO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -36928,20 +37081,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"smy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	layer = 2.4;
-	name = "Air to Port"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "smN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -37067,6 +37206,19 @@
 "spK" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"spM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/distro)
+"spO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "spU" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -37330,6 +37482,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"stT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/table,
+/obj/item/vending_refill/medical{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/machinery/vending/wallhypo{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "sup" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -37388,6 +37559,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"suE" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "svs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37430,15 +37610,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"swI" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "swR" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -37476,12 +37647,6 @@
 "sxD" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
-"sxM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
 "sxT" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -37674,6 +37839,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"sBB" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "sCP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37839,6 +38012,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"sHg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "sHi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37856,20 +38035,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sJk" = (
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters";
-	pixel_x = 26;
-	pixel_y = 7;
-	req_one_access_txt = "5; 33"
-	},
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37898,19 +38063,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"sKe" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sKm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
@@ -37953,6 +38105,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/prison)
+"sKI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "sKP" = (
 /obj/machinery/door/airlock/mining{
 	req_access_txt = "48"
@@ -37974,14 +38132,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"sLh" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
+"sKZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -29
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "sLi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -38107,6 +38288,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"sOI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sOU" = (
 /obj/machinery/door/window/southright{
 	dir = 8;
@@ -38369,6 +38563,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"sUn" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/command/evac{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sUu" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt1";
@@ -38466,6 +38673,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sWT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38494,6 +38726,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"sXF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "sXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38608,15 +38849,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sZB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "sZH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -38626,6 +38858,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"sZK" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "tai" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
@@ -38668,6 +38918,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tbl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tbn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
@@ -38700,13 +38962,6 @@
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"tcI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tcS" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -38803,21 +39058,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"teH" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "teI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -38971,6 +39211,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"tiO" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 1;
+	name = "Nanite Lab APC";
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "tjk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -39075,6 +39333,24 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"tmB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tmP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -39192,6 +39468,25 @@
 /obj/effect/landmark/start/yogs/brigphsyician,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"tpM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Southeast";
+	dir = 9;
+	network = list("ss13")
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tpP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39262,23 +39557,12 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"tus" = (
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/chapel/office)
+"tuk" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tuM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -39293,6 +39577,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tuV" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -39413,19 +39706,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"tyd" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tyq" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -39586,19 +39866,6 @@
 /obj/machinery/power/smes/fullycharged,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"tBL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "tCd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -39622,20 +39889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"tCW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tDe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera{
@@ -39715,6 +39968,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"tFv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tFK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39913,16 +40174,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
-"tLi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tLT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40085,18 +40336,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tPz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+"tPC" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hallway/primary/fore)
 "tPI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40363,27 +40611,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"tVH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tVR" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -40401,14 +40628,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tWb" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "tWh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40504,6 +40723,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tYT" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tZf" = (
 /obj/machinery/computer/cargo/request,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -40553,13 +40782,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ubP" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -40716,19 +40938,6 @@
 	dir = 6
 	},
 /area/chapel/main)
-"ufp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "ufA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -40807,6 +41016,18 @@
 "uhZ" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/customs)
+"uir" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "uiR" = (
 /obj/structure/sign/departments/minsky/medical/medical2{
 	pixel_x = -32;
@@ -40869,16 +41090,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ujU" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ukr" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 4;
@@ -40886,47 +41097,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uku" = (
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_y = 10
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "ukx" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Staging Area";
@@ -40988,6 +41158,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"ulq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ulx" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/eva)
@@ -41016,19 +41204,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ulK" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ulW" = (
 /obj/machinery/vending/cart,
 /obj/structure/cable{
@@ -41070,6 +41245,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"umF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "unc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -41150,12 +41336,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"upo" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "uqi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41167,6 +41347,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
 /area/space/nearstation)
+"urz" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "urB" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
@@ -41264,6 +41454,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"uwe" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "uwx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -41298,6 +41500,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"uxu" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "uxw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41370,19 +41585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"uyG" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uyM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41425,6 +41627,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"uAW" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uBb" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
@@ -41556,19 +41766,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"uDn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "uDz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41638,12 +41835,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"uFH" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "uFR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
@@ -41667,24 +41858,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"uGW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uGX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42176,24 +42349,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
-"uSq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "uSr" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -42268,17 +42423,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
-"uUg" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "uUA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -42329,13 +42473,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uVk" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "uVJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -42349,6 +42486,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"uWb" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uWi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -42413,13 +42563,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"uXL" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uYJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42660,6 +42803,20 @@
 "vdN" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vea" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Incinerator"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "vei" = (
 /obj/machinery/light{
 	dir = 1
@@ -42690,31 +42847,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vfs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+"vfu" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/hallway/secondary/exit)
 "vfC" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -42877,6 +43022,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"vhw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vhy" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -42951,6 +43115,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"vjF" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "EVA East";
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "vjK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -42973,6 +43148,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vjQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "vjY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -43065,14 +43250,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vmp" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vmy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -43137,6 +43314,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"vnG" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vnT" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43176,6 +43364,33 @@
 "voI" = (
 /turf/closed/wall,
 /area/security/processing)
+"vpb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vpc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -43376,6 +43591,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vub" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vuq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -43385,23 +43619,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"vuM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vuO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -43438,37 +43655,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"vwa" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"vwl" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge South";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "vwP" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -43516,19 +43702,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vxN" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/door/poddoor/shutters{
@@ -43628,6 +43801,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"vzY" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vAc" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -43635,26 +43819,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"vAr" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vAA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/camera{
@@ -43709,15 +43873,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"vBt" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vBx" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 8
@@ -43753,24 +43908,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"vCw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vDA" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -43894,25 +44031,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/library)
-"vHa" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "vHD" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -43951,17 +44069,6 @@
 /obj/effect/spawner/lootdrop/randomdrink,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"vIp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vIr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -44025,24 +44132,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"vJQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "vJZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -44254,6 +44343,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vNE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "vNF" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/reagent_dispensers/watertank,
@@ -44335,6 +44435,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"vQX" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "vRl" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -44353,11 +44460,44 @@
 "vRP" = (
 /turf/open/space/basic,
 /area/space)
+"vRZ" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "vSh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"vSW" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks South";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste to Space"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "vTf" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -44647,15 +44787,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"vZN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "waf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -44697,13 +44828,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wbn" = (
-/obj/structure/bookcase/random/reference,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "wbF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -44886,20 +45010,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"wge" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "wgp" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -45012,20 +45122,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"wiB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Incinerator"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wiI" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -45071,6 +45167,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"wjr" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wjL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/structure/sign/directions/evac{
@@ -45101,16 +45211,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wku" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+"wkP" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "wlz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45471,6 +45578,19 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
+"wux" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "wva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -45482,22 +45602,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wvw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -45632,6 +45736,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"wyz" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"wyO" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "wyR" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -45684,20 +45811,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"wAh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "wAI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46106,6 +46219,18 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"wMC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "wMY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46118,6 +46243,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wNg" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wNm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -46145,35 +46285,6 @@
 "wNW" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
-"wOa" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "wOb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -46232,6 +46343,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wOT" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wPm" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
@@ -46300,10 +46421,35 @@
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"wQh" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wQn" = (
 /obj/structure/disposalpipe/segment,
 /turf/template_noop,
 /area/maintenance/aft)
+"wQp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wQB" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -46343,6 +46489,22 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
+"wQZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46369,40 +46531,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
-"wRG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"wRJ" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Storage";
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wSu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -46469,35 +46597,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"wTR" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "wUk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -46507,6 +46606,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wUr" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "wUH" = (
 /obj/structure/chair{
 	dir = 8
@@ -46526,6 +46639,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"wUU" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wVo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -46639,19 +46765,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wYl" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to distro";
-	target_pressure = 4500
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wYp" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -46663,15 +46776,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"wYF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wYJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -46697,25 +46801,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wZi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wZu" = (
 /obj/machinery/vending/gifts,
 /obj/effect/turf_decal/tile/darkgreen{
@@ -46879,6 +46964,19 @@
 "xbK" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
+"xch" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xcv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -46912,23 +47010,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"xdB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"xdF" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/teleporter)
 "xdK" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -46999,16 +47089,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"xfx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "xfz" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
@@ -47083,14 +47163,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"xhw" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "xhD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -47113,39 +47185,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"xiH" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xiN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xiU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "xjg" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -47236,6 +47287,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xkm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xkF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -47350,14 +47410,6 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"xmD" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "xnp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -47434,6 +47486,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xpD" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xpJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -47632,38 +47694,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"xuB" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	layer = 2.4;
-	name = "Mix Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xuP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"xuX" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47929,6 +47965,15 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"xBR" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "xCs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -47967,16 +48012,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"xDe" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+"xDY" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -48042,16 +48083,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"xFj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "xFt" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -48256,6 +48287,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"xLj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xLC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -48305,6 +48355,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"xMo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -48408,15 +48468,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xOB" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -48544,23 +48595,6 @@
 "xRw" = (
 /turf/open/floor/engine,
 /area/escapepodbay)
-"xRK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "xRO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -48773,15 +48807,6 @@
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"xVY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -49011,6 +49036,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"yba" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ybj" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -49032,24 +49070,28 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"ybN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "yca" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"ycg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ycp" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -49062,24 +49104,6 @@
 "ycy" = (
 /turf/closed/wall,
 /area/security/brig)
-"ycA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ycV" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -49373,25 +49397,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ykg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
-	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ykr" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -66798,7 +66803,7 @@ ejY
 lZB
 xWd
 orF
-hKb
+rxA
 sGB
 dsb
 vpm
@@ -67055,7 +67060,7 @@ bsg
 nky
 apP
 uGF
-tPz
+qpa
 sLY
 lGx
 ydx
@@ -67312,7 +67317,7 @@ cqd
 gHA
 vBr
 ekN
-myJ
+pOQ
 chs
 lJm
 vbO
@@ -67569,9 +67574,9 @@ myw
 fFT
 jzv
 ahZ
-pXK
-qoX
-wiB
+rmK
+jAw
+vea
 eRT
 oEG
 rXM
@@ -67828,7 +67833,7 @@ kcE
 kcE
 aik
 opo
-nZP
+nZO
 wVo
 njB
 dWX
@@ -68076,8 +68081,8 @@ tkl
 tkl
 nKW
 tCd
-wYF
-jap
+iGo
+xDY
 bPu
 knf
 knf
@@ -68085,7 +68090,7 @@ vYY
 jts
 cbm
 eDA
-xuX
+iBP
 dwV
 vTP
 cnI
@@ -68342,7 +68347,7 @@ rbs
 wQK
 buE
 iuS
-rpv
+bcj
 kwv
 rOc
 bQM
@@ -68599,7 +68604,7 @@ fJf
 jEZ
 sAf
 jYT
-xuB
+bkK
 eBt
 bVq
 cEs
@@ -68608,10 +68613,10 @@ lSj
 bVq
 bVq
 svz
-cri
-sdK
-kxz
-pBx
+tFv
+vNE
+xch
+vSW
 acO
 vzR
 hoI
@@ -68856,16 +68861,16 @@ jjX
 jjX
 lYd
 gAG
-ojL
+gxL
 wwC
-bBt
-orT
-orT
-smy
-upo
+nYs
+rEt
+rEt
+rXs
+hUW
 rXM
 rXM
-iwZ
+jWp
 uCi
 uCi
 uCi
@@ -69107,22 +69112,22 @@ lZu
 vsH
 bBo
 cLo
-vmp
+lGw
 eFb
 gph
 qGN
 hpd
-sxM
-wYl
-pBX
-coV
+spM
+dnK
+fyk
+isx
 cCc
 eNL
 cSC
-ycA
-fkN
-qHg
-wZi
+qkT
+anj
+xkm
+xLj
 uCi
 iRz
 wQB
@@ -69364,7 +69369,7 @@ lRP
 mTJ
 rEq
 uMm
-eeW
+rwU
 eRY
 twv
 oxM
@@ -69621,15 +69626,15 @@ teI
 hAJ
 pzD
 rYc
-kdC
+hSi
 eFb
 xkI
 aJz
 bgd
 qiY
-okZ
-hNv
-eHr
+lQu
+dHR
+bmR
 peq
 xge
 bCp
@@ -69884,9 +69889,9 @@ xTt
 xTt
 xTt
 xTt
-wvw
-bem
-hWF
+wQp
+mBv
+kVD
 jjX
 wIS
 tzj
@@ -70398,9 +70403,9 @@ tAe
 wDm
 nAf
 fjD
-aTp
-qIK
-rMB
+xBR
+vpb
+mfK
 xTt
 cNu
 vdN
@@ -70655,9 +70660,9 @@ mLC
 eEF
 eEF
 mki
-hdb
+lIf
 ndj
-btZ
+fSd
 xTt
 cNu
 xZo
@@ -70912,9 +70917,9 @@ elX
 elX
 sxu
 cxc
-swI
-jlZ
-uUg
+rQO
+evJ
+lEs
 xTt
 cNu
 aMM
@@ -71168,9 +71173,9 @@ xTt
 xTt
 xTt
 xTt
-jfg
-jfR
-bJE
+oZp
+tuV
+ewZ
 xTt
 xTt
 lBF
@@ -71425,9 +71430,9 @@ dBO
 kPJ
 kKN
 xTt
-ncO
+oLk
 rcq
-tVH
+bqd
 xTt
 fGF
 xnH
@@ -71436,9 +71441,9 @@ nQW
 cCb
 pBa
 kjX
-mLm
-avt
-nIl
+kUg
+gXm
+ekT
 lPS
 vgx
 kjX
@@ -71682,9 +71687,9 @@ dBO
 dBO
 xib
 xTt
-wRJ
-akz
-pzE
+bMo
+nVW
+gMK
 xTt
 cNu
 oyO
@@ -71946,9 +71951,9 @@ xTt
 cNu
 oyO
 box
-byW
-ixX
-oDl
+wQZ
+eeD
+gJR
 kjX
 aYT
 lVT
@@ -72196,9 +72201,9 @@ vaN
 vaN
 vaN
 xTt
-dsg
-xiU
-eVC
+eXU
+hVH
+ncg
 xTt
 cNu
 oyO
@@ -72446,16 +72451,16 @@ mKW
 tjr
 fhk
 sVE
-nAU
+hjR
 eFb
 xTt
 xTt
 xTt
 xTt
 xTt
-tLi
-dbz
-cmN
+gYz
+mOZ
+uxu
 xTt
 cNu
 oyO
@@ -72703,15 +72708,15 @@ wxQ
 bPw
 aXP
 agn
-mxh
+tuk
 eFb
-bXs
-cni
-qZC
-cni
-cCC
-jfR
-feP
+urz
+jtz
+imZ
+jtz
+anJ
+tuV
+fmT
 xTt
 xTt
 cNu
@@ -72960,15 +72965,15 @@ ceS
 wcG
 xzq
 cmI
-dDI
-jLc
-hZE
+nzw
+kgS
+eci
 ecQ
 eOX
 bon
 kcs
 lXI
-ahX
+noL
 xTt
 fGF
 xnH
@@ -73217,15 +73222,15 @@ byP
 uDP
 byP
 byP
-vAr
+jNV
 eFb
-swI
+rQO
 yfF
 yfF
 yfF
 yfF
 yfF
-mqo
+byX
 xTt
 cNu
 eeV
@@ -73474,15 +73479,15 @@ fdO
 nsR
 uyk
 cmb
-aHQ
+sWT
 eFb
-hnP
-kqO
-lAP
-fdL
-bUT
-oqn
-iSx
+oDt
+mkU
+gAN
+eGp
+eHM
+clv
+oOU
 xTt
 lBF
 uBb
@@ -73994,9 +73999,9 @@ rtq
 ybK
 bEd
 qRW
-kne
-gmR
-ulK
+wNg
+tbl
+aNU
 aMM
 bQv
 uBb
@@ -74208,7 +74213,7 @@ lMu
 hzS
 lMu
 lMu
-avQ
+kou
 lik
 agN
 qBn
@@ -74251,9 +74256,9 @@ bcT
 cXc
 iAE
 cRS
-itj
+hGv
 lqS
-jCf
+fur
 gwb
 are
 uBb
@@ -74465,7 +74470,7 @@ qcw
 aQa
 jUV
 sYQ
-iIe
+umF
 kAo
 agN
 qBn
@@ -74508,9 +74513,9 @@ ybK
 ted
 qfy
 qRW
-gBa
+bZG
 wvU
-mnR
+oyq
 kgb
 cAd
 uBb
@@ -74722,7 +74727,7 @@ mzS
 pmZ
 iZD
 lMu
-xOB
+tPC
 vVa
 eQi
 xXn
@@ -74765,7 +74770,7 @@ qru
 qRW
 qRW
 qRW
-tCW
+wjr
 wvU
 maX
 pQR
@@ -75779,9 +75784,9 @@ aSA
 bYF
 etl
 aVK
-vIp
-qcK
-gve
+lUU
+nFd
+aJY
 vhk
 xZL
 tvh
@@ -76291,7 +76296,7 @@ gug
 lCy
 aEm
 fHg
-iVx
+qyg
 mbY
 kyR
 inD
@@ -76548,7 +76553,7 @@ vLa
 uWR
 pmr
 tvP
-sZB
+sXF
 xOv
 uJU
 esb
@@ -76805,7 +76810,7 @@ gJn
 wEU
 mTE
 jWt
-phi
+stT
 mbY
 nzc
 oul
@@ -77034,9 +77039,9 @@ imX
 aEH
 snE
 dJN
-ruO
-nnE
-vBt
+hNF
+gJy
+suE
 xao
 rMD
 sOD
@@ -77090,7 +77095,7 @@ qdH
 lvp
 pan
 hic
-jKJ
+dbN
 laH
 oPJ
 mMR
@@ -77347,7 +77352,7 @@ lFh
 qhL
 nkP
 sFt
-gNt
+elK
 cWh
 dFr
 hMe
@@ -77604,7 +77609,7 @@ gtb
 fDV
 kGE
 tkB
-gGn
+tYT
 laH
 oXe
 hMe
@@ -77844,10 +77849,10 @@ ewv
 yjm
 twa
 yjm
-cwH
-ala
-opP
-gqW
+muz
+rwE
+jPL
+cAv
 kEF
 vkW
 nEQ
@@ -78099,12 +78104,12 @@ edn
 xVn
 hyf
 onS
-wOa
-nZO
-sjO
+jql
+oyX
+oBO
 jcI
-nFC
-dcO
+spO
+gnw
 kEF
 oRt
 ewA
@@ -78354,13 +78359,13 @@ nhu
 mFg
 sbk
 rjs
-nyW
+bDT
 onS
-hgW
+lhh
 knb
 xRo
 xsV
-uku
+fun
 kEF
 kEF
 jvg
@@ -78566,9 +78571,9 @@ vRP
 aCD
 aCD
 eRC
-xfx
-cZW
-pTV
+gEE
+sKI
+sjj
 vTN
 aTw
 hmB
@@ -78611,15 +78616,15 @@ uBc
 lxh
 lPG
 oXr
-jIh
+cex
 dmV
-lxI
+gwN
 fBu
 fBu
 bpO
-fYg
+nFm
 onS
-rBQ
+aQG
 tkh
 ewA
 maX
@@ -78868,15 +78873,15 @@ hkH
 nXR
 nXR
 jBI
-uDn
+gNN
 tUq
-wge
-sJk
-glX
+aeA
+rlN
+dWH
 qlQ
-jEn
+xiH
 jzY
-fbd
+cRz
 kmr
 ewA
 sKm
@@ -79129,16 +79134,16 @@ raJ
 kEF
 kEF
 kEF
-pPK
-dmK
-fSk
+gDh
+vub
+wOT
 tUq
-xVY
+feV
 kmr
 ewA
 fbN
 geS
-agA
+ecy
 kgb
 nTF
 mQK
@@ -79349,7 +79354,7 @@ eLb
 sIj
 bDb
 kYy
-bgK
+wkP
 gjR
 uKW
 kYy
@@ -79387,7 +79392,7 @@ cwL
 kwH
 kEF
 kEF
-wTR
+lzw
 kEF
 kEF
 aoe
@@ -79395,7 +79400,7 @@ kmr
 atI
 kTM
 kTM
-jCf
+fur
 jCA
 tVD
 pio
@@ -79606,7 +79611,7 @@ jry
 keq
 jKi
 cKN
-gUr
+pOf
 kcF
 eyO
 kYy
@@ -79642,17 +79647,17 @@ klA
 gcJ
 rjs
 sca
-vwa
-uFH
-lZc
-mtw
-bvx
+mad
+ayx
+rju
+gVs
+sKZ
 dNv
 kmr
 ewA
 kmr
 kmr
-lef
+pQY
 wTB
 wTB
 wTB
@@ -79863,7 +79868,7 @@ keq
 keq
 snD
 kYy
-pCM
+nMQ
 njv
 xET
 kYy
@@ -80635,7 +80640,7 @@ grB
 pfR
 hDW
 cNz
-tus
+kOj
 qXf
 eoP
 mrq
@@ -80650,7 +80655,7 @@ wga
 mrq
 aEv
 ptM
-fSh
+hKC
 dCF
 eih
 xrA
@@ -80907,7 +80912,7 @@ lZL
 ooG
 aEv
 ptM
-qKe
+mtl
 ihc
 yjk
 wPU
@@ -81164,7 +81169,7 @@ vFK
 mrq
 aEv
 ptM
-dvv
+oYd
 dCF
 dCF
 uYP
@@ -81411,7 +81416,7 @@ keq
 ooX
 mrq
 mrq
-nUd
+jOx
 oYb
 kbt
 cuu
@@ -81668,7 +81673,7 @@ kmh
 xCs
 bqN
 oHq
-hEr
+wMC
 vGP
 hCH
 agH
@@ -81716,7 +81721,7 @@ aGV
 nOj
 kXa
 dtJ
-vfs
+gYK
 wTB
 wTB
 hBZ
@@ -81925,7 +81930,7 @@ eLb
 rKM
 lxv
 mrq
-wbn
+rkZ
 oTT
 kbt
 fBI
@@ -81973,7 +81978,7 @@ ctb
 kqt
 dtJ
 kqt
-dVM
+kKL
 jQO
 aOB
 wOb
@@ -82230,7 +82235,7 @@ kWZ
 ltI
 mrk
 cry
-joZ
+wUr
 wTB
 nGS
 nYy
@@ -83262,7 +83267,7 @@ jwz
 jSO
 oXR
 hbW
-sLh
+rzw
 wvV
 dXK
 dpf
@@ -83519,7 +83524,7 @@ uJu
 jSO
 fNv
 vwU
-ufp
+nuL
 cyI
 xId
 uRs
@@ -83776,7 +83781,7 @@ rJw
 jSO
 sZa
 hbW
-mGz
+rXf
 yfh
 oCY
 dpf
@@ -84017,9 +84022,9 @@ abV
 abV
 mPa
 oem
-tcI
-sic
-gtV
+pLP
+ghj
+rTH
 hMD
 pdz
 qQY
@@ -84804,9 +84809,9 @@ oCg
 dge
 fEg
 kju
-mMJ
-bYj
-dYs
+lJn
+lCE
+ngm
 hbW
 hLh
 wNm
@@ -85306,7 +85311,7 @@ mMi
 eUZ
 idi
 kov
-erF
+gWm
 ojI
 eZx
 hyE
@@ -85563,7 +85568,7 @@ mHW
 mHW
 mHW
 mHW
-omc
+wyO
 fRr
 cAG
 mrP
@@ -86040,7 +86045,7 @@ keq
 pSg
 bDb
 lFe
-cMb
+vRZ
 dZo
 sWc
 iwn
@@ -86297,14 +86302,14 @@ eLb
 eLb
 hVN
 uhi
-wAh
+bhE
 pNe
 lXw
 bUf
 lFe
-lTf
-vCw
-rTK
+nvb
+ggB
+wQh
 uuV
 lae
 iwi
@@ -86330,7 +86335,7 @@ vRP
 qIk
 nqE
 mHW
-ePp
+tiO
 lIh
 cnh
 kwm
@@ -86554,7 +86559,7 @@ fJJ
 eLb
 rIc
 lFe
-xDe
+dua
 iwn
 lFe
 lFe
@@ -86587,7 +86592,7 @@ aCD
 qIk
 cds
 mtW
-pZQ
+moj
 hZT
 joM
 knX
@@ -86844,7 +86849,7 @@ aCD
 qIk
 dpH
 mHW
-xmD
+hJt
 qWF
 knX
 knX
@@ -87331,7 +87336,7 @@ kva
 kva
 paW
 nYO
-kAF
+mZl
 oqQ
 nYO
 ecN
@@ -87583,12 +87588,12 @@ keq
 scI
 xsB
 xsB
-tBL
-vHa
-osq
+sOI
+flc
+ltg
 gKH
 xZU
-pDz
+oFw
 amp
 nYO
 ycV
@@ -87845,7 +87850,7 @@ toK
 mQt
 mQt
 mQt
-shu
+ahc
 gsL
 kOt
 wPm
@@ -87882,9 +87887,9 @@ jfN
 jfN
 vsT
 lID
-dNj
-edJ
-ktE
+jng
+ieW
+dKs
 uzX
 nuh
 hED
@@ -88097,9 +88102,9 @@ keq
 qjL
 mQt
 cMs
-mSp
-teH
-ccJ
+rXZ
+lse
+uwe
 kHD
 mQt
 cmF
@@ -88396,9 +88401,9 @@ rcm
 oIK
 rcm
 rcm
-hTW
-uSq
-xFj
+csW
+oYz
+xMo
 uzX
 uUA
 hcR
@@ -88610,9 +88615,9 @@ keq
 keq
 qjL
 mQt
-oQx
-miU
-ubP
+qmP
+bnr
+boV
 mQt
 mQt
 mQt
@@ -89124,8 +89129,8 @@ eLb
 mrH
 tNc
 igt
-dyt
-kUL
+hUc
+dRT
 jut
 rny
 cYX
@@ -89642,9 +89647,9 @@ keq
 qjL
 jut
 xaO
-aae
-vJQ
-aJj
+ctN
+kVZ
+dJj
 jut
 cBE
 gia
@@ -90663,8 +90668,8 @@ nKd
 uPj
 aWF
 dLk
-shF
-pTG
+oPx
+oBl
 rsW
 eLb
 eLb
@@ -90676,7 +90681,7 @@ qjL
 keq
 kPR
 kfu
-pgO
+nld
 moB
 uhh
 kfu
@@ -90933,7 +90938,7 @@ ahK
 gtf
 bqN
 srl
-fVh
+neN
 eKQ
 eAn
 kfu
@@ -90956,7 +90961,7 @@ pNL
 vzg
 hfV
 hpP
-rZX
+fHk
 wLj
 oYc
 oYc
@@ -91190,7 +91195,7 @@ icQ
 fEx
 egW
 kfu
-gqx
+awE
 dGa
 bhz
 eMT
@@ -91206,7 +91211,7 @@ fxy
 iyi
 yhE
 myr
-aKd
+jVq
 oYc
 oYc
 oYc
@@ -91429,10 +91434,10 @@ jzc
 laK
 hCF
 aCs
-kby
+seE
 tYq
 vps
-tWb
+uAW
 niO
 uEf
 xPy
@@ -91463,7 +91468,7 @@ fBg
 cFD
 nay
 vZe
-gpv
+wux
 cxh
 ueT
 bbz
@@ -91686,10 +91691,10 @@ vRP
 eqc
 pQh
 eqc
-pge
+wyz
 kxF
 jxt
-aWJ
+oFV
 dLk
 niO
 niO
@@ -91943,22 +91948,22 @@ vRP
 vRP
 aCD
 eqc
-pkJ
+vnG
 amf
 yge
-feO
-ykg
-uyG
-nnG
-vxN
-xRK
-fVp
-nIy
-jcS
-jcS
-jcS
-jcS
-jFL
+fmf
+ofi
+mHI
+pwq
+vfu
+hgD
+vzY
+qQr
+lqA
+lqA
+lqA
+lqA
+kUx
 eyx
 sGA
 eyx
@@ -91986,9 +91991,9 @@ rrG
 vpc
 gbh
 gda
-nOe
-wRG
-tyd
+aEG
+gLY
+bar
 nPi
 vvd
 vmy
@@ -92200,7 +92205,7 @@ vRP
 aCD
 aCD
 eqc
-fgs
+pJs
 kxF
 abU
 ihf
@@ -92457,23 +92462,23 @@ vRP
 vRP
 aCD
 eqc
-pkJ
+vnG
 kxF
-xdB
-nTr
-nTr
-nTr
-rcE
-qJW
-qeA
-pnr
-eDv
-olO
-nzK
-wku
-wku
-wku
-nve
+bXV
+wUU
+wUU
+wUU
+nKY
+sbf
+npt
+sUn
+hvA
+yba
+bKq
+rYZ
+rYZ
+rYZ
+qvR
 ftY
 ftY
 ftY
@@ -92714,14 +92719,14 @@ vRP
 eqc
 pQh
 eqc
-pge
+wyz
 kxF
-lJY
+vhw
 rmW
 iha
 rmW
-nDr
-jDy
+qMq
+gna
 pQh
 pQh
 dIB
@@ -92730,7 +92735,7 @@ dIB
 dIB
 dIB
 dIB
-qGI
+pxJ
 ftY
 ftY
 ftY
@@ -92971,15 +92976,15 @@ vRP
 laK
 pqy
 aCs
-vuM
+bZk
 ibW
-epr
-bMP
-bMP
-bMP
-riG
-feO
-sKe
+pnj
+uWb
+uWb
+uWb
+prX
+fmf
+hFD
 pQh
 dYL
 dYL
@@ -92987,7 +92992,7 @@ dYL
 dYL
 ech
 xgP
-ycg
+hUj
 fyP
 kUU
 fyP
@@ -93002,9 +93007,9 @@ ngI
 pBk
 iKT
 hVM
-uXL
+hPF
 knr
-vZN
+xdF
 syN
 vVi
 xPv
@@ -93228,7 +93233,7 @@ vRP
 eqc
 eqc
 eqc
-nDr
+qMq
 kxF
 mLh
 lWI
@@ -93236,7 +93241,7 @@ kxF
 kxF
 fpk
 kxF
-mLz
+lVz
 pQh
 dYL
 dYL
@@ -93485,15 +93490,15 @@ vRP
 laK
 hCF
 aCs
-uGW
-ccP
-bFq
-oZR
-mhr
-rcE
+tmB
+rJd
+hRP
+njk
+mAK
+nKY
 kxF
 kxF
-jDy
+gna
 pQh
 dYL
 dYL
@@ -93747,10 +93752,10 @@ pQh
 mvV
 pQh
 pQh
-rPc
-gdo
-iMI
-ujU
+mKl
+ybN
+tpM
+xpD
 pQh
 xgP
 xgP
@@ -93773,7 +93778,7 @@ gXE
 rbp
 gam
 hVM
-bzz
+sHg
 kyA
 mKZ
 mKZ
@@ -94042,9 +94047,9 @@ gxH
 kyA
 pWI
 waL
-jRx
-jVa
-hZd
+gBx
+ulq
+eJT
 pKx
 wod
 dvp
@@ -94287,7 +94292,7 @@ iUF
 eNr
 ohE
 hVM
-etP
+bpQ
 oYi
 bTn
 aRj
@@ -94303,7 +94308,7 @@ aLl
 mfP
 aLl
 uhZ
-lSc
+sZK
 rjN
 rrI
 faQ
@@ -94516,7 +94521,7 @@ iLQ
 dty
 fAL
 hGC
-uVk
+vQX
 iLQ
 rGP
 bvm
@@ -94773,7 +94778,7 @@ iLQ
 cBB
 wUI
 jcQ
-bjZ
+uir
 gNl
 nwQ
 lSl
@@ -96073,7 +96078,7 @@ xgP
 ihC
 eWK
 fnc
-jRU
+vjF
 ghk
 egF
 pps
@@ -96096,7 +96101,7 @@ qvo
 fMi
 hmD
 qVl
-xhw
+sBB
 fGy
 vKc
 aLl
@@ -96330,7 +96335,7 @@ xgP
 nCy
 sTM
 uQR
-cDh
+nIR
 cPe
 oyZ
 ilp
@@ -96353,7 +96358,7 @@ eVR
 wgS
 vFm
 qlc
-kCa
+vjQ
 tUy
 ozz
 aLl
@@ -96587,7 +96592,7 @@ xgP
 kIf
 dVD
 fnc
-nKs
+aPt
 eTE
 cTL
 kFN
@@ -96610,7 +96615,7 @@ uQz
 oJi
 hBI
 qdi
-vwl
+mIx
 fGy
 aLl
 aLl

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -201,20 +201,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aeA" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "aeL" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
@@ -323,27 +309,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"ahc" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
+"agT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 23
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/engine/atmos/distro)
 "ahf" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -600,21 +580,6 @@
 	},
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
-"anj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -642,26 +607,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"anJ" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "aoe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -699,6 +644,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aoJ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "aoY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -726,6 +680,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"apt" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "apz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -821,6 +796,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"asT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
+"ath" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "atx" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel,
@@ -841,6 +836,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"atQ" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "atR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -892,6 +896,18 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"avo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "avY" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/department/bridge)
@@ -921,19 +937,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"awE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "axk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -977,12 +980,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ayx" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "ayK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -1163,6 +1160,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"aCX" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "aDO" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1206,15 +1209,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aEG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aEH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
@@ -1233,6 +1227,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"aGk" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "aGU" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
@@ -1360,15 +1363,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aJY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aJZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -1388,6 +1382,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"aKx" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "aKK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -1479,19 +1490,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aNU" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aOh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -1590,18 +1588,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"aPt" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "aPw" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -1681,15 +1667,6 @@
 /obj/machinery/vending/fishing,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"aQG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "aRb" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1759,6 +1736,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aSG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "aSQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
@@ -2082,19 +2073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bar" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bax" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -2198,18 +2176,6 @@
 /obj/machinery/holosign/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"bcj" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "bco" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -2425,20 +2391,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"bhE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "bhL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2453,6 +2405,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"bii" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bim" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2519,19 +2482,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"bkK" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	layer = 2.4;
-	name = "Mix Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2583,22 +2533,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
-"bmR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "bnk" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -2608,12 +2542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"bnr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "bns" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -2685,13 +2613,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"boV" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "bpn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2727,12 +2648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bpQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "bpR" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -2746,27 +2661,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"bqd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bqk" = (
 /obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/carpet/royalblack,
@@ -3060,15 +2954,6 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"byX" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -3098,6 +2983,19 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bAJ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "bBf" = (
 /obj/structure/railing{
 	dir = 4
@@ -3207,6 +3105,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bDt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "bDB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -3224,13 +3136,19 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bDT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
+"bDN" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bEd" = (
 /obj/machinery/computer/apc_control{
 	dir = 1
@@ -3312,6 +3230,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bFo" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "bGo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3475,19 +3408,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bKq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bKw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -3526,22 +3446,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
-"bMo" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Storage";
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3553,6 +3457,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bNa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bNc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3977,6 +3887,13 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"bWl" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "bWu" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
@@ -4010,6 +3927,13 @@
 "bWR" = (
 /turf/open/floor/plasteel,
 /area/teleporter)
+"bXh" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bXk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4046,60 +3970,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bXV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bYF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bZk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"bZG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bZU" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -4135,6 +4011,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"caE" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "caI" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -4244,10 +4127,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cex" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+"ceM" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ceS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4257,6 +4156,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ceW" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cfi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4494,19 +4400,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"clv" = (
-/obj/structure/chair/office/dark{
-	dir = 4
+"ckR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/engine/atmos/distro)
 "clE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -4526,6 +4435,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"clV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "cmb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -4542,6 +4459,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cms" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "cmF" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -4741,17 +4668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"csW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Xenobiology Lab Access";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "csY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4788,14 +4704,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ctN" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "cuo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5107,22 +5015,6 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cAv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "cAC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5203,6 +5095,19 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"cBI" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "cBK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -5276,6 +5181,26 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
+"cCD" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cCG" = (
 /obj/machinery/doppler_array/research/science,
 /obj/machinery/light/small{
@@ -5294,6 +5219,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"cDC" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cDQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -5313,6 +5249,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cEl" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cEs" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	layer = 2.4;
@@ -5367,6 +5318,11 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"cFq" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cFy" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5688,6 +5644,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"cNI" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "cNR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5747,6 +5711,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cPv" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cPG" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -5793,6 +5774,14 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"cPM" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "cPQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5840,12 +5829,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"cRz" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "cRS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6097,6 +6080,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cXA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cXY" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -6250,20 +6246,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"dbN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "dck" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -6306,6 +6288,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"ddc" = (
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters";
+	pixel_x = 26;
+	pixel_y = 7;
+	req_one_access_txt = "5; 33"
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6327,6 +6323,15 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"ddh" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ddu" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
@@ -6334,6 +6339,17 @@
 /area/maintenance/department/bridge)
 "ddA" = (
 /turf/open/floor/engine/co2,
+/area/engine/atmos/distro)
+"ddP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/electrolyzer,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "dea" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
@@ -6447,6 +6463,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/carpet,
 /area/library)
+"dhj" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "dhw" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -6465,6 +6488,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"dig" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dim" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -6656,6 +6708,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dkA" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dkC" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -6744,19 +6806,6 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
-"dnK" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to distro";
-	target_pressure = 4500
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dog" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -6773,6 +6822,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"doP" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dpf" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
@@ -6925,16 +6983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"dua" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "duO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -6979,6 +7027,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"dwa" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dwr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/engineering";
@@ -7012,6 +7073,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"dwS" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dwV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
@@ -7097,6 +7168,15 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"dAy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "dAF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7117,6 +7197,26 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"dAY" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dBz" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -7132,6 +7232,13 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"dBW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dCg" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
@@ -7214,6 +7321,19 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"dEW" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dEZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -7278,6 +7398,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dFv" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/ten,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dFV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -7403,32 +7545,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
-"dHR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7436,13 +7552,6 @@
 "dIB" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
-"dJj" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "dJF" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -7481,19 +7590,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"dKs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dKt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -7698,30 +7794,41 @@
 /obj/effect/spawner/lootdrop/techstorage/service,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"dRT" = (
+"dRI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/machinery/light_switch{
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "dSh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/surgical_drapes,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"dSm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dSp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7851,6 +7958,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"dUL" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Southeast";
+	dir = 9;
+	network = list("ss13")
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dUW" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/roboticist,
@@ -7947,13 +8073,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dWH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dWL" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -7980,12 +8099,30 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"dXe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "dXK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"dYH" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/computer/station_alert{
+	name = "Station Alert Console"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dYL" = (
 /turf/template_noop,
 /area/maintenance/department/eva)
@@ -8073,6 +8210,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"ebE" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ebF" = (
 /obj/structure/window{
 	dir = 1
@@ -8112,37 +8263,10 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/department/eva)
-"eci" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ecv" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
-"ecy" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ecL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -8247,6 +8371,20 @@
 /obj/item/hand_tele,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"edY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "eeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8268,19 +8406,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"eeD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "eeG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -8445,9 +8570,31 @@
 "eiF" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"eiN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ejl" = (
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"ejD" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ejE" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -8501,23 +8648,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"ekT" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "ela" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
@@ -8548,16 +8678,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"elK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "elX" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -8649,6 +8769,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ens" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eoa" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/engine/engineering";
@@ -8676,6 +8820,24 @@
 "eom" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"eot" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eoA" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -8977,6 +9139,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
+"eui" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "euj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/camera{
@@ -9075,22 +9244,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"evJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ewm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9119,24 +9272,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"ewZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "exV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -9368,6 +9503,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"eCb" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "eCc" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -9585,29 +9731,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eGp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eGu" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom";
@@ -9645,18 +9768,6 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"eHM" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/computer/station_alert{
-	name = "Station Alert Console"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eIf" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -9762,16 +9873,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"eJT" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eJX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -9789,6 +9890,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eKg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eKp" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
@@ -10121,6 +10228,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"eQK" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/exit";
+	dir = 8;
+	name = "Escape Hallway APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "eRg" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -10340,16 +10466,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eXU" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eYP" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -10615,15 +10731,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"feV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "ffj" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -10833,6 +10940,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fky" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Service Backroom"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "fkJ" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -10849,25 +10967,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"flc" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fli" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
@@ -10922,15 +11021,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"fmf" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fmk" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -10985,20 +11075,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"fmT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "fnc" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -11056,6 +11132,15 @@
 "fpt" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"fpw" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fpM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -11130,6 +11215,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"fru" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "frz" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt2";
@@ -11221,53 +11321,6 @@
 "ftY" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fun" = (
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_y = 10
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"fur" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fuJ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
@@ -11383,29 +11436,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"fyk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fyD" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
@@ -11468,6 +11498,17 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fzn" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "EVA East";
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "fzA" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
@@ -11888,6 +11929,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fFp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "fFq" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -11979,24 +12034,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"fHk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "fHm" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -12004,6 +12041,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"fHS" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "fIC" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12142,6 +12186,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fNn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fNq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12338,12 +12395,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"fSd" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "fSj" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -12442,6 +12493,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"fUT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12531,6 +12598,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
+"fYr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "fYs" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -12721,6 +12806,31 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"gca" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gcE" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -12830,24 +12940,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"ggB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ggD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12871,15 +12963,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"ghj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ghk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -12892,6 +12975,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"ght" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ghF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12917,6 +13017,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"ghX" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/multitool{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ghZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -12959,6 +13081,19 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
+"gjH" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gjL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -13075,13 +13210,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"gna" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "gnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13096,13 +13224,6 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"gnw" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gnz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13133,6 +13254,23 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gpb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "gph" = (
 /obj/structure/rack,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -13219,6 +13357,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"grG" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "gsb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13474,19 +13628,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"gwN" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gwV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -13513,24 +13654,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/teleporter)
-"gxL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 1;
-	name = "Atmospherics Distribution APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "gyJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13548,6 +13671,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"gzk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gzB" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -13617,22 +13758,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"gAN" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/assembly/igniter,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gBn" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -13640,13 +13765,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gBx" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gBL" = (
 /obj/machinery/light{
 	dir = 1
@@ -13707,20 +13825,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"gDh" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "gDx" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -13749,16 +13853,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gEE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "gFn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13855,6 +13949,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"gGB" = (
+/obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
+	dir = 8;
+	name = "Chemistry APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gGK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14003,24 +14126,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"gJy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "gJz" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
@@ -14029,14 +14134,6 @@
 /area/engine/atmos/distro)
 "gJE" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"gJR" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14061,6 +14158,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gLv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "gLy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -14086,24 +14197,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"gLY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gMh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -14122,23 +14215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"gMK" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gMU" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -14196,19 +14272,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
-"gNN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "gOA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14404,13 +14467,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"gVs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "gVy" = (
 /obj/machinery/light{
 	dir = 1
@@ -14436,30 +14492,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"gWm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "gWp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gXm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "gXo" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -14510,41 +14546,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"gYz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"gYK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "gZh" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -14656,6 +14657,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"hbU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hbW" = (
 /turf/closed/wall,
 /area/science/mixing)
@@ -14842,23 +14850,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"hgD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14978,20 +14969,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"hjR" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hjZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -15369,6 +15346,19 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"hqZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hrj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -15475,6 +15465,23 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"hul" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks North";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "huP" = (
 /obj/machinery/power/apc{
 	areastring = "/area/library";
@@ -15500,20 +15507,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"hvA" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hvC" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -15535,6 +15528,25 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"hwB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hwC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15779,6 +15791,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"hBc" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 1;
+	name = "Atmospherics Distribution APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
+"hBs" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "hBz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -15786,6 +15823,33 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"hBG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hBI" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -15895,6 +15959,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
+"hDY" = (
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"hEh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hEj" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -15916,37 +16003,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hFD" = (
-/obj/structure/chair{
-	dir = 1
+"hFa" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/hallway/primary/central)
 "hFP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hGv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hGw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15976,6 +16045,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"hGD" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hHt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -16024,6 +16107,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/processing)
+"hIS" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to distro";
+	target_pressure = 4500
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -16032,14 +16128,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"hJt" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "hJB" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -16063,12 +16151,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hKC" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hKH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16087,6 +16169,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/prison)
+"hLQ" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "hMe" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
@@ -16142,17 +16235,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"hNF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "hNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -16241,13 +16323,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hPF" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "hPZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
@@ -16272,6 +16347,12 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/lawoffice)
+"hQV" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hRk" = (
 /obj/item/beacon,
 /obj/machinery/navbeacon{
@@ -16283,6 +16364,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hRx" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hRF" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -16307,34 +16399,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"hRP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"hSi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hSr" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "toxins_airlock_exterior";
@@ -16469,34 +16533,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"hUc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"hUj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hUI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -16543,15 +16579,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"hUW" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "hVc" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16599,33 +16626,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hVH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hVM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -16737,6 +16737,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"iaG" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ibe" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
@@ -16852,24 +16863,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/chapel/main)
-"ieW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "ifa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -17094,6 +17087,24 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"ikm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ikO" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -17147,6 +17158,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ilR" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "imt" = (
 /obj/machinery/light{
 	dir = 4
@@ -17165,24 +17194,20 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
+"imO" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "imX" = (
 /turf/open/floor/plasteel/stairs/goon/stairs2_wide{
 	dir = 1
 	},
 /area/hydroponics/garden)
-"imZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "inC" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -17319,6 +17344,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"iqU" = (
+/obj/machinery/camera{
+	c_tag = "Mining Dock";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "iqX" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
@@ -17361,17 +17403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"isx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/electrolyzer,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ite" = (
 /obj/machinery/button/door{
 	id = "escapepodbay";
@@ -17682,6 +17713,44 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"iym" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 11
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"iyH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "iyI" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/morgue";
@@ -17806,19 +17875,25 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"iBP" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+"iCd" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/engine/atmos/storage)
 "iCK" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mix Tank";
@@ -17865,15 +17940,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
-"iGo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iGP" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -17918,6 +17984,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"iID" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "iIW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17986,6 +18070,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"iKi" = (
+/obj/structure/filingcabinet,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "iKS" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -18138,6 +18233,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"iOg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "iOq" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -18493,6 +18604,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iYT" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18827,6 +18946,15 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"jla" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18946,17 +19074,32 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jng" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jnk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -18975,6 +19118,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jok" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "joK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
@@ -19051,35 +19211,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jql" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "jrd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -19148,16 +19279,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"jtz" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jtL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -19203,6 +19324,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"jwn" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "jwz" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
@@ -19295,6 +19431,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"jyp" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jyJ" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -19317,6 +19459,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"jyP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "jzc" = (
 /obj/docking_port/stationary{
 	dwidth = 12;
@@ -19395,23 +19556,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"jAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks North";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19448,6 +19592,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jBG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jBI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -19492,6 +19651,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"jBV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "jCb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/preopen{
@@ -19781,6 +19954,17 @@
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"jJX" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Xenobiology Lab Access";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jKa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19878,26 +20062,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"jNV" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jNW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -19949,16 +20113,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"jOx" = (
-/obj/structure/bookcase/random/reference,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "jOS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -20026,31 +20180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jPL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 11
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -34
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "jQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20060,6 +20189,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jQL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "jQO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Dormitories Maintenance"
@@ -20270,13 +20410,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"jVq" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "jVL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20308,23 +20441,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
-"jWp" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste In";
-	on = 1
-	},
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jWt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -20565,6 +20681,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"keL" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "keR" = (
 /obj/structure/sink{
 	dir = 4;
@@ -20612,27 +20743,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"kgS" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kgT" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -20778,6 +20888,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"kll" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "klv" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -20925,15 +21049,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"kou" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "kov" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -21090,6 +21205,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kus" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "kuv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -21764,22 +21893,6 @@
 "kKp" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/aft)
-"kKL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "kKN" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldgen,
@@ -21873,23 +21986,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"kOj" = (
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/chapel/office)
 "kOr" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -22058,34 +22154,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"kUg" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"kUx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "kUA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22110,20 +22178,6 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
-"kVD" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "kVO" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -22133,24 +22187,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"kVZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "kWf" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -22215,6 +22251,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"kXz" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kYc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -22498,6 +22547,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ldC" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ldQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
@@ -22668,13 +22736,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"lhh" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lhn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22758,6 +22819,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/broken,
 /area/science/mixing)
+"ljd" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ljj" = (
 /obj/machinery/mass_driver{
 	id = "trash"
@@ -22826,6 +22908,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"llO" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "llZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -22983,17 +23078,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"lqA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "lqS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -23030,21 +23114,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"lse" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "lsK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -23070,21 +23139,6 @@
 	},
 /turf/open/floor/plating,
 /area/hydroponics/garden)
-"ltg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ltm" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23232,6 +23286,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lwK" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "lwO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23243,6 +23305,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"lwS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "lxf" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -23415,35 +23483,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"lzw" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lzE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23562,25 +23601,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"lCE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "lDa" = (
 /obj/machinery/status_display/supply{
 	pixel_y = 2
@@ -23643,17 +23663,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"lEs" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lEH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23752,14 +23761,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
-"lGw" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
@@ -23823,20 +23824,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lIf" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lIh" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -23873,20 +23860,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"lJn" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "lKJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24119,20 +24092,6 @@
 "lQe" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
-"lQu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "lQR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -24358,28 +24317,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lUU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
+"lUQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"lVz" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
+/turf/open/floor/plasteel,
+/area/janitor)
+"lUZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/hallway/primary/central)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -24541,23 +24499,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"mad" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
+"maR" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
 /turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/area/medical/chemistry)
 "maX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -24606,6 +24553,19 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"mcJ" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mcP" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -24704,6 +24664,17 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"mfh" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/broken/two,
+/area/science/mixing)
 "mfl" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -24725,22 +24696,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"mfK" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/magboots,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mfP" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only{
@@ -24948,6 +24903,12 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"mjX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "mki" = (
 /obj/machinery/door/window/westleft{
 	dir = 2;
@@ -24984,31 +24945,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mky" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Airlocks";
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mkA" = (
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"mkU" = (
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 2;
-	pixel_y = 2
+"mkD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/t_scanner{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/multitool{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/quartermaster/office)
 "mlb" = (
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
@@ -25122,15 +25086,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"moj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+"mom" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "moz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25390,10 +25359,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"mtl" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mtp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25413,15 +25378,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"muz" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "muA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
@@ -25547,6 +25503,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mxN" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "mxQ" = (
 /mob/living/simple_animal/pet/snail/gary,
 /turf/open/floor/carpet,
@@ -25584,6 +25547,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"myl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "myr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25675,19 +25650,6 @@
 "mAC" = (
 /turf/closed/wall,
 /area/chapel/main)
-"mAK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "mAL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25712,29 +25674,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
-"mBv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "mCq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -25885,22 +25824,18 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
-"mHI" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "mHW" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
+"mHY" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "mIq" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = -32
@@ -25929,20 +25864,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"mIx" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge South";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "mIS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -25963,22 +25884,16 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"mKl" = (
-/obj/structure/chair{
-	dir = 8
+"mKD" = (
+/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/turf/open/floor/carpet,
+/area/library)
 "mKF" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Containment Chamber";
@@ -26098,6 +26013,25 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"mNv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mOj" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -26147,23 +26081,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mOZ" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mPa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -26278,6 +26195,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"mRK" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mRM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fitness Maintenance"
@@ -26537,23 +26462,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"mZl" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "mZK" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -26594,16 +26502,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"ncg" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ncC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -26622,6 +26520,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ncE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "ncW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26708,20 +26615,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"neN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "neP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26756,20 +26649,22 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nfL" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ngm" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/broken/two,
-/area/science/mixing)
 "ngI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -26808,6 +26703,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nhc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	layer = 2.4;
+	name = "Mix Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "nhh" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/preopen{
@@ -26823,6 +26731,31 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nhO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Dormitory South";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "nig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -26851,16 +26784,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
-"njk" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "njp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
@@ -26890,6 +26813,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"njU" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nkd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -26942,18 +26872,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"nld" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nlq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -27029,6 +26947,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nmy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nmK" = (
 /obj/machinery/light{
 	dir = 1
@@ -27059,26 +26983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"noL" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	name = "Atmospherics Storage Room APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "noP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -27092,19 +26996,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"npt" = (
-/obj/item/radio/intercom{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "npL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -27113,6 +27004,33 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"npN" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"npO" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "npV" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
@@ -27209,6 +27127,17 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"nsC" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nsK" = (
 /obj/machinery/air_sensor{
 	id_tag = "air_sensor"
@@ -27331,19 +27260,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"nuL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "nuS" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
@@ -27351,13 +27267,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nvb" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
+"nvs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -27474,6 +27396,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nyE" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nzc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27534,33 +27462,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nzw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nzG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27669,6 +27570,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"nBn" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "nBv" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -27825,29 +27739,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"nFd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nFm" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "nFB" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -27999,20 +27890,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"nIR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "nJe" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -28170,15 +28047,14 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"nKY" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+"nLc" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "nLn" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit,
@@ -28204,27 +28080,22 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
+"nMe" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "nMP" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nMQ" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "nMW" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
@@ -28508,30 +28379,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"nVW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+"nWv" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 1;
+	name = "Nanite Lab APC";
+	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "nWJ" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -28592,14 +28457,6 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"nYs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "nYy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -28667,19 +28524,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"nZO" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "nZY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
@@ -28858,25 +28702,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ofi" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
-	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ofj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -29224,6 +29049,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"opy" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "opJ" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
@@ -29487,13 +29319,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"oyq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oyB" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
@@ -29506,12 +29331,6 @@
 "oyO" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
-"oyX" = (
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "oyZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -29559,6 +29378,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"ozB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ozS" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -29621,17 +29449,29 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"oBl" = (
-/obj/structure/filingcabinet,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 10
+"oBw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
+/area/engine/atmos/distro)
 "oBB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29641,13 +29481,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"oBO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "oBV" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
@@ -29656,6 +29489,10 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
+"oCd" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "oCg" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -29693,28 +29530,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oDt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/ten,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "oEt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
@@ -29722,6 +29537,22 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oEB" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/magboots,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oEG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -29746,20 +29577,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"oFw" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "oFK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -29771,19 +29588,23 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"oFV" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "oFX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"oGc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "oGt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29933,6 +29754,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"oJP" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	layer = 2.4;
+	name = "Air to Port"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "oKt" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
@@ -29954,19 +29789,57 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/main)
-"oLk" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
+"oKx" = (
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 1;
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+/obj/item/grenade/chem_grenade{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 10
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"oLJ" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/janitor)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -29982,10 +29855,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oNc" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oNB" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oNM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oNX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -29997,6 +29886,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"oOp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Waste In";
+	on = 1
+	},
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "oOB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -30024,19 +29930,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
-"oOU" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "oOX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -30059,24 +29952,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"oPx" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "oPz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -30181,6 +30056,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oSD" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "oTT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30193,6 +30076,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"oVp" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "oVU" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -30308,13 +30204,6 @@
 "oYc" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
-"oYd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oYi" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -30333,39 +30222,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"oYz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"oZp" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "oZJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -30382,6 +30238,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"pab" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "pan" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -30715,6 +30592,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"phE" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "phU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30964,6 +30850,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"pmI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "pmL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31001,23 +30905,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"pnj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pno" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -31050,6 +30937,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pnF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "pnP" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
@@ -31206,15 +31102,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
-"prX" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "psc" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -31240,6 +31127,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"ptp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "pts" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -31320,16 +31231,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pwq" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pwH" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -31364,6 +31265,32 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"pxm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"pxv" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	name = "Atmospheric Alert Console"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "pxC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
@@ -31371,19 +31298,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pxJ" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "pxU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31757,6 +31671,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"pHS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "pIe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31809,21 +31730,6 @@
 /obj/item/storage/box/mousetraps,
 /turf/open/floor/plasteel,
 /area/janitor)
-"pJs" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pJJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/airless,
@@ -31908,13 +31814,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"pLP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pLY" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -32039,17 +31938,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pOf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "pOz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -32065,35 +31953,23 @@
 /obj/item/storage/box/firingpins,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"pOQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "pOV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pOX" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pPd" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
@@ -32160,16 +32036,6 @@
 "pQR" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
-"pQY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pRc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -32193,6 +32059,18 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pRp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "pRv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -32405,6 +32283,25 @@
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"pWm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/table,
+/obj/item/vending_refill/medical{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/machinery/vending/wallhypo{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "pWF" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -32734,6 +32631,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"qeo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "qeq" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/glowstick,
@@ -32759,6 +32674,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qfe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "qfj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -32780,6 +32701,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"qfo" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/storage";
+	name = "Atmospherics Storage Room APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "qfy" = (
 /obj/machinery/computer/station_alert{
 	dir = 1
@@ -33043,24 +32984,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qkT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qlc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33113,6 +33036,24 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"qmC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "qmG" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -33126,17 +33067,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"qmP" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Service Backroom"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "qmZ" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -33274,18 +33204,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"qpa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qpr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -33437,15 +33355,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qvR" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qwa" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -33586,14 +33495,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"qyg" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "qyL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -33733,6 +33634,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"qFF" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qFR" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -33777,6 +33688,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"qGr" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -33820,6 +33741,23 @@
 "qIk" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
+"qIp" = (
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/chapel/office)
 "qIO" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -33949,16 +33887,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"qMq" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qNI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -34057,21 +33985,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"qQr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qQC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHW";
@@ -34116,6 +34029,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"qRy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qRD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -34144,6 +34066,20 @@
 "qRW" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
+"qSh" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "qSj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -34224,6 +34160,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"qTj" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qTE" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/bot,
@@ -34329,6 +34275,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"qWS" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qXf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance";
@@ -34362,6 +34317,13 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/starboard/fore)
+"qXY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "qYa" = (
 /obj/structure/rack,
 /obj/item/grenade/chem_grenade/cleaner{
@@ -34461,6 +34423,19 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"raL" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "rbj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -34866,30 +34841,6 @@
 "rjs" = (
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"rju" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "rjC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -34948,13 +34899,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rkZ" = (
-/obj/structure/bookcase/random/reference,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "rlg" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -34974,20 +34918,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"rlN" = (
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters";
-	pixel_x = 26;
-	pixel_y = 7;
-	req_one_access_txt = "5; 33"
-	},
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "rlY" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -35001,19 +34931,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"rmK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+"rmC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hydroponics/garden)
 "rmT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -35053,6 +34981,16 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"rnN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "rnT" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -35340,11 +35278,31 @@
 "rsW" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/auxiliary)
+"rsX" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/burnt/two,
+/area/science/mixing)
 "rtc" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rtf" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "rtg" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -35480,41 +35438,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"rwE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 8;
-	name = "Chemistry APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
+"rxd" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"rwU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "rxj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -35534,26 +35471,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"rxA" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump";
-	target_pressure = 4500
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rxG" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -35629,14 +35546,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"rzw" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"rzE" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/hallway/secondary/exit)
 "rzT" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -35834,6 +35756,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"rDY" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/distro)
 "rEq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -35843,15 +35771,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"rEt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rEQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -36046,6 +35965,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rIs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "rIB" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -36076,18 +36012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rJd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rJw" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -36209,6 +36133,23 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"rOm" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "rOC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36296,15 +36237,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"rQO" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -36396,15 +36328,37 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"rTH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
+"rUb" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -29
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "rUk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -36554,39 +36508,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rXf" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = 32
-	},
-/obj/structure/chair/comfy/beige{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/burnt/two,
-/area/science/mixing)
 "rXh" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"rXs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	layer = 2.4;
-	name = "Air to Port"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rXw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36638,13 +36565,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"rXZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "rYc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -36664,16 +36584,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"rYZ" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sar" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -36683,6 +36593,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"saQ" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "saY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -36692,14 +36612,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"sbf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sbk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36758,6 +36670,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"scm" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "scr" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -36839,23 +36764,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"seE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "seF" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -36965,6 +36873,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"sif" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/computer/atmos_control{
+	dir = 1;
+	name = "Tank Monitor"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "sil" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -36998,21 +36919,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sjj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+"siX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
 	},
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/secondary/exit)
 "sjm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -37051,6 +36975,14 @@
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"skG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "skY" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -37105,6 +37037,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"smY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "snf" = (
 /obj/machinery/light{
 	dir = 8
@@ -37171,6 +37111,21 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"sof" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sog" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/airalarm{
@@ -37206,19 +37161,6 @@
 "spK" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"spM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
-"spO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "spU" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -37256,6 +37198,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sqt" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "sqz" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -37482,25 +37434,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"stT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/structure/table,
-/obj/item/vending_refill/medical{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/hand_labeler{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/machinery/vending/wallhypo{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "sup" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -37559,15 +37492,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"suE" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "svs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37839,14 +37763,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"sBB" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "sCP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38012,12 +37928,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"sHg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "sHi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38063,6 +37973,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"sKk" = (
+/obj/structure/bookcase/random/reference,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "sKm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
@@ -38105,12 +38022,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/prison)
-"sKI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "sKP" = (
 /obj/machinery/door/airlock/mining{
 	req_access_txt = "48"
@@ -38132,37 +38043,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"sKZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -29
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "sLi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -38231,6 +38111,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"sNc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sNz" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -38288,19 +38180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"sOI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "sOU" = (
 /obj/machinery/door/window/southright{
 	dir = 8;
@@ -38409,6 +38288,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sQI" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sQP" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -38563,19 +38471,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sUn" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/command/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sUu" = (
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt1";
@@ -38673,31 +38568,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sWT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38726,15 +38596,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"sXF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "sXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38858,24 +38719,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"sZK" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "tai" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
@@ -38902,6 +38745,23 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"taR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "taS" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -38918,18 +38778,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"tbl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tbn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
@@ -39024,6 +38872,20 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"teb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Incinerator"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ted" = (
 /obj/machinery/light{
 	dir = 4
@@ -39076,6 +38938,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"tge" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tgi" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -39211,24 +39086,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"tiO" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	dir = 1;
-	name = "Nanite Lab APC";
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "tjk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -39236,6 +39093,24 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"tjo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "tjr" = (
 /turf/closed/wall,
 /area/engine/engineering)
@@ -39263,6 +39138,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tjW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tkg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -39333,24 +39217,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"tmB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "tmP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -39468,25 +39334,6 @@
 /obj/effect/landmark/start/yogs/brigphsyician,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"tpM" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Southeast";
-	dir = 9;
-	network = list("ss13")
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "tpP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39509,6 +39356,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"tqs" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/flashlight,
+/obj/item/assembly/igniter,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tqI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
@@ -39536,6 +39399,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hydroponics)
+"trH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "trI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -39557,12 +39430,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"tuk" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tuM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -39577,15 +39444,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"tuV" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -39606,6 +39464,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tvw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tvD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -39832,6 +39713,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tBi" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tBu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39968,14 +39872,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"tFv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "tFK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40053,6 +39949,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"tHR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "tIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40336,15 +40244,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tPC" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "tPI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40512,6 +40411,24 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"tUh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tUq" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/closed/wall,
@@ -40658,6 +40575,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"tXd" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "tXg" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -40668,6 +40594,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tXr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tXV" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -40723,16 +40660,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"tYT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "tZf" = (
 /obj/machinery/computer/cargo/request,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -40743,6 +40670,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"tZm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tZp" = (
 /turf/closed/wall,
 /area/maintenance/department/science)
@@ -40864,6 +40804,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"udl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "udS" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -41016,18 +40965,6 @@
 "uhZ" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/customs)
-"uir" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "uiR" = (
 /obj/structure/sign/departments/minsky/medical/medical2{
 	pixel_x = -32;
@@ -41158,24 +41095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"ulq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "ulx" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/eva)
@@ -41197,6 +41116,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ulB" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ulF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -41245,17 +41176,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"umF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "unc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -41347,16 +41267,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
 /area/space/nearstation)
-"urz" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "urB" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
@@ -41454,18 +41364,31 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"uwe" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+"uvV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
+"uwi" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hallway/secondary/exit)
 "uwx" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -41500,19 +41423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"uxu" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "uxw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41627,14 +41537,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"uAW" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uBb" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/supply)
@@ -41718,6 +41620,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"uCS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "uCW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -42003,6 +41924,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"uJR" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge South";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "uJU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -42104,6 +42039,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uMr" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "uMD" = (
 /turf/open/water/safe,
 /area/hydroponics/garden)
@@ -42261,6 +42210,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uPS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uPW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42339,6 +42306,13 @@
 "uRB" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uRD" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "uRS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -42423,6 +42397,20 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
+"uUj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "uUA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -42486,19 +42474,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"uWb" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uWi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -42800,23 +42775,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vdN" = (
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"vea" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Incinerator"
+"vdu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hallway/primary/starboard)
+"vdN" = (
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"veh" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vei" = (
 /obj/machinery/light{
 	dir = 1
@@ -42847,17 +42831,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vfu" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+"vfs" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "vfC" = (
@@ -42881,6 +42860,24 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"vfV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vgs" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
@@ -43022,25 +43019,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"vhw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vhy" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -43115,17 +43093,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"vjF" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "EVA East";
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "vjK" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -43148,16 +43115,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vjQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "vjY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -43178,6 +43135,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"vkA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vkE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -43192,6 +43163,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"vkH" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vkW" = (
 /obj/machinery/light{
 	dir = 1
@@ -43314,17 +43295,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
-"vnG" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vnT" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43364,30 +43334,19 @@
 "voI" = (
 /turf/closed/wall,
 /area/security/processing)
-"vpb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+"voL" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
@@ -43591,25 +43550,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vub" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "vuq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -43725,6 +43665,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"vyS" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vzg" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -43801,17 +43751,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"vzY" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vAc" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -44076,6 +44015,21 @@
 "vIw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vIE" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
+"vIH" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44343,17 +44297,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vNE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "vNF" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/reagent_dispensers/watertank,
@@ -44435,13 +44378,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"vQX" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
+"vQQ" = (
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "vRl" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -44460,44 +44404,11 @@
 "vRP" = (
 /turf/open/space/basic,
 /area/space)
-"vRZ" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "vSh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"vSW" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks South";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste to Space"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "vTf" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -44778,6 +44689,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"vZw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vZM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
@@ -44846,6 +44768,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"wbX" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "wcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45010,6 +44942,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"wgl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wgp" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -45167,20 +45111,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"wjr" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wjL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/structure/sign/directions/evac{
@@ -45211,13 +45141,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wkP" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "wlz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45499,6 +45422,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wrA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wrC" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
@@ -45578,19 +45520,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
-"wux" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "wva" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -45736,29 +45665,41 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"wyz" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+"wyg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/engine/atmos/distro)
+"wyn" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"wyO" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "wyR" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -45844,6 +45785,20 @@
 "wCC" = (
 /turf/template_noop,
 /area/maintenance/starboard/fore)
+"wCD" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wCG" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -45874,6 +45829,19 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"wEi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "wEs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -45944,6 +45912,19 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"wFQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "wFZ" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -46219,18 +46200,6 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"wMC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "wMY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46243,21 +46212,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wNg" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wNm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -46343,16 +46297,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"wOT" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "wPm" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
@@ -46421,35 +46365,10 @@
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"wQh" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wQn" = (
 /obj/structure/disposalpipe/segment,
 /turf/template_noop,
 /area/maintenance/aft)
-"wQp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "wQB" = (
 /obj/machinery/power/solar_control{
 	dir = 4;
@@ -46489,22 +46408,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
-"wQZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46531,6 +46434,28 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"wSt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks South";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste to Space"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wSu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -46597,6 +46522,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"wUe" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wUk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -46606,20 +46544,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wUr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "wUH" = (
 /obj/structure/chair{
 	dir = 8
@@ -46639,19 +46563,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"wUU" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wVo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -46899,6 +46810,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"xbi" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xbl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -46964,19 +46881,6 @@
 "xbK" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
-"xch" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xcv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -46990,6 +46894,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"xcQ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xcW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -47010,15 +46927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"xdF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "xdK" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -47109,6 +47017,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"xfY" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "xga" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -47185,12 +47116,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"xiH" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "xiN" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -47287,15 +47212,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xkm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xkF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -47335,6 +47251,18 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"xld" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xle" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47486,16 +47414,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xpD" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "xpJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -47616,6 +47534,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"xrI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xrK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47957,6 +47891,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"xBC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xBE" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos/distro)
@@ -47965,15 +47909,6 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/genetics)
-"xBR" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "xCs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -48012,12 +47947,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"xDY" = (
-/obj/effect/turf_decal/stripes/line{
+"xDa" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -48071,6 +48016,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"xEO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "xET" = (
 /obj/machinery/power/apc{
 	areastring = "/area/chapel/office";
@@ -48198,6 +48155,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"xIk" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xIl" = (
 /turf/open/floor/carpet,
 /area/library)
@@ -48287,25 +48248,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"xLj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+"xLp" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/sign/departments/minsky/command/evac{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hallway/secondary/exit)
 "xLC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -48355,16 +48310,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"xMo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "xMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -48408,6 +48353,20 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xNy" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xNC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "xNI" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/electrolyzer,
@@ -48489,6 +48448,33 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"xPf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xPg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -48807,6 +48793,24 @@
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"xWa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -48930,6 +48934,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xZl" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xZo" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
@@ -49036,19 +49049,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
-"yba" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ybj" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -49070,23 +49070,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
-"ybN" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "yca" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
@@ -49403,6 +49386,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"yla" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "yld" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Aft";
@@ -66803,7 +66804,7 @@ ejY
 lZB
 xWd
 orF
-rxA
+ceM
 sGB
 dsb
 vpm
@@ -67060,7 +67061,7 @@ bsg
 nky
 apP
 uGF
-qpa
+avo
 sLY
 lGx
 ydx
@@ -67317,7 +67318,7 @@ cqd
 gHA
 vBr
 ekN
-pOQ
+tBi
 chs
 lJm
 vbO
@@ -67574,9 +67575,9 @@ myw
 fFT
 jzv
 ahZ
-rmK
-jAw
-vea
+fNn
+hul
+teb
 eRT
 oEG
 rXM
@@ -67833,7 +67834,7 @@ kcE
 kcE
 aik
 opo
-nZO
+scm
 wVo
 njB
 dWX
@@ -68081,8 +68082,8 @@ tkl
 tkl
 nKW
 tCd
-iGo
-xDY
+jla
+bNa
 bPu
 knf
 knf
@@ -68090,7 +68091,7 @@ vYY
 jts
 cbm
 eDA
-iBP
+xcQ
 dwV
 vTP
 cnI
@@ -68347,7 +68348,7 @@ rbs
 wQK
 buE
 iuS
-bcj
+ulB
 kwv
 rOc
 bQM
@@ -68604,7 +68605,7 @@ fJf
 jEZ
 sAf
 jYT
-bkK
+nhc
 eBt
 bVq
 cEs
@@ -68613,10 +68614,10 @@ lSj
 bVq
 bVq
 svz
-tFv
-vNE
-xch
-vSW
+clV
+tXr
+bAJ
+wSt
 acO
 vzR
 hoI
@@ -68861,16 +68862,16 @@ jjX
 jjX
 lYd
 gAG
-gxL
+hBc
 wwC
-nYs
-rEt
-rEt
-rXs
-hUW
+skG
+aoJ
+aoJ
+oJP
+qWS
 rXM
 rXM
-jWp
+oOp
 uCi
 uCi
 uCi
@@ -69112,22 +69113,22 @@ lZu
 vsH
 bBo
 cLo
-lGw
+mRK
 eFb
 gph
 qGN
 hpd
-spM
-dnK
-fyk
-isx
+rDY
+hIS
+tvw
+ddP
 cCc
 eNL
 cSC
-qkT
-anj
-xkm
-xLj
+tUh
+agT
+tjW
+wrA
 uCi
 iRz
 wQB
@@ -69369,7 +69370,7 @@ lRP
 mTJ
 rEq
 uMm
-rwU
+eKg
 eRY
 twv
 oxM
@@ -69626,15 +69627,15 @@ teI
 hAJ
 pzD
 rYc
-hSi
+xZl
 eFb
 xkI
 aJz
 bgd
 qiY
-lQu
-dHR
-bmR
+edY
+wyg
+ckR
 peq
 xge
 bCp
@@ -69889,9 +69890,9 @@ xTt
 xTt
 xTt
 xTt
-wQp
-mBv
-kVD
+xrI
+oBw
+bDt
 jjX
 wIS
 tzj
@@ -70403,9 +70404,9 @@ tAe
 wDm
 nAf
 fjD
-xBR
-vpb
-mfK
+veh
+jng
+oEB
 xTt
 cNu
 vdN
@@ -70660,9 +70661,9 @@ mLC
 eEF
 eEF
 mki
-lIf
+wCD
 ndj
-fSd
+hQV
 xTt
 cNu
 xZo
@@ -70917,9 +70918,9 @@ elX
 elX
 sxu
 cxc
-rQO
-evJ
-lEs
+vIH
+rIs
+cDC
 xTt
 cNu
 aMM
@@ -71173,9 +71174,9 @@ xTt
 xTt
 xTt
 xTt
-oZp
-tuV
-ewZ
+keL
+oNc
+fYr
 xTt
 xTt
 lBF
@@ -71430,9 +71431,9 @@ dBO
 kPJ
 kKN
 xTt
-oLk
+dEW
 rcq
-bqd
+pab
 xTt
 fGF
 xnH
@@ -71441,9 +71442,9 @@ nQW
 cCb
 pBa
 kjX
-kUg
-gXm
-ekT
+sqt
+dXe
+iqU
 lPS
 vgx
 kjX
@@ -71687,9 +71688,9 @@ dBO
 dBO
 xib
 xTt
-bMo
-nVW
-gMK
+voL
+ens
+cPv
 xTt
 cNu
 oyO
@@ -71951,9 +71952,9 @@ xTt
 cNu
 oyO
 box
-wQZ
-eeD
-gJR
+grG
+wEi
+oSD
 kjX
 aYT
 lVT
@@ -72201,9 +72202,9 @@ vaN
 vaN
 vaN
 xTt
-eXU
-hVH
-ncg
+nMe
+hBG
+vkH
 xTt
 cNu
 oyO
@@ -72451,16 +72452,16 @@ mKW
 tjr
 fhk
 sVE
-hjR
+ebE
 eFb
 xTt
 xTt
 xTt
 xTt
 xTt
-gYz
-mOZ
-uxu
+hEh
+npO
+raL
 xTt
 cNu
 oyO
@@ -72708,15 +72709,15 @@ wxQ
 bPw
 aXP
 agn
-tuk
+nyE
 eFb
-urz
-jtz
-imZ
-jtz
-anJ
-tuV
-fmT
+dkA
+qGr
+asT
+qGr
+dAY
+oNc
+vkA
 xTt
 xTt
 cNu
@@ -72965,15 +72966,15 @@ ceS
 wcG
 xzq
 cmI
-nzw
-kgS
-eci
+xPf
+ljd
+iCd
 ecQ
 eOX
 bon
 kcs
 lXI
-noL
+qfo
 xTt
 fGF
 xnH
@@ -73222,15 +73223,15 @@ byP
 uDP
 byP
 byP
-jNV
+cCD
 eFb
-rQO
+vIH
 yfF
 yfF
 yfF
 yfF
 yfF
-byX
+pxv
 xTt
 cNu
 eeV
@@ -73479,15 +73480,15 @@ fdO
 nsR
 uyk
 cmb
-sWT
+gca
 eFb
-oDt
-mkU
-gAN
-eGp
-eHM
-clv
-oOU
+dFv
+ghX
+tqs
+xfY
+dYH
+nBn
+sif
 xTt
 lBF
 uBb
@@ -73999,9 +74000,9 @@ rtq
 ybK
 bEd
 qRW
-wNg
-tbl
-aNU
+cEl
+sNc
+nfL
 aMM
 bQv
 uBb
@@ -74213,7 +74214,7 @@ lMu
 hzS
 lMu
 lMu
-kou
+aGk
 lik
 agN
 qBn
@@ -74256,9 +74257,9 @@ bcT
 cXc
 iAE
 cRS
-hGv
+aSG
 lqS
-fur
+nmy
 gwb
 are
 uBb
@@ -74470,7 +74471,7 @@ qcw
 aQa
 jUV
 sYQ
-umF
+vZw
 kAo
 agN
 qBn
@@ -74513,9 +74514,9 @@ ybK
 ted
 qfy
 qRW
-bZG
+qSh
 wvU
-oyq
+lUZ
 kgb
 cAd
 uBb
@@ -74727,7 +74728,7 @@ mzS
 pmZ
 iZD
 lMu
-tPC
+phE
 vVa
 eQi
 xXn
@@ -74770,7 +74771,7 @@ qru
 qRW
 qRW
 qRW
-wjr
+uMr
 wvU
 maX
 pQR
@@ -75784,9 +75785,9 @@ aSA
 bYF
 etl
 aVK
-lUU
-nFd
-aJY
+bii
+xWa
+ozB
 vhk
 xZL
 tvh
@@ -76296,7 +76297,7 @@ gug
 lCy
 aEm
 fHg
-qyg
+vQQ
 mbY
 kyR
 inD
@@ -76553,7 +76554,7 @@ vLa
 uWR
 pmr
 tvP
-sXF
+pnF
 xOv
 uJU
 esb
@@ -76810,7 +76811,7 @@ gJn
 wEU
 mTE
 jWt
-stT
+pWm
 mbY
 nzc
 oul
@@ -77039,9 +77040,9 @@ imX
 aEH
 snE
 dJN
-hNF
-gJy
-suE
+rmC
+qmC
+ddh
 xao
 rMD
 sOD
@@ -77095,7 +77096,7 @@ qdH
 lvp
 pan
 hic
-dbN
+mom
 laH
 oPJ
 mMR
@@ -77352,7 +77353,7 @@ lFh
 qhL
 nkP
 sFt
-elK
+mkD
 cWh
 dFr
 hMe
@@ -77609,7 +77610,7 @@ gtb
 fDV
 kGE
 tkB
-tYT
+wbX
 laH
 oXe
 hMe
@@ -77849,10 +77850,10 @@ ewv
 yjm
 twa
 yjm
-muz
-rwE
-jPL
-cAv
+doP
+gGB
+iym
+iOg
 kEF
 vkW
 nEQ
@@ -78104,12 +78105,12 @@ edn
 xVn
 hyf
 onS
-jql
-oyX
-oBO
+dig
+xbi
+qXY
 jcI
-spO
-gnw
+ath
+ceW
 kEF
 oRt
 ewA
@@ -78359,13 +78360,13 @@ nhu
 mFg
 sbk
 rjs
-bDT
+bXh
 onS
-lhh
+uRD
 knb
 xRo
 xsV
-fun
+oKx
 kEF
 kEF
 jvg
@@ -78571,9 +78572,9 @@ vRP
 aCD
 aCD
 eRC
-gEE
-sKI
-sjj
+cms
+mjX
+uvV
 vTN
 aTw
 hmB
@@ -78616,15 +78617,15 @@ uBc
 lxh
 lPG
 oXr
-cex
+oCd
 dmV
-gwN
+gjH
 fBu
 fBu
 bpO
-nFm
+cFq
 onS
-aQG
+ncE
 tkh
 ewA
 maX
@@ -78873,15 +78874,15 @@ hkH
 nXR
 nXR
 jBI
-gNN
+llO
 tUq
-aeA
-rlN
-dWH
+hGD
+ddc
+oNM
 qlQ
-xiH
+maR
 jzY
-cRz
+vIE
 kmr
 ewA
 sKm
@@ -79134,16 +79135,16 @@ raJ
 kEF
 kEF
 kEF
-gDh
-vub
-wOT
+uUj
+mNv
+dwS
 tUq
-feV
+tXd
 kmr
 ewA
 fbN
 geS
-ecy
+xNy
 kgb
 nTF
 mQK
@@ -79354,7 +79355,7 @@ eLb
 sIj
 bDb
 kYy
-wkP
+rtf
 gjR
 uKW
 kYy
@@ -79392,7 +79393,7 @@ cwL
 kwH
 kEF
 kEF
-lzw
+sQI
 kEF
 kEF
 aoe
@@ -79400,7 +79401,7 @@ kmr
 atI
 kTM
 kTM
-fur
+nmy
 jCA
 tVD
 pio
@@ -79611,7 +79612,7 @@ jry
 keq
 jKi
 cKN
-pOf
+jQL
 kcF
 eyO
 kYy
@@ -79647,17 +79648,17 @@ klA
 gcJ
 rjs
 sca
-mad
-ayx
-rju
-gVs
-sKZ
+rOm
+aCX
+ptp
+opy
+rUb
 dNv
 kmr
 ewA
 kmr
 kmr
-pQY
+trH
 wTB
 wTB
 wTB
@@ -79868,7 +79869,7 @@ keq
 keq
 snD
 kYy
-nMQ
+bFo
 njv
 xET
 kYy
@@ -80640,7 +80641,7 @@ grB
 pfR
 hDW
 cNz
-kOj
+qIp
 qXf
 eoP
 mrq
@@ -80655,7 +80656,7 @@ wga
 mrq
 aEv
 ptM
-hKC
+jyp
 dCF
 eih
 xrA
@@ -80912,7 +80913,7 @@ lZL
 ooG
 aEv
 ptM
-mtl
+xIk
 ihc
 yjk
 wPU
@@ -81169,7 +81170,7 @@ vFK
 mrq
 aEv
 ptM
-oYd
+hbU
 dCF
 dCF
 uYP
@@ -81416,7 +81417,7 @@ keq
 ooX
 mrq
 mrq
-jOx
+mKD
 oYb
 kbt
 cuu
@@ -81673,7 +81674,7 @@ kmh
 xCs
 bqN
 oHq
-wMC
+oGc
 vGP
 hCH
 agH
@@ -81721,7 +81722,7 @@ aGV
 nOj
 kXa
 dtJ
-gYK
+nhO
 wTB
 wTB
 hBZ
@@ -81930,7 +81931,7 @@ eLb
 rKM
 lxv
 mrq
-rkZ
+sKk
 oTT
 kbt
 fBI
@@ -81978,7 +81979,7 @@ ctb
 kqt
 dtJ
 kqt
-kKL
+fUT
 jQO
 aOB
 wOb
@@ -82235,7 +82236,7 @@ kWZ
 ltI
 mrk
 cry
-wUr
+fFp
 wTB
 nGS
 nYy
@@ -83267,7 +83268,7 @@ jwz
 jSO
 oXR
 hbW
-rzw
+lwK
 wvV
 dXK
 dpf
@@ -83524,7 +83525,7 @@ uJu
 jSO
 fNv
 vwU
-nuL
+cXA
 cyI
 xId
 uRs
@@ -83781,7 +83782,7 @@ rJw
 jSO
 sZa
 hbW
-rXf
+rsX
 yfh
 oCY
 dpf
@@ -84022,9 +84023,9 @@ abV
 abV
 mPa
 oem
-pLP
-ghj
-rTH
+dBW
+qRy
+hFa
 hMD
 pdz
 qQY
@@ -84809,9 +84810,9 @@ oCg
 dge
 fEg
 kju
-lJn
-lCE
-ngm
+rxd
+jyP
+mfh
 hbW
 hLh
 wNm
@@ -85311,7 +85312,7 @@ mMi
 eUZ
 idi
 kov
-gWm
+kus
 ojI
 eZx
 hyE
@@ -85568,7 +85569,7 @@ mHW
 mHW
 mHW
 mHW
-wyO
+tHR
 fRr
 cAG
 mrP
@@ -86045,7 +86046,7 @@ keq
 pSg
 bDb
 lFe
-vRZ
+hLQ
 dZo
 sWc
 iwn
@@ -86302,14 +86303,14 @@ eLb
 eLb
 hVN
 uhi
-bhE
+lUQ
 pNe
 lXw
 bUf
 lFe
-nvb
-ggB
-wQh
+njU
+ikm
+ejD
 uuV
 lae
 iwi
@@ -86335,7 +86336,7 @@ vRP
 qIk
 nqE
 mHW
-tiO
+nWv
 lIh
 cnh
 kwm
@@ -86559,7 +86560,7 @@ fJJ
 eLb
 rIc
 lFe
-dua
+oLJ
 iwn
 lFe
 lFe
@@ -86592,7 +86593,7 @@ aCD
 qIk
 cds
 mtW
-moj
+udl
 hZT
 joM
 knX
@@ -86849,7 +86850,7 @@ aCD
 qIk
 dpH
 mHW
-hJt
+cNI
 qWF
 knX
 knX
@@ -87336,7 +87337,7 @@ kva
 kva
 paW
 nYO
-mZl
+jok
 oqQ
 nYO
 ecN
@@ -87588,12 +87589,12 @@ keq
 scI
 xsB
 xsB
-sOI
-flc
-ltg
+nvs
+uCS
+fru
 gKH
 xZU
-oFw
+kll
 amp
 nYO
 ycV
@@ -87850,7 +87851,7 @@ toK
 mQt
 mQt
 mQt
-ahc
+apt
 gsL
 kOt
 wPm
@@ -87887,9 +87888,9 @@ jfN
 jfN
 vsT
 lID
-jng
-ieW
-dKs
+xld
+iID
+wFQ
 uzX
 nuh
 hED
@@ -88102,9 +88103,9 @@ keq
 qjL
 mQt
 cMs
-rXZ
-lse
-uwe
+eui
+jwn
+dRI
 kHD
 mQt
 cmF
@@ -88401,9 +88402,9 @@ rcm
 oIK
 rcm
 rcm
-csW
-oYz
-xMo
+jJX
+qeo
+xBC
 uzX
 uUA
 hcR
@@ -88615,9 +88616,9 @@ keq
 keq
 qjL
 mQt
-qmP
-bnr
-boV
+fky
+xNC
+hBs
 mQt
 mQt
 mQt
@@ -89129,8 +89130,8 @@ eLb
 mrH
 tNc
 igt
-hUc
-dRT
+sof
+eot
 jut
 rny
 cYX
@@ -89647,9 +89648,9 @@ keq
 qjL
 jut
 xaO
-ctN
-kVZ
-dJj
+nLc
+pmI
+mxN
 jut
 cBE
 gia
@@ -90668,8 +90669,8 @@ nKd
 uPj
 aWF
 dLk
-oPx
-oBl
+yla
+iKi
 rsW
 eLb
 eLb
@@ -90681,7 +90682,7 @@ qjL
 keq
 kPR
 kfu
-nld
+xEO
 moB
 uhh
 kfu
@@ -90938,7 +90939,7 @@ ahK
 gtf
 bqN
 srl
-neN
+jBV
 eKQ
 eAn
 kfu
@@ -90961,7 +90962,7 @@ pNL
 vzg
 hfV
 hpP
-fHk
+tjo
 wLj
 oYc
 oYc
@@ -91195,7 +91196,7 @@ icQ
 fEx
 egW
 kfu
-awE
+eiN
 dGa
 bhz
 eMT
@@ -91211,7 +91212,7 @@ fxy
 iyi
 yhE
 myr
-jVq
+bWl
 oYc
 oYc
 oYc
@@ -91434,10 +91435,10 @@ jzc
 laK
 hCF
 aCs
-seE
+dSm
 tYq
 vps
-uAW
+vfs
 niO
 uEf
 xPy
@@ -91468,7 +91469,7 @@ fBg
 cFD
 nay
 vZe
-wux
+iyH
 cxh
 ueT
 bbz
@@ -91691,10 +91692,10 @@ vRP
 eqc
 pQh
 eqc
-wyz
+iaG
 kxF
 jxt
-oFV
+cPM
 dLk
 niO
 niO
@@ -91948,22 +91949,22 @@ vRP
 vRP
 aCD
 eqc
-vnG
+hRx
 amf
 yge
-fmf
-ofi
-mHI
-pwq
-vfu
-hgD
-vzY
-qQr
-lqA
-lqA
-lqA
-lqA
-kUx
+imO
+eQK
+mcJ
+saQ
+rzE
+pxm
+eCb
+jBG
+pOX
+pOX
+pOX
+pOX
+vfV
 eyx
 sGA
 eyx
@@ -91991,9 +91992,9 @@ rrG
 vpc
 gbh
 gda
-aEG
-gLY
-bar
+fpw
+gzk
+wUe
 nPi
 vvd
 vmy
@@ -92205,7 +92206,7 @@ vRP
 aCD
 aCD
 eqc
-pJs
+mky
 kxF
 abU
 ihf
@@ -92462,23 +92463,23 @@ vRP
 vRP
 aCD
 eqc
-vnG
+hRx
 kxF
-bXV
-wUU
-wUU
-wUU
-nKY
-sbf
-npt
-sUn
-hvA
-yba
-bKq
-rYZ
-rYZ
-rYZ
-qvR
+taR
+cBI
+cBI
+cBI
+wyn
+smY
+hDY
+xLp
+vdu
+dwa
+oVp
+npN
+npN
+npN
+mHY
 ftY
 ftY
 ftY
@@ -92719,14 +92720,14 @@ vRP
 eqc
 pQh
 eqc
-wyz
+iaG
 kxF
-vhw
+hwB
 rmW
 iha
 rmW
-qMq
-gna
+uwi
+caE
 pQh
 pQh
 dIB
@@ -92735,7 +92736,7 @@ dIB
 dIB
 dIB
 dIB
-pxJ
+bDN
 ftY
 ftY
 ftY
@@ -92976,15 +92977,15 @@ vRP
 laK
 pqy
 aCs
-bZk
+gpb
 ibW
-pnj
-uWb
-uWb
-uWb
-prX
-fmf
-hFD
+aKx
+kXz
+kXz
+kXz
+atQ
+imO
+tge
 pQh
 dYL
 dYL
@@ -92992,7 +92993,7 @@ dYL
 dYL
 ech
 xgP
-hUj
+hqZ
 fyP
 kUU
 fyP
@@ -93007,9 +93008,9 @@ ngI
 pBk
 iKT
 hVM
-hPF
+pHS
 knr
-xdF
+dAy
 syN
 vVi
 xPv
@@ -93233,7 +93234,7 @@ vRP
 eqc
 eqc
 eqc
-qMq
+uwi
 kxF
 mLh
 lWI
@@ -93241,7 +93242,7 @@ kxF
 kxF
 fpk
 kxF
-lVz
+nsC
 pQh
 dYL
 dYL
@@ -93490,15 +93491,15 @@ vRP
 laK
 hCF
 aCs
-tmB
-rJd
-hRP
-njk
-mAK
-nKY
+siX
+wgl
+ldC
+vyS
+tZm
+wyn
 kxF
 kxF
-gna
+caE
 pQh
 dYL
 dYL
@@ -93752,10 +93753,10 @@ pQh
 mvV
 pQh
 pQh
-mKl
-ybN
-tpM
-xpD
+xDa
+ght
+dUL
+qTj
 pQh
 xgP
 xgP
@@ -93778,7 +93779,7 @@ gXE
 rbp
 gam
 hVM
-sHg
+lwS
 kyA
 mKZ
 mKZ
@@ -94047,9 +94048,9 @@ gxH
 kyA
 pWI
 waL
-gBx
-ulq
-eJT
+dhj
+uPS
+qFF
 pKx
 wod
 dvp
@@ -94292,7 +94293,7 @@ iUF
 eNr
 ohE
 hVM
-bpQ
+qfe
 oYi
 bTn
 aRj
@@ -94308,7 +94309,7 @@ aLl
 mfP
 aLl
 uhZ
-sZK
+ilR
 rjN
 rrI
 faQ
@@ -94521,7 +94522,7 @@ iLQ
 dty
 fAL
 hGC
-vQX
+fHS
 iLQ
 rGP
 bvm
@@ -94778,7 +94779,7 @@ iLQ
 cBB
 wUI
 jcQ
-uir
+myl
 gNl
 nwQ
 lSl
@@ -96078,7 +96079,7 @@ xgP
 ihC
 eWK
 fnc
-vjF
+fzn
 ghk
 egF
 pps
@@ -96101,7 +96102,7 @@ qvo
 fMi
 hmD
 qVl
-sBB
+iYT
 fGy
 vKc
 aLl
@@ -96335,7 +96336,7 @@ xgP
 nCy
 sTM
 uQR
-nIR
+gLv
 cPe
 oyZ
 ilp
@@ -96358,7 +96359,7 @@ eVR
 wgS
 vFm
 qlc
-vjQ
+rnN
 tUy
 ozz
 aLl
@@ -96592,7 +96593,7 @@ xgP
 kIf
 dVD
 fnc
-aPt
+pRp
 eTE
 cTL
 kFN
@@ -96615,7 +96616,7 @@ uQz
 oJi
 hBI
 qdi
-mIx
+uJR
 fGy
 aLl
 aLl

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1,4 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aae" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "aau" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 10
@@ -13,17 +21,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"aaO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "aaP" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -272,20 +269,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"afZ" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "agb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -312,6 +295,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"agA" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "agH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -370,6 +361,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ahX" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/storage";
+	name = "Atmospherics Storage Room APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ahZ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
@@ -424,34 +435,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
-"ajj" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
-"ajC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "ajE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
@@ -483,6 +466,30 @@
 "ajU" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/bridge)
+"akz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "akL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -497,6 +504,35 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
+"ala" = (
+/obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
+	dir = 8;
+	name = "Chemistry APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "all" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -618,15 +654,6 @@
 	},
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
-"anl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -761,12 +788,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/paramedic)
-"arL" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "asc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -777,19 +798,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"asd" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "asu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/cable{
@@ -903,21 +911,24 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"avY" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/maintenance/department/bridge)
-"awd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+"avt" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/miningdock)
+"avQ" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"avY" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/maintenance/department/bridge)
 "awh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -955,19 +966,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"axl" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "axz" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -1241,19 +1239,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"aFU" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "aGU" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
@@ -1276,6 +1261,31 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"aHQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aId" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -1344,6 +1354,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"aJj" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "aJn" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 4;
@@ -1388,15 +1405,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"aKc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+"aKd" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "aKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1766,6 +1781,15 @@
 	dir = 8
 	},
 /area/chapel/main)
+"aTp" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "aTw" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -1840,13 +1864,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
-"aUQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aVs" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -1864,12 +1881,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"aVJ" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aVK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -1944,6 +1955,14 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"aWJ" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -2056,20 +2075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aZH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "baa" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -2333,6 +2338,29 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"bem" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "bez" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -2386,6 +2414,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bgK" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "bgP" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -2477,6 +2512,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"bjZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "bkx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2494,13 +2541,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"bkY" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2825,6 +2865,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"btZ" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "buw" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -2857,6 +2903,37 @@
 "bvm" = (
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"bvx" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -29
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "bvC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2965,38 +3042,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"byq" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"byG" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "byH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
@@ -3005,11 +3050,26 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"bzD" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"byW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"bzz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "bzM" = (
@@ -3174,13 +3234,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"bDG" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bEd" = (
 /obj/machinery/computer/apc_control{
 	dir = 1
@@ -3262,6 +3315,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bFq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bGo" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3398,6 +3470,24 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
+"bJE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bJG" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/stripes/line{
@@ -3463,6 +3553,19 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
+"bMP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bMW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -3499,16 +3602,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"bNU" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "bOi" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -3634,19 +3727,6 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"bQq" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -3897,6 +3977,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"bUT" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/computer/station_alert{
+	name = "Station Alert Console"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bVm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3914,20 +4006,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bVL" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bVZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3992,6 +4070,16 @@
 /obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"bXs" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bXA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4004,34 +4092,31 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bYj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "bYF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bZe" = (
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/t_scanner{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/multitool{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bZU" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -4094,23 +4179,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cco" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "ccs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4125,6 +4193,30 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"ccJ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
+"ccP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ccU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4458,22 +4550,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"cma" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "cmb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -4518,6 +4594,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"cmN" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cnh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4528,6 +4617,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"cni" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cnI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Port"
@@ -4589,6 +4688,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"coV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/electrolyzer,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "cpF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -4833,6 +4943,15 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cwH" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "cwL" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -4873,29 +4992,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"cxw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "cxG" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -5030,19 +5126,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"czA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "czC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5054,14 +5137,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"czF" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "czG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -5072,18 +5147,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"czS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "czT" = (
 /turf/closed/wall,
 /area/ai_monitored/security/armory)
@@ -5252,6 +5315,26 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
+"cCC" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cCG" = (
 /obj/machinery/doppler_array/research/science,
 /obj/machinery/light/small{
@@ -5270,6 +5353,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"cDh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "cDQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -5296,24 +5393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"cEu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cEv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -5425,14 +5504,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
-"cGw" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -5467,14 +5538,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cIi" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "cIF" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -5536,13 +5599,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
-"cKs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "cKA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -5637,6 +5693,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"cMb" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "cMn" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -5764,20 +5831,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cPz" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cPG" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -5842,25 +5895,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"cQr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cQK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6211,25 +6245,17 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/port/aft)
-"cZp" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	layer = 2.4;
-	name = "Air to Port"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "cZF" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cZW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "cZX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -6308,6 +6334,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/office)
+"dbz" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dck" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -6350,6 +6393,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"dcO" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6645,32 +6695,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"djH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "djJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6768,6 +6792,25 @@
 "dll" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
+"dmK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dmV" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -6851,25 +6894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"dpC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dpD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6936,44 +6960,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"dsm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"dsA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
+"dsg" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+	dir = 9
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
@@ -7064,6 +7057,13 @@
 /obj/effect/landmark/start/depsec/service,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"dvv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dvC" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -7086,12 +7086,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"dwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dwr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/engineering";
@@ -7125,19 +7119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"dwP" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "dwV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
@@ -7157,13 +7138,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"dxB" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dxH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -7173,18 +7147,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"dxK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dxR" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -7195,6 +7157,21 @@
 /obj/machinery/grill,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"dyt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dyu" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7340,6 +7317,33 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"dDI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dEb" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -7654,19 +7658,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"dMm" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
+"dNj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -7710,26 +7713,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"dOi" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump";
-	target_pressure = 4500
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dOn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -7758,20 +7741,6 @@
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"dOw" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"dOF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dPW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7800,23 +7769,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/office)
-"dQs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste In";
-	on = 1
-	},
-/obj/machinery/light,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dQz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -8049,6 +8001,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"dVM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "dVZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -8123,6 +8091,17 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
+/area/science/mixing)
+"dYs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/broken/two,
 /area/science/mixing)
 "dYL" = (
 /turf/template_noop,
@@ -8201,35 +8180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eaT" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8382,6 +8332,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"edJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "edS" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -8418,6 +8386,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"eeW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "efb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -8785,32 +8759,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"eoG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"eoI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eoN" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -8846,21 +8794,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"epa" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eph" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -8886,6 +8819,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"epr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ept" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
@@ -8980,6 +8930,20 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"erF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "erK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8989,13 +8953,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"erR" = (
-/obj/structure/bookcase/random/reference,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/library)
 "erT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9107,6 +9064,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"etP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "etW" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
@@ -9251,39 +9214,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"exq" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
-"exu" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"exz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "exV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -9451,16 +9381,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eAL" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "eAQ" = (
 /obj/structure/chair{
 	dir = 8
@@ -9565,6 +9485,20 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"eDv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eDx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -9773,19 +9707,22 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"eHm" = (
-/obj/item/radio/intercom{
-	pixel_x = 25
+"eHr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/distro)
 "eHz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9870,14 +9807,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"eIY" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "eIZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10224,6 +10153,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"ePp" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 1;
+	name = "Nanite Lab APC";
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "ePC" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10342,16 +10289,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eSI" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eTE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10383,6 +10320,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"eVC" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/sign/departments/minsky/medical/medical1{
@@ -10590,6 +10537,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
+"fbd" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "fbl" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/item/radio/intercom{
@@ -10704,6 +10657,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fdL" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "fdO" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -10748,6 +10724,29 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"feO" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"feP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ffj" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -10789,6 +10788,21 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
+"fgs" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Airlocks";
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fgB" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -10941,12 +10955,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"fjn" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "fjD" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot,
@@ -10963,21 +10971,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fkF" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "fkJ" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -10986,6 +10979,21 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"fkN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fkR" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -11279,20 +11287,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/engine/gravity_generator)
-"fsu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Incinerator"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fsD" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -11327,19 +11321,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fsZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	layer = 2.4;
-	name = "Mix Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ftr" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -11408,18 +11389,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"fwh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
@@ -11989,14 +11958,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"fGc" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "fGf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -12142,24 +12103,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fLb" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 1;
-	name = "Atmospherics Distribution APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fLC" = (
 /obj/structure/bed/pod{
 	desc = "The latest in lying down technology";
@@ -12214,20 +12157,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"fMC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "fNm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/sign/departments/minsky/command/bridge{
@@ -12305,15 +12234,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"fOh" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "fOF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -12323,24 +12243,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fPr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	dir = 1;
-	name = "Nanite Lab APC";
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "fPN" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -12459,6 +12361,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"fSh" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fSj" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -12466,6 +12374,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fSk" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "fSF" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/firealarm{
@@ -12557,6 +12475,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"fVh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"fVp" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -12603,24 +12546,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"fWI" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fXo" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12659,6 +12584,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"fYg" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "fYp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -12824,19 +12754,6 @@
 "gbt" = (
 /turf/closed/wall,
 /area/medical/storage)
-"gbE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "gbL" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -12860,23 +12777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gbQ" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gbT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
@@ -12901,6 +12801,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gdo" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "gdE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -13178,20 +13095,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"glN" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "glR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -13204,33 +13107,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"gmo" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
+"glX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"gmu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "gmv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13252,6 +13135,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"gmR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gnc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13296,17 +13191,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"goq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/electrolyzer,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "gph" = (
 /obj/structure/rack,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -13325,6 +13209,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"gpv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "gpG" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -13349,16 +13246,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"gqj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "gql" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -13369,10 +13256,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"gqD" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+"gqx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gqK" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable{
@@ -13396,27 +13292,26 @@
 "gqR" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"gqW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "grf" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"grl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks North";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "grB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -13424,26 +13319,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"grH" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"grP" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gsb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13564,6 +13439,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"gtV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gtZ" = (
 /obj/machinery/mass_driver{
 	id = "toxinsdriver"
@@ -13645,6 +13529,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"gve" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gvS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -13721,19 +13614,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"gxA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "gxH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -13748,31 +13628,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/grass,
 /area/medical/virology)
-"gyV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gyY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -13780,15 +13635,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"gzl" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gzB" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -13858,6 +13704,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"gBa" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "gBn" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -14049,20 +13909,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"gGA" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
+"gGn" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 6
 	},
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters";
-	pixel_x = 26;
-	pixel_y = 7;
-	req_one_access_txt = "5; 33"
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "gGK" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14134,13 +13990,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gIa" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "gIn" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -14171,15 +14020,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gIA" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gIT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -14322,6 +14162,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"gNt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "gNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -14538,6 +14388,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"gUr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "gUD" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
@@ -14668,12 +14529,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"gZt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "gZR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14793,6 +14648,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"hdb" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hdd" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -14807,19 +14676,6 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
-"hdi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "hdt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -14949,6 +14805,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"hgW" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "hht" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -15085,14 +14948,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"hks" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hkv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -15208,18 +15063,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"hmh" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "hmi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15320,6 +15163,28 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"hnP" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/ten,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hoI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -15539,27 +15404,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"hss" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "htr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
@@ -15950,18 +15794,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"hCU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "hDi" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/power/apc{
@@ -16006,20 +15838,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hDO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "hDW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16033,6 +15851,18 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"hEr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "hED" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -16049,11 +15879,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hGn" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "hGw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16148,6 +15973,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hKb" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hKr" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
@@ -16190,16 +16035,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
-"hMp" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hMv" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -16245,6 +16080,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"hNv" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -16263,15 +16124,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"hOh" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "hOo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16401,12 +16253,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"hSg" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hSr" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "toxins_airlock_exterior";
@@ -16532,15 +16378,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hUa" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
+"hTW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Xenobiology Lab Access";
+	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
+/area/science/xenobiology)
 "hUb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16714,6 +16562,20 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hWF" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "hXw" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/bot,
@@ -16742,36 +16604,41 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hZd" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hZj" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/teleporter)
-"hZr" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "EVA East";
-	dir = 6
+"hZE" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
-"hZR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/engine/atmos/storage)
 "hZT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16893,37 +16760,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/chapel/main)
-"ieC" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"ieX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "ifa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16960,22 +16796,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ifS" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Storage";
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "igr" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/table,
@@ -17122,13 +16942,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"iiN" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "iiR" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -17171,17 +16984,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"ikg" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Service Backroom"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "ikO" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -17235,12 +17037,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"img" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "imt" = (
 /obj/machinery/light{
 	dir = 4
@@ -17264,25 +17060,6 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
-"inB" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
-	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "inC" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -17480,6 +17257,20 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"itj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "itk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -17683,6 +17474,23 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"iwZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Waste In";
+	on = 1
+	},
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ixg" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -17748,6 +17556,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ixX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "iyb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -17800,22 +17621,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"izm" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "izN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -17939,20 +17744,6 @@
 /mob/living/simple_animal/pet/axolotl/bap,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"iEC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "iGa" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -18008,6 +17799,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"iIe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iIi" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -18160,6 +17962,25 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"iMI" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Southeast";
+	dir = 9;
+	network = list("ss13")
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "iMK" = (
 /obj/structure/railing{
 	dir = 1
@@ -18440,6 +18261,19 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iSx" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/computer/atmos_control{
+	dir = 1;
+	name = "Tank Monitor"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "iSN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -18522,6 +18356,14 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"iVx" = (
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "iVM" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/firealarm{
@@ -18590,19 +18432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iXX" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18663,6 +18492,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"jap" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jaK" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -18764,6 +18599,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"jcS" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jdr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
@@ -18807,23 +18653,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jeq" = (
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/chapel/office)
 "jeu" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
@@ -18839,19 +18668,21 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jfh" = (
-/obj/structure/chair{
+"jfg" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/storage)
 "jfL" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -18861,6 +18692,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jfR" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jfX" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -18967,20 +18807,6 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"jkV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -19039,6 +18865,22 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"jlZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -19148,6 +18990,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
+"joZ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "jpb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -19222,17 +19078,6 @@
 /obj/item/stack/sheet/mineral/sandstone/thirty,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"jrE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jrJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer,
@@ -19260,22 +19105,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jsV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jta" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -19303,15 +19132,6 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"jub" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
 "jun" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -19342,29 +19162,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"jwl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jwz" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
@@ -19457,17 +19254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"jyz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "jyJ" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -19552,17 +19338,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
-"jAa" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/item/pipe_dispenser,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jAi" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -19579,27 +19354,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"jAk" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19694,6 +19448,12 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"jCf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jCh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -19781,6 +19541,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"jDy" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "jDz" = (
 /turf/closed/wall/rust,
 /area/maintenance/solars/starboard/fore)
@@ -19835,6 +19602,12 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"jEn" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "jEp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -19861,19 +19634,24 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"jFW" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+"jFL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/area/hallway/primary/starboard)
 "jGi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19903,19 +19681,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jHb" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jHj" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -19927,30 +19692,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"jHR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "jHX" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jIh" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20049,25 +19800,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jKC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jKH" = (
 /obj/machinery/light{
 	dir = 8
@@ -20080,6 +19812,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jKJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jKW" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -20093,6 +19839,27 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"jLc" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jLo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -20222,17 +19989,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jPd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "jPk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20304,6 +20060,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"jRx" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"jRU" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "EVA East";
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "jSg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -20464,6 +20238,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"jVa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jVp" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -20565,17 +20357,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"jXM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jYF" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -20628,20 +20409,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"jZR" = (
-/obj/structure/bodycontainer/morgue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"kaj" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "kar" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -20658,16 +20425,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"kat" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "kaR" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
@@ -20685,6 +20442,23 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/library)
+"kby" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kbG" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
@@ -20737,13 +20511,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"kdu" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+"kdC" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kdG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -20837,13 +20613,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"kgR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "kgT" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -20851,12 +20620,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"khB" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "kia" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -21025,12 +20788,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
-"klP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "klZ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -21080,21 +20837,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kmI" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "kmL" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/auxiliary)
@@ -21117,6 +20859,21 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"kne" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "knf" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/distro)
@@ -21179,16 +20936,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"kpt" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "kpN" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -21231,6 +20978,28 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"kqO" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/multitool{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "krf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -21313,6 +21082,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ktE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ktG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21320,12 +21102,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"kum" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kup" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -21497,25 +21273,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"kxC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"kxz" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/distro)
 "kxF" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -21552,18 +21322,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
-"kzz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/computer/station_alert{
-	name = "Station Alert Console"
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "kzS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21614,6 +21372,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kAF" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "kAM" = (
 /obj/structure/rack,
 /obj/item/gun/energy/disabler{
@@ -21658,6 +21433,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"kCa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "kCl" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -22293,19 +22078,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"kTV" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "kUf" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -22321,6 +22093,24 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"kUL" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kUU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -22622,35 +22412,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"lbU" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lcc" = (
 /obj/machinery/door/airlock{
 	name = "Aft Emergency Storage"
@@ -22663,17 +22424,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"lci" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "lcA" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -22748,6 +22498,16 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"lef" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "leg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -23025,33 +22785,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ljJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lkC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -23258,24 +22991,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lrE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lrP" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -23550,24 +23265,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"lxJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"lxI" = (
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
 	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "lxW" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -23725,6 +23435,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"lAP" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/flashlight,
+/obj/item/assembly/igniter,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "lAW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -23771,20 +23497,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"lCw" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge South";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "lCy" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -23888,19 +23600,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"lEZ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lFe" = (
 /turf/closed/wall,
 /area/janitor)
@@ -24070,6 +23769,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"lJY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lKJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24302,15 +24020,6 @@
 "lQe" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
-"lQA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "lQR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -24359,15 +24068,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
-"lRn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lRp" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -24426,6 +24126,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"lSc" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
 "lSj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -24483,6 +24201,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lTf" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lTB" = (
 /obj/machinery/button/door{
 	id = "evashutter";
@@ -24545,66 +24270,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lUz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/table/glass,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -9;
-	pixel_y = 7
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_y = 10
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/stack/cable_coil/random{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"lUN" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Southeast";
-	dir = 9;
-	network = list("ss13")
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -24730,6 +24395,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lZc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "lZt" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -24754,23 +24443,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"lZE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lZL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -24791,21 +24463,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mby" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "mbA" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -24920,19 +24577,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mew" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = 32
-	},
-/obj/structure/chair/comfy/beige{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/burnt/two,
-/area/science/mixing)
 "meD" = (
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -25030,6 +24674,19 @@
 /obj/item/multitool,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"mhr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mhx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -25051,13 +24708,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mhG" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "mik" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -25110,19 +24760,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"miX" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
+"miU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/secondary/service)
 "mjc" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
@@ -25194,20 +24837,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"mjM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "mjN" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -25371,6 +25000,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mnR" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "moz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25418,16 +25054,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"mpo" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "mpp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -25485,6 +25111,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mqo" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	name = "Atmospheric Alert Console"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "mqx" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
@@ -25648,6 +25283,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mtw" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "mtW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Nanite Laboratory Maintenance";
@@ -25695,17 +25337,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
-"mvn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Xenobiology Lab Access";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mvs" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -25772,6 +25403,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"mxh" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mxk" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -25786,15 +25423,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mxA" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mxD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -25874,6 +25502,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"myJ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "myQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -26106,6 +25757,19 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload)
+"mGz" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/burnt/two,
+/area/science/mixing)
 "mHW" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -26197,6 +25861,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"mLm" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"mLz" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mLC" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Canister Storage";
@@ -26248,6 +25933,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"mMJ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mMR" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Disposals Access";
@@ -26355,16 +26054,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mPZ" = (
-/obj/structure/bookcase/random/reference,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/library)
 "mQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26489,6 +26178,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"mSp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "mSy" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -26702,21 +26398,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"mXY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "mYp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -26754,27 +26435,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"nbJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "nbL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -26802,6 +26462,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ncO" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ncW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26845,18 +26518,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"ndh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ndj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26870,12 +26531,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"nei" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26923,18 +26578,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"nfw" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "nfz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -26955,15 +26598,6 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"nge" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ngI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -27151,19 +26785,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"nmk" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nmn" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
@@ -27223,6 +26844,34 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nnE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nnG" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "noh" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -27490,6 +27139,15 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nve" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -27524,22 +27182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"nwU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 9
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "nxe" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -27605,15 +27247,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"nyx" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "nyC" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -27631,19 +27264,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"nyD" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+"nyW" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
 	},
-/obj/structure/sign/departments/minsky/command/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "nzc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27724,6 +27351,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"nzK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nzN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -27812,6 +27452,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"nAU" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nBv" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -27894,6 +27548,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"nDr" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nDx" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -27986,6 +27650,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nFC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "nFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28119,26 +27790,41 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"nJe" = (
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"nJt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+"nIl" = (
+/obj/machinery/camera{
+	c_tag = "Mining Dock";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"nIy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_x = -32
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"nJe" = (
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nJE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -28204,6 +27890,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"nKs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "nKu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28357,6 +28055,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"nOe" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nOj" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -28518,6 +28225,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"nTr" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nTx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -28563,6 +28283,16 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nUd" = (
+/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "nUm" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -28734,6 +28464,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nZO" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"nZP" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "nZY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
@@ -29060,6 +28809,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ojL" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 1;
+	name = "Atmospherics Distribution APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ojV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29091,6 +28858,45 @@
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"okZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
+"olO" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"omc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "omn" = (
 /obj/machinery/rnd/production/techfab/department/armory,
 /obj/machinery/firealarm{
@@ -29272,6 +29078,31 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
+"opP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 11
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "oqd" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cmo";
@@ -29290,23 +29121,19 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"oqs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"oqn" = (
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/storage)
 "oqA" = (
 /obj/machinery/light{
 	dir = 8
@@ -29366,6 +29193,15 @@
 "orF" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"orT" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ose" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -29391,6 +29227,21 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"osq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "osE" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet,
@@ -29405,31 +29256,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
-"otr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "ots" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -29644,21 +29470,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"oAa" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "oAk" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -29725,28 +29536,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oCh" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/ten,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "oCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -29776,25 +29565,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oDg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
+"oDl" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/quartermaster/storage)
 "oEt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
@@ -29912,17 +29690,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"oIT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "oIU" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -29967,20 +29734,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"oJC" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "oJD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
@@ -30056,19 +29809,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"oNG" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to distro";
-	target_pressure = 4500
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "oNX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -30179,6 +29919,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"oQx" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Service Backroom"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "oQX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -30217,19 +29968,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oSj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "oSl" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -30407,6 +30145,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"oZR" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pan" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -30666,6 +30414,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"pge" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pgs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -30696,6 +30455,18 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"pgO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "pgQ" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -30705,6 +30476,25 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
+"phi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/table,
+/obj/item/vending_refill/medical{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/machinery/vending/wallhypo{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "php" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -30825,23 +30615,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"pje" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pjg" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -30904,6 +30677,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"pkJ" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pkV" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
@@ -31052,6 +30836,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pnr" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/command/evac{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pns" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -31097,24 +30894,6 @@
 "poB" = (
 /turf/open/floor/plasteel,
 /area/security/warden)
-"poH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "pph" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -31130,30 +30909,6 @@
 "pps" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
-"ppz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ppI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -31480,6 +31235,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"pzE" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "pAz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -31532,6 +31304,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"pBx" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks South";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste to Space"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pBD" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -31594,6 +31388,29 @@
 /obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"pBX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pCi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
@@ -31652,11 +31469,40 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pCM" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "pDd" = (
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"pDz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31759,10 +31605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pHq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "pHr" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plating,
@@ -31877,18 +31719,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"pKp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "pKt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/preopen{
@@ -32099,6 +31929,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pPK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "pQh" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -32263,12 +32107,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"pTG" = (
+/obj/structure/filingcabinet,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "pTI" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"pTV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "pTW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -32456,6 +32326,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pXK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "pXP" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -32544,15 +32427,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"pYC" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "pYV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32582,6 +32456,15 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"pZQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "qaG" = (
 /obj/structure/table,
 /obj/item/cultivator{
@@ -32682,6 +32565,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"qcK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -32747,6 +32648,19 @@
 /obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/library)
+"qeA" = (
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qeR" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -33089,15 +33003,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"qmz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qmG" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -33248,6 +33153,23 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"qoX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks North";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qpr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -33326,48 +33248,6 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"qrz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"qsa" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
-"qst" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "qsy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -33429,20 +33309,6 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"qva" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "qvf" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -33540,25 +33406,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qxs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/structure/table,
-/obj/item/vending_refill/medical{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/hand_labeler{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/machinery/vending/wallhypo{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "qxw" = (
 /obj/machinery/light{
 	dir = 4
@@ -33709,28 +33556,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qDf" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks South";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste to Space"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qDp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33819,6 +33644,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"qGI" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -33845,6 +33683,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"qHg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qHC" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -33862,6 +33709,33 @@
 "qIk" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
+"qIK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "qIO" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -33904,13 +33778,18 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"qKa" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+"qJW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"qKe" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qKg" = (
 /obj/machinery/button/door{
 	id = "Dorm2";
@@ -34165,15 +34044,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"qRR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "qRW" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/chief)
@@ -34377,13 +34247,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qXt" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "qXw" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
@@ -34456,6 +34319,19 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"qZC" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "qZW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34471,31 +34347,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rac" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 11
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -34
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "rak" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -34634,6 +34485,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"rcE" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rcK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
@@ -34921,22 +34781,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"riY" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+"riG" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"riZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "rjf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -34994,17 +34847,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"rkv" = (
-/obj/structure/filingcabinet,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "rkx" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/airless,
@@ -35035,15 +34877,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"rlw" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rlY" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -35174,6 +35007,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rpv" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "rpx" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -35300,15 +35145,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"rrl" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rrx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35480,6 +35316,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"ruO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "rvb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -35498,24 +35345,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
-"rvh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "rvK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -35644,15 +35473,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"rzg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "rzT" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -35760,6 +35580,15 @@
 "rBC" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
+"rBQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "rBR" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -36044,12 +35873,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"rIn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos/distro)
 "rIp" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -36131,17 +35954,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"rLs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/broken/two,
-/area/science/mixing)
 "rMp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -36152,6 +35964,22 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"rMB" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/magboots,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "rMD" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -36262,6 +36090,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rPc" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rPz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -36308,23 +36152,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"rQL" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -36398,24 +36225,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"rTs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "rTz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -36434,16 +36243,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"rTN" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
+"rTK" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/hallway/primary/central)
 "rUk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -36570,20 +36378,6 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"rWO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "rWP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -36683,19 +36477,24 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"rZc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+"rZX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/area/science/robotics/lab)
 "sar" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -36846,6 +36645,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sdK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "sep" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -36962,6 +36772,54 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"shu" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"shF" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
+"sic" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sil" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -37030,17 +36888,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sjO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"sjW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "skY" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -37071,6 +36928,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"smy" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	layer = 2.4;
+	name = "Air to Port"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "smN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -37331,22 +37202,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"ssS" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/assembly/igniter,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ssT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
@@ -37533,57 +37388,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"suZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"svr" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "svs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37596,24 +37400,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"swa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "swg" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -37644,6 +37430,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"swI" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "swR" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -37681,6 +37476,12 @@
 "sxD" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
+"sxM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/distro)
 "sxT" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -37722,26 +37523,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"syl" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "syN" = (
 /obj/machinery/firealarm{
@@ -38075,6 +37856,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sJk" = (
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters";
+	pixel_x = 26;
+	pixel_y = 7;
+	req_one_access_txt = "5; 33"
+	},
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -38103,6 +37898,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"sKe" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sKm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
@@ -38166,6 +37974,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"sLh" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "sLi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -38221,17 +38037,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"sMd" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sMM" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
@@ -38319,24 +38124,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
-"sOV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "sPf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -38428,12 +38215,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"sQJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sQP" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -38713,20 +38494,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"sXJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "sXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38745,24 +38512,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
-"sYg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "sYN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38859,6 +38608,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sZB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "sZH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -38910,16 +38668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"tbj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "tbn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
@@ -38952,6 +38700,13 @@
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"tcI" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tcS" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39048,6 +38803,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"teH" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "teI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -39095,22 +38865,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"tgI" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/magboots,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "thJ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
@@ -39298,24 +39052,6 @@
 "tlg" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"tlj" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "tlr" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -39526,6 +39262,23 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"tus" = (
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/chapel/office)
 "tuM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -39660,6 +39413,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"tyd" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tyq" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -39820,6 +39586,19 @@
 /obj/machinery/power/smes/fullycharged,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"tBL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tCd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -39843,6 +39622,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tCW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tDe" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/camera{
@@ -39922,25 +39715,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"tFG" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tFK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39994,17 +39768,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tGE" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "tHe" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -40150,6 +39913,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"tLi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tLT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40312,6 +40085,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tPz" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "tPI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40365,16 +40150,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"tRc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tRW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -40464,25 +40239,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"tTP" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "tTT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40607,6 +40363,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tVH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tVR" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -40624,6 +40401,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tWb" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "tWh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40768,6 +40553,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ubP" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -40924,6 +40716,19 @@
 	dir = 6
 	},
 /area/chapel/main)
+"ufp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "ufA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -41064,6 +40869,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ujU" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ukr" = (
 /obj/machinery/computer/turbine_computer{
 	dir = 4;
@@ -41071,6 +40886,47 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"uku" = (
+/obj/structure/table/glass,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Chemistry";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -6;
+	pixel_y = 13
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_y = 10
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/stack/cable_coil/random{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "ukx" = (
 /obj/machinery/door/airlock/medical{
 	name = "Paramedic Staging Area";
@@ -41153,15 +41009,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ulE" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ulF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -41169,6 +41016,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ulK" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ulW" = (
 /obj/machinery/vending/cart,
 /obj/structure/cable{
@@ -41255,24 +41115,6 @@
 /obj/item/geiger_counter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"unN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "unP" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -41528,6 +41370,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"uyG" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uyM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41580,17 +41435,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"uBg" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uBP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -41607,21 +41451,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"uBX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "uCc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -41694,12 +41523,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"uDg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "uDh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -41733,6 +41556,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"uDn" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "uDz" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41802,6 +41638,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"uFH" = (
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "uFR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
@@ -41825,6 +41667,24 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"uGW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uGX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42306,19 +42166,6 @@
 "uRB" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uRR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uRS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -42329,6 +42176,24 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"uSq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "uSr" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -42403,6 +42268,17 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
+"uUg" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "uUA" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -42453,6 +42329,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uVk" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "uVJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -42501,21 +42384,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"uWD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uWE" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -42545,6 +42413,13 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"uXL" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "uYJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42687,22 +42562,6 @@
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"vaV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "vbo" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -42831,6 +42690,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vfs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Dormitory South";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "vfC" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -43006,16 +42890,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"vif" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "vin" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -43061,22 +42935,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"vje" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "vjf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -43201,33 +43059,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"vlM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "vlQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"vmp" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vmy" = (
@@ -43310,18 +43153,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"voy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "voA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -43466,19 +43297,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"vsn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "vsB" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -43567,6 +43385,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vuM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vuO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -43603,6 +43438,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"vwa" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"vwl" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge South";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "vwP" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -43650,6 +43516,19 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vxN" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/door/poddoor/shutters{
@@ -43756,6 +43635,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"vAr" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vAA" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/camera{
@@ -43810,6 +43709,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"vBt" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "vBx" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 8
@@ -43830,13 +43738,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"vBC" = (
-/obj/structure/kitchenspike,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "vBO" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -43852,6 +43753,24 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vCw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vDA" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -43975,16 +43894,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/library)
-"vGS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+"vHa" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vHD" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -44023,6 +43951,17 @@
 /obj/effect/spawner/lootdrop/randomdrink,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vIp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vIr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -44086,6 +44025,24 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vJQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "vJZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -44367,19 +44324,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"vPd" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vPh" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
@@ -44565,35 +44509,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vVq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 8;
-	name = "Chemistry APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "vVB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -44659,26 +44574,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"vWo" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	name = "Atmospherics Storage Room APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "vXr" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -44752,6 +44647,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"vZN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "waf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -44793,14 +44697,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wbo" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/bot,
+"wbn" = (
+/obj/structure/bookcase/random/reference,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/turf/open/floor/carpet,
+/area/library)
 "wbF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -44906,16 +44809,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"wdZ" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wef" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -44993,6 +44886,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"wge" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wgp" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -45009,14 +44916,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"wgr" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wgx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -45059,23 +44958,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
-"whX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "whZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -45130,6 +45012,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"wiB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Incinerator"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wiI" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -45205,21 +45101,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wly" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+"wku" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
+/area/hallway/primary/starboard)
 "wlz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -45233,15 +45124,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"wlE" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "wlG" = (
 /obj/structure/chair{
 	dir = 8
@@ -45544,16 +45426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"wti" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wtt" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/red/arrow_ccw{
@@ -45610,6 +45482,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wvw" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -45796,32 +45684,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wAh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "wAI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wBI" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wBM" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -45897,14 +45779,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"wEC" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "wEJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46208,19 +46082,6 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
-"wKv" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wKH" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -46238,12 +46099,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"wLf" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "wLj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
@@ -46290,6 +46145,35 @@
 "wNW" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
+"wOa" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = -32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wOb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -46459,19 +46343,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
-"wQR" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46498,6 +46369,40 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"wRG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"wRJ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage";
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wSu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -46564,6 +46469,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"wTR" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
+/obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "wUk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -46705,6 +46639,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wYl" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to distro";
+	target_pressure = 4500
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wYp" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -46716,6 +46663,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"wYF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wYJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -46741,6 +46697,25 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wZi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "wZu" = (
 /obj/machinery/vending/gifts,
 /obj/effect/turf_decal/tile/darkgreen{
@@ -46937,6 +46912,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"xdB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xdK" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics/cloning)
@@ -47007,6 +46999,16 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"xfx" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "xfz" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
@@ -47054,37 +47056,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xgB" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -29
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "xgP" = (
 /turf/closed/wall,
 /area/maintenance/department/eva)
@@ -47112,6 +47083,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"xhw" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "xhD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -47140,6 +47119,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xiU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "xjg" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -47344,6 +47350,14 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
+"xmD" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "xnp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -47457,23 +47471,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xqE" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "xrb" = (
 /obj/structure/table,
 /obj/item/nanite_scanner{
@@ -47617,19 +47614,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"xuf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "xui" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -47648,12 +47632,38 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"xuB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	layer = 2.4;
+	name = "Mix Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xuP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"xuX" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "xvb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47678,16 +47688,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xwj" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "xwU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47904,20 +47904,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xAH" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "xAK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47981,6 +47967,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"xDe" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -48046,6 +48042,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"xFj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xFt" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
@@ -48137,15 +48143,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xHH" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "xHK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48308,15 +48305,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
-"xMs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -48420,6 +48408,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"xOB" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -48547,6 +48544,23 @@
 "xRw" = (
 /turf/open/floor/engine,
 /area/escapepodbay)
+"xRK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xRO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -48672,13 +48686,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/space/basic,
 /area/space/nearstation)
-"xTY" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "xUB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -48766,6 +48773,15 @@
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"xVY" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -48794,22 +48810,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xXl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "xXn" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
@@ -48844,16 +48844,6 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"xYu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "xYw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -48870,18 +48860,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xYx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "xYz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -48946,16 +48924,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"xZH" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "xZL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -49011,20 +48979,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"yaq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "yay" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -49083,6 +49037,19 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"ycg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ycp" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -49095,6 +49062,24 @@
 "ycy" = (
 /turf/closed/wall,
 /area/security/brig)
+"ycA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ycV" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -49388,6 +49373,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"ykg" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/exit";
+	dir = 8;
+	name = "Escape Hallway APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ykr" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -66794,7 +66798,7 @@ ejY
 lZB
 xWd
 orF
-dOi
+hKb
 sGB
 dsb
 vpm
@@ -67051,7 +67055,7 @@ bsg
 nky
 apP
 uGF
-dxK
+tPz
 sLY
 lGx
 ydx
@@ -67308,7 +67312,7 @@ cqd
 gHA
 vBr
 ekN
-vlM
+myJ
 chs
 lJm
 vbO
@@ -67565,9 +67569,9 @@ myw
 fFT
 jzv
 ahZ
-oSj
-grl
-fsu
+pXK
+qoX
+wiB
 eRT
 oEG
 rXM
@@ -67824,7 +67828,7 @@ kcE
 kcE
 aik
 opo
-jFW
+nZP
 wVo
 njB
 dWX
@@ -68072,8 +68076,8 @@ tkl
 tkl
 nKW
 tCd
-jub
-sQJ
+wYF
+jap
 bPu
 knf
 knf
@@ -68081,7 +68085,7 @@ vYY
 jts
 cbm
 eDA
-iXX
+xuX
 dwV
 vTP
 cnI
@@ -68338,7 +68342,7 @@ rbs
 wQK
 buE
 iuS
-nfw
+rpv
 kwv
 rOc
 bQM
@@ -68595,7 +68599,7 @@ fJf
 jEZ
 sAf
 jYT
-fsZ
+xuB
 eBt
 bVq
 cEs
@@ -68605,9 +68609,9 @@ bVq
 bVq
 svz
 cri
-jrE
-dMm
-qDf
+sdK
+kxz
+pBx
 acO
 vzR
 hoI
@@ -68852,16 +68856,16 @@ jjX
 jjX
 lYd
 gAG
-fLb
+ojL
 wwC
 bBt
-nyx
-nyx
-cZp
+orT
+orT
+smy
 upo
 rXM
 rXM
-dQs
+iwZ
 uCi
 uCi
 uCi
@@ -69103,22 +69107,22 @@ lZu
 vsH
 bBo
 cLo
-cGw
+vmp
 eFb
 gph
 qGN
 hpd
-rIn
-oNG
-jwl
-goq
+sxM
+wYl
+pBX
+coV
 cCc
 eNL
 cSC
-unN
-uBX
-anl
-jKC
+ycA
+fkN
+qHg
+wZi
 uCi
 iRz
 wQB
@@ -69360,7 +69364,7 @@ lRP
 mTJ
 rEq
 uMm
-kum
+eeW
 eRY
 twv
 oxM
@@ -69617,15 +69621,15 @@ teI
 hAJ
 pzD
 rYc
-eoG
+kdC
 eFb
 xkI
 aJz
 bgd
 qiY
-mjM
-djH
-vaV
+okZ
+hNv
+eHr
 peq
 xge
 bCp
@@ -69880,9 +69884,9 @@ xTt
 xTt
 xTt
 xTt
-jsV
-cxw
-yaq
+wvw
+bem
+hWF
 jjX
 wIS
 tzj
@@ -70394,9 +70398,9 @@ tAe
 wDm
 nAf
 fjD
-gzl
-ljJ
-tgI
+aTp
+qIK
+rMB
 xTt
 cNu
 vdN
@@ -70651,9 +70655,9 @@ mLC
 eEF
 eEF
 mki
-afZ
+hdb
 ndj
-khB
+btZ
 xTt
 cNu
 xZo
@@ -70908,9 +70912,9 @@ elX
 elX
 sxu
 cxc
-rzg
-xXl
-jAa
+swI
+jlZ
+uUg
 xTt
 cNu
 aMM
@@ -71164,9 +71168,9 @@ xTt
 xTt
 xTt
 xTt
-epa
-ulE
-poH
+jfg
+jfR
+bJE
 xTt
 xTt
 lBF
@@ -71421,9 +71425,9 @@ dBO
 kPJ
 kKN
 xTt
-miX
+ncO
 rcq
-nbJ
+tVH
 xTt
 fGF
 xnH
@@ -71432,9 +71436,9 @@ nQW
 cCb
 pBa
 kjX
-bNU
-riZ
-cco
+mLm
+avt
+nIl
 lPS
 vgx
 kjX
@@ -71678,9 +71682,9 @@ dBO
 dBO
 xib
 xTt
-ifS
-ppz
-gbQ
+wRJ
+akz
+pzE
 xTt
 cNu
 oyO
@@ -71942,9 +71946,9 @@ xTt
 cNu
 oyO
 box
-nwU
-vsn
-wEC
+byW
+ixX
+oDl
 kjX
 aYT
 lVT
@@ -72192,9 +72196,9 @@ vaN
 vaN
 vaN
 xTt
-vif
-dsm
-wdZ
+dsg
+xiU
+eVC
 xTt
 cNu
 oyO
@@ -72442,16 +72446,16 @@ mKW
 tjr
 fhk
 sVE
-vPd
+nAU
 eFb
 xTt
 xTt
 xTt
 xTt
 xTt
-xYu
-qrz
-dwP
+tLi
+dbz
+cmN
 xTt
 cNu
 oyO
@@ -72699,15 +72703,15 @@ wxQ
 bPw
 aXP
 agn
-hSg
+mxh
 eFb
-wti
-hMp
-kTV
-hMp
-wBI
-ulE
-sXJ
+bXs
+cni
+qZC
+cni
+cCC
+jfR
+feP
 xTt
 xTt
 cNu
@@ -72956,15 +72960,15 @@ ceS
 wcG
 xzq
 cmI
-suZ
-jAk
-tFG
+dDI
+jLc
+hZE
 ecQ
 eOX
 bon
 kcs
 lXI
-vWo
+ahX
 xTt
 fGF
 xnH
@@ -73213,15 +73217,15 @@ byP
 uDP
 byP
 byP
-syl
+vAr
 eFb
-rzg
+swI
 yfF
 yfF
 yfF
 yfF
 yfF
-mxA
+mqo
 xTt
 cNu
 eeV
@@ -73470,15 +73474,15 @@ fdO
 nsR
 uyk
 cmb
-gyV
+aHQ
 eFb
-oCh
-bZe
-ssS
-byq
-kzz
-wKv
-jHb
+hnP
+kqO
+lAP
+fdL
+bUT
+oqn
+iSx
 xTt
 lBF
 uBb
@@ -73990,9 +73994,9 @@ rtq
 ybK
 bEd
 qRW
-kmI
-awd
-nmk
+kne
+gmR
+ulK
 aMM
 bQv
 uBb
@@ -74204,7 +74208,7 @@ lMu
 hzS
 lMu
 lMu
-gmo
+avQ
 lik
 agN
 qBn
@@ -74247,9 +74251,9 @@ bcT
 cXc
 iAE
 cRS
-dsA
+itj
 lqS
-dwc
+jCf
 gwb
 are
 uBb
@@ -74461,7 +74465,7 @@ qcw
 aQa
 jUV
 sYQ
-jyz
+iIe
 kAo
 agN
 qBn
@@ -74504,9 +74508,9 @@ ybK
 ted
 qfy
 qRW
-cPz
+gBa
 wvU
-grP
+mnR
 kgb
 cAd
 uBb
@@ -74718,7 +74722,7 @@ mzS
 pmZ
 iZD
 lMu
-hOh
+xOB
 vVa
 eQi
 xXn
@@ -74761,7 +74765,7 @@ qru
 qRW
 qRW
 qRW
-aZH
+tCW
 wvU
 maX
 pQR
@@ -75775,9 +75779,9 @@ aSA
 bYF
 etl
 aVK
-jXM
-gmu
-xMs
+vIp
+qcK
+gve
 vhk
 xZL
 tvh
@@ -76287,7 +76291,7 @@ gug
 lCy
 aEm
 fHg
-exq
+iVx
 mbY
 kyR
 inD
@@ -76544,7 +76548,7 @@ vLa
 uWR
 pmr
 tvP
-aKc
+sZB
 xOv
 uJU
 esb
@@ -76801,7 +76805,7 @@ gJn
 wEU
 mTE
 jWt
-qxs
+phi
 mbY
 nzc
 oul
@@ -77030,9 +77034,9 @@ imX
 aEH
 snE
 dJN
-jPd
-sYg
-byG
+ruO
+nnE
+vBt
 xao
 rMD
 sOD
@@ -77086,7 +77090,7 @@ qdH
 lvp
 pan
 hic
-hDO
+jKJ
 laH
 oPJ
 mMR
@@ -77343,7 +77347,7 @@ lFh
 qhL
 nkP
 sFt
-vGS
+gNt
 cWh
 dFr
 hMe
@@ -77600,7 +77604,7 @@ gtb
 fDV
 kGE
 tkB
-tbj
+gGn
 laH
 oXe
 hMe
@@ -77840,10 +77844,10 @@ ewv
 yjm
 twa
 yjm
-wlE
-vVq
-rac
-izm
+cwH
+ala
+opP
+gqW
 kEF
 vkW
 nEQ
@@ -78095,12 +78099,12 @@ edn
 xVn
 hyf
 onS
-eaT
-arL
-kgR
+wOa
+nZO
+sjO
 jcI
-iiN
-mhG
+nFC
+dcO
 kEF
 oRt
 ewA
@@ -78350,13 +78354,13 @@ nhu
 mFg
 sbk
 rjs
-qKa
+nyW
 onS
-xTY
+hgW
 knb
 xRo
 xsV
-lUz
+uku
 kEF
 kEF
 jvg
@@ -78562,9 +78566,9 @@ vRP
 aCD
 aCD
 eRC
-kat
-nei
-wly
+xfx
+cZW
+pTV
 vTN
 aTw
 hmB
@@ -78607,15 +78611,15 @@ uBc
 lxh
 lPG
 oXr
-pHq
+jIh
 dmV
-xZH
+lxI
 fBu
 fBu
 bpO
-hGn
+fYg
 onS
-hUa
+rBQ
 tkh
 ewA
 maX
@@ -78864,15 +78868,15 @@ hkH
 nXR
 nXR
 jBI
-aFU
+uDn
 tUq
-glN
-gGA
-dxB
+wge
+sJk
+glX
 qlQ
-fjn
+jEn
 jzY
-wLf
+fbd
 kmr
 ewA
 sKm
@@ -79125,16 +79129,16 @@ raJ
 kEF
 kEF
 kEF
-iEC
-dpC
-eAL
+pPK
+dmK
+fSk
 tUq
-fOh
+xVY
 kmr
 ewA
 fbN
 geS
-czF
+agA
 kgb
 nTF
 mQK
@@ -79345,7 +79349,7 @@ eLb
 sIj
 bDb
 kYy
-jZR
+bgK
 gjR
 uKW
 kYy
@@ -79383,7 +79387,7 @@ cwL
 kwH
 kEF
 kEF
-lbU
+wTR
 kEF
 kEF
 aoe
@@ -79391,7 +79395,7 @@ kmr
 atI
 kTM
 kTM
-dwc
+jCf
 jCA
 tVD
 pio
@@ -79602,7 +79606,7 @@ jry
 keq
 jKi
 cKN
-aaO
+gUr
 kcF
 eyO
 kYy
@@ -79638,17 +79642,17 @@ klA
 gcJ
 rjs
 sca
-nJt
-uDg
-svr
-dOw
-xgB
+vwa
+uFH
+lZc
+mtw
+bvx
 dNv
 kmr
 ewA
 kmr
 kmr
-tRc
+lef
 wTB
 wTB
 wTB
@@ -79859,7 +79863,7 @@ keq
 keq
 snD
 kYy
-qst
+pCM
 njv
 xET
 kYy
@@ -80631,7 +80635,7 @@ grB
 pfR
 hDW
 cNz
-jeq
+tus
 qXf
 eoP
 mrq
@@ -80646,7 +80650,7 @@ wga
 mrq
 aEv
 ptM
-aVJ
+fSh
 dCF
 eih
 xrA
@@ -80903,7 +80907,7 @@ lZL
 ooG
 aEv
 ptM
-gqD
+qKe
 ihc
 yjk
 wPU
@@ -81160,7 +81164,7 @@ vFK
 mrq
 aEv
 ptM
-aUQ
+dvv
 dCF
 dCF
 uYP
@@ -81407,7 +81411,7 @@ keq
 ooX
 mrq
 mrq
-mPZ
+nUd
 oYb
 kbt
 cuu
@@ -81664,7 +81668,7 @@ kmh
 xCs
 bqN
 oHq
-czS
+hEr
 vGP
 hCH
 agH
@@ -81712,7 +81716,7 @@ aGV
 nOj
 kXa
 dtJ
-otr
+vfs
 wTB
 wTB
 hBZ
@@ -81921,7 +81925,7 @@ eLb
 rKM
 lxv
 mrq
-erR
+wbn
 oTT
 kbt
 fBI
@@ -81969,7 +81973,7 @@ ctb
 kqt
 dtJ
 kqt
-vje
+dVM
 jQO
 aOB
 wOb
@@ -82226,7 +82230,7 @@ kWZ
 ltI
 mrk
 cry
-oJC
+joZ
 wTB
 nGS
 nYy
@@ -83258,7 +83262,7 @@ jwz
 jSO
 oXR
 hbW
-fGc
+sLh
 wvV
 dXK
 dpf
@@ -83515,7 +83519,7 @@ uJu
 jSO
 fNv
 vwU
-hdi
+ufp
 cyI
 xId
 uRs
@@ -83772,7 +83776,7 @@ rJw
 jSO
 sZa
 hbW
-mew
+mGz
 yfh
 oCY
 dpf
@@ -84013,9 +84017,9 @@ abV
 abV
 mPa
 oem
-dOF
-qmz
-lRn
+tcI
+sic
+gtV
 hMD
 pdz
 qQY
@@ -84800,9 +84804,9 @@ oCg
 dge
 fEg
 kju
-xAH
-cQr
-rLs
+mMJ
+bYj
+dYs
 hbW
 hLh
 wNm
@@ -85302,7 +85306,7 @@ mMi
 eUZ
 idi
 kov
-fMC
+erF
 ojI
 eZx
 hyE
@@ -85559,7 +85563,7 @@ mHW
 mHW
 mHW
 mHW
-hCU
+omc
 fRr
 cAG
 mrP
@@ -86036,7 +86040,7 @@ keq
 pSg
 bDb
 lFe
-tGE
+cMb
 dZo
 sWc
 iwn
@@ -86293,14 +86297,14 @@ eLb
 eLb
 hVN
 uhi
-jkV
+wAh
 pNe
 lXw
 bUf
 lFe
-bDG
-cEu
-gIA
+lTf
+vCw
+rTK
 uuV
 lae
 iwi
@@ -86326,7 +86330,7 @@ vRP
 qIk
 nqE
 mHW
-fPr
+ePp
 lIh
 cnh
 kwm
@@ -86550,7 +86554,7 @@ fJJ
 eLb
 rIc
 lFe
-qsa
+xDe
 iwn
 lFe
 lFe
@@ -86583,7 +86587,7 @@ aCD
 qIk
 cds
 mtW
-lQA
+pZQ
 hZT
 joM
 knX
@@ -86840,7 +86844,7 @@ aCD
 qIk
 dpH
 mHW
-wbo
+xmD
 qWF
 knX
 knX
@@ -87327,7 +87331,7 @@ kva
 kva
 paW
 nYO
-xqE
+kAF
 oqQ
 nYO
 ecN
@@ -87579,12 +87583,12 @@ keq
 scI
 xsB
 xsB
-gbE
-tTP
-mXY
+tBL
+vHa
+osq
 gKH
 xZU
-qva
+pDz
 amp
 nYO
 ycV
@@ -87841,7 +87845,7 @@ toK
 mQt
 mQt
 mQt
-hss
+shu
 gsL
 kOt
 wPm
@@ -87878,9 +87882,9 @@ jfN
 jfN
 vsT
 lID
-pKp
-tlj
-czA
+dNj
+edJ
+ktE
 uzX
 nuh
 hED
@@ -88093,9 +88097,9 @@ keq
 qjL
 mQt
 cMs
-cKs
-fkF
-hmh
+mSp
+teH
+ccJ
 kHD
 mQt
 cmF
@@ -88392,9 +88396,9 @@ rcm
 oIK
 rcm
 rcm
-mvn
-jHR
-ajC
+hTW
+uSq
+xFj
 uzX
 uUA
 hcR
@@ -88606,9 +88610,9 @@ keq
 keq
 qjL
 mQt
-ikg
-img
-bkY
+oQx
+miU
+ubP
 mQt
 mQt
 mQt
@@ -89120,8 +89124,8 @@ eLb
 mrH
 tNc
 igt
-mby
-fWI
+dyt
+kUL
 jut
 rny
 cYX
@@ -89638,9 +89642,9 @@ keq
 qjL
 jut
 xaO
-eIY
-sOV
-vBC
+aae
+vJQ
+aJj
 jut
 cBE
 gia
@@ -90659,8 +90663,8 @@ nKd
 uPj
 aWF
 dLk
-ieX
-rkv
+shF
+pTG
 rsW
 eLb
 eLb
@@ -90672,7 +90676,7 @@ qjL
 keq
 kPR
 kfu
-fwh
+pgO
 moB
 uhh
 kfu
@@ -90929,7 +90933,7 @@ ahK
 gtf
 bqN
 srl
-rWO
+fVh
 eKQ
 eAn
 kfu
@@ -90952,7 +90956,7 @@ pNL
 vzg
 hfV
 hpP
-rTs
+rZX
 wLj
 oYc
 oYc
@@ -91186,7 +91190,7 @@ icQ
 fEx
 egW
 kfu
-gxA
+gqx
 dGa
 bhz
 eMT
@@ -91202,7 +91206,7 @@ fxy
 iyi
 yhE
 myr
-gIa
+aKd
 oYc
 oYc
 oYc
@@ -91425,10 +91429,10 @@ jzc
 laK
 hCF
 aCs
-eoI
+kby
 tYq
 vps
-wgr
+tWb
 niO
 uEf
 xPy
@@ -91459,7 +91463,7 @@ fBg
 cFD
 nay
 vZe
-xuf
+gpv
 cxh
 ueT
 bbz
@@ -91682,10 +91686,10 @@ vRP
 eqc
 pQh
 eqc
-uBg
+pge
 kxF
 jxt
-hks
+aWJ
 dLk
 niO
 niO
@@ -91939,22 +91943,22 @@ vRP
 vRP
 aCD
 eqc
-oIT
+pkJ
 amf
 yge
-nge
-inB
-ieC
-mpo
-asd
-whX
-exu
-uWD
-lci
-lci
-lci
-lci
-lxJ
+feO
+ykg
+uyG
+nnG
+vxN
+xRK
+fVp
+nIy
+jcS
+jcS
+jcS
+jcS
+jFL
 eyx
 sGA
 eyx
@@ -91982,9 +91986,9 @@ rrG
 vpc
 gbh
 gda
-rrl
-rvh
-wQR
+nOe
+wRG
+tyd
 nPi
 vvd
 vmy
@@ -92196,7 +92200,7 @@ vRP
 aCD
 aCD
 eqc
-oAa
+fgs
 kxF
 abU
 ihf
@@ -92453,23 +92457,23 @@ vRP
 vRP
 aCD
 eqc
-oIT
+pkJ
 kxF
-oqs
-jfh
-jfh
-jfh
-xHH
-sjW
-eHm
-nyD
-bVL
-grH
-hZR
-rTN
-rTN
-rTN
-rlw
+xdB
+nTr
+nTr
+nTr
+rcE
+qJW
+qeA
+pnr
+eDv
+olO
+nzK
+wku
+wku
+wku
+nve
 ftY
 ftY
 ftY
@@ -92710,14 +92714,14 @@ vRP
 eqc
 pQh
 eqc
-uBg
+pge
 kxF
-kxC
+lJY
 rmW
 iha
 rmW
-kpt
-kaj
+nDr
+jDy
 pQh
 pQh
 dIB
@@ -92726,7 +92730,7 @@ dIB
 dIB
 dIB
 dIB
-axl
+qGI
 ftY
 ftY
 ftY
@@ -92967,15 +92971,15 @@ vRP
 laK
 pqy
 aCs
-lZE
+vuM
 ibW
-rQL
-lEZ
-lEZ
-lEZ
-pYC
-nge
-bQq
+epr
+bMP
+bMP
+bMP
+riG
+feO
+sKe
 pQh
 dYL
 dYL
@@ -92983,7 +92987,7 @@ dYL
 dYL
 ech
 xgP
-rZc
+ycg
 fyP
 kUU
 fyP
@@ -92998,9 +93002,9 @@ ngI
 pBk
 iKT
 hVM
-bzD
+uXL
 knr
-qRR
+vZN
 syN
 vVi
 xPv
@@ -93224,7 +93228,7 @@ vRP
 eqc
 eqc
 eqc
-kpt
+nDr
 kxF
 mLh
 lWI
@@ -93232,7 +93236,7 @@ kxF
 kxF
 fpk
 kxF
-sMd
+mLz
 pQh
 dYL
 dYL
@@ -93481,15 +93485,15 @@ vRP
 laK
 hCF
 aCs
-lrE
-ndh
-oDg
-riY
-uRR
-xHH
+uGW
+ccP
+bFq
+oZR
+mhr
+rcE
 kxF
 kxF
-kaj
+jDy
 pQh
 dYL
 dYL
@@ -93743,10 +93747,10 @@ pQh
 mvV
 pQh
 pQh
-cma
-pje
-lUN
-xwj
+rPc
+gdo
+iMI
+ujU
 pQh
 xgP
 xgP
@@ -93769,7 +93773,7 @@ gXE
 rbp
 gam
 hVM
-klP
+bzz
 kyA
 mKZ
 mKZ
@@ -94038,9 +94042,9 @@ gxH
 kyA
 pWI
 waL
-kdu
-swa
-eSI
+jRx
+jVa
+hZd
 pKx
 wod
 dvp
@@ -94283,7 +94287,7 @@ iUF
 eNr
 ohE
 hVM
-gZt
+etP
 oYi
 bTn
 aRj
@@ -94299,7 +94303,7 @@ aLl
 mfP
 aLl
 uhZ
-ajj
+lSc
 rjN
 rrI
 faQ
@@ -94512,7 +94516,7 @@ iLQ
 dty
 fAL
 hGC
-qXt
+uVk
 iLQ
 rGP
 bvm
@@ -94769,7 +94773,7 @@ iLQ
 cBB
 wUI
 jcQ
-voy
+bjZ
 gNl
 nwQ
 lSl
@@ -96069,7 +96073,7 @@ xgP
 ihC
 eWK
 fnc
-hZr
+jRU
 ghk
 egF
 pps
@@ -96092,7 +96096,7 @@ qvo
 fMi
 hmD
 qVl
-cIi
+xhw
 fGy
 vKc
 aLl
@@ -96326,7 +96330,7 @@ xgP
 nCy
 sTM
 uQR
-exz
+cDh
 cPe
 oyZ
 ilp
@@ -96349,7 +96353,7 @@ eVR
 wgS
 vFm
 qlc
-gqj
+kCa
 tUy
 ozz
 aLl
@@ -96583,7 +96587,7 @@ xgP
 kIf
 dVD
 fnc
-xYx
+nKs
 eTE
 cTL
 kFN
@@ -96606,7 +96610,7 @@ uQz
 oJi
 hBI
 qdi
-lCw
+vwl
 fGy
 aLl
 aLl

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -7,12 +7,23 @@
 /area/medical/sleeper)
 "aav" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"aaO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "aaP" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -40,7 +51,7 @@
 /area/space/nearstation)
 "abw" = (
 /obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -79,7 +90,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "abV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -103,14 +114,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"acW" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/janitor)
 "adc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -122,10 +125,10 @@
 	name = "Bridge";
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -147,29 +150,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ady" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "adH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -181,13 +163,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"adM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "adT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -196,7 +171,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "adU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -222,7 +197,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aeq" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light{
@@ -238,13 +213,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aeL" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aeV" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -268,10 +243,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -297,18 +272,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"afZ" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "agb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"agf" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "agn" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -317,14 +300,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "agx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "agy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -342,7 +325,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "agN" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "agO" = (
@@ -352,7 +335,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "ahf" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -376,20 +359,8 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ahO" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "ahP" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -443,16 +414,44 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "aiJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"ajj" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
+"ajC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ajE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
@@ -473,10 +472,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -499,7 +498,7 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
 "all" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -525,7 +524,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "amp" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -552,7 +551,7 @@
 /turf/closed/wall,
 /area/maintenance/department/medical/central)
 "amE" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -619,6 +618,15 @@
 	},
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
+"anl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -647,7 +655,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aoe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -725,16 +733,6 @@
 "apP" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"aqc" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "arc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -764,7 +762,7 @@
 /turf/open/floor/plating,
 /area/medical/paramedic)
 "arL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -779,8 +777,21 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"asd" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "asu" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -805,12 +816,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "asR" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -862,24 +873,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"auc" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"auf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "avc" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -896,7 +889,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/firealarm{
@@ -913,6 +906,18 @@
 "avY" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/department/bridge)
+"awd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "awh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -923,7 +928,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -932,20 +937,14 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "awl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"awX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "axk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -956,25 +955,24 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"axl" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "axz" = (
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"axG" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "axR" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -993,10 +991,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "ayh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -1012,7 +1010,7 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "ayM" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -30
@@ -1119,7 +1117,7 @@
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
 "aCj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -1143,7 +1141,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aCJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/bed/roller,
@@ -1161,14 +1159,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1177,13 +1175,13 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aDO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
@@ -1197,7 +1195,7 @@
 /area/engine/engine_smes)
 "aEm" = (
 /obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -1207,7 +1205,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "aEv" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1226,7 +1224,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aEH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1244,10 +1242,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "aFU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -1257,7 +1255,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "aGU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/table,
@@ -1279,7 +1277,7 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "aId" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1390,6 +1388,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"aKc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "aKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1422,7 +1429,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1446,10 +1453,10 @@
 /turf/closed/wall,
 /area/maintenance/department/bridge)
 "aLB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -1509,7 +1516,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "aOA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -1555,10 +1562,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aPs" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -1596,7 +1603,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aPG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -1663,16 +1670,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aQA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	layer = 2.4;
-	name = "Mix Outlet Pump"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "aQF" = (
 /obj/machinery/light{
 	dir = 1
@@ -1734,14 +1731,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aSd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aSA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -1754,7 +1751,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aSW" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -1831,8 +1828,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1843,6 +1840,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
+"aUQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aVs" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -1860,8 +1864,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"aVJ" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aVK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -1871,7 +1881,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -1932,18 +1942,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aWK" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aWN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -1978,7 +1988,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2007,10 +2017,10 @@
 /area/hallway/primary/central)
 "aYT" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aZy" = (
@@ -2031,21 +2041,35 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aZG" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"aZH" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "baa" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -2060,7 +2084,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bae" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bal" = (
@@ -2105,17 +2129,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bbe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bbz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2154,7 +2167,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bch" = (
@@ -2167,10 +2180,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "bci" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical{
@@ -2190,7 +2203,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bcq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair,
@@ -2227,7 +2240,7 @@
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -2243,10 +2256,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -2256,7 +2269,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/closet/l3closet,
 /obj/item/geiger_counter,
 /turf/open/floor/plasteel/white,
@@ -2296,7 +2309,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -2305,7 +2318,7 @@
 /obj/structure/sign/departments/minsky/medical/clone/cloning2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -2339,55 +2352,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
-"bfK" = (
-/obj/machinery/light,
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "bfP" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"bfW" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bgd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bgo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bgF" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory_eva";
@@ -2405,7 +2378,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bgH" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/supply/hydroponics{
@@ -2474,10 +2447,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2513,7 +2486,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bkG" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/security/security{
@@ -2521,23 +2494,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"blm" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/head/welding,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+"bkY" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/secondary/service)
 "blt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -2590,16 +2553,16 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "bnk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bns" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2722,7 +2685,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
 "bqz" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
@@ -2754,7 +2717,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "brD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2765,25 +2728,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"brF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "brT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2829,20 +2773,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"btb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "btg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/storage/eva";
@@ -2868,7 +2798,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -2935,7 +2865,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bvH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -2944,30 +2874,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bwc" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "bwu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bwD" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3004,7 +2917,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -3052,6 +2965,38 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"byq" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
+"byG" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "byH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
@@ -3060,6 +3005,13 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bzD" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -3086,7 +3038,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bAq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bBf" = (
@@ -3109,7 +3061,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "bBB" = (
@@ -3120,10 +3072,10 @@
 	name = "Robotics Desk";
 	req_one_access_txt = "29;75"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bBE" = (
@@ -3191,7 +3143,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bDi" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -3206,7 +3158,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bDB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -3222,6 +3174,13 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"bDG" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bEd" = (
 /obj/machinery/computer/apc_control{
 	dir = 1
@@ -3236,7 +3195,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bEx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -3272,7 +3231,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bEN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/disposal/bin,
@@ -3345,7 +3304,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bHi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -3359,7 +3318,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bHA" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -3390,7 +3349,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "bIB" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -3466,16 +3425,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"bJT" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bKw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -3500,7 +3449,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "bLu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -3550,6 +3499,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"bNU" = (
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "bOi" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -3586,7 +3545,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "bPi" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -3609,7 +3568,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3621,7 +3580,7 @@
 	name = "Medbay Security APC";
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3670,11 +3629,24 @@
 "bQp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"bQq" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -3735,7 +3707,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3753,17 +3725,17 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bRm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bRY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -3774,18 +3746,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"bSD" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -3805,7 +3765,7 @@
 	pixel_x = 8;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -3887,7 +3847,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "bUr" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/research/research{
@@ -3918,13 +3878,13 @@
 	c_tag = "Bridge North"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bUS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -3954,6 +3914,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bVL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bVZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3962,10 +3936,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bWu" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -4010,7 +3984,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "bXn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical3,
@@ -4022,8 +3996,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4031,11 +4005,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bYF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bZe" = (
+/obj/structure/table,
+/obj/item/analyzer{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/t_scanner{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/multitool{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "bZU" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
@@ -4060,10 +4056,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -4098,16 +4094,23 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cbr" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = 32
+"cco" = (
+/obj/machinery/camera{
+	c_tag = "Mining Dock";
+	dir = 5
 	},
-/obj/structure/chair/comfy/beige{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/burnt/two,
-/area/science/mixing)
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "ccs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4143,7 +4146,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cdG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Port Hallway 3";
 	dir = 1
@@ -4175,7 +4178,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cej" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/medical/virology";
 	name = "Virology APC";
@@ -4190,18 +4193,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ceE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "ceS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4300,8 +4291,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -4364,37 +4355,16 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cjp" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cjr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cjy" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -4403,7 +4373,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "cjE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -4421,7 +4391,7 @@
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4447,7 +4417,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -4469,14 +4439,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ckS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "clE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -4494,8 +4458,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cma" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "cmb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table,
@@ -4507,11 +4487,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cmq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cmF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light/small{
@@ -4532,7 +4512,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -4601,7 +4581,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -4610,10 +4590,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "cpF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4648,7 +4628,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cqj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -4682,21 +4662,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "cry" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/green,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "crK" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -4770,26 +4750,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"cuq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cur" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -4825,7 +4785,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cvi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/directions/security{
@@ -4855,7 +4815,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "cvF" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/table,
@@ -4875,7 +4835,7 @@
 /area/maintenance/starboard/fore)
 "cwL" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4887,7 +4847,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cxb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4913,6 +4873,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"cxw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "cxG" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -4978,7 +4961,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cyw" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/table,
@@ -5033,7 +5016,7 @@
 /area/science/mixing)
 "cyK" = (
 /obj/structure/closet/secure_closet/paramedic,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -5047,6 +5030,19 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"czA" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/departments/minsky/research/xenobiology{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "czC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5058,6 +5054,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"czF" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "czG" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -5068,6 +5072,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"czS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "czT" = (
 /turf/closed/wall,
 /area/ai_monitored/security/armory)
@@ -5108,8 +5124,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -5126,19 +5142,8 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"cAY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "cBa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/engineering/engineering{
@@ -5234,10 +5239,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -5255,7 +5260,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cDb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -5266,7 +5271,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cDQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -5291,6 +5296,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"cEu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cEv" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -5299,7 +5322,7 @@
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
 "cEI" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -5338,17 +5361,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
-"cFs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "cFy" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5413,6 +5425,14 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
+"cGw" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cGy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -5432,7 +5452,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cGW" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -5442,11 +5462,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cHZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cIi" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "cIF" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -5508,14 +5536,15 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
-"cKj" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
+"cKs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/service)
 "cKA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -5561,7 +5590,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "cLa" = (
@@ -5598,7 +5627,7 @@
 /area/engine/engineering)
 "cLq" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -5609,7 +5638,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cMn" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -5730,11 +5759,25 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "cPi" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cPz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "cPG" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -5752,8 +5795,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -5769,10 +5812,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -5799,16 +5842,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"cQr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cQK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -5817,7 +5879,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -5889,7 +5951,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
@@ -5919,7 +5981,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "cUC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table/reinforced,
@@ -5933,16 +5995,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"cUY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cVa" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -5958,7 +6010,7 @@
 /area/hallway/primary/central)
 "cVd" = (
 /obj/effect/turf_decal/box,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5999,7 +6051,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6029,7 +6081,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cWx" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -6081,7 +6133,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -6092,15 +6144,6 @@
 "cXY" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"cYt" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/obj/structure/sign/departments/minsky/command/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "cYC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -6168,6 +6211,20 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/port/aft)
+"cZp" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	layer = 2.4;
+	name = "Air to Port"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "cZF" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -6239,7 +6296,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -6314,20 +6371,6 @@
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"ddt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ddu" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
@@ -6337,8 +6380,8 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
 "dea" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6364,10 +6407,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "deS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -6375,16 +6418,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"dfj" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dfE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6419,10 +6452,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "dge" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6487,10 +6520,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -6501,7 +6534,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "div" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/computer/operating{
@@ -6532,7 +6565,7 @@
 	},
 /area/crew_quarters/bar)
 "diI" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -6593,7 +6626,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "djA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -6612,6 +6645,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"djH" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "djJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6619,10 +6678,10 @@
 	id = "Cell 2";
 	name = "Cell 2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -6659,7 +6718,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "dkw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -6668,7 +6727,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dkC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/light_switch{
@@ -6682,7 +6741,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "dkD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/table,
@@ -6706,14 +6765,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"dkW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dll" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -6770,7 +6821,7 @@
 /obj/machinery/computer/aifixer{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "doI" = (
@@ -6792,7 +6843,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -6801,8 +6852,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "dpC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6854,7 +6905,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dru" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/medical2,
@@ -6870,21 +6921,62 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dsb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"dsm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
+"dsA" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dsF" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6908,7 +7000,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dta" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/photocopier,
@@ -6951,7 +7043,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "duO" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -6977,7 +7069,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "dvJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -6986,7 +7078,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "dvZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair/office/light{
@@ -6994,6 +7086,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"dwc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dwr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/engineering";
@@ -7001,7 +7099,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/table,
@@ -7027,6 +7125,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"dwP" = (
+/obj/machinery/light,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "dwV" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
@@ -7043,11 +7154,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "dxA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "dxB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -7062,6 +7173,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"dxK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "dxR" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -7081,7 +7204,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "dzh" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/secure_closet/security/med,
@@ -7106,27 +7229,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"dzX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "dAf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -7159,7 +7263,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "dBz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -7174,7 +7278,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dCg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/computer/rdconsole/production{
@@ -7237,10 +7341,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "dEb" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -7326,10 +7430,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "dFX" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -7356,10 +7460,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -7391,7 +7495,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "dGB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
 	dir = 1
@@ -7451,13 +7555,6 @@
 "dIB" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
-"dJv" = (
-/obj/effect/turf_decal/trimline/white/filled/line,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dJF" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -7470,7 +7567,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "dJN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7503,26 +7600,8 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dKG" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "dKK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -7575,17 +7654,30 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"dNv" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+"dMm" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
+"dNv" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "dNz" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7618,8 +7710,28 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"dOi" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump";
+	target_pressure = 4500
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "dOn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -7647,20 +7759,27 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "dOw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"dOF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dPW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -7681,6 +7800,23 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/office)
+"dQs" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Waste In";
+	on = 1
+	},
+/obj/machinery/light,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "dQz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -7745,7 +7881,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dSW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/firealarm{
@@ -7770,36 +7906,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dTN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"dTO" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"dTU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "dUm" = (
 /obj/machinery/air_sensor{
 	id_tag = "tox_sensor"
@@ -7856,10 +7968,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7984,7 +8096,7 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -7993,7 +8105,7 @@
 /obj/machinery/ministile/hop{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -8007,20 +8119,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "dXK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"dXU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/library)
 "dYL" = (
 /turf/template_noop,
 /area/maintenance/department/eva)
@@ -8037,7 +8140,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dZl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -8046,18 +8149,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"dZn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dZo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -8105,14 +8196,14 @@
 	},
 /area/maintenance/starboard/fore)
 "eay" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eaT" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /obj/item/storage/box/syringes{
@@ -8160,7 +8251,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
 "ebI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8221,7 +8312,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ecN" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -8278,7 +8369,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "edq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -8328,7 +8419,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "efb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -8338,7 +8429,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "efh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -8481,16 +8572,6 @@
 "eiF" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
-"eje" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Service Backroom"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "ejl" = (
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -8511,7 +8592,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ekn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/scan_consolenew,
@@ -8525,7 +8606,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ekL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -8552,7 +8633,7 @@
 /turf/open/space/basic,
 /area/space)
 "elm" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair/office/dark{
@@ -8583,10 +8664,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
 "emd" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -8624,22 +8705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"emo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "emt" = (
 /obj/effect/turf_decal/caution{
 	dir = 1
@@ -8648,7 +8713,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "emJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
@@ -8666,7 +8731,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/starboard/fore)
 "ene" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/sign/directions/evac{
@@ -8697,13 +8762,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eoh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8720,11 +8785,37 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"eoN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"eoG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"eoI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"eoN" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -8746,7 +8837,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "eoW" = (
@@ -8755,6 +8846,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"epa" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "eph" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -8781,7 +8887,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ept" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -8804,7 +8910,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "epS" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/sign/directions/medical{
@@ -8829,7 +8935,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "eqy" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -8838,7 +8944,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -8883,6 +8989,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"erR" = (
+/obj/structure/bookcase/random/reference,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/library)
 "erT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8908,15 +9021,15 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "esy" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "esE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8928,13 +9041,13 @@
 	network = list("ss13","medbay");
 	pixel_x = 0
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "etl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -8985,10 +9098,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "etE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
@@ -9013,7 +9126,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
 "euj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 1
@@ -9036,7 +9149,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "euF" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -9055,7 +9168,7 @@
 /area/quartermaster/storage)
 "euN" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/airalarm{
@@ -9086,7 +9199,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "euU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/table/glass,
@@ -9110,22 +9223,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"evo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ewm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9154,6 +9251,39 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"exq" = (
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
+"exu" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"exz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "exV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -9168,17 +9298,17 @@
 	name = "Operating Theatre";
 	req_access_txt = "45"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/holosign/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "exW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -9205,7 +9335,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "eyx" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -9227,10 +9357,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9245,20 +9375,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"eyP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ezb" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -9283,7 +9399,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ezB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table,
@@ -9336,7 +9452,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eAL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -9409,19 +9525,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"eBY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "eCc" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9441,23 +9546,13 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "eCE" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eCM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "eCN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -9564,11 +9659,11 @@
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eEj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -9588,17 +9683,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"eEw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	layer = 2.4;
-	name = "Air to Port"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "eEB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -9632,12 +9716,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "eFs" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -9689,6 +9773,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"eHm" = (
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "eHz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9746,10 +9843,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "eIA" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
@@ -9773,6 +9870,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"eIY" = (
+/obj/machinery/chem_master/condimaster,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "eIZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9801,7 +9906,7 @@
 /turf/open/floor/plating,
 /area/security/main)
 "eJX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -9932,7 +10037,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "eMC" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/sign/directions/evac{
@@ -9991,10 +10096,10 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "eNr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eNu" = (
@@ -10021,7 +10126,7 @@
 /turf/open/floor/carpet/exoticpurple,
 /area/crew_quarters/heads/hor)
 "eNI" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -10048,11 +10153,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"eOi" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eOq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10106,7 +10206,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "ePa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -10125,7 +10225,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "ePC" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -10144,11 +10244,11 @@
 /area/engine/engineering)
 "ePR" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "eQi" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -10234,7 +10334,7 @@
 /area/maintenance/department/engine)
 "eSb" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -10242,13 +10342,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eSn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+"eSI" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/entry)
 "eTE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10272,15 +10375,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"eUq" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -10289,29 +10383,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"eVA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eVI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/sign/departments/minsky/medical/medical1{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eVO" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eVR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -10358,7 +10436,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -10396,7 +10474,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "eXJ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -10405,13 +10483,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"eYN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "eYP" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -10440,7 +10511,7 @@
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
 "eZx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -10453,7 +10524,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eZT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -10520,7 +10591,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
 "fbl" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -10529,7 +10600,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fbr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -10539,12 +10610,12 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "fbD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fbN" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10564,7 +10635,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "fcu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/computer/operating{
@@ -10583,7 +10654,7 @@
 /area/chapel/main)
 "fcF" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -10634,7 +10705,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fdO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -10650,7 +10721,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/sleeper{
@@ -10721,17 +10792,6 @@
 "fgB" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"fgJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "fgN" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -10787,7 +10847,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -10816,7 +10876,7 @@
 /area/maintenance/department/science)
 "fhS" = (
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/wardrobe/genetics_white,
@@ -10882,7 +10942,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "fjn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
@@ -10894,7 +10954,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
 "fkk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/painting{
@@ -10903,6 +10963,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fkF" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "fkJ" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -10912,7 +10987,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "fkR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair,
@@ -10974,7 +11049,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "fmk" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -11007,11 +11082,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fmG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -11038,7 +11113,7 @@
 /turf/open/space/basic,
 /area/solar/starboard/fore)
 "fom" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/dna_scannernew,
@@ -11100,19 +11175,6 @@
 /obj/structure/closet/secure_closet/injection,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"fqd" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fqe" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -11130,7 +11192,7 @@
 /turf/closed/wall,
 /area/medical/genetics/cloning)
 "fqN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -11157,7 +11219,7 @@
 "fra" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/secure_closet/physician,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -11192,10 +11254,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fsa" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -11217,6 +11279,20 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/engine/gravity_generator)
+"fsu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Incinerator"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fsD" = (
 /obj/machinery/button/door{
 	id = "kitchen";
@@ -11243,7 +11319,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "fsY" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/light,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -11251,6 +11327,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fsZ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	layer = 2.4;
+	name = "Mix Outlet Pump"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "ftr" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -11319,10 +11408,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fwh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "fwr" = (
 /obj/machinery/smoke_machine,
 /obj/item/reagent_containers/glass/beaker/large/silver_sulfadiazine{
-	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin=100);
+	list_reagents = list(/datum/reagent/consumable/condensedcapsaicin = 100);
 	name = "liquid pepper spray"
 	},
 /turf/open/floor/plasteel/dark,
@@ -11377,15 +11478,9 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"fyb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/teleporter)
 "fyD" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -11404,7 +11499,7 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "fyG" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -11414,14 +11509,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fyP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fyU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11430,7 +11525,7 @@
 /obj/structure/table/optable{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -11445,15 +11540,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"fzx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "fzA" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
@@ -11468,10 +11554,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_target{
@@ -11490,10 +11576,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -11503,20 +11589,20 @@
 /obj/machinery/computer/prisoner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fAF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/doorButtons/access_button{
@@ -11534,7 +11620,7 @@
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "fAN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -11546,7 +11632,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fAQ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -11642,7 +11728,7 @@
 /area/chapel/main)
 "fCm" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -11651,7 +11737,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11671,19 +11757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"fCZ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "fDs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11698,7 +11771,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11734,7 +11807,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fDV" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -11763,10 +11836,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "fEi" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
 	req_access_txt = "50"
@@ -11793,7 +11866,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "fEl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -11852,10 +11925,10 @@
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -11874,10 +11947,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "fFc" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -11898,7 +11971,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fFy" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -11916,6 +11989,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fGc" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fGf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -11924,7 +12005,7 @@
 /area/security/execution/transfer)
 "fGl" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/cell_charger{
@@ -11961,7 +12042,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fHg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -12061,12 +12142,30 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fLb" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/distro";
+	dir = 1;
+	name = "Atmospherics Distribution APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "fLC" = (
 /obj/structure/bed/pod{
 	desc = "The latest in lying down technology";
 	name = "Advanced medical bed"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -12115,18 +12214,22 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"fMN" = (
-/obj/machinery/light/small{
+"fMC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fNm" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/sign/departments/minsky/command/bridge{
 	pixel_x = 32;
 	pixel_y = -32
@@ -12203,16 +12306,16 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "fOh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "fOF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12220,8 +12323,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fPr" = (
+/obj/machinery/power/apc{
+	areastring = "/area/science/nanite";
+	dir = 1;
+	name = "Nanite Lab APC";
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "fPN" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -12259,7 +12380,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fRa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12290,7 +12411,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
 "fRH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -12305,7 +12426,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fRO" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/reagentgrinder{
@@ -12346,7 +12467,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fSF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -12381,7 +12502,7 @@
 	c_tag = "Research Division South";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/vending/assist,
@@ -12399,7 +12520,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fUA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -12418,7 +12539,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "fUO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/modular_computer/console/preset/mining{
@@ -12436,26 +12557,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"fVB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/electrolyzer,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "fVJ" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fVP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -12469,18 +12582,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"fWk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "fWw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/cryopods";
@@ -12502,6 +12603,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fWI" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fXo" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12547,7 +12666,7 @@
 /area/lawoffice)
 "fYs" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -12585,10 +12704,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "fZx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -12652,7 +12771,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "gam" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -12663,15 +12782,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"gar" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "gav" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -12681,7 +12796,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "gbh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12709,15 +12824,28 @@
 "gbt" = (
 /turf/closed/wall,
 /area/medical/storage)
+"gbE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gbL" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -12726,14 +12854,31 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "gbP" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gbQ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "gbT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -12747,20 +12892,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"gcL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/computer/station_alert{
-	name = "Station Alert Console"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "gda" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12781,7 +12917,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "geh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -12789,13 +12925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"gen" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "gev" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -12818,7 +12947,7 @@
 /area/ai_monitored/nuke_storage)
 "geS" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12831,7 +12960,7 @@
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/railing{
@@ -12858,7 +12987,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "ggu" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/snack/random,
@@ -12870,7 +12999,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -12911,7 +13040,7 @@
 /obj/machinery/vending/sustenance{
 	onstation = 0
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -12952,19 +13081,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"giC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "giF" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -13063,7 +13179,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "glN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/table/glass,
@@ -13076,15 +13192,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"glO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "glR" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -13097,6 +13204,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"gmo" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"gmu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gmv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13138,8 +13272,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13156,12 +13290,23 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "goh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"goq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/electrolyzer,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "gph" = (
 /obj/structure/rack,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -13199,11 +13344,21 @@
 /area/science/xenobiology)
 "gqg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"gqj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "gql" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -13214,6 +13369,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"gqD" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gqK" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable{
@@ -13241,6 +13400,23 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"grl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks North";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "grB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -13248,6 +13424,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"grH" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"grP" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gsb" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13276,10 +13472,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gsL" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
@@ -13310,7 +13506,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "gtb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/computer/cargo{
@@ -13337,7 +13533,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gtA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -13379,10 +13575,10 @@
 	pixel_x = 32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -13396,7 +13592,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
 	dir = 4;
-	sensors = list("tox_sensor"="Tank")
+	sensors = list("tox_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -13410,7 +13606,7 @@
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -13450,7 +13646,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "gvS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -13488,7 +13684,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gwk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -13525,6 +13721,19 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"gxA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Storage"
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "gxH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -13539,6 +13748,31 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/grass,
 /area/medical/virology)
+"gyV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gyY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -13546,8 +13780,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"gzl" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "gzB" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposaloutlet{
@@ -13587,7 +13830,7 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "gAz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/papershredder,
@@ -13598,7 +13841,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13616,7 +13859,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "gBn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -13665,7 +13908,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gCR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Central Hallway North";
 	dir = 1
@@ -13687,7 +13930,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "gDI" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/status_display/supply{
@@ -13807,7 +14050,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "gGA" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -13840,30 +14083,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"gHm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "gHq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -13877,7 +14104,7 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/requests_console{
@@ -13907,6 +14134,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gIa" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "gIn" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -13932,11 +14166,20 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gIA" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gIT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13970,10 +14213,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gJn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -13991,7 +14234,7 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
 "gJE" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14024,14 +14267,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"gLD" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gLV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -14060,13 +14297,13 @@
 /turf/open/floor/wood,
 /area/library)
 "gMy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gMU" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gNl" = (
@@ -14114,10 +14351,10 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -14153,24 +14390,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gQh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gRz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Incinerator"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "gRH" = (
 /obj/machinery/light{
 	dir = 4
@@ -14198,13 +14424,13 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
 "gSf" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gSg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -14220,13 +14446,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
-"gSz" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "gSI" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -14238,7 +14457,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "gTq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
@@ -14261,7 +14480,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "gTy" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/airalarm{
@@ -14310,7 +14529,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "gUh" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -14376,7 +14595,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14393,7 +14612,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gYg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -14425,15 +14644,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
-"gZn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gZq" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
@@ -14458,6 +14668,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"gZt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "gZR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14470,7 +14686,7 @@
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "hae" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14510,7 +14726,7 @@
 "haX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/tank/internals/emergency_oxygen,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/airalarm{
@@ -14524,7 +14740,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hbu" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14582,7 +14798,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14591,13 +14807,26 @@
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
 /area/janitor)
+"hdi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "hdt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "hdw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -14628,7 +14857,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hff" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/modularpc,
@@ -14655,7 +14884,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "hfA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -14687,7 +14916,7 @@
 "hfV" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -14730,7 +14959,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hic" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -14768,10 +14997,10 @@
 /area/ai_monitored/secondarydatacore)
 "hiw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -14785,17 +15014,8 @@
 	},
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"hjd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "hjl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14865,6 +15085,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"hks" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hkv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -14888,7 +15116,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "hkH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
@@ -14900,16 +15128,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hkM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "hlg" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -14944,10 +15162,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hlr" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14968,7 +15186,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14990,6 +15208,18 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"hmh" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "hmi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15004,7 +15234,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "hmr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -15059,7 +15289,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "hnn" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15115,25 +15345,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"hoU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "hpd" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -15158,7 +15369,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "hpm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -15191,26 +15402,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hpx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "hpP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/modular_computer/console/preset/research{
@@ -15220,17 +15418,17 @@
 /area/science/robotics/lab)
 "hpU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hqm" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -15239,20 +15437,6 @@
 /obj/item/clothing/head/soft,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"hqo" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Southeast";
-	dir = 9;
-	network = list("ss13")
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hqB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15268,8 +15452,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15317,7 +15501,7 @@
 	pixel_x = 0;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/item/storage/lockbox/vialbox/virology{
@@ -15328,7 +15512,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hsa" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -15355,8 +15539,29 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"hss" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "htr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/table,
@@ -15413,7 +15618,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "hvC" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "hvG" = (
@@ -15498,7 +15703,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -15512,17 +15717,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"hxY" = (
-/obj/structure/filingcabinet,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "hyf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical1,
@@ -15534,7 +15731,7 @@
 /area/science/mixing)
 "hzb" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hzo" = (
@@ -15544,7 +15741,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "hzF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -15621,7 +15818,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -15753,8 +15950,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hCU" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hDi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/port";
 	name = "Port Hall APC";
@@ -15773,10 +15982,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15790,13 +15999,27 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hDH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hDO" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "hDW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15823,21 +16046,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hFP" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "hGn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"hGv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "hGw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15924,7 +16140,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "hJB" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -15934,7 +16150,7 @@
 /area/hallway/primary/starboard)
 "hKr" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hKs" = (
@@ -15959,15 +16175,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"hLq" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "hLy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15983,6 +16190,16 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"hMp" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "hMv" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -16046,6 +16263,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"hOh" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "hOo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16064,7 +16290,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -16090,10 +16316,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "hOz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -16109,7 +16335,7 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hOJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
@@ -16117,7 +16343,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hPZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -16163,7 +16389,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "hRH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/chair{
@@ -16175,13 +16401,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"hSo" = (
-/obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+"hSg" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hSr" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "toxins_airlock_exterior";
@@ -16217,7 +16442,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -16229,8 +16454,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16248,7 +16473,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "hSZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTa" = (
@@ -16258,7 +16483,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -16268,7 +16493,7 @@
 /area/security/prison)
 "hTe" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -16308,10 +16533,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hUa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16325,14 +16550,8 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"hUk" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "hUI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -16362,10 +16581,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -16383,7 +16602,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 4;
-	sensors = list("o2_sensor"="Tank")
+	sensors = list("o2_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/door/firedoor/border_only{
@@ -16448,7 +16667,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hVZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -16466,7 +16685,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "hWh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/chair{
@@ -16507,7 +16726,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -16518,7 +16737,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hYs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16529,21 +16748,41 @@
 	},
 /turf/open/floor/plating,
 /area/teleporter)
+"hZr" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "EVA East";
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
+"hZR" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "hZT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"iak" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "ibe" = (
 /obj/machinery/computer/security/qm{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "ibf" = (
@@ -16574,7 +16813,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "icJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -16589,10 +16828,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ide" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -16654,6 +16893,37 @@
 	icon_state = "carpetsymbol"
 	},
 /area/chapel/main)
+"ieC" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"ieX" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/auxiliary";
+	dir = 1;
+	name = "Security Checkpoint APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "ifa" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -16670,7 +16940,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 1;
-	sensors = list("co2_sensor"="Tank")
+	sensors = list("co2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -16690,8 +16960,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ifS" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Storage";
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "igr" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel,
@@ -16776,7 +17062,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ihl" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/light,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -16837,7 +17123,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "iiN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -16885,12 +17171,23 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"ikg" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Service Backroom"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "ikO" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -16925,19 +17222,25 @@
 	dirx = -2;
 	diry = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ilz" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"img" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "imt" = (
 /obj/machinery/light{
 	dir = 4
@@ -16961,6 +17264,25 @@
 	dir = 1
 	},
 /area/hydroponics/garden)
+"inB" = (
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/exit";
+	dir = 8;
+	name = "Escape Hallway APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "inC" = (
 /obj/structure/table,
 /obj/structure/cable{
@@ -17003,7 +17325,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
 "ioF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -17024,7 +17346,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ioL" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -17043,7 +17365,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "ipy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -17061,14 +17383,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"ipI" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/broken/two,
-/area/science/mixing)
 "ipU" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17079,10 +17393,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ipY" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -17139,7 +17453,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "isk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -17180,7 +17494,7 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "itC" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -17192,25 +17506,18 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"iud" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "iuS" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
-	sensors = list("mix_sensor"="Tank")
+	sensors = list("mix_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -17247,7 +17554,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17268,16 +17575,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"iwh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "iwi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
@@ -17306,7 +17603,7 @@
 	pixel_x = -25
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17331,7 +17628,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "iww" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/disposal/bin,
@@ -17341,7 +17638,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "iwJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/door/window/northleft{
@@ -17387,7 +17684,7 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "ixg" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -17395,7 +17692,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -17441,7 +17738,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -17494,7 +17791,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/lapvend,
@@ -17503,6 +17800,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"izm" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "izN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -17516,7 +17829,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "iAA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light,
@@ -17606,7 +17919,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/distro)
 "iCY" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "iDe" = (
@@ -17627,7 +17940,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iEC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/light{
@@ -17659,7 +17972,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
 "iGP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -17721,11 +18034,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "iIZ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "iJg" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
 	dir = 1;
@@ -17737,7 +18050,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "iJN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table,
@@ -17778,7 +18091,7 @@
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "iKT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iKZ" = (
@@ -17788,7 +18101,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "iLn" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/office";
 	name = "Cargo Office APC";
@@ -17891,7 +18204,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -17923,14 +18236,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iOq" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "iOZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/lapvend,
@@ -17966,7 +18279,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "iQy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/table/glass,
@@ -17985,8 +18298,8 @@
 "iRa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17994,7 +18307,7 @@
 "iRb" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/tank/internals/emergency_oxygen,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/light{
@@ -18056,7 +18369,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "iRF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -18065,7 +18378,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iRR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -18074,7 +18387,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "iSc" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/camera{
@@ -18104,7 +18417,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "iSi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/computer/security{
@@ -18139,7 +18452,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "iTl" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/painting{
@@ -18148,16 +18461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"iTv" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -18168,10 +18471,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -18185,7 +18488,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "iUF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -18220,7 +18523,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
 "iVM" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -18253,10 +18556,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "iXw" = (
@@ -18270,11 +18573,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "iXH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -18287,6 +18590,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iXX" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "iYY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -18299,7 +18615,7 @@
 /turf/open/space/basic,
 /area/space)
 "iZa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -18309,23 +18625,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"iZk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -18365,7 +18664,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "jaK" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -18374,7 +18673,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "jaW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jbv" = (
@@ -18386,19 +18685,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"jbT" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/shoes/magboots,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jbW" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -18414,7 +18700,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/item/extinguisher,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light{
@@ -18491,7 +18777,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "jdT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/chair{
@@ -18516,14 +18802,31 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jeq" = (
+/obj/machinery/button/massdriver{
+	id = "chapelgun";
+	name = "Chapel Mass Driver";
+	pixel_x = -24;
+	pixel_y = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/chapel/office)
 "jeu" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/landmark/start/virologist,
@@ -18536,50 +18839,38 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jfh" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "jfL" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "jfN" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jfV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "jfX" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jgj" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "jgO" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "jgT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/autolathe,
@@ -18616,7 +18907,7 @@
 /area/ai_monitored/security/armory)
 "jip" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -18644,14 +18935,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "jiV" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jjq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -18676,6 +18967,20 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"jkV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
 "jlg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -18717,7 +19022,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -18735,7 +19040,7 @@
 	},
 /area/crew_quarters/kitchen)
 "jmq" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -18757,7 +19062,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "jmK" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18781,7 +19086,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jmY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/table,
@@ -18789,7 +19094,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jnc" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18798,7 +19103,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18812,21 +19117,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jnW" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "joK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -18893,7 +19185,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "jqf" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -18908,7 +19200,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
 "jrk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/computer/crew,
@@ -18924,19 +19216,30 @@
 /obj/item/wirecutters,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/shovel/spade,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /obj/item/stack/sheet/mineral/sandstone/thirty,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jrE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jrJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "jrO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18949,7 +19252,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jsq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -18957,6 +19260,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jsV" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jta" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -18985,6 +19304,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jub" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jun" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -18996,53 +19324,53 @@
 /area/crew_quarters/kitchen)
 "juB" = (
 /obj/structure/chair/office,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "jvg" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jvK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "jvU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"jwp" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+"jwl" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jww" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos/distro)
 "jwz" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "jxi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19051,7 +19379,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -19129,6 +19457,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"jyz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "jyJ" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -19139,10 +19478,10 @@
 /turf/open/floor/carpet/exoticpurple,
 /area/crew_quarters/heads/hor)
 "jyN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -19179,10 +19518,10 @@
 "jzM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19213,6 +19552,17 @@
 	},
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"jAa" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/item/pipe_dispenser,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jAi" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -19229,6 +19579,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"jAk" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics";
+	req_access_txt = "24"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jAP" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -19266,7 +19637,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jBI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -19363,14 +19734,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"jCC" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "jCE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -19389,10 +19752,10 @@
 	dirx = -5;
 	diry = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -19426,7 +19789,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -19458,8 +19821,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -19483,27 +19846,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"jEY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "jEZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/grille,
@@ -19519,6 +19861,19 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"jFW" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jGi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19543,36 +19898,55 @@
 /obj/structure/fireaxecabinet/bridge{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jHb" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/computer/atmos_control{
+	dir = 1;
+	name = "Tank Monitor"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "jHj" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
 /area/chapel/main)
 "jHK" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"jHQ" = (
-/obj/machinery/computer/station_alert{
+"jHR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jHX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19590,7 +19964,7 @@
 /area/hallway/secondary/exit)
 "jII" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_x = 0;
 	pixel_y = -32
@@ -19666,7 +20040,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jKx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -19675,11 +20049,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jKC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "jKH" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -19707,19 +20100,6 @@
 /obj/effect/spawner/lootdrop/tanks,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"jMK" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to distro";
-	target_pressure = 4500
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "jMO" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 1
@@ -19742,7 +20122,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "jNx" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
@@ -19842,6 +20222,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jPd" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "jPk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -19859,7 +20250,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "jPl" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -19867,25 +20258,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jQr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "jQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19915,7 +20287,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19924,7 +20296,7 @@
 /obj/structure/sign/departments/minsky/research/robotics{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -19963,10 +20335,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
@@ -20011,10 +20383,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "jTA" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -20065,7 +20437,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "jUB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20193,6 +20565,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"jXM" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jYF" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -20223,7 +20606,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "jZd" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20232,22 +20615,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"jZz" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Xenobiology Lab Access";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "jZB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -20255,8 +20628,22 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"jZR" = (
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"kaj" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kar" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters{
@@ -20271,64 +20658,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"kaA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"kat" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics/garden)
 "kaR" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kaU" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"kbj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/storage";
-	name = "Atmospherics Storage Room APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "kbt" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet,
 /area/library)
 "kbG" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20378,6 +20737,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"kdu" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kdG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -20415,7 +20781,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "keK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -20452,7 +20818,7 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "kgy" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20473,7 +20839,7 @@
 /area/hydroponics)
 "kgR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -20485,16 +20851,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"khz" = (
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_x = 0;
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
+"khB" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "kia" = (
@@ -20524,7 +20884,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/camera{
@@ -20541,7 +20901,7 @@
 /area/bridge/meeting_room)
 "kiS" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20649,7 +21009,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -20665,6 +21025,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/surgery)
+"klP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "klZ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -20714,6 +21080,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kmI" = (
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "kmL" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/auxiliary)
@@ -20776,7 +21157,7 @@
 /turf/closed/wall,
 /area/science/nanite)
 "koc" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -20798,11 +21179,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"kpt" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kpN" = (
 /turf/closed/wall,
 /area/medical/paramedic)
 "kpV" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -20825,17 +21216,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kqo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "kqt" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"kqD" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "kqF" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/machinery/firealarm{
@@ -20849,7 +21236,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20891,7 +21278,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kst" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20903,7 +21290,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "ksW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -20933,8 +21320,14 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"kum" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kup" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -20951,7 +21344,7 @@
 	},
 /area/crew_quarters/kitchen)
 "kuP" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -20964,12 +21357,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kvB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20980,7 +21367,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -20989,7 +21376,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "kwf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/button/door{
@@ -21038,10 +21425,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -21050,10 +21437,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kwD" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -21070,7 +21457,7 @@
 	pixel_x = 6;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/wallmed{
@@ -21079,7 +21466,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "kxf" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32;
 	pixel_y = -32
@@ -21110,6 +21497,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"kxC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kxF" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -21119,10 +21525,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "kym" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21131,7 +21537,7 @@
 /turf/closed/wall/r_wall,
 /area/teleporter)
 "kyI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kyR" = (
@@ -21146,6 +21552,18 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
+"kzz" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/computer/station_alert{
+	name = "Station Alert Console"
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "kzS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21172,7 +21590,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21241,7 +21659,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "kCl" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -21253,7 +21671,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kCY" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "kDf" = (
@@ -21266,7 +21684,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/requests_console{
@@ -21346,8 +21764,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -21358,7 +21776,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "kGD" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/computer/secure_data{
@@ -21431,7 +21849,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21463,7 +21881,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "kHq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21495,11 +21913,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kIc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kIf" = (
 /obj/effect/spawner/lootdrop/tanks/midchance,
 /turf/open/floor/plating,
@@ -21521,7 +21934,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "kIT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -21544,10 +21957,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "kIZ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -21633,7 +22046,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "kKS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -21650,7 +22063,7 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "kLK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21681,7 +22094,7 @@
 	dir = 4
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21700,7 +22113,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "kNr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -21733,10 +22146,10 @@
 	name = "Hydroponics Backroom";
 	req_access_txt = "35"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -21757,10 +22170,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
@@ -21830,12 +22243,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"kRw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kRz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -21886,6 +22293,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"kTV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "kUf" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -21902,7 +22322,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "kUU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21913,11 +22333,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"kVx" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kVA" = (
 /turf/open/floor/plasteel/stairs/goon/stairs_wide{
 	dir = 1
@@ -21936,7 +22351,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -21949,7 +22364,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "kWr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/chair/office/light{
@@ -21964,7 +22379,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kWZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21991,32 +22406,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"kXA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "kYc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -22055,7 +22449,7 @@
 /turf/closed/wall,
 /area/chapel/office)
 "kYR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet{
@@ -22064,7 +22458,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "kYZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -22087,21 +22481,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kZg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	dir = 1;
-	name = "Nanite Lab APC";
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "kZA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -22109,10 +22488,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/door/airlock/medical{
@@ -22131,8 +22510,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -22254,8 +22633,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -22284,6 +22663,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"lci" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lcA" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -22295,7 +22685,7 @@
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -22304,14 +22694,14 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lcO" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ldb" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/secure_closet/brig,
@@ -22344,24 +22734,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ldE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste In";
-	on = 1
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "ldQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22375,8 +22749,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
 "leg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -22402,7 +22776,7 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "ley" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/quartermaster,
@@ -22427,7 +22801,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "leU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -22552,7 +22926,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lhH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/firecloset,
@@ -22580,7 +22954,7 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "lik" = (
@@ -22646,11 +23020,38 @@
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
 "ljA" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ljJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "lkC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -22659,7 +23060,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "lkI" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lkR" = (
@@ -22674,7 +23075,7 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
 "llu" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -22766,7 +23167,7 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "lnx" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -22774,18 +23175,6 @@
 "lnE" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"lor" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "loS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -22813,8 +23202,8 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "lpt" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -22823,7 +23212,7 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "lqe" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22869,6 +23258,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lrE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lrP" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -22887,7 +23294,7 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "lsK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22919,7 +23326,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ltI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/white,
@@ -22975,13 +23382,13 @@
 /area/science/xenobiology)
 "lvk" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lvl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "lvo" = (
@@ -22992,7 +23399,7 @@
 /area/maintenance/department/medical/morgue)
 "lvp" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/item/paper_bin{
@@ -23030,7 +23437,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1;
-	sensors = list("n2o_sensor"="Tank")
+	sensors = list("n2o_sensor" = "Tank")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -23053,7 +23460,7 @@
 /area/science/storage)
 "lwC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23075,25 +23482,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"lxg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lxh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/sink{
@@ -23160,12 +23550,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"lxJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lxW" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "lxY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -23253,7 +23661,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -23270,7 +23678,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -23280,7 +23688,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "lzK" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23318,17 +23726,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "lAW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"lBk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "lBu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -23363,15 +23765,29 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "lCs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"lCw" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/camera{
+	c_tag = "Bridge South";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "lCy" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/item/storage/box/masks,
@@ -23436,10 +23852,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23452,7 +23868,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lEO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -23472,11 +23888,24 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"lEZ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lFe" = (
 /turf/closed/wall,
 /area/janitor)
 "lFh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair/office/dark{
@@ -23503,7 +23932,7 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "lFt" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/computer/secure_data{
@@ -23554,14 +23983,6 @@
 	},
 /turf/open/floor/plating/dirt/station,
 /area/hydroponics/garden)
-"lGC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/computer/atmos_alert{
-	dir = 1;
-	name = "Atmospheric Alert Console"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "lGK" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -23628,15 +24049,8 @@
 "lID" = (
 /turf/closed/wall,
 /area/science/xenobiology)
-"lIQ" = (
-/obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "lIW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -23675,10 +24089,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "lKT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -23694,7 +24108,7 @@
 "lLw" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
 	pixel_y = 2
@@ -23772,8 +24186,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23823,23 +24237,8 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"lOQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lOU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/power/apc{
@@ -23860,43 +24259,17 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"lPi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 8;
-	name = "Chemistry APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "lPo" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "lPr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lPG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -23921,7 +24294,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23929,6 +24302,15 @@
 "lQe" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/fore)
+"lQA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "lQR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -23947,7 +24329,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lQU" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/computer/bounty{
@@ -23977,6 +24359,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
+"lRn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lRp" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -24051,13 +24442,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "lSo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "lSp" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24083,7 +24474,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -24092,13 +24483,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lTu" = (
-/obj/structure/bookcase/random/reference,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/carpet,
-/area/library)
 "lTB" = (
 /obj/machinery/button/door{
 	id = "evashutter";
@@ -24151,7 +24535,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -24162,7 +24546,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "lUz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/table/glass,
 /obj/machinery/airalarm{
 	dir = 1;
@@ -24202,22 +24586,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"lUK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table,
-/obj/item/vending_refill/medical{
-	pixel_x = -3;
-	pixel_y = 5
+"lUN" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/item/hand_labeler{
-	pixel_x = 6;
-	pixel_y = -6
+/obj/machinery/camera{
+	c_tag = "Escape Southeast";
+	dir = 9;
+	network = list("ss13")
 	},
-/obj/machinery/vending/wallhypo{
-	pixel_y = -28
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -24238,7 +24625,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24271,7 +24658,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lWG" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
@@ -24298,13 +24685,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lWU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lXw" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet/janitor,
@@ -24364,12 +24744,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"lZx" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "lZB" = (
 /obj/machinery/light{
 	dir = 8
@@ -24380,6 +24754,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"lZE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lZL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -24393,13 +24784,28 @@
 /turf/open/floor/wood,
 /area/library)
 "maX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mbx" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mby" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mbA" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -24441,7 +24847,7 @@
 /turf/open/space/basic,
 /area/solar/starboard/fore)
 "mcP" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -24450,7 +24856,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mdj" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -24459,7 +24865,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "mdy" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -24484,7 +24890,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "mec" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -24500,10 +24906,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "mei" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24514,11 +24920,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mew" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/burnt/two,
+/area/science/mixing)
 "meD" = (
 /turf/open/floor/plating,
 /area/science/mixing)
 "meF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -24596,18 +25015,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mgf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "mgL" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -24642,14 +25052,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mhG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "mik" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -24700,29 +25110,25 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"miR" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+"miX" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/engine/atmos/storage)
 "mjc" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mjp" = (
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "mjy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -24733,7 +25139,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -24788,6 +25194,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"mjM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "mjN" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -24843,7 +25263,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/rack,
@@ -24869,7 +25289,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "mmj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -24919,7 +25339,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -24998,6 +25418,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"mpo" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mpp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -25018,7 +25448,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25049,14 +25479,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "mqk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mqx" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
@@ -25065,7 +25495,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mqz" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -25082,7 +25512,7 @@
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/secondarydatacore)
 "mrk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/mixed,
@@ -25101,30 +25531,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"mrp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/analyzer{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/t_scanner{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/multitool{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mrq" = (
 /turf/closed/wall,
 /area/library)
 "mrs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -25145,7 +25556,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -25179,10 +25590,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -25194,13 +25605,13 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "msR" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -25248,28 +25659,8 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
-"mup" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"muw" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "muA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/window/reinforced{
@@ -25304,11 +25695,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
+"mvn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Xenobiology Lab Access";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mvs" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25338,10 +25740,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25355,7 +25757,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mwP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -25376,14 +25778,23 @@
 /turf/open/floor/plating,
 /area/escapepodbay)
 "mxs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mxA" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	name = "Atmospheric Alert Console"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "mxD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -25419,7 +25830,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -25445,7 +25856,7 @@
 	name = "N2 Outlet Pump";
 	target_pressure = 4500
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25546,7 +25957,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/auxiliary)
 "mCq" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -25575,7 +25986,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mCw" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -25593,7 +26004,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mCC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -25606,7 +26017,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25622,10 +26033,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -25663,13 +26074,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mFx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "mFD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -25702,7 +26113,7 @@
 /obj/structure/sign/departments/restroom{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -25735,7 +26146,7 @@
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25762,7 +26173,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -25811,19 +26222,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"mLS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/flashlight,
-/obj/item/assembly/igniter,
-/obj/item/book/manual/wiki/atmospherics,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "mMi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/science/central";
@@ -25879,10 +26277,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mOj" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25928,7 +26326,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "mPa" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -25957,6 +26355,16 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mPZ" = (
+/obj/structure/bookcase/random/reference,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/library)
 "mQh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25966,16 +26374,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"mQo" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "mQt" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -25986,7 +26384,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mQR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -26113,10 +26511,10 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "mSX" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -26151,7 +26549,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mTX" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -26184,7 +26582,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "mUA" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "mUL" = (
@@ -26216,7 +26614,7 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "mVg" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26292,7 +26690,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "mXM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -26304,22 +26702,27 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"mXY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mYp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"mYX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/obj/structure/sign/departments/minsky/research/xenobiology{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mZK" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -26331,13 +26734,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"naq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nay" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -26351,30 +26747,36 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"nbr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "nby" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"nbJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "nbL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -26443,6 +26845,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"ndh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ndj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26456,6 +26870,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"nei" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26503,15 +26923,16 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"nfl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
+"nfw" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
 	},
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "nfz" = (
@@ -26525,7 +26946,7 @@
 /area/ai_monitored/secondarydatacore)
 "nfG" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
@@ -26534,14 +26955,23 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"nge" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ngI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ngS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/item/storage/box/prisoner,
@@ -26587,16 +27017,6 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"nhz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "nig" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -26721,7 +27141,7 @@
 /area/bridge)
 "nlR" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/item/pen,
@@ -26731,8 +27151,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"nmk" = (
+/obj/structure/table,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nmn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -26769,10 +27202,10 @@
 	id = "Cell 1";
 	name = "Cell 1"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -26790,14 +27223,8 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nnn" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "noh" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26824,7 +27251,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "noQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -26869,7 +27296,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26944,8 +27371,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -26985,7 +27412,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "nub" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
@@ -26997,7 +27424,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "nuh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -27023,24 +27450,13 @@
 	pixel_x = 2;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nuw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"nuz" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "nuI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/paramedic";
 	name = "Paramedic APC";
@@ -27068,7 +27484,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "nuS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -27076,7 +27492,7 @@
 /area/hallway/primary/central)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -27108,6 +27524,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"nwU" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 9
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "nxe" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -27116,10 +27548,10 @@
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
 "nxm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27141,10 +27573,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27173,11 +27605,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"nyx" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "nyC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27190,6 +27631,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nyD" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/command/evac{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "nzc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27212,10 +27666,10 @@
 	name = "Genetics Research";
 	req_access_txt = "5; 9; 68"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -27225,10 +27679,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -27247,22 +27701,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nzp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "nzG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27324,7 +27765,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "nAo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -27342,7 +27783,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "nAM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -27373,7 +27814,7 @@
 /area/maintenance/solars/starboard/aft)
 "nBv" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27418,10 +27859,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27454,7 +27895,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "nDx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -27490,7 +27931,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
 "nEp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/rnd/production/protolathe/department/engineering,
@@ -27528,10 +27969,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "nFB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -27625,7 +28066,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27681,21 +28122,11 @@
 "nJe" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nJs" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nJt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -27734,7 +28165,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -27750,10 +28181,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -27811,10 +28242,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "nKB" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -27888,17 +28319,11 @@
 	},
 /area/maintenance/starboard/fore)
 "nMP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nMV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "nMW" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 8
@@ -27932,17 +28357,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"nOb" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Bridge South";
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "nOj" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -27967,7 +28381,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "nOF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -27977,7 +28391,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nOU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/wheelchair,
 /obj/item/wheelchair{
 	pixel_y = 6
@@ -28006,7 +28420,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "nPi" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28045,7 +28459,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28062,23 +28476,11 @@
 /turf/open/floor/plating,
 /area/library)
 "nRn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nRr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/sign/warning/pods{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "nRu" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/bridge";
@@ -28117,7 +28519,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "nTx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/chair{
@@ -28144,7 +28546,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -28216,13 +28618,13 @@
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "nXs" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/chair/office/light,
 /mob/living/simple_animal/crab/kreb{
 	desc = "Here to lay down the hard claws of the law!";
@@ -28259,7 +28661,7 @@
 /turf/closed/wall,
 /area/medical/sleeper)
 "nXU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -28314,7 +28716,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "nZD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/light{
@@ -28333,7 +28735,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nZY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -28371,27 +28773,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "oaM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oaP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "obf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -28491,14 +28878,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "oea" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oem" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -28533,7 +28920,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ogh" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "oha" = (
@@ -28548,19 +28935,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"ohb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Storage";
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "ohg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28579,13 +28953,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ohE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ohL" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/painting{
@@ -28595,7 +28969,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ohM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -28620,7 +28994,7 @@
 /area/medical/sleeper)
 "ohU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28675,10 +29049,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -28732,11 +29106,11 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "omU" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28768,14 +29142,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"onN" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "onQ" = (
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -28794,10 +29160,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28924,6 +29290,23 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"oqs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "oqA" = (
 /obj/machinery/light{
 	dir = 8
@@ -28955,7 +29338,7 @@
 /area/maintenance/department/science)
 "oqQ" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/light/small{
@@ -28971,7 +29354,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "orC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -29008,23 +29391,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"osy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/shoes/jackboots,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "osE" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "otc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29033,6 +29405,31 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
+"otr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Dormitory South";
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "ots" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -29052,7 +29449,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29081,7 +29478,7 @@
 /area/medical/genetics/cloning)
 "ouk" = (
 /obj/machinery/gulag_processor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -29102,15 +29499,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"ovh" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ovx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -29200,7 +29588,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ozp" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/power/apc{
@@ -29256,11 +29644,26 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"oAa" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Escape Arm Airlocks";
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "oAk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29306,18 +29709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"oBJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "oBV" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
@@ -29334,6 +29725,28 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"oCh" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Corridor North"
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/ten,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "oCu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
@@ -29357,28 +29770,33 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "oCY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"oDl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"oDg" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"oEb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/hallway/secondary/exit)
 "oEt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -29404,7 +29822,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "oFb" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -29440,13 +29858,13 @@
 /area/medical/sleeper)
 "oGQ" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oHn" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "oHq" = (
@@ -29466,17 +29884,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oIA" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "oIJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29500,6 +29912,17 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
+"oIT" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "oIU" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -29526,7 +29949,7 @@
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
 "oJl" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/computer/bounty{
@@ -29535,7 +29958,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "oJy" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -29544,6 +29967,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"oJC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "oJD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
@@ -29580,7 +30017,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "oKt" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/filingcabinet,
@@ -29594,7 +30031,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "oKw" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/holopad,
@@ -29608,8 +30045,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -29619,6 +30056,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"oNG" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to distro";
+	target_pressure = 4500
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "oNX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -29747,19 +30197,19 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "oRf" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "oRt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oRQ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -29767,11 +30217,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oSj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "oSl" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -29789,20 +30252,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"oUD" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"oUF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics/garden)
 "oUZ" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -29869,14 +30318,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "oXp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oXr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -29894,7 +30343,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "oXL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29948,18 +30397,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "pan" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -29975,7 +30424,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "paE" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "paW" = (
@@ -30038,7 +30487,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pcs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/paramedic,
@@ -30063,7 +30512,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pcW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /obj/item/radio/intercom{
@@ -30102,16 +30551,16 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "pdL" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pdQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/cloning,
@@ -30152,12 +30601,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "peJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "peO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "CO2 Outlet Pump"
@@ -30191,7 +30640,7 @@
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/railing{
@@ -30218,7 +30667,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "pgs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30283,7 +30732,7 @@
 "phA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -30311,14 +30760,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
-"pih" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "pil" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/preopen{
@@ -30351,7 +30792,7 @@
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "piF" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30384,6 +30825,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"pje" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pjg" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line{
@@ -30480,7 +30938,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -30502,10 +30960,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -30605,7 +31063,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Security Post - Service";
 	dir = 1;
@@ -30639,24 +31097,22 @@
 "poB" = (
 /turf/open/floor/plasteel,
 /area/security/warden)
-"poU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+"poH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/fuel_input,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "pph" = (
@@ -30674,6 +31130,30 @@
 "pps" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
+"ppz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ppI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30727,10 +31207,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30780,7 +31260,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "prg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -30795,7 +31275,7 @@
 /area/crew_quarters/heads/captain)
 "psc" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -30871,16 +31351,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "pwi" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "pwl" = (
@@ -30902,7 +31382,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -30933,7 +31413,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "pxC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/firecloset,
@@ -30965,20 +31445,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"pyf" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump";
-	target_pressure = 4500
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "pyH" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
@@ -30994,7 +31460,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "pzA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -31015,10 +31481,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "pAz" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -31080,10 +31546,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -31109,7 +31575,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pBL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -31129,7 +31595,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "pCi" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -31178,19 +31644,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pCu" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	anchored = 1
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pCv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pCE" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pDd" = (
@@ -31198,11 +31657,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"pDZ" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -31229,7 +31683,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "pEG" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "pEO" = (
@@ -31274,7 +31728,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "pGA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -31285,7 +31739,7 @@
 "pHb" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/potato,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -31297,7 +31751,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pHf" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/machinery/light,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -31306,7 +31760,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "pHq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pHr" = (
@@ -31423,6 +31877,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"pKp" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pKt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/door/poddoor/preopen{
@@ -31473,7 +31939,7 @@
 	dir = 4;
 	name = "Plasma Outlet Pump"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31505,11 +31971,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -31528,7 +31994,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "pNC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -31552,10 +32018,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31569,13 +32035,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "pNT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -31586,10 +32052,10 @@
 "pOe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -31627,7 +32093,7 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
 "pPw" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -31647,10 +32113,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "pQs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -31677,7 +32143,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "pQK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pQO" = (
@@ -31689,16 +32155,6 @@
 "pQR" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
-"pQV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pRc" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -31707,7 +32163,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "pRd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -31719,7 +32175,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pRg" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pRv" = (
@@ -31737,10 +32193,10 @@
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
 "pRL" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "pSg" = (
@@ -31748,7 +32204,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pSt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -31774,8 +32230,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31795,7 +32251,7 @@
 /area/ai_monitored/storage/satellite/teleporter)
 "pTr" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -31839,34 +32295,15 @@
 /area/science/xenobiology)
 "pUA" = (
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"pVb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pVm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -31915,7 +32352,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pVM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -31934,7 +32371,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31966,7 +32403,7 @@
 /area/ai_monitored/storage/eva)
 "pWI" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/light{
@@ -31981,7 +32418,7 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos/distro)
 "pXc" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -32043,7 +32480,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "pXZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical3,
@@ -32055,8 +32492,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "pYt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/airlock/command/glass{
@@ -32107,13 +32544,22 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"pYC" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "pYV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -32121,7 +32567,7 @@
 /area/medical/virology)
 "pZb" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32130,7 +32576,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/science/test_area)
 "pZo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/medical_kiosk,
@@ -32153,7 +32599,7 @@
 	c_tag = "Prison Common Room North";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -32162,7 +32608,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qaS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -32236,16 +32682,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"qcA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qcV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
@@ -32284,7 +32720,7 @@
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
 "qdH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/modular_computer/console/preset/cargo{
@@ -32299,7 +32735,7 @@
 /area/maintenance/department/science/xenobiology)
 "qet" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -32312,13 +32748,13 @@
 /turf/open/floor/wood,
 /area/library)
 "qeR" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qfj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
@@ -32330,7 +32766,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/unres{
@@ -32351,10 +32787,10 @@
 "qfO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32369,7 +32805,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "qgl" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/chair{
@@ -32377,15 +32813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"qgA" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qgD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32401,13 +32828,13 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "qgY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -32429,13 +32856,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qhj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -32516,7 +32943,7 @@
 /area/maintenance/department/engine)
 "qja" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qjt" = (
@@ -32526,8 +32953,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -32632,7 +33059,7 @@
 /area/science/storage)
 "qlO" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "qlQ" = (
@@ -32662,6 +33089,15 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
+"qmz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qmG" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -32679,7 +33115,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -32736,7 +33172,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/rnd/production/circuit_imprinter/department/science{
@@ -32771,10 +33207,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "qor" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32812,12 +33248,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"qoO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qpr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -32827,13 +33257,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"qpv" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "qpx" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -32844,7 +33267,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -32892,7 +33315,7 @@
 /area/ai_monitored/storage/eva)
 "qqQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "qru" = (
@@ -32903,6 +33326,48 @@
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"qrz" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
+"qsa" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/janitor)
+"qst" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "qsy" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -32922,15 +33387,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qtt" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -32956,7 +33412,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -32965,7 +33421,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "quU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/table,
@@ -32973,6 +33429,20 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"qva" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "qvf" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -33020,13 +33490,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qwV" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -33041,10 +33511,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qxa" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -33070,6 +33540,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qxs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/table,
+/obj/item/vending_refill/medical{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/hand_labeler{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/machinery/vending/wallhypo{
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "qxw" = (
 /obj/machinery/light{
 	dir = 4
@@ -33105,8 +33594,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -33120,7 +33609,7 @@
 	network = list("rd");
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33163,7 +33652,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qzW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -33191,17 +33680,11 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/starboard)
-"qAm" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qBd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33215,14 +33698,6 @@
 "qBn" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
-"qCF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/machinery/light/small,
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qCJ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
@@ -33234,6 +33709,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qDf" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tanks South";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste to Space"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "qDp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33245,7 +33742,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33256,7 +33753,7 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/mmi,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -33279,7 +33776,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qFR" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -33322,21 +33819,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qGI" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -33372,7 +33854,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qHI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33381,7 +33863,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/central)
 "qIO" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -33390,27 +33872,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"qJf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qJl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -33443,23 +33904,9 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"qJT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qKa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -33499,7 +33946,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "qKI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/firecloset,
@@ -33510,7 +33957,7 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "qKS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -33534,15 +33981,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qLC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/nanite)
 "qLE" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
@@ -33560,12 +33998,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"qMm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qNI" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -33592,7 +34024,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qOj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/holy{
@@ -33603,15 +34035,6 @@
 "qOt" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"qOv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/end{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "qPn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -33668,7 +34091,7 @@
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hydroponics/garden)
 "qQn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -33709,7 +34132,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "qRw" = (
@@ -33742,15 +34165,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"qRW" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/chief)
-"qRX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+"qRR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos/storage)
+/area/teleporter)
+"qRW" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/chief)
 "qSj" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -33761,10 +34187,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -33793,10 +34219,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qST" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/door/airlock/medical{
 	id_tag = "GeneticsDoor";
 	name = "Cloning";
@@ -33889,7 +34315,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "qVS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -33899,7 +34325,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "qVW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/cable{
@@ -33951,10 +34377,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qXt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "qXw" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/carrot,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -33989,8 +34422,8 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "qYC" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/window/northright{
@@ -34011,22 +34444,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"qYW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "qZz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -34054,6 +34471,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rac" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 11
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "rak" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
@@ -34077,7 +34519,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "raJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -34094,7 +34536,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34114,7 +34556,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -34151,7 +34593,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rcc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
 	dir = 1
@@ -34197,25 +34639,6 @@
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"rcU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rcY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34253,7 +34676,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/railing{
@@ -34261,13 +34684,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rdJ" = (
-/obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "rdP" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/structure/window/reinforced{
@@ -34310,7 +34726,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -34324,10 +34740,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34377,7 +34793,7 @@
 /turf/open/floor/grass,
 /area/hallway/primary/starboard)
 "rgb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -34405,15 +34821,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rgt" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rgP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -34434,7 +34841,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rhC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -34459,7 +34866,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "rih" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -34505,15 +34912,31 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"riY" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"riZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "rjf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -34547,7 +34970,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/computer/secure_data{
@@ -34555,21 +34978,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"rjX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos/distro";
-	dir = 1;
-	name = "Atmospherics Distribution APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rkj" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -34586,6 +34994,17 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"rkv" = (
+/obj/structure/filingcabinet,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/auxiliary)
 "rkx" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/airless,
@@ -34594,14 +35013,14 @@
 /obj/machinery/vending/cola/shamblers/prison{
 	onstation = 0
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rlg" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -34616,6 +35035,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"rlw" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rlY" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -34636,7 +35064,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "rmU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -34709,13 +35137,13 @@
 	name = "O2 Outlet Pump";
 	target_pressure = 4500
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "rpr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -34730,14 +35158,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "rps" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rpt" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34748,7 +35176,7 @@
 /area/hallway/secondary/entry)
 "rpx" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -34872,6 +35300,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"rrl" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rrx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34888,7 +35325,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "rrG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -34903,7 +35340,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rrI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -34916,7 +35353,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "rrV" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34947,7 +35384,7 @@
 "rsT" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -34955,12 +35392,6 @@
 "rsW" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/auxiliary)
-"rsZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rtc" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
@@ -34968,7 +35399,7 @@
 /area/space/nearstation)
 "rtg" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -35022,15 +35453,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "ruh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rui" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35067,6 +35498,24 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
+"rvh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "rvK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -35084,7 +35533,7 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "rwo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -35130,7 +35579,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "rxI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rxK" = (
@@ -35195,6 +35644,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rzg" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "rzT" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -35203,7 +35661,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "rAg" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -35280,13 +35738,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "rBn" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rBq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light{
@@ -35392,12 +35850,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"rDM" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "rEq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -35407,24 +35859,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"rEu" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rEQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "rET" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/firecloset,
@@ -35435,7 +35878,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "rFX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -35468,25 +35911,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"rGe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks North";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "rGj" = (
 /obj/structure/sign/departments/minsky/supply/mining{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35511,14 +35940,14 @@
 /area/hallway/primary/central)
 "rGo" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rGr" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35553,9 +35982,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"rGK" = (
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "rGM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
@@ -35581,24 +36007,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"rHw" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rHT" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -35627,11 +36044,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rIn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/rack,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos/distro)
 "rIp" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35646,7 +36069,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "rIQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/status_display/supply{
@@ -35655,7 +36078,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rIX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/sign/warning/pods{
@@ -35708,6 +36131,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rLs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/broken/two,
+/area/science/mixing)
 "rMp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -35719,7 +36153,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "rMD" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -35823,13 +36257,13 @@
 /area/medical/medbay/central)
 "rOS" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rPz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35838,10 +36272,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35874,6 +36308,23 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"rQL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -35881,7 +36332,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35890,10 +36341,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35947,6 +36398,24 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rTs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "rTz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -35965,14 +36434,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"rTN" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rUk" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "rUN" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -36081,7 +36560,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "rWu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/rnd/production/techfab/department/medical,
@@ -36091,6 +36570,20 @@
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"rWO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "rWP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -36102,11 +36595,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rWQ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rWX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/computer/cargo/request{
@@ -36126,10 +36619,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36138,7 +36631,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "rXN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -36148,7 +36641,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rXO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36186,28 +36679,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"rYD" = (
-/obj/machinery/button/massdriver{
-	id = "chapelgun";
-	name = "Chapel Mass Driver";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/chapel/office)
 "rYG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"rZc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sar" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/supply/janitorial{
@@ -36255,22 +36745,22 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "sbJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sbR" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "sca" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36302,10 +36792,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "scs" = (
@@ -36358,7 +36848,7 @@
 /area/maintenance/starboard/fore)
 "sep" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -36430,13 +36920,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -36449,7 +36939,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "shd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -36458,7 +36948,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "shj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -36473,7 +36963,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sil" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light_switch{
@@ -36512,7 +37002,7 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "sju" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -36529,7 +37019,7 @@
 "sjG" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/ambrosia,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -36543,6 +37033,14 @@
 "sjP" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"sjW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "skY" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -36558,43 +37056,6 @@
 /obj/item/stamp/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"slm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Tanks South";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste to Space"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"slG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/auxiliary)
 "slR" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -36605,7 +37066,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36634,16 +37095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"snb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	name = "Tank Monitor"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "snf" = (
 /obj/machinery/light{
 	dir = 8
@@ -36687,7 +37138,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "snE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -36711,7 +37162,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "sog" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
@@ -36726,8 +37177,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -36746,7 +37197,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "spU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -36776,7 +37227,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sqc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
@@ -36790,30 +37241,11 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
-"sqN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "sqY" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36831,7 +37263,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "sqZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -36899,8 +37331,24 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"ssS" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/flashlight,
+/obj/item/assembly/igniter,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ssT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -36915,10 +37363,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "ssV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -36996,7 +37444,7 @@
 	c_tag = "Fore Primary Hallway West";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "stL" = (
@@ -37015,7 +37463,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "stM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -37050,10 +37498,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -37068,8 +37516,8 @@
 	name = "Monkey Pen";
 	req_access_txt = "9"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -37085,11 +37533,38 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"svr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+"suZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	sortType = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"svr" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -37121,6 +37596,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"swa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "swg" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -37158,17 +37651,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"swY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "sxt" = (
 /obj/machinery/turnstile/brig{
 	dir = 1
@@ -37177,7 +37659,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37188,7 +37670,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
 "sxC" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -37204,10 +37686,10 @@
 	name = "Morgue";
 	req_access_txt = "45;5"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -37241,6 +37723,26 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"syl" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/engineering/atmospherics{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "syN" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -37263,25 +37765,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"szi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
-"szj" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "szl" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -37289,8 +37772,8 @@
 	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -37410,33 +37893,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"sBg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
-"sBE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "sCP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37451,7 +37907,7 @@
 "sDr" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -37463,7 +37919,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "sEp" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
 	dir = 1
@@ -37577,13 +38033,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sGA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -37597,7 +38053,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37619,25 +38075,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sIn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37654,7 +38091,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "sJU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/wardrobe/gene_wardrobe,
@@ -37667,7 +38104,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "sKm" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_x = 0;
 	pixel_y = -32
@@ -37675,7 +38112,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sKr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/power/apc{
@@ -37721,10 +38158,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37784,8 +38221,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"sMd" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sMM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -37849,7 +38297,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37871,12 +38319,30 @@
 	},
 /turf/open/floor/plating,
 /area/science/lab)
+"sOV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "sPf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "sPi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -37940,7 +38406,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -37962,6 +38428,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"sQJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sQP" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -37981,7 +38453,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "sRY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -38002,7 +38474,7 @@
 "sSH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -38041,14 +38513,14 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "sTx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "sTC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -38101,7 +38573,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "sUk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -38160,7 +38632,7 @@
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38205,7 +38677,7 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -38241,11 +38713,18 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"sXA" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+"sXJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "sXP" = (
@@ -38266,6 +38745,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
+"sYg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "sYN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38354,7 +38851,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -38372,7 +38869,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "tai" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/rnd/production/techfab/department/security,
@@ -38413,9 +38910,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"tbj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 6
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tbn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -38473,15 +38980,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tdd" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -38553,8 +39060,8 @@
 "tfA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38588,11 +39095,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"tgI" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/shoes/magboots,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "thJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -38620,16 +39143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"thP" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tia" = (
 /turf/closed/wall,
 /area/clerk)
@@ -38674,10 +39187,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "tiF" = (
@@ -38715,7 +39228,7 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "tjI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -38733,7 +39246,7 @@
 	pixel_x = 32;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38752,7 +39265,7 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "tkh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38779,14 +39292,32 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "tkB" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tlg" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
+"tlj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "tlr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -38809,7 +39340,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "tmP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/research/genetics{
@@ -38936,7 +39467,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/heads/captain)
 "tpS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -38956,7 +39487,7 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "tqY" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/seed_extractor,
@@ -38983,7 +39514,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "tsB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39010,7 +39541,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "tva" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -39020,7 +39551,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tvh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -39035,15 +39566,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"tvM" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "tvO" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
@@ -39151,7 +39673,7 @@
 /turf/open/floor/grass,
 /area/crew_quarters/bar)
 "tyI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/med_data,
@@ -39201,7 +39723,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39228,28 +39750,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"tAa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tAe" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
@@ -39320,25 +39820,6 @@
 /obj/machinery/power/smes/fullycharged,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"tBO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "tCd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -39384,7 +39865,7 @@
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -39398,7 +39879,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "tEb" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -39422,7 +39903,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "tEC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -39441,6 +39922,25 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"tFG" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "tFK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39479,7 +39979,7 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "tGw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -39494,6 +39994,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tGE" = (
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/janitor)
 "tHe" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -39507,15 +40018,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"tHh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "tHs" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/eva";
@@ -39580,27 +40082,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"tJX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "tKa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39674,7 +40164,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "tLX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -39697,7 +40187,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39752,18 +40242,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tNm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "tNs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -39779,7 +40262,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tNJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -39804,8 +40287,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -39824,7 +40307,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39842,13 +40325,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "tPJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tQi" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/tool,
@@ -39882,6 +40365,16 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"tRc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tRW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -39889,7 +40382,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -39951,10 +40444,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tSW" = (
@@ -39971,14 +40464,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"tTP" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tTT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
@@ -40063,10 +40575,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -40096,7 +40608,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "tVR" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -40142,19 +40654,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"tXd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/janitor)
 "tXg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
@@ -40174,7 +40675,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "tYa" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -40187,21 +40688,21 @@
 "tYq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "tYA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "tYL" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40220,7 +40721,7 @@
 /area/medical/virology)
 "tZf" = (
 /obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -40235,7 +40736,7 @@
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -40255,12 +40756,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
-"tZP" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uaV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -40273,15 +40768,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ubr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ubS" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -40337,10 +40823,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "ucL" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -40365,7 +40851,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "udS" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40426,7 +40912,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40459,13 +40945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ufR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ugy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -40483,7 +40962,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light_switch{
 	pixel_x = 12;
 	pixel_y = -25
@@ -40515,7 +40994,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uhN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40528,7 +41007,7 @@
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -40538,7 +41017,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uje" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -40573,7 +41052,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "ujT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -40601,10 +41080,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -40616,7 +41095,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "ukY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -40674,6 +41153,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ulE" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "ulF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -40745,8 +41233,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -40767,23 +41255,26 @@
 /obj/item/geiger_counter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"unI" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
+"unN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
+	pixel_x = 28
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/engine/atmos/distro)
 "unP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40799,7 +41290,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "uok" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -40818,7 +41309,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "upo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40839,7 +41330,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "usc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/firecloset,
@@ -40939,7 +41430,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "uwH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -40960,7 +41451,7 @@
 /area/space/nearstation)
 "uxf" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -40983,27 +41474,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"uxx" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uxE" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41017,7 +41487,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 4;
-	sensors = list("n2_sensor"="Tank")
+	sensors = list("n2_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -41029,8 +41499,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "uyk" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/rack,
@@ -41046,7 +41516,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uyo" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -41081,7 +41551,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41107,9 +41577,20 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"uBg" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uBP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -41118,7 +41599,7 @@
 /area/medical/surgery)
 "uBR" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light{
@@ -41126,6 +41607,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"uBX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "uCc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -41138,7 +41634,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "uCj" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -41151,7 +41647,7 @@
 /obj/machinery/ministile/hop{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41165,10 +41661,10 @@
 	name = "Genetics Research Access";
 	req_access_txt = "9"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -41199,16 +41695,16 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "uDg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "uDh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -41223,10 +41719,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "uDk" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -41270,7 +41766,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -41319,19 +41815,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"uGJ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "uGS" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable{
@@ -41373,7 +41856,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uHC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	dir = 1;
@@ -41403,11 +41886,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uIy" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "uIF" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41453,36 +41931,8 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
-"uJG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 11
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -34
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "uJH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -41550,7 +42000,7 @@
 /area/hallway/primary/port)
 "uKz" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -41566,7 +42016,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "uKT" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -41588,7 +42038,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "uLY" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41596,7 +42046,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uLZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41616,7 +42066,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uMn" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41633,7 +42083,7 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/disposal/bin,
@@ -41688,7 +42138,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
@@ -41701,7 +42151,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uNv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/warning/vacuum/external{
@@ -41714,7 +42164,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "uNN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -41728,7 +42178,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -41743,7 +42193,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
 "uON" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -41756,7 +42206,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -41821,10 +42271,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -41850,12 +42300,25 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
 "uRz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uRB" = (
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uRR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uRS" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -41882,7 +42345,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "uSD" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41914,7 +42377,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uTM" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/wallmed{
@@ -41941,7 +42404,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
 "uUA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
@@ -41963,7 +42426,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -41979,7 +42442,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "uUV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42038,8 +42501,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"uWD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "uWE" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -42052,7 +42530,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "uXE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -42061,26 +42539,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uXJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"uYy" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "uYJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42141,7 +42605,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "uZr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -42153,7 +42617,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uZz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -42202,7 +42666,7 @@
 /turf/open/space/basic,
 /area/solar/starboard/aft)
 "vao" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -42217,12 +42681,28 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vaO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/anesthetic_machine/roundstart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"vaV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "vbo" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -42252,7 +42732,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "vcc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/closet/wardrobe/pjs,
@@ -42276,10 +42756,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -42325,7 +42805,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42352,7 +42832,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vfC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -42373,7 +42853,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "vgs" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/reagent_dispensers/watertank/high,
@@ -42412,13 +42892,13 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vgB" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -42428,13 +42908,13 @@
 /area/security/checkpoint/customs)
 "vgD" = (
 /obj/structure/closet/wardrobe/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vgF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/railing,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -42471,7 +42951,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -42487,7 +42967,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "vhk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -42500,7 +42980,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "vho" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -42526,8 +43006,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"vif" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "vin" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42566,13 +43056,29 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"vje" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "vjf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -42591,8 +43097,8 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42601,16 +43107,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vjY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -42620,7 +43126,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vkn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -42647,43 +43153,37 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vlk" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vln" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "vlv" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/biogenerator,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vlx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vlK" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
@@ -42701,6 +43201,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"vlM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "vlQ" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -42714,7 +43237,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vmI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/table/glass,
@@ -42737,21 +43260,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vnq" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "vnv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -42774,19 +43297,6 @@
 "vnT" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"voe" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/photocopier,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "vom" = (
 /obj/structure/alien/resin/membrane,
 /turf/open/floor/engine,
@@ -42800,12 +43310,24 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"voy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "voA" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "voD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/table,
@@ -42824,7 +43346,7 @@
 /turf/closed/wall,
 /area/security/processing)
 "vpc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -42837,10 +43359,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42848,10 +43370,10 @@
 "vps" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42897,7 +43419,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "vro" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -42931,10 +43453,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "vrX" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -42944,11 +43466,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"vsn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "vsB" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42968,7 +43503,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "vsT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/sign/departments/minsky/research/xenobiology{
@@ -42982,13 +43517,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"vtA" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vtG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -42997,7 +43525,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -43010,7 +43538,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "vtV" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -43019,10 +43547,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vtY" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43031,7 +43559,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vuq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/status_display/supply{
@@ -43043,7 +43571,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43058,10 +43586,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vvN" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -43103,7 +43631,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vwY" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -43123,7 +43651,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vyw" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "warehouse shutters"
@@ -43148,7 +43676,7 @@
 "vzg" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -43160,7 +43688,7 @@
 	name = "Engineering Foyer APC";
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -43175,7 +43703,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "vzG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table,
@@ -43201,7 +43729,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "vzN" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/flasher{
@@ -43223,13 +43751,13 @@
 /area/space/nearstation)
 "vAc" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "vAA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South-West";
 	dir = 1
@@ -43259,8 +43787,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vBd" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -43291,7 +43819,7 @@
 /area/engine/engineering)
 "vBz" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/cable{
@@ -43302,6 +43830,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"vBC" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "vBO" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -43318,14 +43853,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vDA" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "vDI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "N2O Outlet Pump"
@@ -43333,7 +43868,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "vEi" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -43341,7 +43876,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vEr" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -43440,8 +43975,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/library)
+"vGS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "vHD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -43464,10 +44009,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "vHJ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vHP" = (
@@ -43515,7 +44060,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -43530,7 +44075,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43542,7 +44087,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vJZ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -43574,7 +44119,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "vKC" = (
@@ -43598,7 +44143,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/medical/medical1{
@@ -43644,10 +44189,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -43714,10 +44259,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43758,7 +44303,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vNR" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -43771,7 +44316,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -43822,22 +44367,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"vPd" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vPh" = (
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"vPK" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "vQk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -43867,25 +44414,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"vSZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Corridor North"
-	},
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/ten,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "vTf" = (
 /obj/machinery/porta_turret/ai{
 	scan_range = 5
@@ -43937,7 +44465,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vUi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -43989,19 +44517,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"vUS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "vUX" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -44050,16 +44565,45 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vVq" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
+	dir = 8;
+	name = "Chemistry APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "vVB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -44080,7 +44624,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen{
@@ -44115,28 +44659,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"vWY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+"vWo" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos/storage";
+	name = "Atmospherics Storage Room APC";
+	pixel_y = -23
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/engine/atmos/storage)
 "vXr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/rdconsole/robotics,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "vXu" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -44193,10 +44744,10 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "vZM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44230,7 +44781,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "waL" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44242,6 +44793,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wbo" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "wbF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -44255,7 +44814,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "wbW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44267,7 +44826,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wcp" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -44324,8 +44883,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -44347,6 +44906,16 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"wdZ" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wef" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -44368,7 +44937,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "wfe" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -44414,8 +44983,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -44440,14 +45009,22 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"wgr" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wgx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "wgK" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 1;
@@ -44482,9 +45059,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
+"whX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "whZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44546,7 +45140,7 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wja" = (
@@ -44572,7 +45166,7 @@
 /area/maintenance/department/bridge)
 "wji" = (
 /obj/machinery/clonepod,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/shower{
@@ -44582,7 +45176,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "wjL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /obj/structure/sign/directions/evac{
 	dir = 4;
 	pixel_x = 32;
@@ -44611,6 +45205,21 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"wly" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/sign/warning/pods{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
 "wlz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -44625,7 +45234,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "wlE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/chemical,
@@ -44670,8 +45279,8 @@
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44687,7 +45296,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "wnh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/cola,
@@ -44730,7 +45339,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "wod" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -44757,10 +45366,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -44812,14 +45421,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
 "wpP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/computer/scan_consolenew,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "wqk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "wqp" = (
@@ -44831,7 +45440,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wqv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
@@ -44864,22 +45473,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"wqQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wqZ" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/cola/random,
@@ -44946,6 +45544,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wti" = (
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wtt" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/red/arrow_ccw{
@@ -44963,22 +45571,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"wtI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "wtT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -44990,10 +45582,10 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -45114,13 +45706,13 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "wxI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "wxQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45210,6 +45802,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wBI" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "wBM" = (
 /obj/structure/rack,
 /obj/machinery/light/small{
@@ -45280,19 +45892,27 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "wEB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"wEC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "wEJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -45323,10 +45943,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45349,17 +45969,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"wGz" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wHj" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -45424,7 +46033,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -45437,10 +46046,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wIm" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wIo" = (
 /turf/open/floor/wood,
 /area/library)
@@ -45495,7 +46100,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "wIB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -45528,7 +46133,7 @@
 	},
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 4;
-	sensors = list("air_sensor"="Tank")
+	sensors = list("air_sensor" = "Tank")
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -45567,7 +46172,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45595,13 +46200,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wKh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/dark,
+/area/engine/atmos/storage)
+"wKv" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "wKH" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -45620,23 +46238,14 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"wLa" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "wLf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "wLj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/vending/wardrobe/robo_wardrobe,
@@ -45665,7 +46274,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/table,
@@ -45740,10 +46349,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wPm" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45758,17 +46367,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "wPo" = (
 /obj/structure/table/optable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/item/storage/backpack/duffelbag/sec/surgery,
@@ -45850,6 +46459,19 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/secondarydatacore)
+"wQR" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wRl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45877,14 +46499,14 @@
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
 "wSu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wST" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -45927,7 +46549,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wTM" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -45955,7 +46577,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -45990,7 +46612,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45999,7 +46621,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46009,7 +46631,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wWU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/secure_closet/security/cargo,
@@ -46027,10 +46649,10 @@
 /turf/closed/wall,
 /area/security/prison)
 "wXN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wXQ" = (
@@ -46044,7 +46666,7 @@
 /turf/open/space/basic,
 /area/solar/starboard/fore)
 "wXT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -46053,7 +46675,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wXW" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/sign/directions/medical{
@@ -46116,7 +46738,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
 "wYP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wZu" = (
@@ -46134,7 +46756,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "wZV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -46153,7 +46775,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "xao" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46244,10 +46866,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -46256,30 +46878,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"xbn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "xbr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -46314,7 +46912,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "xcG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46369,7 +46967,7 @@
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/storage/lockbox/vialbox/blood,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -46378,7 +46976,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "xeH" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/window/reinforced{
@@ -46396,21 +46994,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xeO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xfz" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -46457,10 +47055,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xgB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/door/airlock/medical/glass{
@@ -46472,7 +47070,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
@@ -46492,7 +47090,7 @@
 /area/maintenance/department/eva)
 "xht" = (
 /obj/structure/chair/office,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -46519,10 +47117,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xhQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46537,20 +47135,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xiN" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xiZ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "xjg" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -46597,7 +47186,7 @@
 /obj/machinery/shower{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -46633,7 +47222,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "xke" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/chair{
@@ -46642,7 +47231,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xkF" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -46706,7 +47295,7 @@
 /area/hallway/secondary/entry)
 "xlQ" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46715,7 +47304,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "xlW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -46743,7 +47332,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xmi" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -46755,20 +47344,8 @@
 /obj/machinery/holopad,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
-"xmW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "xnp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -46787,15 +47364,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/exoticpurple,
 /area/crew_quarters/heads/hor)
-"xnG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xnH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -46815,7 +47383,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -46827,16 +47395,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xol" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xoB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -46887,7 +47445,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -46899,6 +47457,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xqE" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "xrb" = (
 /obj/structure/table,
 /obj/item/nanite_scanner{
@@ -46919,7 +47494,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "xrw" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -46988,25 +47563,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"xsi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "xst" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/machinery/modular_computer/telescreen/preset/medical{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -47054,8 +47617,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xuf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "xui" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -47073,7 +47649,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "xuP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47098,19 +47674,20 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"xvr" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "xvX" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"xwj" = (
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/warning/lower{
+	alpha = 220
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xwU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47119,23 +47696,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xxd" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "EVA East";
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
 "xxe" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -47149,7 +47718,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -47159,7 +47728,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xxH" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -47178,10 +47747,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -47202,7 +47771,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -47212,7 +47781,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "xzj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -47227,7 +47796,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -47317,10 +47886,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -47329,12 +47898,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "xAk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xAH" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "xAK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47383,7 +47966,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/medical/medical2{
@@ -47412,10 +47995,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -47434,10 +48017,10 @@
 	name = "Security Office";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -47461,10 +48044,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"xEU" = (
-/obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "xFt" = (
@@ -47500,7 +48079,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xFQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xFT" = (
@@ -47512,7 +48091,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/storage)
 "xGG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/vending/clothing,
@@ -47552,12 +48131,21 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "xHC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xHH" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "xHK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -47565,7 +48153,7 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "xId" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -47589,7 +48177,7 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -47625,7 +48213,7 @@
 	},
 /area/crew_quarters/kitchen)
 "xJC" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47640,7 +48228,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xKZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47651,10 +48239,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xLg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -47671,13 +48259,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"xLi" = (
-/obj/machinery/suit_storage_unit/atmos,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/storage)
 "xLC" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -47706,13 +48287,13 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xLJ" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xMh" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47727,6 +48308,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)
+"xMs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xMB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47802,10 +48392,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xOb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -47852,7 +48442,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "xPg" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/status_display/supply{
@@ -47900,7 +48490,7 @@
 /area/teleporter)
 "xPy" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -47978,7 +48568,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "xSF" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/structure/sign/directions/science{
 	dir = 4;
 	pixel_x = 32;
@@ -47999,14 +48589,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "xSZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light/small{
@@ -48084,7 +48674,7 @@
 /area/space/nearstation)
 "xTY" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48141,7 +48731,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "xVn" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48176,16 +48766,6 @@
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"xWa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "xWd" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -48214,11 +48794,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"xXl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "xXn" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
 "xXt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xXP" = (
@@ -48248,6 +48844,16 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"xYu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/storage)
 "xYw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -48264,12 +48870,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"xYx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/eva)
 "xYz" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -48300,7 +48918,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xZj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
 	name = "Central Hall APC";
@@ -48314,7 +48932,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xZs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -48323,7 +48941,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xZx" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48332,14 +48950,14 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xZL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -48366,7 +48984,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xZY" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/modular_computer/console/preset/cargo/qm{
@@ -48388,11 +49006,25 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"yaq" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos/distro)
 "yay" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -48429,29 +49061,6 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"ybl" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"ybr" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 1;
-	name = "Security Checkpoint APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "ybJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -48487,7 +49096,7 @@
 /turf/closed/wall,
 /area/security/brig)
 "ycV" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/chem_master/condimaster,
@@ -48501,7 +49110,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ydf" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -48593,7 +49202,7 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos/distro)
 "yeK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48644,13 +49253,13 @@
 /area/hallway/secondary/exit)
 "ygi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ygj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/painting{
@@ -48679,8 +49288,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -48736,26 +49345,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"yiI" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/distro)
 "yjk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -48800,7 +49389,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "ykr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48818,7 +49407,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ylj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66205,7 +66794,7 @@ ejY
 lZB
 xWd
 orF
-pyf
+dOi
 sGB
 dsb
 vpm
@@ -66462,7 +67051,7 @@ bsg
 nky
 apP
 uGF
-mgf
+dxK
 sLY
 lGx
 ydx
@@ -66719,7 +67308,7 @@ cqd
 gHA
 vBr
 ekN
-iZk
+vlM
 chs
 lJm
 vbO
@@ -66976,9 +67565,9 @@ myw
 fFT
 jzv
 ahZ
-xWa
-rGe
-gRz
+oSj
+grl
+fsu
 eRT
 oEG
 rXM
@@ -67235,7 +67824,7 @@ kcE
 kcE
 aik
 opo
-aqc
+jFW
 wVo
 njB
 dWX
@@ -67483,8 +68072,8 @@ tkl
 tkl
 nKW
 tCd
-rsZ
-uRB
+jub
+sQJ
 bPu
 knf
 knf
@@ -67492,7 +68081,7 @@ vYY
 jts
 cbm
 eDA
-mQo
+iXX
 dwV
 vTP
 cnI
@@ -67749,7 +68338,7 @@ rbs
 wQK
 buE
 iuS
-glO
+nfw
 kwv
 rOc
 bQM
@@ -68006,7 +68595,7 @@ fJf
 jEZ
 sAf
 jYT
-aQA
+fsZ
 eBt
 bVq
 cEs
@@ -68016,9 +68605,9 @@ bVq
 bVq
 svz
 cri
-oDl
-xol
-slm
+jrE
+dMm
+qDf
 acO
 vzR
 hoI
@@ -68263,16 +68852,16 @@ jjX
 jjX
 lYd
 gAG
-rjX
+fLb
 wwC
 bBt
-kvB
-qMm
-eEw
+nyx
+nyx
+cZp
 upo
 rXM
 rXM
-ldE
+dQs
 uCi
 uCi
 uCi
@@ -68514,22 +69103,22 @@ lZu
 vsH
 bBo
 cLo
-pCu
+cGw
 eFb
 gph
 qGN
 hpd
-qOv
-jMK
-dzX
-fVB
+rIn
+oNG
+jwl
+goq
 cCc
 eNL
 cSC
-oaP
-nfl
-iTv
-hpx
+unN
+uBX
+anl
+jKC
 uCi
 iRz
 wQB
@@ -68771,7 +69360,7 @@ lRP
 mTJ
 rEq
 uMm
-kIc
+kum
 eRY
 twv
 oxM
@@ -69028,15 +69617,15 @@ teI
 hAJ
 pzD
 rYc
-oIA
+eoG
 eFb
 xkI
 aJz
 bgd
 qiY
-swY
-yiI
-szi
+mjM
+djH
+vaV
 peq
 xge
 bCp
@@ -69291,9 +69880,9 @@ xTt
 xTt
 xTt
 xTt
-fMN
-sIn
-qCF
+jsV
+cxw
+yaq
 jjX
 wIS
 tzj
@@ -69805,9 +70394,9 @@ tAe
 wDm
 nAf
 fjD
-nuw
-jEY
-jbT
+gzl
+ljJ
+tgI
 xTt
 cNu
 vdN
@@ -70062,9 +70651,9 @@ mLC
 eEF
 eEF
 mki
-dTO
+afZ
 ndj
-uIy
+khB
 xTt
 cNu
 xZo
@@ -70319,9 +70908,9 @@ elX
 elX
 sxu
 cxc
-ckS
-qYW
-onN
+rzg
+xXl
+jAa
 xTt
 cNu
 aMM
@@ -70575,9 +71164,9 @@ xTt
 xTt
 xTt
 xTt
-fWk
-hUk
-lxg
+epa
+ulE
+poH
 xTt
 xTt
 lBF
@@ -70832,9 +71421,9 @@ dBO
 kPJ
 kKN
 xTt
-iwh
+miX
 rcq
-cuq
+nbJ
 xTt
 fGF
 xnH
@@ -70843,9 +71432,9 @@ nQW
 cCb
 pBa
 kjX
-rdJ
-auc
-axG
+bNU
+riZ
+cco
 lPS
 vgx
 kjX
@@ -71089,9 +71678,9 @@ dBO
 dBO
 xib
 xTt
-ohb
-sBg
-btb
+ifS
+ppz
+gbQ
 xTt
 cNu
 oyO
@@ -71353,9 +71942,9 @@ xTt
 cNu
 oyO
 box
-uGJ
-vUS
-oUD
+nwU
+vsn
+wEC
 kjX
 aYT
 lVT
@@ -71603,9 +72192,9 @@ vaN
 vaN
 vaN
 xTt
-tNm
-cjr
-qpv
+vif
+dsm
+wdZ
 xTt
 cNu
 oyO
@@ -71853,16 +72442,16 @@ mKW
 tjr
 fhk
 sVE
-jHQ
+vPd
 eFb
 xTt
 xTt
 xTt
 xTt
 xTt
-eYN
-wtI
-bfK
+xYu
+qrz
+dwP
 xTt
 cNu
 oyO
@@ -72110,15 +72699,15 @@ wxQ
 bPw
 aXP
 agn
-kVx
+hSg
 eFb
-xLi
-sXA
-eVA
-sXA
-blm
-qRX
-nzp
+wti
+hMp
+kTV
+hMp
+wBI
+ulE
+sXJ
 xTt
 xTt
 cNu
@@ -72367,15 +72956,15 @@ ceS
 wcG
 xzq
 cmI
-bgo
-uxx
-giC
+suZ
+jAk
+tFG
 ecQ
 eOX
 bon
 kcs
 lXI
-kbj
+vWo
 xTt
 fGF
 xnH
@@ -72624,15 +73213,15 @@ byP
 uDP
 byP
 byP
-rcU
+syl
 eFb
-oEb
+rzg
 yfF
 yfF
 yfF
 yfF
 yfF
-lGC
+mxA
 xTt
 cNu
 eeV
@@ -72881,15 +73470,15 @@ fdO
 nsR
 uyk
 cmb
-tAa
+gyV
 eFb
-vSZ
-mrp
-mLS
-poU
-gcL
-thP
-snb
+oCh
+bZe
+ssS
+byq
+kzz
+wKv
+jHb
 xTt
 lBF
 uBb
@@ -73401,9 +73990,9 @@ rtq
 ybK
 bEd
 qRW
-khz
-xnG
-mup
+kmI
+awd
+nmk
 aMM
 bQv
 uBb
@@ -73615,7 +74204,7 @@ lMu
 hzS
 lMu
 lMu
-awX
+gmo
 lik
 agN
 qBn
@@ -73658,9 +74247,9 @@ bcT
 cXc
 iAE
 cRS
-cFs
+dsA
 lqS
-jww
+dwc
 gwb
 are
 uBb
@@ -73872,7 +74461,7 @@ qcw
 aQa
 jUV
 sYQ
-uYy
+jyz
 kAo
 agN
 qBn
@@ -73915,9 +74504,9 @@ ybK
 ted
 qfy
 qRW
-muw
+cPz
 wvU
-maX
+grP
 kgb
 cAd
 uBb
@@ -74129,7 +74718,7 @@ mzS
 pmZ
 iZD
 lMu
-awX
+hOh
 vVa
 eQi
 xXn
@@ -74172,7 +74761,7 @@ qru
 qRW
 qRW
 qRW
-vPK
+aZH
 wvU
 maX
 pQR
@@ -75186,9 +75775,9 @@ aSA
 bYF
 etl
 aVK
-pQV
-pVb
-bYF
+jXM
+gmu
+xMs
 vhk
 xZL
 tvh
@@ -75698,7 +76287,7 @@ gug
 lCy
 aEm
 fHg
-hSo
+exq
 mbY
 kyR
 inD
@@ -75955,7 +76544,7 @@ vLa
 uWR
 pmr
 tvP
-ceE
+aKc
 xOv
 uJU
 esb
@@ -76212,7 +76801,7 @@ gJn
 wEU
 mTE
 jWt
-lUK
+qxs
 mbY
 nzc
 oul
@@ -76441,9 +77030,9 @@ imX
 aEH
 snE
 dJN
-hkM
-brF
-xao
+jPd
+sYg
+byG
 xao
 rMD
 sOD
@@ -76497,7 +77086,7 @@ qdH
 lvp
 pan
 hic
-voe
+hDO
 laH
 oPJ
 mMR
@@ -76754,7 +77343,7 @@ lFh
 qhL
 nkP
 sFt
-jnW
+vGS
 cWh
 dFr
 hMe
@@ -77011,7 +77600,7 @@ gtb
 fDV
 kGE
 tkB
-ybl
+tbj
 laH
 oXe
 hMe
@@ -77252,9 +77841,9 @@ yjm
 twa
 yjm
 wlE
-lPi
-uJG
-dTU
+vVq
+rac
+izm
 kEF
 vkW
 nEQ
@@ -77973,9 +78562,9 @@ vRP
 aCD
 aCD
 eRC
-oUF
-hGv
-nRr
+kat
+nei
+wly
 vTN
 aTw
 hmB
@@ -78545,7 +79134,7 @@ kmr
 ewA
 fbN
 geS
-jwp
+czF
 kgb
 nTF
 mQK
@@ -78756,7 +79345,7 @@ eLb
 sIj
 bDb
 kYy
-xEU
+jZR
 gjR
 uKW
 kYy
@@ -78802,7 +79391,7 @@ kmr
 atI
 kTM
 kTM
-gZn
+dwc
 jCA
 tVD
 pio
@@ -79013,7 +79602,7 @@ jry
 keq
 jKi
 cKN
-pih
+aaO
 kcF
 eyO
 kYy
@@ -79059,7 +79648,7 @@ kmr
 ewA
 kmr
 kmr
-bfW
+tRc
 wTB
 wTB
 wTB
@@ -79270,7 +79859,7 @@ keq
 keq
 snD
 kYy
-ahO
+qst
 njv
 xET
 kYy
@@ -80042,7 +80631,7 @@ grB
 pfR
 hDW
 cNz
-rYD
+jeq
 qXf
 eoP
 mrq
@@ -80057,7 +80646,7 @@ wga
 mrq
 aEv
 ptM
-qja
+aVJ
 dCF
 eih
 xrA
@@ -80314,7 +80903,7 @@ lZL
 ooG
 aEv
 ptM
-eSn
+gqD
 ihc
 yjk
 wPU
@@ -80571,7 +81160,7 @@ vFK
 mrq
 aEv
 ptM
-pQK
+aUQ
 dCF
 dCF
 uYP
@@ -80818,7 +81407,7 @@ keq
 ooX
 mrq
 mrq
-lTu
+mPZ
 oYb
 kbt
 cuu
@@ -81075,7 +81664,7 @@ kmh
 xCs
 bqN
 oHq
-dXU
+czS
 vGP
 hCH
 agH
@@ -81123,7 +81712,7 @@ aGV
 nOj
 kXa
 dtJ
-xbn
+otr
 wTB
 wTB
 hBZ
@@ -81332,7 +81921,7 @@ eLb
 rKM
 lxv
 mrq
-kbt
+erR
 oTT
 kbt
 fBI
@@ -81380,7 +81969,7 @@ ctb
 kqt
 dtJ
 kqt
-sqN
+vje
 jQO
 aOB
 wOb
@@ -81637,7 +82226,7 @@ kWZ
 ltI
 mrk
 cry
-osy
+oJC
 wTB
 nGS
 nYy
@@ -82669,7 +83258,7 @@ jwz
 jSO
 oXR
 hbW
-nuz
+fGc
 wvV
 dXK
 dpf
@@ -82926,7 +83515,7 @@ uJu
 jSO
 fNv
 vwU
-eCM
+hdi
 cyI
 xId
 uRs
@@ -83183,7 +83772,7 @@ rJw
 jSO
 sZa
 hbW
-cbr
+mew
 yfh
 oCY
 dpf
@@ -83424,9 +84013,9 @@ abV
 abV
 mPa
 oem
-abV
-qcA
-kRw
+dOF
+qmz
+lRn
 hMD
 pdz
 qQY
@@ -84211,9 +84800,9 @@ oCg
 dge
 fEg
 kju
-vWY
-emo
-ipI
+xAH
+cQr
+rLs
 hbW
 hLh
 wNm
@@ -84713,7 +85302,7 @@ mMi
 eUZ
 idi
 kov
-eyP
+fMC
 ojI
 eZx
 hyE
@@ -84970,7 +85559,7 @@ mHW
 mHW
 mHW
 mHW
-rHw
+hCU
 fRr
 cAG
 mrP
@@ -85447,7 +86036,7 @@ keq
 pSg
 bDb
 lFe
-acW
+tGE
 dZo
 sWc
 iwn
@@ -85704,14 +86293,14 @@ eLb
 eLb
 hVN
 uhi
-tXd
+jkV
 pNe
 lXw
 bUf
 lFe
-szj
-kaA
-gLD
+bDG
+cEu
+gIA
 uuV
 lae
 iwi
@@ -85737,7 +86326,7 @@ vRP
 qIk
 nqE
 mHW
-kZg
+fPr
 lIh
 cnh
 kwm
@@ -85961,7 +86550,7 @@ fJJ
 eLb
 rIc
 lFe
-jvK
+qsa
 iwn
 lFe
 lFe
@@ -85994,7 +86583,7 @@ aCD
 qIk
 cds
 mtW
-qLC
+lQA
 hZT
 joM
 knX
@@ -86251,7 +86840,7 @@ aCD
 qIk
 dpH
 mHW
-pDZ
+wbo
 qWF
 knX
 knX
@@ -86738,7 +87327,7 @@ kva
 kva
 paW
 nYO
-miR
+xqE
 oqQ
 nYO
 ecN
@@ -86990,12 +87579,12 @@ keq
 scI
 xsB
 xsB
-dZn
-jfV
-oBJ
+gbE
+tTP
+mXY
 gKH
 xZU
-bwc
+qva
 amp
 nYO
 ycV
@@ -87252,7 +87841,7 @@ toK
 mQt
 mQt
 mQt
-dKG
+hss
 gsL
 kOt
 wPm
@@ -87289,9 +87878,9 @@ jfN
 jfN
 vsT
 lID
-fzx
-kXA
-mYX
+pKp
+tlj
+czA
 uzX
 nuh
 hED
@@ -87504,9 +88093,9 @@ keq
 qjL
 mQt
 cMs
-iak
-bSD
-tvM
+cKs
+fkF
+hmh
 kHD
 mQt
 cmF
@@ -87803,9 +88392,9 @@ rcm
 oIK
 rcm
 rcm
-jZz
-hoU
-gSz
+mvn
+jHR
+ajC
 uzX
 uUA
 hcR
@@ -88017,9 +88606,9 @@ keq
 keq
 qjL
 mQt
-eje
-lKR
-kqD
+ikg
+img
+bkY
 mQt
 mQt
 mQt
@@ -88531,8 +89120,8 @@ eLb
 mrH
 tNc
 igt
-tJX
-qGI
+mby
+fWI
 jut
 rny
 cYX
@@ -89049,9 +89638,9 @@ keq
 qjL
 jut
 xaO
-lIQ
-nbr
-gar
+eIY
+sOV
+vBC
 jut
 cBE
 gia
@@ -90070,8 +90659,8 @@ nKd
 uPj
 aWF
 dLk
-slG
-hxY
+ieX
+rkv
 rsW
 eLb
 eLb
@@ -90083,7 +90672,7 @@ qjL
 keq
 kPR
 kfu
-auf
+fwh
 moB
 uhh
 kfu
@@ -90340,7 +90929,7 @@ ahK
 gtf
 bqN
 srl
-cAY
+rWO
 eKQ
 eAn
 kfu
@@ -90363,7 +90952,7 @@ pNL
 vzg
 hfV
 hpP
-tBO
+rTs
 wLj
 oYc
 oYc
@@ -90597,7 +91186,7 @@ icQ
 fEx
 egW
 kfu
-nhz
+gxA
 dGa
 bhz
 eMT
@@ -90613,7 +91202,7 @@ fxy
 iyi
 yhE
 myr
-rDM
+gIa
 oYc
 oYc
 oYc
@@ -90836,10 +91425,10 @@ jzc
 laK
 hCF
 aCs
-ddt
+eoI
 tYq
 vps
-iud
+wgr
 niO
 uEf
 xPy
@@ -90870,7 +91459,7 @@ fBg
 cFD
 nay
 vZe
-xsi
+xuf
 cxh
 ueT
 bbz
@@ -91093,10 +91682,10 @@ vRP
 eqc
 pQh
 eqc
-vtA
+uBg
 kxF
 jxt
-eOi
+hks
 dLk
 niO
 niO
@@ -91350,22 +91939,22 @@ vRP
 vRP
 aCD
 eqc
-adM
+oIT
 amf
 yge
-qAm
-unI
-hLq
-qoO
-qgA
-fqd
-lWU
-fgJ
-sBE
-ufR
-sBE
-ufR
-qJf
+nge
+inB
+ieC
+mpo
+asd
+whX
+exu
+uWD
+lci
+lci
+lci
+lci
+lxJ
 eyx
 sGA
 eyx
@@ -91393,9 +91982,9 @@ rrG
 vpc
 gbh
 gda
-gbh
-ady
-bJT
+rrl
+rvh
+wQR
 nPi
 vvd
 vmy
@@ -91607,7 +92196,7 @@ vRP
 aCD
 aCD
 eqc
-wGz
+oAa
 kxF
 abU
 ihf
@@ -91864,23 +92453,23 @@ vRP
 vRP
 aCD
 eqc
-adM
+oIT
 kxF
-evo
-xiZ
-ovh
-xiZ
-tZP
-naq
-qtt
-cYt
-dfj
-rEu
-ubr
-nnn
-lBk
-nnn
-hnn
+oqs
+jfh
+jfh
+jfh
+xHH
+sjW
+eHm
+nyD
+bVL
+grH
+hZR
+rTN
+rTN
+rTN
+rlw
 ftY
 ftY
 ftY
@@ -92121,14 +92710,14 @@ vRP
 eqc
 pQh
 eqc
-vtA
+uBg
 kxF
-gHm
+kxC
 rmW
 iha
 rmW
-nMV
-wIm
+kpt
+kaj
 pQh
 pQh
 dIB
@@ -92137,7 +92726,7 @@ dIB
 dIB
 dIB
 dIB
-xvr
+axl
 ftY
 ftY
 ftY
@@ -92378,15 +92967,15 @@ vRP
 laK
 pqy
 aCs
-wqQ
+lZE
 ibW
-qJT
-rgt
-eUq
-rgt
-vlk
-qAm
-jgj
+rQL
+lEZ
+lEZ
+lEZ
+pYC
+nge
+bQq
 pQh
 dYL
 dYL
@@ -92394,7 +92983,7 @@ dYL
 dYL
 ech
 xgP
-cUY
+rZc
 fyP
 kUU
 fyP
@@ -92409,9 +92998,9 @@ ngI
 pBk
 iKT
 hVM
-agf
+bzD
 knr
-fyb
+qRR
 syN
 vVi
 xPv
@@ -92635,7 +93224,7 @@ vRP
 eqc
 eqc
 eqc
-eVO
+kpt
 kxF
 mLh
 lWI
@@ -92643,7 +93232,7 @@ kxF
 kxF
 fpk
 kxF
-jCC
+sMd
 pQh
 dYL
 dYL
@@ -92892,15 +93481,15 @@ vRP
 laK
 hCF
 aCs
-bbe
-dkW
-lOQ
-cKj
-wLa
-tZP
+lrE
+ndh
+oDg
+riY
+uRR
+xHH
 kxF
 kxF
-wIm
+kaj
 pQh
 dYL
 dYL
@@ -93154,10 +93743,10 @@ pQh
 mvV
 pQh
 pQh
-lor
-fCZ
-hqo
-dJv
+cma
+pje
+lUN
+xwj
 pQh
 xgP
 xgP
@@ -93180,7 +93769,7 @@ gXE
 rbp
 gam
 hVM
-mjp
+klP
 kyA
 mKZ
 mKZ
@@ -93449,9 +94038,9 @@ gxH
 kyA
 pWI
 waL
-waL
-jQr
-nJs
+kdu
+swa
+eSI
 pKx
 wod
 dvp
@@ -93694,7 +94283,7 @@ iUF
 eNr
 ohE
 hVM
-rGK
+gZt
 oYi
 bTn
 aRj
@@ -93710,7 +94299,7 @@ aLl
 mfP
 aLl
 uhZ
-ybr
+ajj
 rjN
 rrI
 faQ
@@ -93923,7 +94512,7 @@ iLQ
 dty
 fAL
 hGC
-lZx
+qXt
 iLQ
 rGP
 bvm
@@ -94180,7 +94769,7 @@ iLQ
 cBB
 wUI
 jcQ
-xmW
+voy
 gNl
 nwQ
 lSl
@@ -95480,7 +96069,7 @@ xgP
 ihC
 eWK
 fnc
-xxd
+hZr
 ghk
 egF
 pps
@@ -95503,7 +96092,7 @@ qvo
 fMi
 hmD
 qVl
-gen
+cIi
 fGy
 vKc
 aLl
@@ -95737,7 +96326,7 @@ xgP
 nCy
 sTM
 uQR
-eBY
+exz
 cPe
 oyZ
 ilp
@@ -95760,7 +96349,7 @@ eVR
 wgS
 vFm
 qlc
-tHh
+gqj
 tUy
 ozz
 aLl
@@ -95994,7 +96583,7 @@ xgP
 kIf
 dVD
 fnc
-hjd
+xYx
 eTE
 cTL
 kFN
@@ -96017,7 +96606,7 @@ uQz
 oJi
 hBI
 qdi
-nOb
+lCw
 fGy
 aLl
 aLl


### PR DESCRIPTION
# Document the changes in your pull request

gives gax the facelift that box got a bit ago
- smaller trims
- escape and atmos stripes
- engi yellow
- sec red
- chemistry orange
- all maint doors now have warning stripes

![image](https://github.com/yogstation13/Yogstation/assets/5091394/c0dc5869-6e11-4610-b3eb-0dd9bdd82603)
![image](https://github.com/yogstation13/Yogstation/assets/5091394/baf4130f-53bb-4ff5-b6d4-eb0064ee708e)
![image](https://github.com/yogstation13/Yogstation/assets/5091394/1f0e7fe4-c0ac-4855-a5f5-db56cf230b76)
![image](https://github.com/yogstation13/Yogstation/assets/5091394/66c02df5-c406-4e5e-b4b7-29029033867d)



# Wiki Documentation

functionally all of gax looks different good luck tho

# Changelog

:cl:  
mapping: nvs gax gets a trim overhaul
/:cl:
