### PR TITLE
Tweaks some surgery stuff

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -18,6 +18,9 @@
 #define TOOL_SAW			"saw"
 #define TOOL_BONESET		"bonesetter"
 
+#define MECHANICAL_TOOLS list(TOOL_CROWBAR, TOOL_MULTITOOL, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH, TOOL_WELDER, TOOL_ANALYZER)
+#define MEDICAL_TOOLS list(TOOL_RETRACTOR, TOOL_HEMOSTAT, TOOL_CAUTERY, TOOL_DRILL, TOOL_SCALPEL, TOOL_SAW, TOOL_BONESET)
+
 // If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,
 // tool sound is only played when op is started. If not, it's played twice.
 #define MIN_TOOL_SOUND_DELAY 20

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -870,11 +870,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return
 	delay *= toolspeed
 
-	if((IS_ENGINEERING(user) || (robo_check && IS_JOB(user, "Roboticist"))) && tool_behaviour != TOOL_MINING) //if the user is an engineer, they'll use the tool faster. Doesn't apply to mining tools.
-		delay *= 0.8
+	if(((IS_ENGINEERING(user) || (robo_check && IS_JOB(user, "Roboticist"))) && (tool_behaviour in MECHANICAL_TOOLS)) || (IS_MEDICAL(user) && tool_behaviour in MEDICAL_TOOLS))
+		delay *= 0.8 // engineers and doctors use their own tools faster
 
-	// Play tool sound at the beginning of tool usage.
-	play_tool_sound(target, volume)
+	if(volume) // Play tool sound at the beginning of tool usage.
+		play_tool_sound(target, volume)
 
 	if(delay)
 		// Create a callback with checks that would be called every tick by do_after.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -870,7 +870,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return
 	delay *= toolspeed
 
-	if(((IS_ENGINEERING(user) || (robo_check && IS_JOB(user, "Roboticist"))) && (tool_behaviour in MECHANICAL_TOOLS)) || (IS_MEDICAL(user) && tool_behaviour in MEDICAL_TOOLS))
+	if(((IS_ENGINEERING(user) || (robo_check && IS_JOB(user, "Roboticist"))) && (tool_behaviour in MECHANICAL_TOOLS)) || (IS_MEDICAL(user) && (tool_behaviour in MEDICAL_TOOLS)))
 		delay *= 0.8 // engineers and doctors use their own tools faster
 
 	if(volume) // Play tool sound at the beginning of tool usage.

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -94,20 +94,16 @@
 	var/advance = FALSE
 
 	var/speed_mod = 1
+	if(user == target)
+		speed_mod *= 2 // harder to do on yourself
 
 	if(preop(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = FALSE
 		return FALSE
 	play_preop_sound(user, target, target_zone, tool, surgery)
 
-	if(tool)
-		speed_mod = tool.toolspeed
-
 	if(is_species(user, /datum/species/lizard/ashwalker/shaman))//shaman is slightly better at surgeries
 		speed_mod *= 0.9
-
-	if(IS_MEDICAL(user))
-		speed_mod *= 0.8
 
 	if(istype(user.get_item_by_slot(ITEM_SLOT_GLOVES), /obj/item/clothing/gloves/color/latex))
 		var/obj/item/clothing/gloves/color/latex/surgicalgloves = user.get_item_by_slot(ITEM_SLOT_GLOVES)
@@ -115,7 +111,8 @@
 
 	var/previous_loc = user.loc
 
-	if(do_after(user, time * speed_mod, target))
+	// If we have a tool, use it
+	if((tool && tool.use_tool(target, user, time * speed_mod)) || do_after(user, time * speed_mod, target))
 		var/prob_chance = 100
 
 		if(implement_type)	//this means it isn't a require hand or any item step.

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -112,7 +112,7 @@
 	var/previous_loc = user.loc
 
 	// If we have a tool, use it
-	if((tool && tool.use_tool(target, user, time * speed_mod)) || do_after(user, time * speed_mod, target))
+	if((tool && tool.use_tool(target, user, time * speed_mod, robo_check = TRUE)) || do_after(user, time * speed_mod, target))
 		var/prob_chance = 100
 
 		if(implement_type)	//this means it isn't a require hand or any item step.

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -94,8 +94,6 @@
 	var/advance = FALSE
 
 	var/speed_mod = 1
-	if(user == target)
-		speed_mod *= 2 // harder to do on yourself
 
 	if(preop(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = FALSE

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -94,6 +94,8 @@
 	var/advance = FALSE
 
 	var/speed_mod = 1
+	if(user == target)
+		speed_mod *= 3 // harder to do on yourself
 
 	if(preop(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Self-surgery is now slower, but engineers/roboticists can do mechanical surgery faster. Also, doctors can use medical tools faster, and engineers no longer get a tool speed bonus when using medical tools.

Intent of this PR is both to nerf self-surgery a bit as well as make roboticists and doctors a bit better at their job.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: self-surgery is slower
tweak: engineers and roboticists can do mechanical surgery faster
tweak: engineers no longer use medical tools faster
tweak: medical staff can use medical tools faster
/:cl:
