### PR TITLE
Tracking implants no longer act as teleporter beacons

### DIFF
--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -3,7 +3,7 @@
 	desc = "Track with this."
 	actions_types = null
 	var/lifespan_postmortem = 10 MINUTES //for how long after user death will the implant work?
-	var/allow_teleport = TRUE //will people implanted with this act as teleporter beacons?
+	var/allow_teleport = FALSE //will people implanted with this act as teleporter beacons? (god i hope not)
 
 /obj/item/implant/tracking/tra32
 	name = "TRAC implant"


### PR DESCRIPTION
# Document the changes in your pull request

Tracking implants are no longer teleporter beacons.

They are already effective enough with their ability to track from anywhere, being able to teleport directly on top of people is just overkill.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: tracking implants are no longer teleporter beacons
/:cl:
