### PR TITLE
lets photogeists heal non plants (at a far reduced rate)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -729,10 +729,16 @@ Difficulty: Very Hard
 	var/datum/action/cooldown/spell/conjure/plants/terrarium = new(src)
 	terrarium.Grant(src)
 
-/mob/living/simple_animal/hostile/lightgeist/healing/photogeist/AttackingTarget() //photogeists can only heal plantlike stuff
+/mob/living/simple_animal/hostile/lightgeist/healing/photogeist/AttackingTarget() //photogeists can heal non plant stuff, but its incredibly low healing
 	var/mob/living/L = target
-	if(!("vines" in L.faction) && !("plants" in L.faction))
-		return FALSE
+	if(L.stat != DEAD)
+		if(!("vines" in L.faction) && !("plants" in L.faction))
+			L.heal_overall_damage(heal_power/6, heal_power/6)
+			new /obj/effect/temp_visual/heal(get_turf(target), heal_color)
+		else
+			L.heal_overall_damage(heal_power, heal_power)
+			new /obj/effect/temp_visual/heal(get_turf(target), heal_color)
+
 	. = ..()
 
 /datum/action/cooldown/spell/conjure/plants
@@ -768,7 +774,7 @@ Difficulty: Very Hard
 	death = FALSE
 	roundstart = FALSE
 	short_desc = "You are a photogeist, a peaceful creature summoned by a plant god"
-	flavour_text = "Try to prevent plant creatures from dying and listen to your summoner otherwise. You can also click a plantlike creature to heal them and can seed flowers and bushes into the floor."
+	flavour_text = "Try to prevent plant creatures from dying and listen to your summoner otherwise. You can also click a plantlike creature to heal them and can seed flowers and bushes into the floor. Healing non plantlike creatures is possible, but far slower."
 
 /obj/effect/mob_spawn/photogeist/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -739,8 +739,6 @@ Difficulty: Very Hard
 			L.heal_overall_damage(heal_power, heal_power)
 			new /obj/effect/temp_visual/heal(get_turf(target), heal_color)
 
-	. = ..()
-
 /datum/action/cooldown/spell/conjure/plants
 	name = "Seed Plants"
 	desc = "This spell seeds a random plant into the floor."


### PR DESCRIPTION


# Document the changes in your pull request

Photogeists from the kudzu chaplain sect can now heal non plantlike creatures at a 6x reduced rate (0.5 healing per click). Previously they couldn't, so if there were no podpeople or anything (most of the time, there is like 3 pod people mains) they were pretty useless. The healing they can give to non plants is useless for any combat stuff but gives them more stuff to do.

# Changelog

:cl:  
tweak: photogeists can now heal non plantlike creatures, though at a far reduced rate.
/:cl:
