### PR TITLE
switches quiet mode checks to check the mind and not the client prefs

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -131,7 +131,7 @@ GLOBAL_LIST_EMPTY(objectives)
 		if(is_valid_target(possible_target) && !(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target,dupe_search_range))
 			//yogs start -- Quiet Rounds
 			var/mob/living/carbon/human/guy = possible_target.current
-			if(possible_target.antag_datums || !(guy.client && (guy.client.prefs.yogtoggles & QUIET_ROUND)))
+			if(possible_target.antag_datums || !(guy.mind.quiet_round))
 				if (!(possible_target in blacklist))
 					possible_targets += possible_target//yogs indent
 			//yogs end

--- a/code/modules/events/monsterhunter.dm
+++ b/code/modules/events/monsterhunter.dm
@@ -35,7 +35,7 @@
 	for(var/mob/living/carbon/human/all_players in shuffle(GLOB.player_list))
 		if(!all_players.client || !all_players.mind || !(ROLE_MONSTERHUNTER in all_players.client.prefs.be_special))
 			continue
-		if(all_players.client.prefs.yogtoggles & QUIET_ROUND)
+		if(all_players.mind.quiet_round)
 			continue
 		if(all_players.stat == DEAD)
 			continue


### PR DESCRIPTION
# Document the changes in your pull request

if you have no client then the game cant tell if you have quiet mode on

so if you're an aghost or get in interesting positions you have no more quiet mode

# Changelog

:cl:  
bugfix: fixes quiet mode checks using client prefs where they're might not always be a client
/:cl:
