### PR TITLE
chicken nugget needs batter to craft

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -61,6 +61,7 @@
 /datum/crafting_recipe/food/nugget
 	name = "Chicken Nugget"
 	reqs = list(
+		/datum/reagent/consumable/batter = 2,
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/nugget
@@ -142,7 +143,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/stewedsoymeat
 	subcategory = CAT_MEAT
-	
+
 /datum/crafting_recipe/food/meatclown
 	name = "Meat Clown"
 	reqs = list(


### PR DESCRIPTION
Makes nuggets need 2u batter, same as battered fish. For realism I guess? And the sprite is a battered nugget.


# Wiki Documentation

add batter to nugget i will do this


:cl:  Ktlwjec
tweak: Chicken nuggets require 2u of batter to craft, along with the cutlet.
/:cl: