### PR TITLE
Hall of Vending machines + Vending Icon fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25645,16 +25645,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"bie" = (
-/obj/machinery/vending/cigarette/syndicate,
+"bwc" = (
+/obj/machinery/vending/medical,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"boE" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
+"byP" = (
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"bBA" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "bDC" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -25666,6 +25668,14 @@
 	icon_state = "info16"
 	},
 /area/centcom/testchamber)
+"bGs" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"bGJ" = (
+/obj/machinery/vending/syndichem,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "bSb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -25712,25 +25722,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/yogs/infiltrator_base)
+"bUq" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "cgW" = (
 /turf/open/indestructible/wiki/whitescreen,
 /area/centcom/testchamber)
-"cpw" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "crH" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info29"
 	},
 /area/centcom/testchamber)
-"cuY" = (
-/obj/machinery/vending/gifts,
+"cAw" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"cQl" = (
+/obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "dbb" = (
 /turf/open/indestructible/wiki/greenscreen,
 /area/centcom/testchamber)
+"dgc" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small{
@@ -25752,6 +25770,10 @@
 	icon_state = "info25"
 	},
 /area/centcom/testchamber)
+"dhh" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "dwq" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info18"
@@ -25765,8 +25787,8 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"dRc" = (
-/obj/machinery/vending/robotics,
+"eeI" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "eiz" = (
@@ -25777,8 +25799,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
-"evC" = (
-/obj/machinery/vending/snack/orange,
+"evO" = (
+/obj/machinery/vending/cola/starkist,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "eDa" = (
@@ -25786,8 +25808,24 @@
 	icon_state = "title1"
 	},
 /area/centcom/testchamber)
-"fjV" = (
-/obj/machinery/vending/modularpc,
+"eIe" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"eLY" = (
+/obj/machinery/vending/snack/orange,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"eSN" = (
+/obj/machinery/vending/cola/black,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"ffi" = (
+/obj/machinery/vending,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"fgJ" = (
+/obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "fka" = (
@@ -25815,8 +25853,8 @@
 	icon_state = "title5"
 	},
 /area/centcom/testchamber)
-"fzd" = (
-/obj/machinery/vending/boozeomat,
+"fxK" = (
+/obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "fAk" = (
@@ -25825,20 +25863,24 @@
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"fNW" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"fVm" = (
-/obj/machinery/vending/cart,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "gbG" = (
 /obj/structure/goalnet{
 	dir = 1
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"gcY" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/centcom)
+"gfq" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"ggv" = (
+/obj/machinery/vending/wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "gkW" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/wood,
@@ -25878,12 +25920,12 @@
 /obj/item/reagent_containers/medspray/sterilizine,
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
-"gDX" = (
-/obj/machinery/vending/cola/shamblers/prison,
+"gEA" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"gEX" = (
-/obj/machinery/vending/games,
+"gOv" = (
+/obj/machinery/vending/cola/shamblers/prison,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "gQd" = (
@@ -25891,16 +25933,8 @@
 	icon_state = "info20"
 	},
 /area/centcom/testchamber)
-"gXv" = (
-/obj/machinery/vending/cola/sodie,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"gYd" = (
-/obj/machinery/vending/medical/syndicate_access,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"hiU" = (
-/obj/machinery/vending/cigarette/beach,
+"hgl" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "hpv" = (
@@ -25913,6 +25947,14 @@
 	icon_state = "title7"
 	},
 /area/centcom/testchamber)
+"hxb" = (
+/obj/machinery/vending/wallgene,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"hHB" = (
+/obj/machinery/vending/cola/shamblers,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "hHV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -25924,12 +25966,20 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"hUF" = (
-/obj/machinery/vending/assist,
+"hUh" = (
+/obj/machinery/vending/sovietsoda,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"icO" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
+"hUC" = (
+/obj/machinery/vending/cola/red,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"hVR" = (
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"iih" = (
+/obj/machinery/vending/cola/blue,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "ilg" = (
@@ -25937,8 +25987,15 @@
 	icon_state = "title11"
 	},
 /area/centcom/testchamber)
-"iAN" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
+"ilE" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	req_access_txt = "102"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeadmin)
+"iuX" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "iCm" = (
@@ -25946,6 +26003,10 @@
 	icon_state = "info19"
 	},
 /area/centcom/testchamber)
+"iCt" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "iSo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -25954,12 +26015,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"jgs" = (
-/obj/machinery/vending/cigarette,
+"iZw" = (
+/obj/machinery/vending/cigarette/beach,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"jib" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+"jjO" = (
+/obj/machinery/vending/gifts,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "jqy" = (
@@ -25967,8 +26028,8 @@
 	icon_state = "info22"
 	},
 /area/centcom/testchamber)
-"jCr" = (
-/obj/machinery/vending/snack/teal,
+"juA" = (
+/obj/machinery/vending/plasmaresearch,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "jJm" = (
@@ -26000,8 +26061,12 @@
 	icon_state = "info26"
 	},
 /area/centcom/testchamber)
-"jQJ" = (
-/obj/machinery/vending/tool,
+"jQM" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"jSk" = (
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "kaB" = (
@@ -26009,15 +26074,15 @@
 	icon_state = "64"
 	},
 /area/centcom/testchamber)
+"kdU" = (
+/obj/machinery/vending/autodrobe/capdrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "kkU" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info3"
 	},
 /area/centcom/testchamber)
-"koQ" = (
-/obj/machinery/vending/wardrobe/sig_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "krq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -26036,8 +26101,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"ktZ" = (
-/obj/machinery/vending/sustenance,
+"kBy" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"kGd" = (
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "kMR" = (
@@ -26045,35 +26114,17 @@
 	icon_state = "info28"
 	},
 /area/centcom/testchamber)
-"kNP" = (
-/obj/machinery/vending/boozeomat/syndicate_access,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"ljl" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
 "lnJ" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Shoe Storage"
 	},
 /area/yogs/infiltrator_base/jail)
-"lnY" = (
-/obj/machinery/vending/engivend,
+"lFR" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"lpe" = (
-/obj/machinery/vending/wallhypo,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"lDK" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"lTy" = (
-/obj/machinery/vending/wardrobe,
+"lUC" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "lVQ" = (
@@ -26099,24 +26150,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"mmb" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "moB" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info12"
 	},
 /area/centcom/testchamber)
-"mxu" = (
-/obj/machinery/vending/toyliberationstation,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "mFt" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info17"
 	},
 /area/centcom/testchamber)
+"mGx" = (
+/obj/machinery/vending/snack/teal,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "mIu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26164,14 +26211,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"noT" = (
-/obj/machinery/vending/cola/shamblers,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"npQ" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "nuH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26185,15 +26224,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"nuU" = (
+/obj/machinery/vending/boozeomat/syndicate_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"nvq" = (
+/obj/machinery/vending/cart,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"nFx" = (
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeadmin)
 "nIM" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title8"
 	},
 /area/centcom/testchamber)
-"nMD" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "nNJ" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info8"
@@ -26212,16 +26258,20 @@
 "nYo" = (
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"nYX" = (
+/obj/machinery/vending/medical/syndicate_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "obi" = (
 /obj/structure/goalnet/goalpost/left{
 	dir = 1
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"ogV" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
+"ofS" = (
+/obj/machinery/door/airlock/diamond,
+/turf/open/floor/plasteel/dark,
+/area/tdome/tdomeadmin)
 "oxS" = (
 /obj/item/clothing/shoes/combat/coldres{
 	pixel_x = 6;
@@ -26259,24 +26309,13 @@
 /obj/machinery/papershredder,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"oBf" = (
-/obj/machinery/vending/snack/blue,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "oCO" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info9"
 	},
 /area/centcom/testchamber)
-"oNr" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration";
-	req_access_txt = "102"
-	},
-/turf/open/floor/plasteel,
-/area/tdome/tdomeadmin)
-"oUF" = (
-/obj/machinery/vending/liberationstation,
+"oWM" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "oXi" = (
@@ -26291,20 +26330,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/yogs/infiltrator_base)
-"pda" = (
-/obj/machinery/vending/sovietsoda,
-/turf/open/floor/plasteel/bluespace,
+"pCa" = (
+/turf/closed/indestructible/riveted,
 /area/centcom)
-"ppJ" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"pzR" = (
-/obj/machinery/vending/wallgene,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"pEX" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
+"pGs" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "pGS" = (
@@ -26319,8 +26349,8 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"pHd" = (
-/obj/machinery/vending/cola/black,
+"pLF" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "pQy" = (
@@ -26334,16 +26364,8 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"qaK" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"qdE" = (
+"qhc" = (
 /obj/machinery/vending/engineering,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"qfg" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "qhf" = (
@@ -26351,20 +26373,35 @@
 	icon_state = "info11"
 	},
 /area/centcom/testchamber)
-"qjp" = (
-/obj/machinery/vending/security,
+"qiu" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/centcom)
+"qoc" = (
+/obj/machinery/vending/cola/sodie,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"qnZ" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
+"qtF" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"qzr" = (
-/obj/machinery/vending/cola,
+"qIV" = (
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
-"qNB" = (
-/obj/machinery/vending/plasmaresearch,
+"qKV" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"qSU" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"qXG" = (
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "ria" = (
@@ -26381,8 +26418,8 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/centcom/holding)
-"rsL" = (
-/obj/machinery/vending/boozeomat/all_access,
+"rpI" = (
+/obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "ruy" = (
@@ -26397,27 +26434,19 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark,
 /area/yogs/infiltrator_base)
-"ryg" = (
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"rzJ" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"rCl" = (
-/obj/machinery/vending/snack/green,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"rEC" = (
-/obj/machinery/vending/cola/blue,
-/turf/open/floor/plasteel/bluespace,
+"rBK" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/dark,
 /area/centcom)
 "rEF" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info21"
 	},
 /area/centcom/testchamber)
+"rIx" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "rIC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26432,40 +26461,21 @@
 /obj/effect/landmark/centcom,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rMa" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"rOa" = (
-/obj/machinery/vending/syndichem,
+"rVA" = (
+/obj/machinery/vending/magivend,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "rVP" = (
 /obj/item/soccerball,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"sfr" = (
-/obj/machinery/vending,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "spc" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title9"
 	},
 /area/centcom/testchamber)
-"svy" = (
-/turf/closed/indestructible/riveted,
-/area/centcom)
-"szz" = (
-/obj/machinery/vending/autodrobe/capdrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"sGj" = (
-/obj/machinery/vending/autodrobe/all_access,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"sGn" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
+"sqW" = (
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "sSY" = (
@@ -26473,12 +26483,24 @@
 	icon_state = "info10"
 	},
 /area/centcom/testchamber)
+"tkz" = (
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"tlY" = (
+/obj/machinery/vending/fishing,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"tnm" = (
+/obj/machinery/vending/wallhypo,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "twc" = (
 /obj/structure/goalnet/goalpost/left,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"tER" = (
-/obj/machinery/vending/hydroseeds/weak,
+"tBh" = (
+/obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "tID" = (
@@ -26486,6 +26508,10 @@
 	icon_state = "info6"
 	},
 /area/centcom/testchamber)
+"tLI" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "tVg" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "256"
@@ -26496,6 +26522,10 @@
 	icon_state = "title3"
 	},
 /area/centcom/testchamber)
+"una" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "uwR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -26532,10 +26562,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
-"uDM" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "uEX" = (
 /turf/open/indestructible/wiki/greenscreen/border,
 /area/centcom/testchamber)
@@ -26560,17 +26586,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
-"uPa" = (
-/turf/open/floor/plasteel,
-/area/centcom)
-"uVZ" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"uWn" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "uXx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -26581,20 +26596,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"vbC" = (
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "vci" = (
 /turf/open/indestructible/wiki/bluescreen,
 /area/centcom/testchamber)
-"vdL" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "vgL" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title10"
 	},
 /area/centcom/testchamber)
-"vjr" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
+"vim" = (
+/obj/machinery/vending/wallmed,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "vpx" = (
@@ -26624,6 +26639,17 @@
 	icon_state = "info1"
 	},
 /area/centcom/testchamber)
+"vOU" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"vPD" = (
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"vPZ" = (
+/turf/open/floor/plasteel/dark,
+/area/centcom)
 "vUr" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "128"
@@ -26634,6 +26660,10 @@
 	icon_state = "info15"
 	},
 /area/centcom/testchamber)
+"wbL" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "wdp" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -26664,8 +26694,8 @@
 /obj/structure/goalnet,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"wyd" = (
-/obj/machinery/vending/cola/pwr_game,
+"wxA" = (
+/obj/machinery/vending/snack/blue,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom)
 "wyM" = (
@@ -26680,14 +26710,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"wBJ" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"wBO" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "wDa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/holodeck_effect/mobspawner{
@@ -26714,14 +26736,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"wYy" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"wZu" = (
-/obj/machinery/vending/magivend,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "xgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/defibrillator_mount/loaded{
@@ -26777,23 +26791,19 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"xDu" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"xEy" = (
-/obj/machinery/vending/fishing,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
-"xFq" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 "xGe" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info31"
 	},
 /area/centcom/testchamber)
+"xKb" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"xXc" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "xXR" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -26826,6 +26836,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/yogs/infiltrator_base)
+"ydH" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "ydX" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info4"
@@ -26843,10 +26857,6 @@
 	dir = 2
 	},
 /area/yogs/infiltrator_base)
-"ylb" = (
-/obj/machinery/vending/wallmed,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom)
 
 (1,1,1) = {"
 azH
@@ -60684,20 +60694,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-svy
-svy
-svy
-svy
-svy
-svy
-svy
-svy
-aaa
-aaa
-aaa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
+pCa
 aaa
 aaa
 aaa
@@ -60941,20 +60951,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-svy
-uPa
-mxu
-wZu
-oUF
-qdE
-uPa
-svy
-aaa
-aaa
-aaa
+pCa
+qiu
+vPZ
+vPZ
+vPZ
+qSU
+rVA
+tkz
+qhc
+vPZ
+vPZ
+vPZ
+gcY
+pCa
 aaa
 aaa
 aaa
@@ -61198,20 +61208,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-svy
-svy
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
-svy
-svy
-svy
+pCa
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+pCa
 aaa
 aaa
 aaa
@@ -61455,20 +61465,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-sGn
-wBJ
-uDM
-fNW
-rzJ
-uPa
-uPa
-qnZ
-uVZ
-rMa
-wYy
-jib
-svy
+pCa
+rIx
+pGs
+oWM
+ydH
+eeI
+rBK
+rBK
+lUC
+iuX
+lFR
+vOU
+jQM
+pCa
 aaa
 aaa
 aaa
@@ -61712,20 +61722,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-jQJ
-vjr
-lpe
-pzR
-ylb
-uPa
-uPa
-lTy
-qfg
-pEX
-icO
-iAN
-svy
+pCa
+bGs
+qtF
+tnm
+hxb
+vim
+vPZ
+vPZ
+ggv
+kBy
+gEA
+pLF
+wbL
+pCa
 aaa
 aaa
 aaa
@@ -61969,20 +61979,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+qiu
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+gcY
+pCa
 aaa
 aaa
 aaa
@@ -62226,20 +62236,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+pCa
 aaa
 aaa
 aaa
@@ -62483,20 +62493,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-dRc
-qjp
-uWn
-oBf
-rCl
-uPa
-uPa
-evC
-jCr
-pda
-ktZ
-rOa
-svy
+pCa
+bBA
+vPD
+cAw
+wxA
+dgc
+rBK
+rBK
+eLY
+mGx
+hUh
+cQl
+bGJ
+pCa
 aaa
 aaa
 aaa
@@ -62740,20 +62750,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-cuY
-xFq
-cpw
-tER
-koQ
-uPa
-uPa
-xDu
-ogV
-gYd
-fjV
-qNB
-svy
+pCa
+jjO
+jSk
+eIe
+fgJ
+hVR
+vPZ
+vPZ
+hgl
+bwc
+nYX
+fxK
+juA
+pCa
 aaa
 aaa
 aaa
@@ -62997,20 +63007,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+qiu
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+gcY
+pCa
 aaa
 aaa
 aaa
@@ -63254,20 +63264,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+pCa
 aaa
 aaa
 aaa
@@ -63511,20 +63521,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-gDX
-gXv
-ryg
-ppJ
-wBO
-uPa
-uPa
-vdL
-lDK
-lnY
-xEy
-gEX
-svy
+pCa
+gOv
+qoc
+byP
+evO
+bUq
+rBK
+rBK
+iCt
+una
+qKV
+tlY
+vbC
+pCa
 aaa
 aaa
 aaa
@@ -63768,20 +63778,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-hiU
-bie
-nMD
-qaK
-qzr
-uPa
-uPa
-pHd
-rEC
-wyd
-mmb
-noT
-svy
+pCa
+iZw
+rpI
+kGd
+dhh
+xXc
+vPZ
+vPZ
+eSN
+iih
+tBh
+hUC
+hHB
+pCa
 aaa
 aaa
 aaa
@@ -64025,20 +64035,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+qiu
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+gcY
+pCa
 aaa
 aaa
 aaa
@@ -64282,20 +64292,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-uPa
-svy
+pCa
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+vPZ
+pCa
 aaa
 aaa
 aaa
@@ -64539,20 +64549,20 @@ aaa
 aaa
 aaa
 aaa
-svy
-sfr
-hUF
-npQ
-sGj
-szz
-uPa
-uPa
-fzd
-rsL
-kNP
-fVm
-jgs
-svy
+pCa
+ffi
+qIV
+xKb
+tLI
+kdU
+vPZ
+vPZ
+sqW
+gfq
+nuU
+nvq
+qXG
+pCa
 aaa
 aaa
 aaa
@@ -64802,8 +64812,8 @@ aEp
 aEp
 aIv
 aIv
-oNr
-oNr
+ofS
+ofS
 aIv
 aIv
 aIv
@@ -65059,8 +65069,8 @@ aEH
 aEv
 aIw
 aIR
-ljl
-boE
+nFx
+nFx
 aIR
 aIw
 aIR
@@ -65316,8 +65326,8 @@ aEv
 aEp
 aIv
 aIv
-oNr
-oNr
+ilE
+ilE
 aIv
 aIv
 aIv

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -18819,7 +18819,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -19802,7 +19802,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -20438,7 +20438,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -22642,7 +22642,7 @@
 /area/holodeck/rec_center/chapelcourt)
 "aTW" = (
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
 	name = "Test Chamber Blast Doors"
 	},
 /obj/structure/fans/tiny,
@@ -25645,6 +25645,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
+"blc" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"btc" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "bDC" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -25918,6 +25926,14 @@
 /turf/open/indestructible/wiki/info{
 	icon_state = "64"
 	},
+/area/centcom/testchamber)
+"kkd" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"kkF" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "kkU" = (
 /turf/open/indestructible/wiki/info{
@@ -26459,7 +26475,7 @@
 /area/centcom/testchamber)
 "xuU" = (
 /obj/machinery/door/airlock/centcom{
-	armor = list("melee"=90,"bullet"=90,"laser"=90,"energy"=90,"bomb"=90,"bio"=100,"rad"=100,"fire"=100,"acid"=90);
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 90, "energy" = 90, "bomb" = 90, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90);
 	name = "Test Chamber Blast Doors"
 	},
 /turf/open/floor/plasteel,
@@ -72485,8 +72501,8 @@ aQE
 aZZ
 aQQ
 aNt
-aaa
-aaa
+btc
+aNt
 aaa
 aaa
 aaa
@@ -72742,8 +72758,8 @@ aXI
 aQB
 aOu
 aNt
-aaa
-aaa
+kkd
+aNt
 aaa
 aaa
 aaa
@@ -72999,8 +73015,8 @@ aZg
 aQE
 aZZ
 aNt
-aaa
-aaa
+blc
+aNt
 aaa
 aaa
 aaa
@@ -73256,8 +73272,8 @@ aNt
 aNt
 aNt
 aNt
-aaa
-aaa
+kkF
+aNt
 aaa
 aaa
 aaa
@@ -73513,8 +73529,8 @@ aXI
 aCQ
 aNx
 aNt
-aaa
-aaa
+aNt
+aNt
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25645,12 +25645,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"blc" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"btc" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
+"bna" = (
+/obj/machinery/vending/toyliberationstation,
 /turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "bDC" = (
@@ -25718,8 +25714,24 @@
 	icon_state = "info29"
 	},
 /area/centcom/testchamber)
+"cSW" = (
+/obj/machinery/vending/snack/teal,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"cWx" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"cXM" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "dbb" = (
 /turf/open/indestructible/wiki/greenscreen,
+/area/centcom/testchamber)
+"dcG" = (
+/obj/machinery/vending/cola/pwr_game,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line,
@@ -25747,6 +25759,10 @@
 	icon_state = "info18"
 	},
 /area/centcom/testchamber)
+"dJX" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "dLa" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -25755,6 +25771,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"dSt" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"ebD" = (
+/obj/machinery/vending/cart,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "eiz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/bluespace_locker";
@@ -25763,10 +25787,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
+"eji" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"emY" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "eDa" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title1"
 	},
+/area/centcom/testchamber)
+"eNO" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"eUq" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "fka" = (
 /turf/open/indestructible/wiki/info{
@@ -25799,6 +25839,18 @@
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"fKT" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"fRI" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"fWL" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "gbG" = (
 /obj/structure/goalnet{
 	dir = 1
@@ -25809,6 +25861,10 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"gvk" = (
+/obj/machinery/vending/magivend,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "gxx" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -25844,20 +25900,40 @@
 /obj/item/reagent_containers/medspray/sterilizine,
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
+"gId" = (
+/obj/machinery/vending/sustenance,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"gMI" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "gQd" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info20"
 	},
+/area/centcom/testchamber)
+"gTX" = (
+/obj/machinery/vending/modularpc,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "hpv" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info27"
 	},
 /area/centcom/testchamber)
+"hpJ" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "hww" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title7"
 	},
+/area/centcom/testchamber)
+"hzH" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "hHV" = (
 /obj/effect/turf_decal/tile/blue,
@@ -25875,10 +25951,22 @@
 	icon_state = "title11"
 	},
 /area/centcom/testchamber)
+"imf" = (
+/obj/machinery/vending/wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "iCm" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info19"
 	},
+/area/centcom/testchamber)
+"iHV" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"iIX" = (
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "iSo" = (
 /obj/effect/turf_decal/tile/blue,
@@ -25888,6 +25976,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"jbX" = (
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"jcn" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"jjU" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "jqy" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info22"
@@ -25927,14 +26027,6 @@
 	icon_state = "64"
 	},
 /area/centcom/testchamber)
-"kkd" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"kkF" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "kkU" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info3"
@@ -25958,10 +26050,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"kAc" = (
+/obj/machinery/vending/medical/syndicate_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "kMR" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info28"
 	},
+/area/centcom/testchamber)
+"laA" = (
+/obj/machinery/vending/cigarette/beach,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "lnJ" = (
 /turf/closed/indestructible/fakedoor{
@@ -26016,6 +26116,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"mVx" = (
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "nbn" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info13"
@@ -26048,6 +26152,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"nlo" = (
+/obj/machinery/vending/fishing,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"ntY" = (
+/obj/machinery/vending/wallhypo,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "nuH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26065,6 +26177,10 @@
 /turf/open/indestructible/wiki/title{
 	icon_state = "title8"
 	},
+/area/centcom/testchamber)
+"nKZ" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "nNJ" = (
 /turf/open/indestructible/wiki/info{
@@ -26090,6 +26206,10 @@
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"onD" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "oxS" = (
 /obj/item/clothing/shoes/combat/coldres{
 	pixel_x = 6;
@@ -26132,6 +26252,10 @@
 	icon_state = "info9"
 	},
 /area/centcom/testchamber)
+"oLA" = (
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "oXi" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small{
@@ -26144,6 +26268,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/yogs/infiltrator_base)
+"puz" = (
+/obj/machinery/vending/gifts,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "pGS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26156,6 +26284,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"pHG" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"pPU" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "pQy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26167,10 +26303,26 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"qfK" = (
+/obj/machinery/vending/engineering,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "qhf" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info11"
 	},
+/area/centcom/testchamber)
+"qjz" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"qkJ" = (
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"qPG" = (
+/obj/machinery/vending/wallmed,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "ria" = (
 /obj/machinery/recharge_station/fullupgrade,
@@ -26198,10 +26350,26 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark,
 /area/yogs/infiltrator_base)
+"ryO" = (
+/obj/machinery/vending,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"rzE" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "rEF" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info21"
 	},
+/area/centcom/testchamber)
+"rGE" = (
+/obj/machinery/vending/cola/shamblers,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"rHL" = (
+/obj/machinery/vending/cola/blue,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "rIC" = (
 /obj/effect/turf_decal/tile/blue{
@@ -26217,19 +26385,51 @@
 /obj/effect/landmark/centcom,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
+"rOn" = (
+/obj/machinery/vending/snack/orange,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "rVP" = (
 /obj/item/soccerball,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"rXE" = (
+/obj/machinery/vending/plasmaresearch,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"rXQ" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"rYl" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"rYI" = (
+/obj/machinery/vending/snack/blue,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "spc" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title9"
 	},
 /area/centcom/testchamber)
+"syr" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "sSY" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info10"
 	},
+/area/centcom/testchamber)
+"sTn" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"tfn" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "twc" = (
 /obj/structure/goalnet/goalpost/left,
@@ -26240,15 +26440,35 @@
 	icon_state = "info6"
 	},
 /area/centcom/testchamber)
+"tJn" = (
+/obj/machinery/vending/cola/red,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "tVg" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "256"
 	},
 /area/centcom/testchamber)
+"tVh" = (
+/obj/machinery/vending/cola/black,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "uaZ" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title3"
 	},
+/area/centcom/testchamber)
+"ubw" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"uiU" = (
+/obj/machinery/vending/boozeomat/syndicate_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"unW" = (
+/obj/machinery/vending/autodrobe/capdrobe,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "uwR" = (
 /obj/structure/window/reinforced{
@@ -26263,6 +26483,10 @@
 	dir = 2
 	},
 /area/yogs/infiltrator_base)
+"uDm" = (
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "uDo" = (
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/o2{
@@ -26320,13 +26544,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"vaq" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "vci" = (
 /turf/open/indestructible/wiki/bluescreen,
+/area/centcom/testchamber)
+"vcl" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "vgL" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title10"
 	},
+/area/centcom/testchamber)
+"vjp" = (
+/obj/machinery/vending/cola/shamblers/prison,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "vpx" = (
 /obj/structure/goalnet/goalpost/right,
@@ -26345,6 +26581,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"vFY" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"vJp" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "vMw" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info14"
@@ -26381,6 +26625,10 @@
 	icon_state = "info32"
 	},
 /area/centcom/testchamber)
+"wkn" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "wkC" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title4"
@@ -26395,6 +26643,10 @@
 /obj/structure/goalnet,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"wvi" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "wyM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26421,6 +26673,14 @@
 	icon_state = "96"
 	},
 /area/centcom/testchamber)
+"wJH" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"wLl" = (
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "wPo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26433,6 +26693,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"wQE" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"wWv" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "xgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/defibrillator_mount/loaded{
@@ -26463,6 +26731,10 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/yogs/infiltrator_base)
+"xjj" = (
+/obj/machinery/vending/syndichem,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
 "xjU" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "32"
@@ -26472,6 +26744,14 @@
 /turf/open/indestructible/wiki/info{
 	icon_state = "info24"
 	},
+/area/centcom/testchamber)
+"xnm" = (
+/obj/machinery/vending/wallgene,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom/testchamber)
+"xpx" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "xuU" = (
 /obj/machinery/door/airlock/centcom{
@@ -72501,14 +72781,14 @@ aQE
 aZZ
 aQQ
 aNt
-btc
+ryO
+iIX
+wLl
+fWL
+wWv
+imf
+eji
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -72758,14 +73038,14 @@ aXI
 aQB
 aOu
 aNt
-kkd
+dSt
+ubw
+jbX
+uDm
+rOn
+wvi
+rXQ
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -73015,14 +73295,14 @@ aZg
 aQE
 aZZ
 aNt
-blc
+nKZ
+vJp
+qjz
+gvk
+cSW
+cWx
+vcl
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -73272,14 +73552,14 @@ aNt
 aNt
 aNt
 aNt
-kkF
+hzH
+cXM
+rYl
+hpJ
+jjU
+pHG
+vFY
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -73529,14 +73809,14 @@ aXI
 aCQ
 aNx
 aNt
+unW
+tVh
+qfK
+kAc
+gId
+fKT
+xpx
 aNt
-aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -73786,14 +74066,14 @@ aXI
 aQB
 aNx
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iHV
+rHL
+wJH
+gTX
+xjj
+wkn
+sTn
+aNt
 aaa
 aaa
 aaa
@@ -74043,14 +74323,14 @@ aXI
 aNx
 aQq
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+emY
+dcG
+nlo
+rXE
+eUq
+vaq
+qkJ
+aNt
 aaa
 aaa
 aaa
@@ -74300,14 +74580,14 @@ aNt
 aNt
 aNt
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uiU
+tJn
+oLA
+eNO
+bna
+onD
+fRI
+aNt
 aaa
 aaa
 aaa
@@ -74557,14 +74837,14 @@ aZg
 aXI
 aXI
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ebD
+rGE
+puz
+mVx
+ntY
+wQE
+aNt
+aNt
 aaa
 aaa
 aaa
@@ -74814,13 +75094,13 @@ aXI
 aMj
 aSo
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jcn
+vjp
+pPU
+rzE
+xnm
+gMI
+aNt
 aaa
 aaa
 aaa
@@ -75071,13 +75351,13 @@ aSa
 aRA
 aNf
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+laA
+syr
+dJX
+rYI
+qPG
+tfn
+aNt
 aaa
 aaa
 aaa
@@ -75328,13 +75608,13 @@ aNt
 aNt
 aNt
 aNt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aNt
+aNt
+aNt
+aNt
+aNt
+aNt
+aNt
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25645,10 +25645,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
-"bna" = (
-/obj/machinery/vending/toyliberationstation,
+"bie" = (
+/obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"boE" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
 "bDC" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -25709,29 +25715,21 @@
 "cgW" = (
 /turf/open/indestructible/wiki/whitescreen,
 /area/centcom/testchamber)
+"cpw" = (
+/obj/machinery/vending/hydroseeds,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "crH" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info29"
 	},
 /area/centcom/testchamber)
-"cSW" = (
-/obj/machinery/vending/snack/teal,
+"cuY" = (
+/obj/machinery/vending/gifts,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"cWx" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"cXM" = (
-/obj/machinery/vending/cola,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "dbb" = (
 /turf/open/indestructible/wiki/greenscreen,
-/area/centcom/testchamber)
-"dcG" = (
-/obj/machinery/vending/cola/pwr_game,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line,
@@ -25759,10 +25757,6 @@
 	icon_state = "info18"
 	},
 /area/centcom/testchamber)
-"dJX" = (
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "dLa" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -25771,14 +25765,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"dSt" = (
-/obj/machinery/vending/assist,
+"dRc" = (
+/obj/machinery/vending/robotics,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"ebD" = (
-/obj/machinery/vending/cart,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "eiz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/bluespace_locker";
@@ -25787,27 +25777,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bluespace_locker)
-"eji" = (
-/obj/machinery/vending/wardrobe/jani_wardrobe,
+"evC" = (
+/obj/machinery/vending/snack/orange,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"emY" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "eDa" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title1"
 	},
 /area/centcom/testchamber)
-"eNO" = (
-/obj/machinery/vending/robotics,
+"fjV" = (
+/obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"eUq" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "fka" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info2"
@@ -25833,24 +25815,24 @@
 	icon_state = "title5"
 	},
 /area/centcom/testchamber)
+"fzd" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "fAk" = (
 /obj/structure/goalnet/goalpost/right{
 	dir = 1
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"fKT" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
+"fNW" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"fRI" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
+/area/centcom)
+"fVm" = (
+/obj/machinery/vending/cart,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"fWL" = (
-/obj/machinery/vending/hydroseeds/weak,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "gbG" = (
 /obj/structure/goalnet{
 	dir = 1
@@ -25861,10 +25843,6 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/wood,
 /area/centcom/holding)
-"gvk" = (
-/obj/machinery/vending/magivend,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "gxx" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -25900,40 +25878,40 @@
 /obj/item/reagent_containers/medspray/sterilizine,
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
-"gId" = (
-/obj/machinery/vending/sustenance,
+"gDX" = (
+/obj/machinery/vending/cola/shamblers/prison,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"gMI" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
+/area/centcom)
+"gEX" = (
+/obj/machinery/vending/games,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "gQd" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info20"
 	},
 /area/centcom/testchamber)
-"gTX" = (
-/obj/machinery/vending/modularpc,
+"gXv" = (
+/obj/machinery/vending/cola/sodie,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"gYd" = (
+/obj/machinery/vending/medical/syndicate_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"hiU" = (
+/obj/machinery/vending/cigarette/beach,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "hpv" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info27"
 	},
 /area/centcom/testchamber)
-"hpJ" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "hww" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title7"
 	},
-/area/centcom/testchamber)
-"hzH" = (
-/obj/machinery/vending/autodrobe/all_access,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "hHV" = (
 /obj/effect/turf_decal/tile/blue,
@@ -25946,27 +25924,27 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"hUF" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"icO" = (
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "ilg" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title11"
 	},
 /area/centcom/testchamber)
-"imf" = (
-/obj/machinery/vending/wardrobe,
+"iAN" = (
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "iCm" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info19"
 	},
-/area/centcom/testchamber)
-"iHV" = (
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"iIX" = (
-/obj/machinery/vending/cigarette/syndicate,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "iSo" = (
 /obj/effect/turf_decal/tile/blue,
@@ -25976,23 +25954,23 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"jbX" = (
-/obj/machinery/vending/cola/starkist,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"jcn" = (
+"jgs" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"jjU" = (
-/obj/machinery/vending/sovietsoda,
+/area/centcom)
+"jib" = (
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "jqy" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info22"
 	},
 /area/centcom/testchamber)
+"jCr" = (
+/obj/machinery/vending/snack/teal,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "jJm" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -26022,6 +26000,10 @@
 	icon_state = "info26"
 	},
 /area/centcom/testchamber)
+"jQJ" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "kaB" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "64"
@@ -26032,6 +26014,10 @@
 	icon_state = "info3"
 	},
 /area/centcom/testchamber)
+"koQ" = (
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "krq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -26050,24 +26036,46 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
-"kAc" = (
-/obj/machinery/vending/medical/syndicate_access,
+"ktZ" = (
+/obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "kMR" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info28"
 	},
 /area/centcom/testchamber)
-"laA" = (
-/obj/machinery/vending/cigarette/beach,
+"kNP" = (
+/obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"ljl" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
 "lnJ" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Shoe Storage"
 	},
 /area/yogs/infiltrator_base/jail)
+"lnY" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"lpe" = (
+/obj/machinery/vending/wallhypo,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"lDK" = (
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"lTy" = (
+/obj/machinery/vending/wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "lVQ" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info5"
@@ -26091,11 +26099,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"mmb" = (
+/obj/machinery/vending/cola/red,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "moB" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info12"
 	},
 /area/centcom/testchamber)
+"mxu" = (
+/obj/machinery/vending/toyliberationstation,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "mFt" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info17"
@@ -26116,10 +26132,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"mVx" = (
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "nbn" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info13"
@@ -26152,14 +26164,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"nlo" = (
-/obj/machinery/vending/fishing,
+"noT" = (
+/obj/machinery/vending/cola/shamblers,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"ntY" = (
-/obj/machinery/vending/wallhypo,
+/area/centcom)
+"npQ" = (
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "nuH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26178,10 +26190,10 @@
 	icon_state = "title8"
 	},
 /area/centcom/testchamber)
-"nKZ" = (
-/obj/machinery/vending/autodrobe,
+"nMD" = (
+/obj/machinery/vending/clothing,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "nNJ" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info8"
@@ -26206,10 +26218,10 @@
 	},
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"onD" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
+"ogV" = (
+/obj/machinery/vending/medical,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "oxS" = (
 /obj/item/clothing/shoes/combat/coldres{
 	pixel_x = 6;
@@ -26247,15 +26259,26 @@
 /obj/machinery/papershredder,
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"oBf" = (
+/obj/machinery/vending/snack/blue,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "oCO" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info9"
 	},
 /area/centcom/testchamber)
-"oLA" = (
-/obj/machinery/vending/games,
+"oNr" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration";
+	req_access_txt = "102"
+	},
+/turf/open/floor/plasteel,
+/area/tdome/tdomeadmin)
+"oUF" = (
+/obj/machinery/vending/liberationstation,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "oXi" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small{
@@ -26268,10 +26291,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/yogs/infiltrator_base)
-"puz" = (
-/obj/machinery/vending/gifts,
+"pda" = (
+/obj/machinery/vending/sovietsoda,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"ppJ" = (
+/obj/machinery/vending/cola/starkist,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"pzR" = (
+/obj/machinery/vending/wallgene,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"pEX" = (
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "pGS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26284,14 +26319,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"pHG" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
+"pHd" = (
+/obj/machinery/vending/cola/black,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"pPU" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "pQy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26303,27 +26334,39 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"qfK" = (
+"qaK" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"qdE" = (
 /obj/machinery/vending/engineering,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"qfg" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "qhf" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info11"
 	},
 /area/centcom/testchamber)
-"qjz" = (
-/obj/machinery/vending/dinnerware,
+"qjp" = (
+/obj/machinery/vending/security,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"qkJ" = (
-/obj/machinery/vending/wardrobe/sig_wardrobe,
+/area/centcom)
+"qnZ" = (
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"qPG" = (
-/obj/machinery/vending/wallmed,
+/area/centcom)
+"qzr" = (
+/obj/machinery/vending/cola,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"qNB" = (
+/obj/machinery/vending/plasmaresearch,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "ria" = (
 /obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/plasteel/dark,
@@ -26338,6 +26381,10 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"rsL" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "ruy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26350,26 +26397,26 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark,
 /area/yogs/infiltrator_base)
-"ryO" = (
-/obj/machinery/vending,
+"ryg" = (
+/obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"rzE" = (
-/obj/machinery/vending/snack,
+/area/centcom)
+"rzJ" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"rCl" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"rEC" = (
+/obj/machinery/vending/cola/blue,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "rEF" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info21"
 	},
-/area/centcom/testchamber)
-"rGE" = (
-/obj/machinery/vending/cola/shamblers,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"rHL" = (
-/obj/machinery/vending/cola/blue,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "rIC" = (
 /obj/effect/turf_decal/tile/blue{
@@ -26385,90 +26432,69 @@
 /obj/effect/landmark/centcom,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"rOn" = (
-/obj/machinery/vending/snack/orange,
+"rMa" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"rOa" = (
+/obj/machinery/vending/syndichem,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "rVP" = (
 /obj/item/soccerball,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"rXE" = (
-/obj/machinery/vending/plasmaresearch,
+"sfr" = (
+/obj/machinery/vending,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"rXQ" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"rYl" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"rYI" = (
-/obj/machinery/vending/snack/blue,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "spc" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title9"
 	},
 /area/centcom/testchamber)
-"syr" = (
-/obj/machinery/vending/cola/sodie,
+"svy" = (
+/turf/closed/indestructible/riveted,
+/area/centcom)
+"szz" = (
+/obj/machinery/vending/autodrobe/capdrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
+"sGj" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"sGn" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "sSY" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info10"
 	},
 /area/centcom/testchamber)
-"sTn" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"tfn" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "twc" = (
 /obj/structure/goalnet/goalpost/left,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
+"tER" = (
+/obj/machinery/vending/hydroseeds/weak,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "tID" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info6"
 	},
-/area/centcom/testchamber)
-"tJn" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "tVg" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "256"
 	},
 /area/centcom/testchamber)
-"tVh" = (
-/obj/machinery/vending/cola/black,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "uaZ" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title3"
 	},
-/area/centcom/testchamber)
-"ubw" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"uiU" = (
-/obj/machinery/vending/boozeomat/syndicate_access,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"unW" = (
-/obj/machinery/vending/autodrobe/capdrobe,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "uwR" = (
 /obj/structure/window/reinforced{
@@ -26483,10 +26509,6 @@
 	dir = 2
 	},
 /area/yogs/infiltrator_base)
-"uDm" = (
-/obj/machinery/vending/liberationstation,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "uDo" = (
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/o2{
@@ -26510,6 +26532,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
+"uDM" = (
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "uEX" = (
 /turf/open/indestructible/wiki/greenscreen/border,
 /area/centcom/testchamber)
@@ -26534,6 +26560,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeobserve)
+"uPa" = (
+/turf/open/floor/plasteel,
+/area/centcom)
+"uVZ" = (
+/obj/machinery/vending/wardrobe/jani_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"uWn" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "uXx" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -26544,26 +26581,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"vaq" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "vci" = (
 /turf/open/indestructible/wiki/bluescreen,
 /area/centcom/testchamber)
-"vcl" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+"vdL" = (
+/obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "vgL" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title10"
 	},
 /area/centcom/testchamber)
-"vjp" = (
-/obj/machinery/vending/cola/shamblers/prison,
+"vjr" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "vpx" = (
 /obj/structure/goalnet/goalpost/right,
 /turf/open/floor/holofloor/grass,
@@ -26581,14 +26614,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"vFY" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"vJp" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "vMw" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info14"
@@ -26625,10 +26650,6 @@
 	icon_state = "info32"
 	},
 /area/centcom/testchamber)
-"wkn" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "wkC" = (
 /turf/open/indestructible/wiki/title{
 	icon_state = "title4"
@@ -26643,10 +26664,10 @@
 /obj/structure/goalnet,
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/soccer)
-"wvi" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
+"wyd" = (
+/obj/machinery/vending/cola/pwr_game,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "wyM" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26659,6 +26680,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"wBJ" = (
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"wBO" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "wDa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/holodeck_effect/mobspawner{
@@ -26673,14 +26702,6 @@
 	icon_state = "96"
 	},
 /area/centcom/testchamber)
-"wJH" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"wLl" = (
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "wPo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26693,14 +26714,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"wQE" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
+"wYy" = (
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"wWv" = (
-/obj/machinery/vending/snack/green,
+/area/centcom)
+"wZu" = (
+/obj/machinery/vending/magivend,
 /turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
+/area/centcom)
 "xgw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/defibrillator_mount/loaded{
@@ -26731,10 +26752,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/yogs/infiltrator_base)
-"xjj" = (
-/obj/machinery/vending/syndichem,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
 "xjU" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "32"
@@ -26744,14 +26761,6 @@
 /turf/open/indestructible/wiki/info{
 	icon_state = "info24"
 	},
-/area/centcom/testchamber)
-"xnm" = (
-/obj/machinery/vending/wallgene,
-/turf/open/floor/plasteel/bluespace,
-/area/centcom/testchamber)
-"xpx" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel/bluespace,
 /area/centcom/testchamber)
 "xuU" = (
 /obj/machinery/door/airlock/centcom{
@@ -26768,6 +26777,18 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"xDu" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"xEy" = (
+/obj/machinery/vending/fishing,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
+"xFq" = (
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 "xGe" = (
 /turf/open/indestructible/wiki/info{
 	icon_state = "info31"
@@ -26822,6 +26843,10 @@
 	dir = 2
 	},
 /area/yogs/infiltrator_base)
+"ylb" = (
+/obj/machinery/vending/wallmed,
+/turf/open/floor/plasteel/bluespace,
+/area/centcom)
 
 (1,1,1) = {"
 azH
@@ -60662,14 +60687,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+svy
+svy
+svy
+svy
+svy
+svy
+svy
 aaa
 aaa
 aaa
@@ -60919,14 +60944,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+mxu
+wZu
+oUF
+qdE
+uPa
+svy
 aaa
 aaa
 aaa
@@ -61173,20 +61198,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+svy
+svy
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
+svy
+svy
+svy
 aaa
 aaa
 aaa
@@ -61430,20 +61455,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+sGn
+wBJ
+uDM
+fNW
+rzJ
+uPa
+uPa
+qnZ
+uVZ
+rMa
+wYy
+jib
+svy
 aaa
 aaa
 aaa
@@ -61687,20 +61712,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+jQJ
+vjr
+lpe
+pzR
+ylb
+uPa
+uPa
+lTy
+qfg
+pEX
+icO
+iAN
+svy
 aaa
 aaa
 aaa
@@ -61944,20 +61969,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -62201,20 +62226,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -62458,20 +62483,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+dRc
+qjp
+uWn
+oBf
+rCl
+uPa
+uPa
+evC
+jCr
+pda
+ktZ
+rOa
+svy
 aaa
 aaa
 aaa
@@ -62715,20 +62740,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+cuY
+xFq
+cpw
+tER
+koQ
+uPa
+uPa
+xDu
+ogV
+gYd
+fjV
+qNB
+svy
 aaa
 aaa
 aaa
@@ -62972,20 +62997,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -63229,20 +63254,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -63486,20 +63511,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+gDX
+gXv
+ryg
+ppJ
+wBO
+uPa
+uPa
+vdL
+lDK
+lnY
+xEy
+gEX
+svy
 aaa
 aaa
 aaa
@@ -63743,20 +63768,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+hiU
+bie
+nMD
+qaK
+qzr
+uPa
+uPa
+pHd
+rEC
+wyd
+mmb
+noT
+svy
 aaa
 aaa
 aaa
@@ -64000,20 +64025,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -64257,20 +64282,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+uPa
+svy
 aaa
 aaa
 aaa
@@ -64514,20 +64539,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+svy
+sfr
+hUF
+npQ
+sGj
+szz
+uPa
+uPa
+fzd
+rsL
+kNP
+fVm
+jgs
+svy
 aaa
 aaa
 aaa
@@ -64777,8 +64802,8 @@ aEp
 aEp
 aIv
 aIv
-aIv
-aIv
+oNr
+oNr
 aIv
 aIv
 aIv
@@ -65034,8 +65059,8 @@ aEH
 aEv
 aIw
 aIR
-aJd
-aJn
+ljl
+boE
 aIR
 aIw
 aIR
@@ -65291,8 +65316,8 @@ aEv
 aEp
 aIv
 aIv
-aIR
-aIR
+oNr
+oNr
 aIv
 aIv
 aIv
@@ -72781,14 +72806,14 @@ aQE
 aZZ
 aQQ
 aNt
-ryO
-iIX
-wLl
-fWL
-wWv
-imf
-eji
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73038,14 +73063,14 @@ aXI
 aQB
 aOu
 aNt
-dSt
-ubw
-jbX
-uDm
-rOn
-wvi
-rXQ
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73295,14 +73320,14 @@ aZg
 aQE
 aZZ
 aNt
-nKZ
-vJp
-qjz
-gvk
-cSW
-cWx
-vcl
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73552,14 +73577,14 @@ aNt
 aNt
 aNt
 aNt
-hzH
-cXM
-rYl
-hpJ
-jjU
-pHG
-vFY
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73809,14 +73834,14 @@ aXI
 aCQ
 aNx
 aNt
-unW
-tVh
-qfK
-kAc
-gId
-fKT
-xpx
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74066,14 +74091,14 @@ aXI
 aQB
 aNx
 aNt
-iHV
-rHL
-wJH
-gTX
-xjj
-wkn
-sTn
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74323,14 +74348,14 @@ aXI
 aNx
 aQq
 aNt
-emY
-dcG
-nlo
-rXE
-eUq
-vaq
-qkJ
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74580,14 +74605,14 @@ aNt
 aNt
 aNt
 aNt
-uiU
-tJn
-oLA
-eNO
-bna
-onD
-fRI
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74837,14 +74862,14 @@ aZg
 aXI
 aXI
 aNt
-ebD
-rGE
-puz
-mVx
-ntY
-wQE
-aNt
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75094,13 +75119,13 @@ aXI
 aMj
 aSo
 aNt
-jcn
-vjp
-pPU
-rzE
-xnm
-gMI
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75351,13 +75376,13 @@ aSa
 aRA
 aNf
 aNt
-laA
-syr
-dJX
-rYI
-qPG
-tfn
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -75608,13 +75633,13 @@ aNt
 aNt
 aNt
 aNt
-aNt
-aNt
-aNt
-aNt
-aNt
-aNt
-aNt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
# Description
This is a fix to a much larger problem noted in #18832 where the chefdrobe, bardrobe, and any other vending machine that wasn't loaded beginning of the round having missing icons. In that PR I added the donksoft, and chefdrobe to CC and that fixed their icons.

This isn't an end all solution but it works, so I thought to add every vending machine to CC map in case there are others with missing icons. I made it into a neat little hall with lights and an entrance for fun.

![image](https://github.com/yogstation13/Yogstation/assets/98609667/dbbcd9ca-9cde-47db-9368-db87ebc88d34)

:cl:  Airlines7
bugfix: Missing icons in vending machines are fixed
mapping: CC now has a hall of vending machines
/:cl:
