### PR TITLE
Electrocution stun time scales with electrical protection

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -381,7 +381,7 @@
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return FALSE
-	var/stuntime = 4*siemens_coeff SECONDS // do this before species adjustments or balancing will be a pain
+	var/stuntime = 8*siemens_coeff SECONDS // do this before species adjustments or balancing will be a pain
 	shock_damage *= siemens_coeff
 	if(dna && dna.species)
 		shock_damage *= dna.species.siemens_coeff
@@ -398,13 +398,14 @@
 		span_userdanger("You feel a powerful shock coursing through your body!"), \
 		span_italics("You hear a heavy electrical crack.") \
 		)
-	do_jitter_animation(stuntime * 6)
-	adjust_stutter(stuntime)
-	adjust_jitter(stuntime * 5)
-	var/should_stun = !tesla_shock || (tesla_shock && siemens_coeff > 0.5) && stun
-	Paralyze(stuntime)
-	if(stuntime > 2 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun), stuntime - (2 SECONDS))
+	do_jitter_animation(stuntime * 3)
+	adjust_stutter(stuntime / 2)
+	adjust_jitter(stuntime * 2)
+	var/should_stun = !tesla_shock || (tesla_shock && siemens_coeff > 0.5)
+	if(stun && should_stun)
+		Paralyze(min(stuntime, 4 SECONDS))
+		if(stuntime > 2 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun, stuntime - (2 SECONDS)), 2 SECONDS)
 	if(stat == DEAD && can_defib()) //yogs: ZZAPP
 		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(80))
 			set_heartattack(FALSE)
@@ -420,9 +421,9 @@
 		return shock_damage
 
 ///Called slightly after electrocute act to apply a secondary stun.
-/mob/living/carbon/proc/secondary_shock(should_stun)
+/mob/living/carbon/proc/secondary_shock(should_stun, stuntime = 6 SECONDS)
 	if(should_stun)
-		Paralyze(6 SECONDS)
+		Paralyze(stuntime)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/M)
 	if(try_extinguish(M))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -381,6 +381,7 @@
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))
 		return FALSE
+	var/stuntime = 4*siemens_coeff SECONDS // do this before species adjustments or balancing will be a pain
 	shock_damage *= siemens_coeff
 	if(dna && dna.species)
 		shock_damage *= dna.species.siemens_coeff
@@ -397,12 +398,13 @@
 		span_userdanger("You feel a powerful shock coursing through your body!"), \
 		span_italics("You hear a heavy electrical crack.") \
 		)
-	do_jitter_animation(300)
-	adjust_stutter(4 SECONDS)
-	adjust_jitter(20 SECONDS)
+	do_jitter_animation(stuntime * 6)
+	adjust_stutter(stuntime)
+	adjust_jitter(stuntime * 5)
 	var/should_stun = !tesla_shock || (tesla_shock && siemens_coeff > 0.5) && stun
-	Paralyze(4 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun), 2 SECONDS)
+	Paralyze(stuntime)
+	if(stuntime > 2 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun), stuntime - (2 SECONDS))
 	if(stat == DEAD && can_defib()) //yogs: ZZAPP
 		if(!illusion && (shock_damage * siemens_coeff >= 1) && prob(80))
 			set_heartattack(FALSE)


### PR DESCRIPTION
# Document the changes in your pull request

How long you get stunned for when electrocuted now depends on your protection from electricity, also fixed a bug where setting stun to false in electrocute_act() didn't actually prevent the stun.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: electrical protection reduces electrocution stun time
bugfix: fixed electrocute_act() causing a stun regardless of whether stun is set to true or not
/:cl:
