### PR TITLE
Brig Phys spawns with a medical belt

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -539,6 +539,7 @@
 
 	pda_type = /obj/item/modular_computer/tablet/pda/preset/basic
 
+	belt = /obj/item/storage/belt/medical
 	head = /obj/item/clothing/head/helmet/space/plasmaman/blue
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
 	mask = /obj/item/clothing/mask/breath

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -50,6 +50,7 @@
 	pda_type = /obj/item/modular_computer/tablet/pda/preset/paramed
 
 	backpack_contents = list(/obj/item/roller = 1)
+	belt = /obj/item/storage/belt/medical
 	ears = /obj/item/radio/headset/headset_medsec
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
 	shoes = /obj/item/clothing/shoes/jackboots


### PR DESCRIPTION
Just like mining medic, they don't have one just lying in their room like how it is for the medbay jobs, 
however, unlike mining medic, they don't spawn with one so they're forced to use their "spare" as their first one

:cl:  
rscadd: Brig physician spawns with an empty medical belt worn
/:cl:
