### PR TITLE
blacklists bounty consoles from the improvised emag

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -102,6 +102,10 @@
 				M.ignite_mob()
 				to_chat(user, span_danger("The card shorts out and catches fire in your hands!"))
 			log_combat(user, target, "attempted to emag")
+			if(istype(target, /obj/machinery/computer/bounty)) //we can't have nice things
+				to_chat(user, span_notice("The cheap circuitry isn't strong enough to subvert this!"))
+				emagging = FALSE
+				return
 			target.emag_act(user)
 		emagging = FALSE
 


### PR DESCRIPTION
access to syndicate bounties is supposed to cost 6tc, not 2. anyone who isn't a traitor with access to the improvised emag won't have an uplink, so this doesn't affect them

if this doesn't fix the problem the next step will be to put syndicate bounties behind a dedicated cargo-only traitor item, and role restricted items are boring and lame so i don't want to do that

# Changelog

:cl:  
tweak: makeshift emag does not work on bounty consoles
/:cl:
