### PR TITLE
Removes YandereDev & calling mob_say on every item in your inventory.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -813,8 +813,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/on_mob_death(mob/living/L, gibbed)
 
-/obj/item/proc/on_mob_say(mob/living/L, message, message_range)
-
 /obj/item/proc/grind_requirements(obj/machinery/reagentgrinder/R) //Used to check for extra requirements for grinding an object
 	return TRUE
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -518,13 +518,11 @@ BLIND     // can't see anything
 	if(visor_vars_to_toggle & VISOR_TINT)
 		tint ^= initial(tint)
 
-
 /obj/item/clothing/proc/can_use(mob/user)
 	if(user && ismob(user))
 		if(!user.incapacitated())
-			return 1
-	return 0
-
+			return TRUE
+	return FALSE
 
 /obj/item/clothing/obj_destruction(damage_flag)
 	if(damage_flag == BOMB)

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -1,4 +1,3 @@
-
 // **** Security gas mask ****
 
 /datum/action/item_action/halt

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -191,7 +191,7 @@
 			if(4)
 				phrase = rand(12,18)	// user has broke the restrictor, it will now only play shitcurity phrases
 
-		if(!(obj_flags & EMAGGED))
+		if(obj_flags & EMAGGED)
 			phrase_text = "FUCK YOUR CUNT YOU SHIT EATING COCKSTORM AND EAT A DONG FUCKING ASS RAMMING SHIT FUCK EAT PENISES IN YOUR FUCK FACE AND SHIT OUT ABORTIONS OF FUCK AND POO AND SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
 			phrase_sound = "emag"
 		else
@@ -253,7 +253,7 @@
 					phrase_sound = "dredd"
 
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[phrase_text]</b></font>")
-		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4)
+		playsound(loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4)
 		cooldown = world.time
 		cooldown_special = world.time
 	
@@ -265,5 +265,5 @@
 	if (!can_use(usr))
 		return
 	to_chat(usr, span_notice("The security mask quickly relays a list of recognized keywords"))
-	to_chat(usr, span_notice("[sechailer_voicelines]"))
-
+	for(var/line in sechailer_voicelines)
+		to_chat(usr, span_notice("[line]"))

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -19,43 +19,58 @@
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_cover = MASKCOVERSMOUTH
 	mutantrace_variation = MUTANTRACE_VARIATION
+	modifies_speech = TRUE
+
 	var/aggressiveness = 2
 	var/cooldown_special
 	var/recent_uses = 0
 	var/broken_hailer = 0
-	var/safety = TRUE
 	var/voicetoggled = TRUE
 
-/obj/item/clothing/mask/gas/sechailer/swat
-	name = "\improper SWAT mask"
-	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."
-	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/dispatch)
-	icon_state = "swat"
-	item_state = "swat"
-	aggressiveness = 3
-	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEYES|HIDEEARS|HIDEHAIR
-	visor_flags_inv = 0
-	mutantrace_variation = MUTANTRACE_VARIATION
-
-/obj/item/clothing/mask/gas/sechailer/swat/encrypted
-	name = "\improper MK.II SWAT mask"
-	desc = "A top-grade mask that encrypts your voice, allowing only other users of the same mask to understand you. \
-			There are some buttons with basic commands to control the locals."
-
-/obj/item/clothing/mask/gas/sechailer/swat/encrypted/equipped(mob/living/user)
-	user.add_blocked_language(subtypesof(/datum/language/) - /datum/language/encrypted, LANGUAGE_HAT)
-	user.grant_language(/datum/language/encrypted, TRUE, TRUE, LANGUAGE_HAT)
-	..()
-
-/obj/item/clothing/mask/gas/sechailer/swat/encrypted/dropped(mob/living/user)
-	user.remove_blocked_language(subtypesof(/datum/language/), LANGUAGE_HAT)
-	user.remove_language(/datum/language/encrypted, TRUE, TRUE, LANGUAGE_HAT)
-	..()
-
-/obj/item/clothing/mask/gas/sechailer/swat/encrypted/on_mob_say(mob/living/carbon/L, message, message_range)
-	if(L.wear_mask == src)
-		var/chosen_sound = file("sound/voice/cpvoice/ds ([rand(1,27)]).ogg")
-		playsound(L, chosen_sound, 50, FALSE)
+	///List of sounds that play on death, randomly selected.
+	var/static/list/death_sounds = list(
+		'sound/voice/cpdeath/die1.ogg',
+		'sound/voice/cpdeath/die2.ogg',
+		'sound/voice/cpdeath/die3.ogg',
+		'sound/voice/cpdeath/die4.ogg',
+	)
+	///List of all lines that can be said by the sechailer, with their respective sound file.
+	var/list/sechailer_voicelines = list(
+		"Affirmative" = 'sound/voice/cpvoicelines/affirmative.ogg',
+		"Copy" = 'sound/voice/cpvoicelines/copy.ogg',
+		"Alright, you can go" = 'sound/voice/cpvoicelines/allrightyoucango.ogg',
+		"Backup" = 'sound/voice/cpvoicelines/backup.ogg',
+		"Citizen" = 'sound/voice/cpvoicelines/citizen.ogg',
+		"Get down" = 'sound/voice/cpvoicelines/getdown.ogg',
+		"Get out of here" = 'sound/voice/cpvoicelines/getoutofhere.ogg',
+		"Grenade" = 'sound/voice/cpvoicelines/grenade.ogg',
+		"Help" = 'sound/voice/cpvoicelines/help.ogg',
+		"Hold it" = 'sound/voice/cpvoicelines/holdit.ogg',
+		"In position" = 'sound/voice/cpvoicelines/inposition.ogg',
+		"I said move along" = 'sound/voice/cpvoicelines/isaidmovealong.ogg',
+		"Keep moving" = 'sound/voice/cpvoicelines/keepmoving.ogg',
+		"Lookout" = 'sound/voice/cpvoicelines/Lookout.ogg',
+		"Move along" = 'sound/voice/cpvoicelines/movealong.ogg',
+		"Move back right now" = 'sound/voice/cpvoicelines/movebackrightnow.ogg',
+		"Move it" = 'sound/voice/cpvoicelines/moveit2.ogg',
+		"Now get out of here" = 'sound/voice/cpvoicelines/nowgetoutofhere.ogg',
+		"Pick up that can" = 'sound/voice/cpvoicelines/pickupthecan1.ogg',
+		"I said pick up the can" = 'sound/voice/cpvoicelines/pickupthecan3.ogg',
+		"Suspect prepare to receive civil judgement" = 'sound/voice/cpvoicelines/prepareforjudgement.ogg',
+		"Now put it in the trash can" = 'sound/voice/cpvoicelines/putitinthetrash1.ogg',
+		"Responding" = 'sound/voice/cpvoicelines/responding2.ogg',
+		"Roger that" = 'sound/voice/cpvoicelines/rodgerthat.ogg',
+		"Shit" = 'sound/voice/cpvoicelines/shit.ogg',
+		"Take cover" = 'sound/voice/cpvoicelines/takecover.ogg',
+		"You knocked it over, pick it up" = 'sound/voice/cpvoicelines/youknockeditover.ogg',
+		"Searching for suspect" = 'sound/voice/cpvoicelines/searchingforsuspect.ogg',
+		"First warning, move away" = 'sound/voice/cpvoicelines/firstwarningmove.ogg',
+		"Sentence delivered" = 'sound/voice/cpvoicelines/sentencedelivered.ogg',
+		"Issuing malcompliant citation" = 'sound/voice/cpvoicelines/issuingmalcompliantcitation.ogg',
+		"Anticitizen" = 'sound/voice/cpvoicelines/anticitizen.ogg',
+		"Apply" = 'sound/voice/cpvoicelines/apply.ogg',
+		"Hehe" = 'sound/voice/cpvoicelines/chuckle.ogg',
+	)
 
 /obj/item/clothing/mask/gas/sechailer/swat/spacepol
 	name = "spacepol mask"
@@ -71,8 +86,21 @@
 	aggressiveness = 1 //Borgs are nicecurity!
 	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/dispatch)
 
+/obj/item/clothing/mask/gas/sechailer/attack_self(mob/user)
+	if(iscyborg(user))
+		return
+	adjustmask(user)
+
+/obj/item/clothing/mask/gas/sechailer/AltClick(mob/user)
+	. = ..()
+	if (!can_use(usr))
+		return
+	voicetoggled = !voicetoggled
+	to_chat(usr, span_notice("You [voicetoggled ? "enable" : "disable"] the security mask's voice modulator."))
+
 /obj/item/clothing/mask/gas/sechailer/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
+	. = ..()
+	if(.)
 		return TRUE
 	switch(aggressiveness)
 		if(1)
@@ -102,19 +130,29 @@
 	else
 		adjustmask(user)
 
-/obj/item/clothing/mask/gas/sechailer/attack_self()
-	halt()
 /obj/item/clothing/mask/gas/sechailer/emag_act(mob/user as mob)
-	if(safety)
-		safety = FALSE
+	if(obj_flags & EMAGGED)
+		obj_flags |= EMAGGED
 		to_chat(user, span_warning("You silently fry [src]'s vocal circuit with the cryptographic sequencer."))
-	else
+
+/obj/item/clothing/mask/gas/sechailer/handle_speech(datum/source, mob/speech_args)
+	if(!voicetoggled)
 		return
+	var/full_message = speech_args[SPEECH_MESSAGE]
+	for(var/lines in sechailer_voicelines)
+		if(findtext(full_message, lines, 1, 30))
+			playsound(source, sechailer_voicelines[lines], 50, FALSE)
+			return // only play the first.
+
+/obj/item/clothing/mask/gas/sechailer/on_mob_death()
+	. = ..()
+	playsound(loc, pick(death_sounds), 50, 0) //lost biosignal for protection team unit 4, remaining units contain.
 
 /obj/item/clothing/mask/gas/sechailer/verb/halt()
 	set category = "Object"
 	set name = "HALT"
 	set src in usr
+
 	if(!isliving(usr))
 		return
 	if(!can_use(usr))
@@ -153,7 +191,7 @@
 			if(4)
 				phrase = rand(12,18)	// user has broke the restrictor, it will now only play shitcurity phrases
 
-		if(!safety)
+		if(!(obj_flags & EMAGGED))
 			phrase_text = "FUCK YOUR CUNT YOU SHIT EATING COCKSTORM AND EAT A DONG FUCKING ASS RAMMING SHIT FUCK EAT PENISES IN YOUR FUCK FACE AND SHIT OUT ABORTIONS OF FUCK AND POO AND SHIT IN YOUR ASS YOU COCK FUCK SHIT MONKEY FUCK ASS WANKER FROM THE DEPTHS OF SHIT."
 			phrase_sound = "emag"
 		else
@@ -218,109 +256,14 @@
 		playsound(src.loc, "sound/voice/complionator/[phrase_sound].ogg", 100, 0, 4)
 		cooldown = world.time
 		cooldown_special = world.time
-
-/obj/item/clothing/mask/gas/sechailer/on_mob_death()
-	. = ..()
-	playsound(loc, pick('sound/voice/cpdeath/die1.ogg', 'sound/voice/cpdeath/die2.ogg', 'sound/voice/cpdeath/die3.ogg', 'sound/voice/cpdeath/die4.ogg'), 50, 0) //lost biosignal for protection team unit 4, remaining units contain 
-
-/obj/item/clothing/mask/gas/sechailer/verb/toggle()
-	set name = "Toggle voice modulator"
-	set category = "Object"
-	set src in usr
-	var/mob/M = usr
-	if (istype(M, /mob/dead/))
-		return
-	if (!can_use(M))
-		return
-	if(voicetoggled == TRUE)
-		to_chat(usr, span_notice("You disable the security mask's voice modulator."))
-		voicetoggled = FALSE
-	else
-		to_chat(usr, span_notice("You enable the security mask's voice modulator."))
-		voicetoggled = TRUE
 	
 /obj/item/clothing/mask/gas/sechailer/verb/viewkeywords()
 	set name = "View voice modulator keywords"
 	set category = "Object"
 	set src in usr
-	var/mob/M = usr
-	if (istype(M, /mob/dead/))
-		return
-	if (!can_use(M))
+
+	if (!can_use(usr))
 		return
 	to_chat(usr, span_notice("The security mask quickly relays a list of recognized keywords"))
-	to_chat(usr, span_notice("Affirmative; Copy; Alright, you can go; Backup; Citizen; Get down; Get out of here; Grenade; Help; Hold it; In position; I said move along; Keep moving; Lookout; Move along; Move back right now; Move it; Now get out of here; Pick up that can; I said pick up the can; Suspect prepare to receive civil judgement; Now put it in the trash can; Responding; Roger that; Shit; Take cover; You knocked it over, pick it up; Searching for suspect; First warning, move away; Sentence delivered; Issuing malcompliant citation; Anticitizen; Apply; Hehe"))
-
-/obj/item/clothing/mask/gas/sechailer/on_mob_say(mob/living/carbon/L, message, message_range)
-	if(voicetoggled == FALSE)
-		return 1
-	if(findtext(message, "Affirmative", 1, 12))
-		playsound(L, 'sound/voice/cpvoicelines/affirmative.ogg', 50, FALSE)
-	else if(findtext(message, "Copy", 1, 5))
-		playsound(L, 'sound/voice/cpvoicelines/copy.ogg', 50, FALSE)
-	else if(findtext(message, "Alright, you can go", 1, 20))
-		playsound(L, 'sound/voice/cpvoicelines/allrightyoucango.ogg', 50, FALSE)
-	else if(findtext(message, "Backup", 1, 7))
-		playsound(L, 'sound/voice/cpvoicelines/backup.ogg', 50, FALSE)
-	else if(findtext(message, "Citizen", 1, 8))
-		playsound(L, 'sound/voice/cpvoicelines/citizen.ogg', 50, FALSE)
-	else if(findtext(message, "Get down", 1, 9))
-		playsound(L, 'sound/voice/cpvoicelines/getdown.ogg', 50, FALSE)
-	else if(findtext(message, "Get out of here", 1, 16))
-		playsound(L, 'sound/voice/cpvoicelines/getoutofhere.ogg', 50, FALSE)
-	else if(findtext(message, "Grenade", 1, 8))
-		playsound(L, 'sound/voice/cpvoicelines/grenade.ogg', 50, FALSE)
-	else if(findtext(message, "Help", 1, 5))
-		playsound(L, 'sound/voice/cpvoicelines/help.ogg', 50, FALSE)
-	else if(findtext(message, "Hold it", 1, 8))
-		playsound(L, 'sound/voice/cpvoicelines/holdit.ogg', 50, FALSE)
-	else if(findtext(message, "In position", 1, 12))
-		playsound(L, 'sound/voice/cpvoicelines/inposition.ogg', 50, FALSE)
-	else if(findtext(message, "I said move along", 1, 18))
-		playsound(L, 'sound/voice/cpvoicelines/isaidmovealong.ogg', 50, FALSE)
-	else if(findtext(message, "Keep moving", 1, 12))
-		playsound(L, 'sound/voice/cpvoicelines/keepmoving.ogg', 50, FALSE)
-	else if(findtext(message, "Lookout", 1, 8))
-		playsound(L, 'sound/voice/cpvoicelines/Lookout.ogg', 50, FALSE)
-	else if(findtext(message, "Move along", 1, 11))
-		playsound(L, 'sound/voice/cpvoicelines/movealong.ogg', 50, FALSE)
-	else if(findtext(message, "Move back right now", 1, 20))
-		playsound(L, 'sound/voice/cpvoicelines/movebackrightnow.ogg', 50, FALSE)
-	else if(findtext(message, "Move it", 1, 8))
-		playsound(L, 'sound/voice/cpvoicelines/moveit2.ogg', 50, FALSE)
-	else if(findtext(message, "Now get out of here", 1, 20))
-		playsound(L, 'sound/voice/cpvoicelines/nowgetoutofhere.ogg', 50, FALSE)
-	else if(findtext(message, "Pick up that can", 1, 17))
-		playsound(L, 'sound/voice/cpvoicelines/pickupthecan1.ogg', 50, FALSE)
-	else if(findtext(message, "I said pick up the can", 1, 24))
-		playsound(L, 'sound/voice/cpvoicelines/pickupthecan3.ogg', 50, FALSE)
-	else if(findtext(message, "Suspect prepare to receive civil judgement", 1, 43))
-		playsound(L, 'sound/voice/cpvoicelines/prepareforjudgement.ogg', 50, FALSE)
-	else if(findtext(message, "Now put it in the trash can", 1, 29))
-		playsound(L, 'sound/voice/cpvoicelines/putitinthetrash1.ogg', 50, FALSE)
-	else if(findtext(message, "Responding", 1, 11))
-		playsound(L, 'sound/voice/cpvoicelines/responding2.ogg', 50, FALSE)
-	else if(findtext(message, "Roger that", 1, 11))
-		playsound(L, 'sound/voice/cpvoicelines/rodgerthat.ogg', 50, FALSE)
-	else if(findtext(message, "Shit", 1, 5))
-		playsound(L, 'sound/voice/cpvoicelines/shit.ogg', 50, FALSE)
-	else if(findtext(message, "Take cover", 1, 11))
-		playsound(L, 'sound/voice/cpvoicelines/takecover.ogg', 50, FALSE)
-	else if(findtext(message, "You knocked it over, pick it up", 1, 32))
-		playsound(L, 'sound/voice/cpvoicelines/youknockeditover.ogg', 50, FALSE)
-	else if(findtext(message, "Searching for suspect", 1, 22))
-		playsound(L, 'sound/voice/cpvoicelines/searchingforsuspect.ogg', 50, FALSE)
-	else if(findtext(message, "First warning, move away", 1, 25))
-		playsound(L, 'sound/voice/cpvoicelines/firstwarningmove.ogg', 50, FALSE)
-	else if(findtext(message, "Sentence delivered", 1, 19))
-		playsound(L, 'sound/voice/cpvoicelines/sentencedelivered.ogg', 50, FALSE)
-	else if(findtext(message, "Issuing malcompliant citation", 1, 30))
-		playsound(L, 'sound/voice/cpvoicelines/issuingmalcompliantcitation.ogg', 50, FALSE)
-	else if(findtext(message, "Anticitizen", 1, 12))
-		playsound(L, 'sound/voice/cpvoicelines/anticitizen.ogg', 50, FALSE)
-	else if(findtext(message, "Apply", 1, 6))
-		playsound(L, 'sound/voice/cpvoicelines/apply.ogg', 50, FALSE)
-	else if(findtext(message, "Hehe", 1, 5))
-		playsound(L, 'sound/voice/cpvoicelines/chuckle.ogg', 50, FALSE)
-	
+	to_chat(usr, span_notice("[sechailer_voicelines]"))
 

--- a/code/modules/clothing/masks/swat.dm
+++ b/code/modules/clothing/masks/swat.dm
@@ -1,0 +1,30 @@
+/obj/item/clothing/mask/gas/sechailer/swat
+	name = "\improper SWAT mask"
+	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."
+	actions_types = list(/datum/action/item_action/halt, /datum/action/item_action/dispatch)
+	icon_state = "swat"
+	item_state = "swat"
+	aggressiveness = 3
+	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEYES|HIDEEARS|HIDEHAIR
+	visor_flags_inv = 0
+	mutantrace_variation = MUTANTRACE_VARIATION
+
+/obj/item/clothing/mask/gas/sechailer/swat/encrypted
+	name = "\improper MK.II SWAT mask"
+	desc = "A top-grade mask that encrypts your voice, allowing only other users of the same mask to understand you. \
+			There are some buttons with basic commands to control the locals."
+
+/obj/item/clothing/mask/gas/sechailer/swat/encrypted/equipped(mob/living/user)
+	. = ..()
+	user.add_blocked_language(subtypesof(/datum/language) - /datum/language/encrypted, LANGUAGE_HAT)
+	user.grant_language(/datum/language/encrypted, TRUE, TRUE, LANGUAGE_HAT)
+
+/obj/item/clothing/mask/gas/sechailer/swat/encrypted/dropped(mob/living/user)
+	user.remove_blocked_language(subtypesof(/datum/language), LANGUAGE_HAT)
+	user.remove_language(/datum/language/encrypted, TRUE, TRUE, LANGUAGE_HAT)
+	return ..()
+
+/obj/item/clothing/mask/gas/sechailer/swat/encrypted/handle_speech(mob/living/carbon/source, mob/speech_args)
+	if(source.wear_mask == src)
+		var/chosen_sound = file("sound/voice/cpvoice/ds ([rand(1,27)]).ogg")
+		playsound(source, chosen_sound, 50, FALSE)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -243,9 +243,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	if(succumbed)
 		succumb(1)
 		to_chat(src, compose_message(src, language, message, , spans, message_mods))
-	for(var/obj/item/I in contents)
-		I.on_mob_say(src, message, message_range)
-	return 1
+	return TRUE
 
 /mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	. = ..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2110,6 +2110,7 @@
 #include "code\modules\clothing\masks\gasmask.dm"
 #include "code\modules\clothing\masks\hailer.dm"
 #include "code\modules\clothing\masks\miscellaneous.dm"
+#include "code\modules\clothing\masks\swat.dm"
 #include "code\modules\clothing\neck\_neck.dm"
 #include "code\modules\clothing\neck\bodycamera.dm"
 #include "code\modules\clothing\neck\skillcapes\skillcape_datums.dm"


### PR DESCRIPTION
# Document the changes in your pull request

if
else if
else if
else if
else if
else if
else if
else if
else if
else if
else if
else if

Also removes making EVERY SINGLE ITEM in someone's contents call ``on_mob_say`` EVERY time you speak because it's absolutely fucking delusional. I replaced it with using the ``modifies_speech`` var.
Removes ``safety`` var and replaces it with the ``EMAGGED`` object flag like God intended.

Lastly, I made disabling sechailer voices be part of Alt Click instead of a verb.
I wanted to make the list of voices be part of double-examine, but apparently that's not a THING here so that's AWESOME.

# Changelog

:cl:  
tweak: You can now Alt Click the sechailer to turn it's audio lines on/off instead of using its right click menu.
/:cl:
