### PR TITLE
modular holotools :3

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3823,6 +3823,7 @@
 #include "yogstation\code\game\objects\items\grenades\glitterbombs.dm"
 #include "yogstation\code\game\objects\items\holotool\holotool.dm"
 #include "yogstation\code\game\objects\items\holotool\modes.dm"
+#include "yogstation\code\game\objects\items\holotool\modules.dm"
 #include "yogstation\code\game\objects\items\implants\implant_dusting.dm"
 #include "yogstation\code\game\objects\items\implants\implant_gang.dm"
 #include "yogstation\code\game\objects\items\implants\implant_infiltrator.dm"

--- a/yogstation/code/game/gamemodes/objective_items.dm
+++ b/yogstation/code/game/gamemodes/objective_items.dm
@@ -1,6 +1,6 @@
 /datum/objective_item/steal/holotool
-	name = "the holotool."
-	targetitem = /obj/item/holotool
+	name = "the experimental holotool."
+	targetitem = /obj/item/holotool/rd
 	difficulty = 5
 	excludefromjob = list("Research Director")
 

--- a/yogstation/code/game/objects/items/holotool/modules.dm
+++ b/yogstation/code/game/objects/items/holotool/modules.dm
@@ -1,0 +1,144 @@
+/obj/item/holotool_module
+    name = "holotool module"
+    desc = "Contact a coder!"
+    icon = 'icons/obj/module.dmi'
+    icon_state = "cyborg_upgrade"
+    w_class = WEIGHT_CLASS_SMALL
+    var/datum/holotool_mode/preset_mode
+    var/datum/holotool_mode/mode
+    var/speed = 1.25
+    var/toolage_use = 1
+
+/obj/item/holotool_module/Initialize()
+    . = ..()
+    mode = new preset_mode()
+    mode.speed = speed
+
+/obj/item/holotool_module/examine()
+    . += "This card takes up [toolage_use] capacity."
+
+/obj/item/holotool_module/off
+    preset_mode = /datum/holotool_mode/off
+
+/obj/item/holotool_module/screwdriver
+    preset_mode = /datum/holotool_mode/screwdriver
+    name = "basic screwdriver holotool card"
+    desc = "A card that lets your holotool take on a screwdriver form. Perfect for screwing around."
+
+/obj/item/holotool_module/screwdriver/advanced
+    name = "advanced screwdriver holotool card"
+    speed = 1
+    toolage_use = 2
+
+/obj/item/holotool_module/screwdriver/elite
+    name = "elite screwdriver holotool card"
+    speed = 0.8
+    toolage_use = 3
+
+/obj/item/holotool_module/screwdriver/rd
+    name = "experimental screwdriver holotool card"
+    speed = 0.4
+    toolage_use = 2
+
+/obj/item/holotool_module/crowbar
+    preset_mode = /datum/holotool_mode/crowbar
+    name = "basic crowbar holotool card"
+    desc = "A card that lets your holotool take on a crowbar form. Not suitable for bludgeoning aliens."
+    toolage_use = 2
+
+/obj/item/holotool_module/crowbar/advanced
+    name = "advanced crowbar holotool card"
+    speed = 1
+    toolage_use = 3
+
+/obj/item/holotool_module/crowbar/elite
+    name = "elite crowbar holotool card"
+    speed = 0.8
+    toolage_use = 4
+
+/obj/item/holotool_module/crowbar/rd
+    name = "experimental crowbar holotool card"
+    speed = 0.4
+    toolage_use = 2
+
+/obj/item/holotool_module/multitool
+    preset_mode = /datum/holotool_mode/multitool
+    name = "basic multitool holotool card"
+    desc = "A card that lets your holotool take on a multitool form. Warranty void if shocked."
+    toolage_use = 2
+
+/obj/item/holotool_module/multitool/advanced
+    name = "advanced multitool holotool card"
+    speed = 1
+    toolage_use = 3
+
+/obj/item/holotool_module/multitool/elite
+    name = "elite multitool holotool card"
+    speed = 0.8
+    toolage_use = 4
+
+/obj/item/holotool_module/multitool/rd
+    name = "experimental multitool holotool card"
+    speed = 0.4
+    toolage_use = 2
+
+/obj/item/holotool_module/wrench
+    preset_mode = /datum/holotool_mode/wrench
+    name = "basic wrench holotool card"
+    desc = "A card that lets your holotool take on a wrench form. Typically used by holographic monkeys."
+
+/obj/item/holotool_module/wrench/advanced
+    name = "advanced wrench holotool card"
+    speed = 1
+    toolage_use = 2
+
+/obj/item/holotool_module/wrench/elite
+    name = "elite wrench holotool card"
+    speed = 0.8
+    toolage_use = 4
+
+/obj/item/holotool_module/wrench/rd
+    name = "experimental wrench wrench holotool card"
+    speed = 0.4
+    toolage_use = 2
+
+/obj/item/holotool_module/snips
+    preset_mode = /datum/holotool_mode/wirecutters
+    name = "basic wirecutters holotool card"
+    desc = "A card that lets your holotool take on a wirecutters form. Keep away from clowns."
+
+/obj/item/holotool_module/snips/advanced
+    name = "advanced wirecutters holotool card"
+    toolage_use = 2
+    speed = 1
+    
+/obj/item/holotool_module/snips/elite
+    name = "elite wirecutters holotool card"
+    toolage_use = 3
+    speed = 0.8
+
+/obj/item/holotool_module/snips/rd
+    name = "experimental wirecutters holotool card"
+    toolage_use = 2
+    speed = 0.4
+
+/obj/item/holotool_module/welder
+    preset_mode = /datum/holotool_mode/welder
+    name = "basic welder holotool card"
+    desc = "A card that lets your holotool take on a welder form. Don't ask how it works."
+    toolage_use = 2
+
+/obj/item/holotool_module/welder/advanced
+    name = "advanced welder holotool card"
+    toolage_use = 3
+    speed = 1
+
+/obj/item/holotool_module/welder/elite
+    name = "elite welder holotool card"
+    toolage_use = 4
+    speed = 0.8
+
+/obj/item/holotool_module/welder/rd
+    name = "experimental welder holotool card"
+    toolage_use = 2
+    speed = 0.4

--- a/yogstation/code/modules/research/designs/tool_designs.dm
+++ b/yogstation/code/modules/research/designs/tool_designs.dm
@@ -17,3 +17,172 @@
 	build_path = /obj/item/multitool/tricorder
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+
+/datum/design/holotool
+	name = "Holotool"
+	desc = "A basic holotool."
+	id = "holotool"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron=1000,/datum/material/silver=300,/datum/material/gold=300)
+	build_path = /obj/item/holotool
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/holotool/advanced
+	name = "Advanced Holotool"
+	desc = "An advanced holotool."
+	id = "advholotool"
+	materials = list(/datum/material/iron=1200,/datum/material/silver=500,/datum/material/gold=500, /datum/material/uranium = 250)
+	build_path = /obj/item/holotool/advanced
+
+/datum/design/holotool/elite
+	name = "Elite Holotool"
+	desc = "An elite holotool."
+	id = "eliteholotool"
+	materials = list(/datum/material/iron=1200,/datum/material/silver=500,/datum/material/gold=500, /datum/material/uranium = 250, /datum/material/diamond = 200, /datum/material/bluespace = 200)
+	build_path = /obj/item/holotool/elite
+
+
+/datum/design/holoscrewdriver
+	name = "Holotool Screwdriver card"
+	id = "holoscrew"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/screwdriver
+
+/datum/design/holocrowbar
+	name = "Holotool Crowbar card"
+	id = "holocrow"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/crowbar
+
+/datum/design/holomultitool
+	name = "Holotool Multitool card"
+	id = "holomulti"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/multitool
+
+/datum/design/holowrench
+	name = "Holotool Wrench card"
+	id = "holowrench"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/wrench
+
+/datum/design/holosnips
+	name = "Holotool Wirecutters card"
+	id = "holosnips"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/snips
+
+/datum/design/holowelder
+	name = "Holotool Welder card"
+	id = "holowelder"
+	materials = list(/datum/material/iron=1000,/datum/material/glass=2000)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/welder
+
+/datum/design/holoadvscrewdriver
+	name = "Advanced Holotool Screwdriver card"
+	id = "holoscrewadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/screwdriver/advanced
+
+/datum/design/holoadvcrowbar
+	name = "Advanced Holotool Crowbar card"
+	id = "holocrowadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/crowbar/advanced
+
+/datum/design/holoadvmultitool
+	name = "Advanced Holotool Multitool card"
+	id = "holomultiadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/multitool/advanced
+
+/datum/design/holoadvwrench
+	name = "Advanced Holotool Wrench card"
+	id = "holowrenchadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/wrench/advanced
+
+/datum/design/holoadvsnips
+	name = "Advanced Holotool Wirecutters card"
+	id = "holosnipsadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/snips/advanced
+
+/datum/design/holoadvwelder
+	name = "Advanced Holotool Welder card"
+	id = "holowelderadvanced"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=150,/datum/material/silver=250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/welder/advanced
+	
+/datum/design/holoelitescrewdriver
+	name = "Elite Holotool Screwdriver card"
+	id = "holoscrewelite"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/screwdriver/elite
+
+/datum/design/holoelitecrowbar
+	name = "Elite Holotool Crowbar card"
+	id = "holocrowbasic"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/crowbar/elite
+
+/datum/design/holoelitemultitool
+	name = "Elite Holotool Multitool card"
+	id = "holomultielite"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/multitool/elite
+
+/datum/design/holoelitewrench
+	name = "Elite Holotool Wrench card"
+	id = "holowrenchelite"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/wrench/elite
+
+/datum/design/holoelitesnips
+	name = "Elite Holotool Wirecutters card"
+	id = "holosnipselite"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/snips/elite
+
+/datum/design/holoelitewelder
+	name = "Elite Holotool Welder card"
+	id = "holowelderelite"
+	materials = list(/datum/material/iron=1500,/datum/material/glass=3000,/datum/material/gold=750, /datum/material/silver=500, /datum/material/diamond = 250)
+	category = list("Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+	build_path = /obj/item/holotool_module/welder/elite

--- a/yogstation/code/modules/research/techweb/all_nodes.dm
+++ b/yogstation/code/modules/research/techweb/all_nodes.dm
@@ -144,3 +144,30 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	prereq_ids = list("weaponry", "anomaly_research", "posibrain", "adv_biotech")
 	design_ids = list("nerd_suit")
+
+/datum/techweb_node/engineering
+	id = "engineering"
+	display_name = "Industrial Engineering"
+	description = "A refresher course on modern engineering technology."
+	prereq_ids = list("base")
+	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
+	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
+	"cell_charger", "stack_console", "stack_machine", "conveyor_belt", "conveyor_switch",
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "ipc_coolant_tank", "electrolyzer", "floorigniter", "crystallizer", "suit_storage_unit", "holotool", "holoscrew", "holocrow", "holomulti", "holowrench", "holosnips", "holowelder")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+
+/datum/techweb_node/high_efficiency
+	id = "high_efficiency"
+	display_name = "High Efficiency Parts"
+	description = "Finely-tooled manufacturing techniques allowing for picometer-perfect precision levels."
+	prereq_ids = list("engineering", "datatheory")
+	design_ids = list("pico_mani", "super_matter_bin", "advholotool", "holoscrewadvanced", "holocrowadvanced", "holomultiadvanced", "holowrenchadvanced", "holosnipsadvanced", "holowelderadvanced")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+
+/datum/techweb_node/micro_bluespace
+	id = "micro_bluespace"
+	display_name = "Miniaturized Bluespace Research"
+	description = "Extreme reduction in space required for bluespace engines, leading to portable bluespace technology."
+	prereq_ids = list("bluespace_travel", "practical_bluespace", "high_efficiency")
+	design_ids = list("bluespace_matter_bin", "femto_mani", "bluespacebodybag", "triphasic_scanning", "quantum_keycard", "wormholeprojector", "eliteholotool", "holoscrewelite", "holocrowelite", "holomultielite", "holowrenchelite", "holosnipselite", "holowelderelite")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)


### PR DESCRIPTION
the holotool is cool and stuff, so this PR basically hypospray's it

starting at industrial engineering, you can print holotools. however, holotools now need tool cards in order to use specific tools. the first holotool unlocked is super shitty, with only a capacity of 5, and all the cards at that level are 25% slower than normal tools.

with high efficiency parts, the advanced holotool is unlocked with 10 capacity and advanced tool cards, which work at the same speed as normal tools.

with mini bluespace, elite holotools are unlocked, with 15 capacity and elite tool cards, which only take 80% as long to complete tasks

the RD's holotool is unaffected, with special RD cards that have the same tool modifier, so nothing is different

cards can be taken out of the holotools with a screwdriver

The steal objective is still the RD's specific holotool, no other holotools will work

# Wiki Documentation

basic cards and holotool unlocked with industrial engineering, tools have 1.25 speed modifier
advanced cards and holotool unlocked with high efficiency parts, tools have 1 speed modifier
elite cards and holotool unlocked with minibluespace, tools have 0.4 speed modifier

# Changelog

:cl:  
rscadd: modular holotools :3
/:cl:
