### PR TITLE
replaces a rogue blast door on the box casino bar variation with the shutter it was always supposed to be

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_casino.dmm
@@ -857,6 +857,14 @@
 	icon_state = "showroomfloor"
 	},
 /area/crew_quarters/kitchen)
+"zt" = (
+/obj/machinery/smartfridge/drinks,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barshutters";
+	name = "bar shutters"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "Ax" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -880,14 +888,6 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barshutters";
 	name = "bar shutters"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"Dp" = (
-/obj/machinery/smartfridge/drinks,
-/obj/machinery/door/poddoor/preopen{
-	id = "barshutters";
-	name = "privacy shutters"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -1327,7 +1327,7 @@ bq
 cm
 bh
 cm
-Dp
+zt
 ap
 db
 ac


### PR DESCRIPTION


# Document the changes in your pull request

rogue ass blast door should have been a shutter

https://github.com/yogstation13/Yogstation/assets/15719834/28bc34af-f37f-4276-8111-6f6da468be4d



# Spriting

N/A

# Wiki Documentation

N/A

# Changelog

:cl:  
tweak: blast door on box casino bar. now shutter :)
/:cl:
