### PR TITLE
Removes negative AP from .38 lethal rounds

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -59,7 +59,7 @@
 
 /obj/item/ammo_box/c38
 	name = "speed loader (.38 special)"
-	desc = "A six-shot speed loader designed for .38 revolvers. These rounds do good damage, but are weak against armor."
+	desc = "A six-shot speed loader designed for .38 revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	caliber = "38"

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -106,7 +106,7 @@
 
 /obj/item/ammo_box/magazine/v38
 	name = "handgun magazine (.38 special)"
-	desc = "A 8-round .38 special magazine designed for the Vatra M38 pistol. Not great against armor."
+	desc = "A 8-round .38 special magazine designed for the Vatra M38 pistol."
 	icon_state = "v38-8"
 	ammo_type = /obj/item/ammo_casing/c38
 	caliber = "38"
@@ -153,7 +153,7 @@
 	icon_state = "v38B-8"
 	ammo_type = /obj/item/ammo_casing/c38/bluespace
 	sprite_designation = "B"
-	
+
 // Bolt Pistol
 
 /obj/item/ammo_box/magazine/boltpistol

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -49,22 +49,9 @@
 
 /obj/item/projectile/bullet/c38/talon
 	name = ".38 talon bullet"
-	damage = 12 //Tested on naked felinids, could never cause a wound type above open cut.
-	stamina = 18
-	armour_penetration = -30 //IF THIS IS EVER MADE POSITIVE, PLEASE REVISE FORMULA IN .38 TALON ON-HIT PROC
+	damage = 12
+	wound_bonus = 5 // Will fuck someone up bad if they get shot ~4+ times
 	sharpness = SHARP_EDGED
-	var/bleed_threshold = 7 //How much damage the bullet must do to bleed
-
-/obj/item/projectile/bullet/c38/talon/on_hit(atom/target, blocked = 0)
-	if(blocked != 100 && ishuman(target))
-		var/mob/living/carbon/human/H = target //Who we're trying to wound
-		var/obj/item/bodypart/B = H.get_bodypart(def_zone) //What we're trying to wound
-		var/armor = H.run_armor_check(def_zone, flag, "","", armour_penetration) //That actual armor of where we're trying to wound
-		var/final_damage = damage * (1 - (armor/100)) //How much damage this bullet will do
-		if(final_damage > bleed_threshold)
-			var/datum/wound/slash/moderate/open_wound = new
-			open_wound.apply_wound(B)
-	return ..()
 
 /obj/item/projectile/bullet/c38/bluespace
 	name = ".38 bluespace bullet"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -19,7 +19,6 @@
 /obj/item/projectile/bullet/c38
 	name = ".38 special bullet"
 	damage = 21
-	armour_penetration = -30 //Armor hit by this is modified by x1.43. IF THIS IS EVER MADE POSITIVE, PLEASE REVISE FORMULA IN .38 TALON ON-HIT PROC
 	wound_bonus = -30
 	wound_falloff_tile = -2.5
 	bare_wound_bonus = 15
@@ -28,6 +27,7 @@
 	name = ".38 rubber bullet"
 	damage = 7
 	stamina = 30
+	armour_penetration = -30 //Armor hit by this is modified by x1.43.
 	sharpness = SHARP_NONE
 
 /obj/item/projectile/bullet/c38/ap
@@ -51,6 +51,7 @@
 	name = ".38 talon bullet"
 	damage = 12 //Tested on naked felinids, could never cause a wound type above open cut.
 	stamina = 18
+	armour_penetration = -30 //IF THIS IS EVER MADE POSITIVE, PLEASE REVISE FORMULA IN .38 TALON ON-HIT PROC
 	sharpness = SHARP_EDGED
 	var/bleed_threshold = 7 //How much damage the bullet must do to bleed
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -49,8 +49,10 @@
 
 /obj/item/projectile/bullet/c38/talon
 	name = ".38 talon bullet"
-	damage = 12
-	wound_bonus = 5 // Will fuck someone up bad if they get shot ~4+ times
+	damage = 8 // 8+20 rolls 21-38 wound dmg vs no armor
+	wound_bonus = 20
+	bare_wound_bonus = 0
+	wound_falloff_tile = -1
 	sharpness = SHARP_EDGED
 
 /obj/item/projectile/bullet/c38/bluespace


### PR DESCRIPTION
# Document the changes in your pull request

-30 AP made sense when .38 lethal was the roundstart standard for detective. Now that is no longer the case, and while .38 rubber has fallen hard from what it once was, I am not concerned for that today.

The .38 lethal rounds stand aside the other lethal weapons which far outclass it. It takes several magazines for the vatra (which is where you'll most commonly see .38 lethal rounds) to down any opponent. It is really pitiful when you compare it to the sheer reliable killing power of the laser gun. Come on. Think about how absolutely frightening a laser gun is as an antagonist.

Anyways,
- .38 rubber unchanged
- .38 AP unchanged (has 15 AP)
- .38 frost unchanged
- **.38 lethal now has 0 AP instead of -30**
  - Still does 21 damage (and -30 wound bonus)
- **.38 talon now has -30->0 AP, 12->8 damage, -10->20 wound bonus, less wound falloff, and no bare wound bonus**
  - **21-38 wound roll vs. no armor**
    - Armor is incredibly effective against wounds
  - **No longer does any stamina damage**
- **.38 bluespace now has 0 AP instead of -30**
  - Still does 12 damage

# Changelog

:cl:  
tweak: .38 bluespace, talon, and standard rounds have had their negative AP removed
tweak: .38 talon is now geared further towards wounds
/:cl:
