### PR TITLE
Nerf syringe embed transfer

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -15,14 +15,14 @@
 	materials = list(/datum/material/iron=10, /datum/material/glass=20)
 	reagent_flags = TRANSPARENT
 	sharpness = SHARP_POINTY
-	embedding = list("embedded_pain_chance" = 0, "embedded_pain_multiplier" = 0, "embedded_unsafe_removal_time" = 0.25 SECONDS, "embedded_unsafe_removal_pain_multiplier" = 0, "embed_chance" = 15, "embedded_fall_chance" = 5, "embedded_bleed_rate" = 0)
+	embedding = list("embedded_pain_chance" = 0, "embedded_pain_multiplier" = 0, "embedded_unsafe_removal_time" = 1 SECONDS, "embedded_unsafe_removal_pain_multiplier" = 0, "embed_chance" = 15, "embedded_fall_chance" = 5, "embedded_bleed_rate" = 0)
 
 /obj/item/reagent_containers/syringe/Initialize(mapload)
 	. = ..()
 	if(list_reagents) //syringe starts in inject mode if its already got something inside
 		mode = SYRINGE_INJECT
 		update_icon()
-	RegisterSignals(src, list(COMSIG_ITEM_EMBEDDED, COMSIG_ITEM_EMBED_TICK), PROC_REF(embed_inject))
+	RegisterSignal(src, COMSIG_ITEM_EMBED_TICK, PROC_REF(embed_inject))
 
 /obj/item/reagent_containers/syringe/on_reagent_change(changetype)
 	update_icon()
@@ -190,11 +190,12 @@
 				injoverlay = "inject"
 		add_overlay(injoverlay)
 		M.update_inv_hands()
-	
+
 /obj/item/reagent_containers/syringe/proc/embed_inject(target, mob/living/carbon/human/embedde, obj/item/bodypart/part)
 	if(!reagents.total_volume)
 		return
-	var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
+	// Half of transfer amount, or 2.5 units per tick for default syringes
+	var/fraction = min((0.5 * amount_per_transfer_from_this) / reagents.total_volume, 1)
 	reagents.reaction(embedde, INJECT, fraction)
 	reagents.trans_to(embedde, amount_per_transfer_from_this)
 


### PR DESCRIPTION
# Document the changes in your pull request

As I see it, syringe embeds are supposed to act like bolas. You get hit, you have to take it off at some point or suffer the consequences.

The way syringes currently work is as follows:
- You get hit, inject instantly (5u for default syringe)
- Every life tick, inject again (every 2 seconds, 5u again)

This gives you 2 seconds to stop what you were doing and take out the syringe, or else you now have 10 units of whatever mix in your bloodstream, which is typically enough to kill or sleep if not severely debilitate you.

To make syringe combat more fair, I have severely nerfed the transfer rates by:
- Removing the instant inject, you now only get injected every 2 seconds
- **Halving** injection rate, which means syringes now inject at **2.5u per tick** and bluespace syringes now inject at 10u per tick

To compensate, removal of syringes now takes a full second rather than 0.25 seconds.

# Changelog

:cl:  
tweak: Syringe embed transfer rate halved, but takes slightly longer to take out
/:cl:
