### PR TITLE
Sawn-off Mosin Nagant changes

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -63,12 +63,6 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 	can_be_sawn_off = TRUE
 	weapon_weight = WEAPON_HEAVY
 
-/obj/item/gun/ballistic/rifle/boltaction/sawoff(mob/user)
-	. = ..()
-	if(.)
-		spread = 36
-		can_bayonet = FALSE
-
 /obj/item/gun/ballistic/rifle/boltaction/blow_up(mob/user)
 	. = 0
 	if(chambered && chambered.BB)
@@ -90,7 +84,8 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 		return
 	. = ..()
 	if(.)
-		spread = 36
+		name = "\improper Mosin Obrez"
+		rack_delay *= 2
 		can_bayonet = FALSE
 		weapon_weight = WEAPON_LIGHT
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Sawing off the Mosin Nagant now renames it to "Mosin Obrez" instead of "sawn-off Mosin Nagant" because it's cooler

The Mosin Obrez no longer has 36 degrees of spread, which previously made it unusable, but now takes twice as long to rack the bolt

Also removed an overridden duplicate definition

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Renamed the sawn-off Mosin Nagant to Mosin Obrez
tweak: Mosin Obrez no longer has 36 degrees of spread
tweak: Mosin Obrez now takes twice as long to rack the bolt
/:cl:
