### PR TITLE
Adds insuls and telecommunication parts to gax tech storage

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -28,16 +28,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/item/aicard{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/item/flashlight{
+	pixel_x = 4
 	},
+/obj/item/clothing/gloves/color/yellow,
 /obj/item/aiModule/reset{
 	pixel_x = -1;
 	pixel_y = 9
 	},
-/obj/item/flashlight{
-	pixel_x = 4
+/obj/item/aicard{
+	pixel_x = -5;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
@@ -3534,6 +3535,21 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"bKG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/storage/tech";
+	dir = 4;
+	name = "Tech Storage APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
 "bLu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -5489,17 +5505,14 @@
 /area/chapel/office)
 "cJc" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = 24
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -8016,9 +8029,7 @@
 	},
 /area/maintenance/starboard/fore)
 "eay" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eaT" = (
@@ -13566,10 +13577,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "gBn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gBL" = (
@@ -14091,6 +14101,9 @@
 "gPn" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
 "gPY" = (
@@ -23903,15 +23916,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/storage/tech";
-	dir = 4;
-	name = "Tech Storage APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -26795,7 +26799,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "npL" = (
@@ -37294,9 +37298,6 @@
 /area/hallway/primary/central)
 "sEs" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -47114,12 +47115,92 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "xAk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = -10;
+	pixel_y = -10
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/stock_parts/subspace/amplifier{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/subspace/analyzer{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/subspace/ansible{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/item/stock_parts/subspace/ansible{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/item/stock_parts/subspace/ansible{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/crystal{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/filter{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/subspace/transmitter{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/subspace/treatment{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/structure/closet{
+	name = "TeleComm parts"
+	},
+/turf/open/floor/plasteel/white,
+/area/storage/tech)
 "xAK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -73929,8 +74010,8 @@ kwC
 fCP
 orC
 eKF
-eKF
-eKF
+xAk
+bKG
 cJc
 gPn
 eKF
@@ -74185,8 +74266,8 @@ sTv
 lPr
 xKc
 eay
-gBn
-xAk
+vhl
+vhl
 eKF
 mFc
 eKF
@@ -74441,9 +74522,9 @@ jju
 sTv
 lPr
 xKc
-kmr
-kmr
-eay
+gBn
+hjl
+hjl
 pVM
 nFB
 hjl

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -47115,87 +47115,27 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "xAk" = (
-/obj/item/stock_parts/subspace/amplifier{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/amplifier{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/amplifier{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/analyzer{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/subspace/analyzer{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/subspace/analyzer{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/subspace/ansible{
-	pixel_x = 10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/ansible{
-	pixel_x = 10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/ansible{
-	pixel_x = 10;
-	pixel_y = -10
-	},
-/obj/item/stock_parts/subspace/crystal{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/crystal{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/crystal{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/filter{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/filter{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/filter{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/obj/item/stock_parts/subspace/transmitter{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/subspace/transmitter{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/subspace/transmitter{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/subspace/treatment{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/subspace/treatment{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/subspace/treatment{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
 /obj/structure/closet{
 	name = "TeleComm parts"
 	},


### PR DESCRIPTION
fixes  #19119

Puts gax in line with other stations by adding tcomm parts and a pair of insuls in the tech storage.
I would have liked to expand it a bit more but given how gax is layed out its nearly impossible.
This will do for now.

has been tested

:cl:  
bugfix: fixed a few things  
mapping: This is a mapping change
/:cl:
