### PR TITLE
Removes the ability to use piercing syringes in syringe guns, again

### DIFF
--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -14,6 +14,7 @@
 	var/list/syringes = list()
 	var/max_syringes = 1
 	var/has_syringe_overlay = TRUE ///If it has an overlay for inserted syringes. If true, the overlay is determined by the number of syringes inserted into it.
+	var/allow_piercing = FALSE // whether it can hold piercing syringes
 
 /obj/item/gun/syringe/Initialize(mapload)
 	. = ..()
@@ -60,6 +61,10 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
+		var/obj/item/reagent_containers/syringe/syringe = A
+		if(syringe.proj_piercing && !allow_piercing)
+			to_chat(user, span_warning("[syringe] won't fit into [src]!"))
+			return FALSE
 		if(syringes.len < max_syringes)
 			if(!user.transferItemToLoc(A, src))
 				return FALSE
@@ -85,6 +90,7 @@
 	desc = "A modification of the syringe gun design, using a rotating cylinder to store up to six syringes."
 	icon_state = "rapidsyringegun"
 	max_syringes = 6
+	allow_piercing = TRUE
 
 /obj/item/gun/syringe/syndicate
 	name = "dart pistol"
@@ -95,10 +101,12 @@
 	force = 2 //Also very weak because it's smaller
 	suppressed = TRUE //Softer fire sound
 	can_unsuppress = FALSE //Permanently silenced
+	allow_piercing = TRUE
 
 /obj/item/gun/syringe/dna
 	name = "modified syringe gun"
 	desc = "A syringe gun that has been modified to fit DNA injectors instead of normal syringes."
+	allow_piercing = TRUE
 
 /obj/item/gun/syringe/dna/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Standard syringe guns were made able to fire piercing syringes after they were removed in #17466, so now that they're back in the hands of the crew this restriction is being re-introduced.


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: piercing syringes don't fit in crew syringe guns anymore (syndicate versions still can)
/:cl:
