### PR TITLE
Jaws of life tweaks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1269,8 +1269,8 @@
 
 	if(istype(I, /obj/item/jawsoflife) || istype(I, /obj/item/mantis/blade))
 		if(isElectrified())
-			shock(user,100)//it's like sticking a fork in a power socket
-			return
+			if(shock(user,100))//it's like sticking a fork in a power socket
+				return
 
 		if(istype(I, /obj/item/mantis/blade))
 			var/obj/item/mantis/blade/secondsword = user.get_inactive_held_item()
@@ -1293,7 +1293,7 @@
 			to_chat(user, span_warning("The airlock won't budge!"))
 			return
 
-		var/time_to_open = 7 SECONDS
+		var/time_to_open = 9 SECONDS
 
 		if(hasPower() && !prying_so_hard)
 			if (I.tool_behaviour == TOOL_CROWBAR) //we need another check, futureproofing for if/when bettertools actually completely replaces the old jaws

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1314,9 +1314,9 @@
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
 				if(I.use_tool(src, user, time_to_open))
-					open(2)
 					if(!istype(I,/obj/item/jawsoflife/jimmy)) //You get to be special
-						take_damage(max_integrity/8) //Forcing open a door messes it up a little
+						take_damage(max_integrity/8, sound_effect = FALSE) //Forcing open a door messes it up a little
+					open(2)
 					if(density && !open(2))
 						to_chat(user, span_warning("Despite your attempts, [src] refuses to open."))
 				prying_so_hard = FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1293,7 +1293,7 @@
 			to_chat(user, span_warning("The airlock won't budge!"))
 			return
 
-		var/time_to_open = 7 SECONDS * I.toolspeed
+		var/time_to_open = 7 SECONDS
 
 		if(hasPower() && !prying_so_hard)
 			if (I.tool_behaviour == TOOL_CROWBAR) //we need another check, futureproofing for if/when bettertools actually completely replaces the old jaws
@@ -1313,9 +1313,9 @@
 
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
 				prying_so_hard = TRUE
-				if(do_after(user, time_to_open, src))
+				if(I.use_tool(src, user, time_to_open))
 					open(2)
-					if(!istype(I,/obj/item/jawsoflife/jimmy)) //You get to be special
+					if(!(istype(I,/obj/item/jawsoflife/jimmy) || IS_ENGINEERING(user))) //You get to be special
 						take_damage(max_integrity/8) //Forcing open a door messes it up a little
 					if(density && !open(2))
 						to_chat(user, span_warning("Despite your attempts, [src] refuses to open."))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1315,7 +1315,7 @@
 				prying_so_hard = TRUE
 				if(I.use_tool(src, user, time_to_open))
 					open(2)
-					if(!(istype(I,/obj/item/jawsoflife/jimmy) || IS_ENGINEERING(user))) //You get to be special
+					if(!istype(I,/obj/item/jawsoflife/jimmy)) //You get to be special
 						take_damage(max_integrity/8) //Forcing open a door messes it up a little
 					if(density && !open(2))
 						to_chat(user, span_warning("Despite your attempts, [src] refuses to open."))

--- a/code/game/objects/items/mantis.dm
+++ b/code/game/objects/items/mantis.dm
@@ -14,7 +14,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_CROWBAR // just a very "sharp" crowbar
-	toolspeed = 0.45 //for door prying speed, ends up at about 3 seconds
+	toolspeed = 0.35 //for door prying speed, ends up at about 3 seconds
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "lacerated", "ripped", "diced", "cut")
 
 /obj/item/mantis/blade/equipped(mob/user, slot, initial)

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -9,7 +9,6 @@
 	item_state = "jawsoflife"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
 	toolspeed = 0.7
@@ -162,6 +161,7 @@
 	materials = list(MAT_METAL=400,MAT_SILVER=10,MAT_TITANIUM=80)
 	toolspeed = 0.3 // Starting minimum value. Pump it up by using it up to the max
 	tool_behaviour = TOOL_CROWBAR
+	w_class = WEIGHT_CLASS_SMALL
 	var/pump_charge = 0
 	var/pump_max = 100
 	var/pump_min = 0


### PR DESCRIPTION
# Document the changes in your pull request

Jaws of life are now normal-sized and slower to use for non-engineers. Also fixes a bug that prevents you from using it on a shocked door even with insulated gloves on.

# Changelog

:cl:  
tweak: jaws of life are normal-sized
tweak: non-engineers take longer to pry open doors with jaws of life
bugfix: fixes not being able to pry open shocked doors with insulated gloves on
/:cl:
