### PR TITLE
Spessmen are now trained to avoid degenerate activities such as aggressive hand wrestling flushered emoji

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -213,7 +213,6 @@
 			else
 				visible_message(span_danger("[user] has grabbed [src] aggressively!"), \
 								span_userdanger("[user] has grabbed you aggressively!"))
-				drop_all_held_items()
 			stop_pulling()
 			log_combat(user, src, "grabbed", addition="aggressive grab[add_log]")
 		if(GRAB_NECK)


### PR DESCRIPTION
You are grabbing their ARMS not their HANDS you DEGENERATE! Gone are the days of free disarms because someone wasn't looking for half a second and you clicked on them twice! You gotta WORK for those disarms, you filthy tiders! Also this means you can more effectively fight back vs non-martial-art grab-fu with objects other than your fists. No this doesn't dunk on sleeping carp, it specifically makes you drop everything anyways and CQC stuns you which also makes you drop stuff.

# Document the changes in your pull request

Aggressive grabs no longer by default make you drop everything you're holding, meaning they are no longer an effective guaranteed disarm if the person isn't able to immediately break your passive grab.


# Wiki Documentation

Aggro grabs don't disarm.

# Changelog



:cl:  

tweak: Aggressive grabs no longer disarm

/:cl:
