### PR TITLE
Actually nerfs preternis, not just a bugfix this time

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -23,15 +23,13 @@ adjust_charge - take a positive or negative value to adjust the charge level
 	toxic_food = NONE
 	liked_food = FRIED | SUGAR | JUNKFOOD
 	disliked_food = GROSS | VEGETABLES
-	brutemod = 0.9 //Have you ever punched a metal plate?
 	burnmod = 1.1 //The plasteel has a really high heat capacity, however, if the heat does get through it will REALLY burn the flesh on the inside
 	coldmod = 3 //The plasteel around them saps their body heat quickly if it gets cold
 	heatmod = 2 //Once the heat gets through it's gonna BURN
 	tempmod = 0.1 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
-	stunmod = 1.1 //Big metal body has difficulty getting back up if it falls down
+	stunmod = 1.2 //Big metal body has difficulty getting back up if it falls down
 	staminamod = 1.1 //Big metal body has difficulty holding it's weight if it gets tired
 	action_speed_coefficient = 0.9 //worker drone do the fast
-	punchdamagelow = 2 //if it hits you, it's always gonna hurt
 	punchdamagehigh = 8 //not built for large high speed acts like punches
 	punchstunthreshold = 7 //if they get a good punch off, you're still seeing lights
 	siemens_coeff = 1.75 //Circuits REALLY don't like extra electricity flying around


### PR DESCRIPTION
They're currently just a bit strong in combat for what i was wanting of them, so i've made a few minor number tweaks
As a side benefit, making brutemod 1 removes one of the little icons in the species selection ui area (already very overloaded with icons for preterni)

:cl:  
tweak: Preterni have a 1.0 brutemod from 0.9 (they still have the flat DR)
tweak: Preterni have a 1.2 stunmod from 1.1
tweak: Preterni have a punchlow of 1 from 2 (less effective stun chance as a result)
/:cl:
