### PR TITLE
Some minor changes to space syndicate base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3478,7 +3478,7 @@
 	frequency = 1442;
 	name = "Nitrogen Supply Control";
 	output_tag = "syndie_lavaland_n2_out";
-	sensors = list("syndie_lavaland_n2_sensor"="Tank")
+	sensors = list("syndie_lavaland_n2_sensor" = "Tank")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -3929,7 +3929,7 @@
 	frequency = 1442;
 	name = "Oxygen Supply Control";
 	output_tag = "syndie_lavaland_o2_out";
-	sensors = list("syndie_lavaland_o2_sensor"="Tank")
+	sensors = list("syndie_lavaland_o2_sensor" = "Tank")
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -4262,7 +4262,7 @@
 	frequency = 1442;
 	name = "Toxins Supply Control";
 	output_tag = "syndie_lavaland_tox_out";
-	sensors = list("syndie_lavaland_tox_sensor"="Tank")
+	sensors = list("syndie_lavaland_tox_sensor" = "Tank")
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5520,7 +5520,7 @@
 "Ay" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/syndichem{
-	products = list(/obj/item/stack/cable_coil/random=20,/obj/item/assembly/igniter=80,/obj/item/assembly/prox_sensor=20,/obj/item/assembly/signaler=20,/obj/item/assembly/timer=20,/obj/item/assembly/voice=20,/obj/item/assembly/health=20,/obj/item/assembly/infra=20,/obj/item/grenade/chem_grenade=20,/obj/item/grenade/chem_grenade/large=20,/obj/item/grenade/chem_grenade/pyro=20,/obj/item/grenade/chem_grenade/cryo=20,/obj/item/grenade/chem_grenade/adv_release=20,/obj/item/reagent_containers/food/drinks/bottle/holywater=1)
+	products = list(/obj/item/stack/cable_coil/random = 20, /obj/item/assembly/igniter = 80, /obj/item/assembly/prox_sensor = 20, /obj/item/assembly/signaler = 20, /obj/item/assembly/timer = 20, /obj/item/assembly/voice = 20, /obj/item/assembly/health = 20, /obj/item/assembly/infra = 20, /obj/item/grenade/chem_grenade = 20, /obj/item/grenade/chem_grenade/large = 20, /obj/item/grenade/chem_grenade/pyro = 20, /obj/item/grenade/chem_grenade/cryo = 20, /obj/item/grenade/chem_grenade/adv_release = 20, /obj/item/reagent_containers/food/drinks/bottle/holywater = 1)
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 6

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -65,8 +65,8 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "ai" = (
 /obj/machinery/door/airlock/grunge{
-	req_access_txt = "150";
-	name = "Bathroom"
+	name = "Bathroom";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -181,10 +181,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
-"aF" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "aG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 6
@@ -334,10 +330,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/button/door{
-	pixel_y = 23;
-	req_access_txt = "150";
+	id = "lpost_privacy_left";
 	name = "Privacy Shutters";
-	id = "lpost_privacy_left"
+	pixel_y = 23;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -438,6 +434,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25;
 	req_access = list(150)
 	},
 /obj/structure/cable{
@@ -480,9 +477,9 @@
 	id = "syndie_listeningpost_external_engi";
 	name = "Airlock Emergency Bolts";
 	normaldoorcontrol = 1;
+	pixel_y = -24;
 	req_access_txt = "150";
-	specialfunctions = 4;
-	pixel_y = -24
+	specialfunctions = 4
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -529,8 +526,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 10;
-	density = 0
+	density = 0;
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -665,6 +662,12 @@
 /obj/machinery/telecomms/relay/preset/ruskie,
 /turf/open/floor/circuit/red/telecomms,
 /area/ruin/space/has_grav/listeningstation/telecomms)
+"el" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "er" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -672,13 +675,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
-"eu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/sink{
-	pixel_y = 23
-	},
-/turf/open/floor/wood,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "ev" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/syndiround,
@@ -687,8 +683,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 5;
-	density = 0
+	density = 0;
+	dir = 5
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -707,9 +703,9 @@
 /area/ruin/space/has_grav/listeningstation/telecomms)
 "eM" = (
 /obj/structure/chair/comfy/shuttle{
+	desc = "A tactical and comfortable chair with a secure buckling system for when you really need to stay at your station.";
 	dir = 8;
-	name = "tactical chair";
-	desc = "A tactical and comfortable chair with a secure buckling system for when you really need to stay at your station."
+	name = "tactical chair"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -744,8 +740,8 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "fl" = (
 /obj/structure/closet/crate/hydroponics{
-	name = "janitorial crate";
-	desc = "All you need to make the station clean."
+	desc = "All you need to make the station clean.";
+	name = "janitorial crate"
 	},
 /obj/item/mop,
 /obj/item/reagent_containers/spray/cleaner,
@@ -929,10 +925,10 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "im" = (
 /obj/machinery/button/door{
-	req_access_txt = "150";
-	pixel_y = -24;
 	id = "lpost_warehouse";
-	name = "Warehouse Shutters"
+	name = "Warehouse Shutters";
+	pixel_y = -24;
+	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/critter,
@@ -1062,10 +1058,10 @@
 /obj/structure/table/wood,
 /obj/item/paper/fluff/ruins/listeningstation/briefing,
 /obj/machinery/button/door{
-	pixel_y = 23;
-	req_access_txt = "150";
+	id = "lpost_privacy_right";
 	name = "Privacy Shutters";
-	id = "lpost_privacy_right"
+	pixel_y = 23;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -1298,8 +1294,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/window/reinforced/survival_pod{
-	dir = 6;
-	density = 0
+	density = 0;
+	dir = 6
 	},
 /obj/item/phone,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -1307,6 +1303,7 @@
 /area/ruin/space/has_grav/listeningstation/hallway)
 "ms" = (
 /obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25;
 	req_access = list(150)
 	},
 /obj/structure/cable{
@@ -1336,15 +1333,16 @@
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "nG" = (
 /obj/machinery/vending/hydronutrients{
+	chef_price = 0;
 	default_price = 0;
 	extra_price = 0;
-	fair_market_price = 0;
-	chef_price = 0
+	fair_market_price = 0
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"nK" = (
-/obj/machinery/griddle,
+"nI" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder/kitchen,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "nM" = (
@@ -1401,8 +1399,8 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/advanced_airlock_controller{
-	req_access = list(150);
-	pixel_x = -24
+	pixel_y = 24;
+	req_access = list(150)
 	},
 /obj/machinery/light/small{
 	brightness = 3;
@@ -1543,6 +1541,10 @@
 "sR" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation/engineering)
+"tb" = (
+/obj/machinery/oven,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "tg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -1552,6 +1554,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23;
 	req_access = list(150)
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1582,8 +1585,8 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "tK" = (
 /obj/machinery/door/airlock/grunge{
-	req_access_txt = "150";
-	name = "Cabin"
+	name = "Cabin";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1768,8 +1771,8 @@
 	name = "Cayenne II's bed"
 	},
 /mob/living/simple_animal/hostile/carp/cayenne{
-	name = "Cayenne II";
-	desc = "A descendant of the legendary Cayenne, a failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
+	desc = "A descendant of the legendary Cayenne, a failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot.";
+	name = "Cayenne II"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -1867,6 +1870,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23;
 	req_access = list(150)
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -1981,6 +1985,27 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
+"Bt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23;
+	req_access = list(150)
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/item/circuitboard/machine/autolathe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/part_replacer/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/obj/item/stock_parts/cell/bluespace,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/listeningstation/warehouse)
 "By" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2023,10 +2048,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation/quarters)
+"CI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sink{
+	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/freezer/fridge{
+	req_access = list(150)
+	},
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "Da" = (
 /obj/machinery/door/airlock/grunge{
-	req_access_txt = "150";
-	name = "Shower"
+	name = "Shower";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2202,9 +2243,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/magboots/syndie{
-	slowdown_active = 5;
+	desc = "Old Syndicate-made magboots with a very heavy pull.";
 	name = "old magboots";
-	desc = "Old Syndicate-made magboots with a very heavy pull."
+	slowdown_active = 5
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
@@ -2252,24 +2293,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"IP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/power/apc/auto_name/north{
-	req_access = list(150)
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
-/obj/item/circuitboard/machine/autolathe,
-/obj/item/storage/box/stockparts/basic,
-/obj/item/storage/box/stockparts/basic,
-/obj/item/storage/box/stockparts/basic,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation/warehouse)
 "IU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2289,10 +2312,10 @@
 	dir = 1
 	},
 /obj/machinery/button/door{
-	req_access_txt = "150";
 	id = "lpost_warehouse";
 	name = "Warehouse Shutters";
-	pixel_x = -24
+	pixel_x = -24;
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/airlock)
@@ -2313,6 +2336,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "JQ" = (
 /obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23;
 	req_access = list(150)
 	},
 /obj/structure/cable{
@@ -2338,6 +2362,11 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
+/area/ruin/space/has_grav/listeningstation/quarters)
+"JZ" = (
+/obj/machinery/griddle,
+/obj/item/reagent_containers/glass/mixbowl,
+/turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "Kh" = (
 /obj/docking_port/stationary{
@@ -2369,9 +2398,9 @@
 "KJ" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Unidentified";
+	desc = "Used to send black pages to Nanotrasen stations.";
 	name = "Syndicate Fax Machine";
-	req_one_access = list(150);
-	desc = "Used to send black pages to Nanotrasen stations."
+	req_one_access = list(150)
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -2462,8 +2491,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/survival_pod{
-	dir = 9;
-	density = 0
+	density = 0;
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -2564,10 +2593,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
-"Oa" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "Od" = (
 /turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -2660,13 +2685,14 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "OY" = (
 /obj/item/pickaxe{
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/listeningstation)
 "OZ" = (
 /obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23;
 	req_access = list(150)
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -2770,8 +2796,8 @@
 /area/ruin/space/has_grav/listeningstation/quarters)
 "QE" = (
 /obj/machinery/door/window/northleft{
-	req_access_txt = "150";
-	name = "Telecommunications"
+	name = "Telecommunications";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2831,8 +2857,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/advanced_airlock_controller{
-	req_access = list(150);
-	pixel_x = -24
+	pixel_y = 24;
+	req_access = list(150)
 	},
 /obj/machinery/light/small{
 	brightness = 3;
@@ -2891,8 +2917,8 @@
 /area/ruin/space/has_grav/listeningstation/airlock)
 "Su" = (
 /obj/machinery/door/airlock/grunge{
-	req_access_txt = "150";
-	name = "Cabin"
+	name = "Cabin";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -2960,8 +2986,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/window/survival_pod{
-	req_access_txt = "150";
-	name = "Showcase and Self-Destruct Access"
+	name = "Showcase and Self-Destruct Access";
+	req_access_txt = "150"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -3121,9 +3147,9 @@
 /area/ruin/space/has_grav/listeningstation/airlock)
 "WM" = (
 /obj/structure/chair/comfy/shuttle{
+	desc = "A tactical and comfortable chair with a secure buckling system for when you really need to stay at your station.";
 	dir = 4;
-	name = "tactical chair";
-	desc = "A tactical and comfortable chair with a secure buckling system for when you really need to stay at your station."
+	name = "tactical chair"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
@@ -3154,8 +3180,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/highsecurity{
-	req_access_txt = "150";
-	name = "Telecommunications"
+	name = "Telecommunications";
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/telecomms)
@@ -3167,8 +3193,8 @@
 	dir = 1
 	},
 /obj/machinery/computer/crew/syndie{
-	name = "suit sensors tracking console";
-	desc = "Used to monitor active health sensors built into most of the uniforms of Nanotrasen employees."
+	desc = "Used to monitor active health sensors built into most of the uniforms of Nanotrasen employees.";
+	name = "suit sensors tracking console"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
@@ -3821,7 +3847,7 @@ iO
 ua
 jN
 tg
-eu
+CI
 bG
 aY
 aY
@@ -3861,7 +3887,7 @@ tg
 tg
 tg
 tg
-aF
+nI
 fF
 aY
 MU
@@ -3881,7 +3907,7 @@ NO
 NO
 NO
 lG
-IP
+Bt
 lg
 tz
 sy
@@ -3981,7 +4007,7 @@ aa
 aK
 aa
 tg
-nK
+JZ
 Pl
 aY
 ai
@@ -4021,7 +4047,7 @@ tg
 tg
 tg
 tg
-aF
+tb
 Mo
 wW
 Iv
@@ -4222,7 +4248,7 @@ NO
 NO
 as
 js
-Oa
+el
 uQ
 az
 DC


### PR DESCRIPTION
# Document the changes in your pull request

Removes basic stock parts from their storage and replaces them with deluxe stock parts to bring it in line with what lavaland syndies have access to.  Also gave them a bluespace RPED and two bluespace cells, things lavaland syndies also have.

Improved their kitchen, supplying an oven and a grinder as well as a stocked fridge.  Also added two wheat seeds to the small botany closet so they can make more flour if they run out. 

Space comms agent can get pretty boring sometimes, this should shake it up and make them capable of doing more which means more fun during downtime.

# Wiki Documentation

Likely changes to the page on space ruins.

# Changelog

:cl:  cark
mapping: space syndicate have a better kitchen and more useful items in their storage.
/:cl:

