### PR TITLE
Fixes surplus crate not spawning correctly in EORG

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -248,13 +248,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	player_minimum = 40
 	starting_crate_value = 125
 
-/datum/uplink_item/bundles_TC/surplus/purchase(mob/user, datum/component/uplink/U)
+/datum/uplink_item/bundles_TC/surplus/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
+	. = ..()
+	var/obj/structure/closet/crate/spawned_crate = .
 	var/list/uplink_items = get_uplink_items(SSticker && SSticker.mode? SSticker.mode : null, FALSE)
-
 	var/crate_value = starting_crate_value
-	var/obj/structure/closet/crate/C = spawn_item(/obj/structure/closet/crate, user, U)
-	if(U.purchase_log)
-		U.purchase_log.LogPurchase(C, src, cost)
 	while(crate_value)
 		var/category = pick(uplink_items)
 		var/item = pick(uplink_items[category])
@@ -265,10 +263,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		if(crate_value < I.cost)
 			continue
 		crate_value -= I.cost
-		var/obj/goods = new I.item(C)
+		var/obj/goods = new I.item(spawned_crate)
 		if(U.purchase_log)
 			U.purchase_log.LogPurchase(goods, I, 0)
-	return C
+	return spawned_crate
 
 /datum/uplink_item/bundles_TC/random
 	name = "Random Item"
@@ -1560,7 +1558,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/monkeycubes/syndicate/mice
 	cost = 1
 	manufacturer = /datum/corporation/traitor/waffleco
-  
+
 /datum/uplink_item/stealthy_tools/angelcoolboy
 	name = "Syndicate Angel Potion"
 	desc = "After many failed attempts, the syndicate has reverse engineered an angel potion smuggled off of the lava planet V-227. \

--- a/code/modules/uplink/uplink_purchase_log.dm
+++ b/code/modules/uplink/uplink_purchase_log.dm
@@ -46,6 +46,8 @@ GLOBAL_LIST(uplink_purchase_logs_by_key)	//assoc key = /datum/uplink_purchase_lo
 		. += span_tooltip_container("\[[UPE.icon_b64][show_key?"([owner])":""]<span class='tooltip_hover'><b>[UPE.name]</b><br>[UPE.spent_cost ? "[UPE.spent_cost] [currency]" : "[UPE.base_cost] [currency]<br>(Surplus)"]<br>[UPE.desc]</span>[(UPE.amount_purchased > 1) ? "x[UPE.amount_purchased]" : ""]\]")
 
 /datum/uplink_purchase_log/proc/LogPurchase(atom/A, datum/uplink_item/uplink_item, spent_cost)
+	if(SSticker.current_state >= GAME_STATE_FINISHED) // Don't log purchases past round-end
+		return
 	var/datum/uplink_purchase_entry/UPE
 	var/hash = hash_purchase(uplink_item, spent_cost)
 	if(purchase_log[hash])


### PR DESCRIPTION
# Document the changes in your pull request

Issue: Surplus crate spawn logic is handled in `purchase()`, but EORG calls `spawn_item()`

Solution: This moves surplus crate spawn logic out of `purchase()` and into `spawn_item()` like proper

Fixes #19328

# Changelog

:cl:  
bugfix: Fixed surplus crate not spawning correctly in EORG
/:cl:
