### PR TITLE
Fixes invisible boxes, boxes spawning in with less than normal amounts, etc

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -70,19 +70,15 @@
 	spawn_type = /obj/item/reagent_containers/food/snacks/donut
 	fancy_open = TRUE
 
-/obj/item/storage/box/fancy/donut_box/update_icon()
-	if(fancy_open && (length(contents) > 6))
-		icon_state = "[icon_type]box6"
-	else if(fancy_open)
-		icon_state = "[icon_type]box[contents.len]"
-	else
-		icon_state = "[icon_type]box"
-
 /obj/item/storage/box/fancy/donut_box/Initialize(mapload)
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
+
+/obj/item/storage/box/fancy/donut_box/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/reagent_containers/food/snacks/donut(src)
 
 /obj/item/storage/box/fancy/donut_box/deadly
 	icon = 'icons/obj/food/containers.dmi'
@@ -97,6 +93,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/donut))
+
+/obj/item/storage/box/fancy/donut_box/deadly/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/reagent_containers/food/snacks/donut/deadly(src)
 
 
 /*
@@ -119,6 +119,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 12
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/egg))
+
+/obj/item/storage/box/fancy/egg_box/PopulateContents()
+	for(var/i in 1 to 12)
+		new /obj/item/reagent_containers/food/snacks/egg(src)
 
 /*
  * Candle Box
@@ -145,6 +149,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 5
 
+/obj/item/storage/box/fancy/candle_box/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/candle(src)
+
 
 ////////////
 //CIG PACK//
@@ -167,6 +175,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 6
 	STR.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
+
+/obj/item/storage/box/fancy/cigarettes/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette(src)
 
 /obj/item/storage/box/fancy/cigarettes/examine(mob/user)
 	. = ..()
@@ -231,11 +243,19 @@
 	icon_state = "dromedary"
 	spawn_type = /obj/item/clothing/mask/cigarette/dromedary
 
+/obj/item/storage/box/fancy/cigarettes/dromedaryco/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/dromedary(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_uplift
 	name = "\improper Uplift Smooth packet"
 	desc = "Your favorite brand, now menthol flavored."
 	icon_state = "uplift"
 	spawn_type = /obj/item/clothing/mask/cigarette/uplift
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_uplift/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/uplift(src)
 
 /obj/item/storage/box/fancy/cigarettes/cigpack_robust
 	name = "\improper Robust packet"
@@ -243,11 +263,19 @@
 	icon_state = "robust"
 	spawn_type = /obj/item/clothing/mask/cigarette/robust
 
+/obj/item/storage/box/fancy/cigarettes/cigpack_robust/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/robust(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_robustgold
 	name = "\improper Robust Gold packet"
 	desc = "Smoked by the truly robust."
 	icon_state = "robustg"
 	spawn_type = /obj/item/clothing/mask/cigarette/robustgold
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_robustgold/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/robustgold(src)
 
 /obj/item/storage/box/fancy/cigarettes/cigpack_carp
 	name = "\improper Carp Classic packet"
@@ -255,11 +283,19 @@
 	icon_state = "carp"
 	spawn_type = /obj/item/clothing/mask/cigarette/carp
 
+/obj/item/storage/box/fancy/cigarettes/cigpack_carp/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/carp(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_syndicate
 	name = "cigarette packet"
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndie"
 	spawn_type = /obj/item/clothing/mask/cigarette/syndicate
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_syndicate/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/syndicate(src)
 
 /obj/item/storage/box/fancy/cigarettes/cigpack_midori
 	name = "\improper Midori Tabako packet"
@@ -267,11 +303,19 @@
 	icon_state = "midori"
 	spawn_type = /obj/item/clothing/mask/cigarette/rollie/nicotine
 
+/obj/item/storage/box/fancy/cigarettes/cigpack_midori/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/rollie/nicotine(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_shadyjims
 	name = "\improper Shady Jim's Super Slims packet"
 	desc = "Is your weight slowing you down? Having trouble running away from gravitational singularities? Can't stop stuffing your mouth? Smoke Shady Jim's Super Slims and watch all that fat burn away. Guaranteed results!"
 	icon_state = "shadyjim"
 	spawn_type = /obj/item/clothing/mask/cigarette/shadyjims
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_shadyjims/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/shadyjims(src)
 
 /obj/item/storage/box/fancy/cigarettes/cigpack_xeno
 	name = "\improper Xeno Filtered packet"
@@ -279,11 +323,19 @@
 	icon_state = "slime"
 	spawn_type = /obj/item/clothing/mask/cigarette/xeno
 
+/obj/item/storage/box/fancy/cigarettes/cigpack_xeno/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/xeno(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_nonico
 	name = "nicotine-free cigarette packet"
 	desc = "A dull-looking pack of cigarettes."
 	icon_state = "nonico"
 	spawn_type = /obj/item/clothing/mask/cigarette/nonico
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_nonico/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/nonico(src)
 
 /obj/item/storage/box/fancy/cigarettes/cigpack_cannabis
 	name = "\improper Freak Brothers' Special packet"
@@ -291,11 +343,19 @@
 	icon_state = "midori"
 	spawn_type = /obj/item/clothing/mask/cigarette/rollie/cannabis
 
+/obj/item/storage/box/fancy/cigarettes/cigpack_cannabis/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/rollie/cannabis(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigpack_mindbreaker
 	name = "\improper Leary's Delight packet"
 	desc = "Banned in over 36 galaxies."
 	icon_state = "shadyjim"
 	spawn_type = /obj/item/clothing/mask/cigarette/rollie/mindbreaker
+
+/obj/item/storage/box/fancy/cigarettes/cigpack_mindbreaker/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/clothing/mask/cigarette/rollie/mindbreaker(src)
 
 /obj/item/storage/box/fancy/rollingpapers
 	name = "rolling paper pack"
@@ -311,6 +371,10 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 10
 	STR.set_holdable(list(/obj/item/rollingpaper))
+
+/obj/item/storage/box/fancy/rollingpapers/PopulateContents()
+	for(var/i in 1 to 10)
+		new /obj/item/rollingpaper(src)
 
 /obj/item/storage/box/fancy/rollingpapers/update_icon()
 	cut_overlays()
@@ -336,6 +400,10 @@
 	STR.max_items = 5
 	STR.set_holdable(list(/obj/item/clothing/mask/cigarette/cigar))
 
+/obj/item/storage/box/fancy/cigarettes/cigars/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/clothing/mask/cigarette/cigar(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigars/update_icon()
 	cut_overlays()
 	if(fancy_open)
@@ -356,11 +424,19 @@
 	icon_state = "cohibacase"
 	spawn_type = /obj/item/clothing/mask/cigarette/cigar/cohiba
 
+/obj/item/storage/box/fancy/cigarettes/cigars/cohiba/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/clothing/mask/cigarette/cigar/cohiba(src)
+
 /obj/item/storage/box/fancy/cigarettes/cigars/havana
 	name = "\improper premium Havanian cigar case"
 	desc = "A case of classy Havanian cigars."
 	icon_state = "cohibacase"
 	spawn_type = /obj/item/clothing/mask/cigarette/cigar/havana
+
+/obj/item/storage/box/fancy/cigarettes/cigars/havana/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/clothing/mask/cigarette/cigar/havana(src)
 
 /*
  * Heart Shaped Box w/ Chocolates
@@ -382,3 +458,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 8
 	STR.set_holdable(list(/obj/item/reagent_containers/food/snacks/tinychocolate))
+
+/obj/item/storage/box/fancy/heart_box/PopulateContents()
+	for(var/i in 1 to 8)
+		new /obj/item/reagent_containers/food/snacks/tinychocolate(src)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -70,6 +70,14 @@
 	spawn_type = /obj/item/reagent_containers/food/snacks/donut
 	fancy_open = TRUE
 
+/obj/item/storage/box/fancy/donut_box/update_icon()
+	if(fancy_open && (length(contents) > 6))
+		icon_state = "[icon_type]box6"
+	else if(fancy_open)
+		icon_state = "[icon_type]box[contents.len]"
+	else
+		icon_state = "[icon_type]box"
+
 /obj/item/storage/box/fancy/donut_box/Initialize(mapload)
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)


### PR DESCRIPTION
all the fancy boxes are spawning in with 7 items i DONT UNDERSTAND but i cant use the round start donut boxes properly right now because of it!!!!!!

Fixes #19291 

:cl:  Ktlwjec
bugfix: Donut and candle boxes are not invisible.
bugfix: Boxes (such as cigarettes, candles, egg boxes) now spawn with the intended amount of items.
/:cl: