### PR TITLE
Taking mats out of lathes requires ORM access, which most jobs have anyways

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -732,7 +732,7 @@
 	if (!issiliconoradminghost(usr))
 		var/obj/item/card/id/idcard = usr.get_idcard()
 		if(!idcard || !(ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
-			balloon_alert(usr, "No access!")
+			balloon_alert(usr, "no access!")
 			return 0
 	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
 	var/list/matlist = list()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -7,7 +7,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 20
 	active_power_usage = 5000
-	
+
 	req_access = list(ACCESS_ROBO_CONTROL)
 	///Whether the access is hacked or not
 	var/hacked = FALSE
@@ -83,7 +83,7 @@
 /obj/machinery/mecha_part_fabricator/Destroy()
 	QDEL_NULL(wires)
 	return ..()
-	
+
 /obj/machinery/mecha_part_fabricator/RefreshParts()
 	var/T = 0
 
@@ -211,7 +211,7 @@
 
 	var/list/category_override = null
 	var/list/sub_category = null
-	
+
 	if(categories)
 		// Handle some special cases to build up sub-categories for the fab interface.
 		// Start with checking if this design builds a cyborg module.
@@ -436,7 +436,7 @@
 		if(process_queue)
 			build_next_in_queue(FALSE)
 		return TRUE
-	
+
 
 /**
   * Dispenses a part to the tile infront of the Exosuit Fab.
@@ -610,7 +610,7 @@
 	data["isProcessingQueue"] = process_queue
 	data["authorization"] = authorization_override
 	data["user_clearance"] = head_or_silicon(user)
-	data["alert_level"] = GLOB.security_level 
+	data["alert_level"] = GLOB.security_level
 	data["combat_parts_allowed"] = combat_parts_allowed(user)
 	data["emagged"] = (obj_flags & EMAGGED)
 	data["silicon_user"] = issilicon(user)
@@ -729,6 +729,11 @@
 	if (rmat.on_hold())
 		say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
+	if (!issiliconoradminghost(usr))
+		var/obj/item/card/id/idcard = usr.get_idcard()
+		if(!idcard || (!ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
+			balloon_alert(usr, "No access!")
+			return 0
 	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
 	var/list/matlist = list()
 	matlist[eject_sheet] = text2num(eject_amt)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -731,7 +731,7 @@
 		return 0
 	if (!issiliconoradminghost(usr))
 		var/obj/item/card/id/idcard = usr.get_idcard()
-		if(!idcard || (!ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
+		if(!idcard || !(ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
 			balloon_alert(usr, "No access!")
 			return 0
 	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -323,7 +323,7 @@
 		return 0
 	if (!issiliconoradminghost(usr))
 		var/obj/item/card/id/idcard = usr.get_idcard()
-		if(!idcard || (!ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
+		if(!idcard || !(ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
 			balloon_alert(usr, "No access!")
 			return 0
 	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -191,7 +191,7 @@
 	for(var/i in 1 to length(ui))
 		if(!findtextEx(ui[i], RDSCREEN_NOBREAK))
 			ui[i] += "<br>"
-	
+
 	. = ui.Join("")
 	return replacetextEx(., RDSCREEN_NOBREAK, "")
 
@@ -321,6 +321,11 @@
 	if (materials.on_hold())
 		say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
+	if (!issiliconoradminghost(usr))
+		var/obj/item/card/id/idcard = usr.get_idcard()
+		if(!idcard || (!ACCESS_MINERAL_STOREROOM in idcard.GetAccess()))
+			balloon_alert(usr, "No access!")
+			return 0
 	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
 	var/list/matlist = list()
 	matlist[eject_sheet] = MINERAL_MATERIAL_AMOUNT


### PR DESCRIPTION
# Document the changes in your pull request

ORM can no longer be raided by unauthorized hoodlums

Jobs that have **do not** have access:
- Artist
- Assistant
- Brig Physician
- Chaplain
- Clerk
- Clown
- Curator
- Lawyer
- Mime
- Network Admin
- Paramedic
- Psychiatrist
- Tourist

# Changelog

:cl:  
tweak: ORM access now applies to protolathe mineral access as well. Lower tier jobs are now forbidden from taking minerals out.
/:cl:
