### PR TITLE
Canister fusion works again

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -169,8 +169,8 @@ nobliumformation = 1001
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 			air.set_temperature((temperature*old_heat_capacity + energy_released)/new_heat_capacity)
 
-	//let the floor know a fire is happening
-	if(istype(location))
+	//let the floor know a fire is happening BUT ONLY IF IT'S ACTUALLY A FLOOR
+	if(istype(location) && isturf(holder))
 		temperature = air.return_temperature()
 		if(temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 			location.hotspot_expose(temperature, CELL_VOLUME)


### PR DESCRIPTION
# Document the changes in your pull request

Fixed an oversight causing tritium fires inside pipes and canisters to burn things on the same tile as the pipe/canister which made canister fusion impossible

Closes #19224

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: canister fusion works again
/:cl:
