### PR TITLE
Makes robotic healing more in line with sutures/mesh

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -15,7 +15,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	///Icon file for right inhand overlays
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 
-	///Icon file for mob worn overlays. 
+	///Icon file for mob worn overlays.
 	///no var for state because it should *always* be the same as icon_state
 	var/icon/mob_overlay_icon
 	//Forced mob worn layer instead of the standard preferred ssize.
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	obj_flags = NONE
 	var/item_flags = NONE
-	
+
 	var/hitsound
 	var/usesound
 	///Used when yate into a mob
@@ -45,7 +45,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/pickup_sound
 	///Sound uses when dropping the item, or when its thrown.
 	var/drop_sound
-	
+
 	var/w_class = WEIGHT_CLASS_NORMAL
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
@@ -1081,9 +1081,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 //specifically for "suture" type robotic healing items
 //amount is either the fuel of a welding tool, or the number of wires consumed
 //volume is how loud the sound of the item is
+#define ROBO_LIMB_HEAL_SELF 6 SECONDS
+#define ROBO_LIMB_HEAL_OTHER 2 SECONDS
 /obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
-	if(I.use_tool(H, user, 2 SECONDS, amount, volume, null, H != user))
+	var/used_delay
+	if(H != user)
+		used_delay = ROBO_LIMB_HEAL_OTHER
+	else
+		used_delay = ROBO_LIMB_HEAL_SELF
+
+	if(I.use_tool(H, user, used_delay, amount, volume, null, TRUE))
 		if(item_heal_robotic(H, user, brute_heal, burn_heal))
 			return heal_robo_limb(I, H, user, brute_heal, burn_heal, amount, volume)
 		return TRUE
-	

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -174,7 +174,10 @@
 
 	playsound(src, 'sound/effects/rip2.ogg', 25)
 
-	if(!do_after(user, (user == M ? self_delay : other_delay), M))
+	/// Use other_delay if healing someone else (usually 1 second)
+	/// Use self_delay if healing yourself (usually 3 seconds)
+	/// Reduce delay by 20% if medical
+	if(!do_after(user, (user == M ? self_delay : other_delay) * (IS_MEDICAL(user) ? 0.8 : 1), M))
 		return
 
 	playsound(src, 'sound/effects/rip1.ogg', 25)


### PR DESCRIPTION
# Document the changes in your pull request

The way robo limb healing works right now is pretty weird.

Robo limb healing worked as follows:
- Takes 2 seconds universally
- If you're an engineer reduce timer by 20%
- If you're a roboticist not healing yourself, reduce timer by 20%, not stacking with the above

This is how sutures/mesh work:
- Take 1 seconds to heal someone else
- Take 3 seconds to heal yourself

To make robo healing more in line with medical, I have nerfed robo limbs to take 3x longer when healing yourself, like medical items. In addition, robos now keep the 20% bonus even if healing themselves.

While making this PR, I also got the idea to make medical items heal 20% faster if used by medical personnel, like robotic healing.

So essentially, robotic healing are now the same as fleshy healing, but takes twice as long due to the overwhelming prevalence and accessibility (especially ability to be printed) of healing items. Not to mention robotic limbs are supposed to be a downside.

#

As an aside, the experimental welding tool has 0.5x toolspeed which means it will heal at a rate of 1 or 3 seconds

# Changelog

:cl:  
tweak: Robotic limbs now take longer to heal if you are healing yourself
tweak: Roboticists are no longer nerfed if healing their own robotic limbs
tweak: Medical personnel now use sutures/meshes/etc 20% faster
/:cl:
