### PR TITLE
Holy Light rod now provides favor upon healing.

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -482,7 +482,6 @@
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
 				SM.adjustHealth(-3.5 * efficiency, forced = TRUE)
-		
 /datum/status_effect/good_music
 	id = "Good Music"
 	alert_type = null

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -482,6 +482,7 @@
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
 				SM.adjustHealth(-3.5 * efficiency, forced = TRUE)
+
 /datum/status_effect/good_music
 	id = "Good Music"
 	alert_type = null

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -463,6 +463,9 @@
 			itemUser.adjustCloneLoss(-0.5 * efficiency) //Becasue apparently clone damage is the bastion of all health
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
+			if(ispath(rod_type, /obj/item/rod_of_asclepius/white)) //Used for adjusting the Holy Light Sect Favor from white rod healing.
+				var/total_healing = (min(L.getBruteLoss(), 3.5*efficiency) + min(L.getFireLoss(), 3.5*efficiency) + min(L.getOxyLoss(), 3.5*efficiency) + min(L.getToxLoss(), 3.5 * efficiency))
+				GLOB.religious_sect.adjust_favor(total_healing)
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
 			if(iscarbon(L))
@@ -479,7 +482,7 @@
 			else if(isanimal(L))
 				var/mob/living/simple_animal/SM = L
 				SM.adjustHealth(-3.5 * efficiency, forced = TRUE)
-
+		
 /datum/status_effect/good_music
 	id = "Good Music"
 	alert_type = null


### PR DESCRIPTION
# Document the changes in your pull request
Never made sense to me that the sect about **healing people** can get a thing that **heals people** and also **reduces your favor** because you wanted to **heal people** that wasn't slapping them with a bible 50 times.

I don't really think the chap should become worse at gaining favor if they want to help the general public by giving them a rod.

My only worry is that if the favor gain is too much (which is rare, but could happen) you could see rods being spammed, but if this is a large concern I can just make the rod favor less and less the more exist.
# Wiki Documentation
Rod of White should be noted that it gives favor equal to what it heals.

# Changelog

:cl:  
tweak: Rod of White now provides favor when healing others.
/:cl:
