### PR TITLE
flavor text for roundstart clockies tweak, lore edition

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -212,7 +212,7 @@ Credit where due:
 	to_chat(M, span_brass("You have approximately <b>[ark_time]</b> minutes until the Ark activates."))
 	to_chat(M, span_brass("Unlock <b>Script</b> scripture by converting a new servant."))
 	to_chat(M, span_brass("<b>Application</b> scripture will be unlocked halfway until the Ark's activation."))
-	to_chat(M, span_brass("Soon, we shall create a new City of Cogs, and forge a golden age for all sentient beings."))
+	to_chat(M, span_brass("Soon, Ratvar shall create a new City of Cogs, and forge a golden age for all sentient beings."))
 	M.playsound_local(get_turf(M), 'sound/ambience/antag/clockcultalr.ogg', 100, FALSE, pressure_affected = FALSE)
 	return 1
 

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -206,9 +206,13 @@ Credit where due:
 	if(!M)
 		return 0
 	to_chat(M, "<span class='bold large_brass'>You are a servant of Ratvar, the Clockwork Justiciar!</span>")
+	to_chat(M, span_brass("He came to you in a dream, whispering softly in your ear, showing you visions of a majestic city, covered in brass. You were not the first to be reached out to by him, and you will not be the last."))
+	to_chat(M, span_brass("However, you are one of the few worthy enough to have found his home, hidden among the stars, and as such you shall be rewarded for your dedication. One last trial remains."))
+	to_chat(M, span_brass("Start the ark to weaken the veil and ensure the return of your lord; but beware, as there are those that seek to hinder you. They are unenlightened, show them Ratvars light to help them gain understanding and join your cause."))
 	to_chat(M, span_brass("You have approximately <b>[ark_time]</b> minutes until the Ark activates."))
 	to_chat(M, span_brass("Unlock <b>Script</b> scripture by converting a new servant."))
 	to_chat(M, span_brass("<b>Application</b> scripture will be unlocked halfway until the Ark's activation."))
+	to_chat(M, span_brass("Soon, we shall create a new City of Cogs, and forge a golden age for all sentient beings."))
 	M.playsound_local(get_turf(M), 'sound/ambience/antag/clockcultalr.ogg', 100, FALSE, pressure_affected = FALSE)
 	return 1
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Alters the flavor text for roundstart clockies, I was going to do epilogues as well but that'll take a bit more work so I'll push this out while I have it.

He came to you in a dream, whispering softly in your ear, showing you visions of a majestic city, covered in brass. You were not the first to be reached out to by him, and you will not be the last.
However, you are one of the few worthy enough to have found his home, hidden among the stars, and as such you shall be rewarded for your dedication. One last trial remains.
Start the ark to weaken the veil and ensure the return of your lord; but beware, as there are those that seek to hinder you. They are unenlightened, show them Ratvars light to help them gain understanding and join your cause.
You have approximately (ark time here) minutes until the Ark activates.
Unlock **Script** scripture by converting a new servant.
**Application** scripture will be unlocked halfway until the Ark's activation."))
Soon, Ratvar shall create a new City of Cogs, and forge a golden age for all sentient beings

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: flavor text for roundstart clock cult is fancier.

/:cl:
