### PR TITLE
Easily dismembered limbs fall off instead of disintegrating

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -20,9 +20,10 @@
 	INVOKE_ASYNC(C, TYPE_PROC_REF(/mob, emote), "scream")
 	playsound(get_turf(C), 'sound/effects/dismember.ogg', 80, TRUE)
 	SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "dismembered", /datum/mood_event/dismembered)
+	var/should_disintegrate = !HAS_TRAIT(owner, TRAIT_EASYDISMEMBER) // if their limb falls off easily it should just fall off instead
 	drop_limb()
 
-	if(dam_type == BURN)
+	if(dam_type == BURN && should_disintegrate)
 		burn()
 		return 1
 	add_mob_blood(C)


### PR DESCRIPTION
# Document the changes in your pull request

TRAIT_EASYDISMEMBER makes limbs dismembered by burn damage fall off instead of completely disintegrating. Mainly for IPCs, because they get dismembered very easily especially from burn damage, because to me, having your head deleted from just 3 laser shots is too harsh (yes, it only takes 3 laser shots to do this).

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: easily dismembered limbs fall off instead of disintegrating
/:cl:
