### PR TITLE
Ranged holoparasites, sleeping carp, and ranged weaponry are now all mutually exclusive

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -173,6 +173,11 @@
 	if(help_verb)
 		add_verb(H, help_verb)
 	H.mind.martial_art = src
+	if(no_guns)
+		for(var/mob/living/simple_animal/hostile/guardian/guardian in H.hasparasites())
+			guardian.stats.ranged = FALSE
+			guardian.ranged = FALSE
+			to_chat(user, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font> loses their ranged attacks in accordance with your martial art!"))
 	return TRUE
 
 /**

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -177,7 +177,7 @@
 		for(var/mob/living/simple_animal/hostile/guardian/guardian in H.hasparasites())
 			guardian.stats.ranged = FALSE
 			guardian.ranged = FALSE
-			to_chat(user, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font> loses their ranged attacks in accordance with your martial art!"))
+			to_chat(H, span_holoparasite("<font color=\"[guardian.namedatum.color]\"><b>[guardian.real_name]</b></font> loses their ranged attacks in accordance with your martial art!"))
 	return TRUE
 
 /**

--- a/tgui/packages/tgui/interfaces/Guardian.js
+++ b/tgui/packages/tgui/interfaces/Guardian.js
@@ -44,7 +44,7 @@ const GuardianGeneralScene = (props, context) => {
           selected={!data.melee}
           disabled={data.melee && data.points < 3}
           onClick={() => act("ranged")}
-          tooltip="Your Guardian will shoot ranged projectiles. Nobody can deflect the Emerald Splash!"
+          tooltip="Your Guardian will shoot ranged projectiles. This will prevent you from using ranged weaponry!"
           tooltipPosition="right"
         />
       </Section>

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -176,8 +176,11 @@
 	if (!user || !iscarbon(user) || !user.mind)
 		return FALSE
 	if (user.mind.martial_art?.no_guns && saved_stats.ranged)
-		to_chat(user, span_danger("You cannot use a ranged holoparasite as you are unable to used ranged projectiles!"))
-		return FALSE
+		if (random)
+			saved_stats.ranged = FALSE // sorry dawg
+		else
+			to_chat(user, span_danger("You cannot use a ranged holoparasite as you are unable to used ranged projectiles!"))
+			return FALSE
 	used = TRUE
 	calc_points()
 	if (points < 0)

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -172,7 +172,7 @@
 		points -= minor.cost
 	return points
 
-/datum/guardianbuilder/proc/spawn_guardian(mob/living/user)
+/datum/guardianbuilder/proc/spawn_guardian(mob/living/user, random = FALSE)
 	if (!user || !iscarbon(user) || !user.mind)
 		return FALSE
 	if (user.mind.martial_art?.no_guns && saved_stats.ranged)
@@ -287,7 +287,7 @@
 		builder.ui_interact(user)
 	else
 		builder.saved_stats = generate_stand()
-		builder.spawn_guardian(user)
+		builder.spawn_guardian(user, TRUE)
 
 /obj/item/guardiancreator/proc/generate_stand()
 	var/points = 15

--- a/yogstation/code/modules/guardian/guardianbuilder.dm
+++ b/yogstation/code/modules/guardian/guardianbuilder.dm
@@ -175,6 +175,9 @@
 /datum/guardianbuilder/proc/spawn_guardian(mob/living/user)
 	if (!user || !iscarbon(user) || !user.mind)
 		return FALSE
+	if (user.mind.martial_art?.no_guns && saved_stats.ranged)
+		to_chat(user, span_danger("You cannot use a ranged holoparasite as you are unable to used ranged projectiles!"))
+		return FALSE
 	used = TRUE
 	calc_points()
 	if (points < 0)
@@ -225,6 +228,9 @@
 				used = TRUE
 				G.Destroy()
 				return FALSE
+		if(saved_stats.ranged)
+			ADD_TRAIT(user, TRAIT_NOGUNS, G.type)
+			to_chat(user, span_holoparasite("<font color=\"[G.namedatum.color]\"><b>[G.real_name]</b></font>'s ranged ability prevents you from using ranged weaponry of your own!"))
 		return TRUE
 	else
 		to_chat(user, "[failure_message]")


### PR DESCRIPTION

# Document the changes in your pull request

If you try to make a ranged holoparasite with a martial art that prevents ranged weaponry, it will not let you.

If you make a ranged holoparasite, you will be thereafter forbidden from using ranged weaponry.

If you have a ranged holoparasite(s) and learn a martial art that prevents ranged weaponry, it will remove their ranged attacks.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Ranged holoparasites now prevent you from using ranged weaponry
tweak: Ranged holoparasites can no longer be used with martial arts that prevent ranged weaponry
/:cl:
