### PR TITLE
Drippin heretic costume

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -784,3 +784,19 @@
 	name = "hide mantle"
 	desc = "The tanned hide of some brown furred creature."
 	icon_state = "mantle_liz"
+
+/obj/item/clothing/head/hooded/cult_hoodie_toy/eldritch_toy
+	name = "fashionable hood"
+	desc = "A stylish and trendy hood perfectly pairing with the robes it comes with. Strange eyes line the inside"
+	icon_state = "eldritch"
+	item_state = "eldritch"
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch_toy
+	name = "fashionable robe"
+	desc = "A stylish and trendy robe straight from this year's Nanotrasen fashion show. Though you can't rememeber seeing this entry on the catwalk."
+	icon_state = "eldritch_armor"
+	item_state = "eldritch_armor"
+	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	allowed = list(/obj/item/gun/magic/hook/sickly_blade, /obj/item/forbidden_book, /obj/item/gun/magic/hook/sickly_blade_toy, /obj/item/toy/eldritch_book) //gonna make it work with this the real stuff as a "fashion statement"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie_toy/eldritch_toy

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -787,14 +787,14 @@
 
 /obj/item/clothing/head/hooded/cult_hoodie_toy/eldritch_toy
 	name = "fashionable hood"
-	desc = "A stylish and trendy hood perfectly pairing with the robes it comes with. Strange eyes line the inside"
+	desc = "A stylish hood perfectly pairing with the robes it comes with. Strange eyes line the inside."
 	icon_state = "eldritch"
 	item_state = "eldritch"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch_toy
 	name = "fashionable robe"
-	desc = "A stylish and trendy robe straight from this year's Nanotrasen fashion show. Though you can't rememeber seeing this entry on the catwalk."
+	desc = "A trendy robe straight from this year's Nanotrasen fashion show. You can't remember seeing this entry on the catwalk."
 	icon_state = "eldritch_armor"
 	item_state = "eldritch_armor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -787,7 +787,7 @@
 
 /obj/item/clothing/head/hooded/cult_hoodie_toy/eldritch_toy
 	name = "fashionable hood"
-	desc = "A stylish hood perfectly pairing with the robes it comes with. Strange eyes line the inside."
+	desc = "A stylish hood perfectly pairing the robe it came with. Strange eyes line the inside."
 	icon_state = "eldritch"
 	item_state = "eldritch"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -798,5 +798,5 @@
 	icon_state = "eldritch_armor"
 	item_state = "eldritch_armor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	allowed = list(/obj/item/gun/magic/hook/sickly_blade, /obj/item/forbidden_book, /obj/item/gun/magic/hook/sickly_blade_toy, /obj/item/toy/eldritch_book) //gonna make it work with this the real stuff as a "fashion statement"
+	allowed = list(/obj/item/gun/magic/hook/sickly_blade, /obj/item/forbidden_book, /obj/item/toy/eldritch_book) //gonna make it work with this the real stuff as a "fashion statement"
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie_toy/eldritch_toy

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -209,7 +209,8 @@
 					  /obj/item/gun/magic/wand = 2,
 					  /obj/item/clothing/glasses/sunglasses/garb = 2,
 					  /obj/item/clothing/glasses/blindfold = 1,
-					  /obj/item/clothing/mask/muzzle = 2)
+					  /obj/item/clothing/mask/muzzle = 2,
+					  /obj/item/clothing/suit/hooded/cultrobes/eldritch_toy = 1)
 	premium = list(/obj/item/clothing/suit/pirate/captain = 2,
 				   /obj/item/clothing/head/pirate/captain = 2,
 				   /obj/item/clothing/under/rank/rainbowclown = 1,


### PR DESCRIPTION
Originally from pull #18832 this is just the robes part of it.

# Description
### TL;DR
Adds a "fashionable robe" to the costume autodrobe as contraband, the costume version of the ominous armor.

### The drippy robe
After all these years the heretic drip now for the common man. I've made sure that it does not decrease damage as it is just a "fashionable" hood and robe. Has some silly flavor text about a massacre at a Nanotrasen fashion show.
Video proof  https://user-images.githubusercontent.com/98609667/236930600-580c9b00-b6a2-4f16-9b83-41228e526487.mp4

![image](https://user-images.githubusercontent.com/98609667/236932658-7718c17a-a962-4a9e-a0a7-33b3e9a79bc8.png)

![image](https://user-images.githubusercontent.com/98609667/236931230-d275fbef-f838-4179-b266-5c85a44c64fd.png)

![image](https://user-images.githubusercontent.com/98609667/236931111-6ea9a5b2-efc4-4f9d-90f1-a79047c9fac1.png)

## Why?
That robe is way to drippin for the clown or mime to not use when pranking sec, a chaplain could also wear it for much more occult religions. The Sprite is just too damn cool for only the heretic to have.

# Changelog

:cl:  Airlines7
rscadd: Heretic costumes for the comedic clown and cynical mime.
/:cl:
