### PR TITLE
Fixes operating computers syncing to tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -531,7 +531,7 @@
 	. = ..()
 	AddComponent(/datum/component/surgery_bed, \
 		success_chance = 1, \
-		extra_surgeries = TRUE, \
+		op_computer_linkable = TRUE, \
 	)
 
 /obj/structure/table/optable/tablepush(mob/living/user, mob/living/pushed_mob)


### PR DESCRIPTION
# Document the changes in your pull request

Closes https://github.com/yogstation13/Yogstation/issues/19264

I read the ``AddComponent`` wrong and thought ``extra_surgeries`` was meant to be set, not ``op_computer_linkable``. This meant operating tables can do all surgeries, but can't connect to operating computers. This fixes that by setting the proper arg this time.

Hey this is pretty cool
![image](https://github.com/yogstation13/Yogstation/assets/53777086/97816476-437c-4154-97d9-d607a4ebf041)

# Changelog

:cl:  
bugfix: Operating computers now connect to operating tables properly again.
/:cl:
