### PR TITLE
Minor sleeper TGUI fix

### DIFF
--- a/tgui/packages/tgui/interfaces/Sleeper.js
+++ b/tgui/packages/tgui/interfaces/Sleeper.js
@@ -57,8 +57,8 @@ export const Sleeper = (props, context) => {
                 minValue={occupant.minHealth}
                 maxValue={occupant.maxHealth}
                 ranges={{
-                  good: [50, Infinity],
-                  average: [0, 50],
+                  good: [occupant.maxHealth / 2, Infinity],
+                  average: [0, occupant.maxHealth / 2],
                   bad: [-Infinity, 0],
                 }} />
               <Box mt={1} />


### PR DESCRIPTION
# Document the changes in your pull request

Fixed the health bar on the sleeper UI not taking max health into account when deciding which color it should be

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: sleeper ui takes max health into account
/:cl:
