### PR TITLE
Free Miner ship now has an RCD in the engineers spawnpoint

### DIFF
--- a/_maps/shuttles/whiteship_miner.dmm
+++ b/_maps/shuttles/whiteship_miner.dmm
@@ -272,6 +272,14 @@
 /obj/item/storage/box/mixedcubes,
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/abandoned)
+"kW" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/welding,
+/obj/item/wrench,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/construction/rcd/loaded,
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -976,13 +984,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/abandoned)
-"IA" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/welding,
-/obj/item/wrench,
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plating,
 /area/shuttle/abandoned)
 "IZ" = (
 /obj/machinery/door/firedoor/border_only{
@@ -1713,7 +1714,7 @@ gE
 bk
 DV
 yT
-IA
+kW
 EI
 "}
 (9,1,1) = {"


### PR DESCRIPTION
# Document the changes in your pull request

Free miners used to just make them with an autolathe, but now that you can't craft them with a hacked autolathe (dumb as hell) anymore, one RCD should be useful enough for the free miners when doing construction in their ship/deconstructing ruins

# Spriting
Nada
# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: free miner ship rcd 
/:cl:
