### PR TITLE
SM now spawns more than Tesla

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 50, "Engine TEG" = 0)
+	template_names = list("Engine SM" = 60, "Engine Singulo And Tesla" = 40, "Engine TEG" = 0)
 	icon = 'yogstation/icons/rooms/box/engine.dmi'
 
 /obj/effect/landmark/stationroom/box/engine/choose()
@@ -140,7 +140,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Chapel 1", "Chapel 2")
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta Singulo And Tesla" = 50, "Meta SM" = 50, "Meta TEG" = 0)
+	template_names = list("Meta Singulo And Tesla" = 40, "Meta SM" = 60, "Meta TEG" = 0)
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION

# Document the changes in your pull request

This is pretty insignificant because it changes it from a 50/50 to a 60/40 in favor of the SM.

# Why this is good for the game

The tesla is boring and lame, and it's very easy to be uncreative. The SM atleast inspires a little bit of creativity, and is also easy to setup, and fun for experienced engineers to fuck with.

# Spriting

# Wiki Documentation

Don't think so

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: changes engine spawn chances making sm have a 60 percent spawn chance compared to the teslas 40
/:cl:
