### PR TITLE
Meth and bathsalts metabolize faster but require more to overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -192,9 +192,9 @@
 	description = "Neutralizes mannitol. Reduces stun times by about 300%, speeds the user up, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
-	overdose_threshold = 20
-	addiction_threshold = 10
-	metabolization_rate = 0.75 * REAGENTS_METABOLISM
+	overdose_threshold = 30
+	addiction_threshold = 20 // make sure this is more than what you can fit in a syringe
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/methamphetamine/on_mob_metabolize(mob/living/L)
 	..()
@@ -275,8 +275,9 @@
 	description = "Makes you impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
-	overdose_threshold = 20
-	addiction_threshold = 10
+	overdose_threshold = 30
+	addiction_threshold = 20 // make sure this is more than one you can fit in a syringe
+	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "salt" // because they're bathsalts?
 	var/datum/brain_trauma/special/psychotic_brawling/bath_salts/rage
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -192,7 +192,7 @@
 	description = "Neutralizes mannitol. Reduces stun times by about 300%, speeds the user up, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
-	overdose_threshold = 30
+	overdose_threshold = 40
 	addiction_threshold = 20 // make sure this is more than what you can fit in a syringe
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
@@ -275,7 +275,7 @@
 	description = "Makes you impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
-	overdose_threshold = 30
+	overdose_threshold = 40
 	addiction_threshold = 20 // make sure this is more than one you can fit in a syringe
 	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "salt" // because they're bathsalts?


### PR DESCRIPTION
# Document the changes in your pull request

Meth and bath salts metabolize twice as quickly but require twice as much to become addicted or overdose.

This is so that it takes more than one syringe of bathsalts or meth to cause addictions or overdose, because they were a big problem in syringe guns before the removal and likely will be again now that they're back.

# Wiki Documentation

For both bathsalts and meth, update the addiction threshold to 20 and overdose threshold to 40 on the guide to chemistry.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: doubles metabolization rate of bathsalts and meth
tweak: doubles addiction/overdose threshold of bathsalts and meth
/:cl:
