### PR TITLE
Nerfs ranged holoparasites into the GROUND (I said I would do it!) (Mqiib hates fun!!!)

### DIFF
--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -359,7 +359,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 /mob/living/simple_animal/hostile/guardian/Shoot(atom/targeted_atom)
 	if (QDELETED(targeted_atom) || targeted_atom == targets_from.loc || targeted_atom == targets_from)
 		return
-	if(!ranged_ammo_current)
+	if(ranged && (ranged_ammo_current < 5))
 		to_chat(src, span_holoparasite("You don't have any ammo ready!"))
 		return
 	var/turf/startloc = get_turf(targets_from)
@@ -379,7 +379,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	emerald_splash.original = targeted_atom
 	emerald_splash.preparePixelProjectile(targeted_atom, src)
 	emerald_splash.fire()
-	ranged_ammo_current -= 1
+	ranged_ammo_current -= 5
 	return emerald_splash
 
 /mob/living/simple_animal/hostile/guardian/RangedAttack(atom/A, params)

--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -12,10 +12,10 @@
 	guardian.range = range * 2
 	if (ranged)
 		guardian.ranged = TRUE
-		guardian.ranged_cooldown_time = 20 / speed				//2, 1, 0.66, 0.5, 0.4 second cooldown time
-		guardian.ranged_ammo_max = potential + 1				//2, 3, 4, 5, 6 ammo max
-		guardian.ranged_ammo_regen = max(1, floor(speed / 1.5))	//1, 1, 2, 2, 3 regen speed
-		guardian.ranged_ammo_current = guardian.ranged_ammo_max	//start with full ammo
+		guardian.ranged_cooldown_time = 20 / speed	//2, 1, 0.66, 0.5, 0.4 second cooldown time
+		guardian.ranged_ammo_max = potential * 5 + 5	//10, 15, 20, 25, 30 ammo max
+		guardian.ranged_ammo_regen = round(speed*1.5)	//1, 3, 4, 6, 7 ammo regenerated every 2 seconds (shots cost 5 ammo)
+		guardian.ranged_ammo_current = guardian.ranged_ammo_max		//start with full ammo
 	else
 		guardian.melee_damage_lower = damage * 5	//5, 10, 15, 20, 25 damage
 		guardian.melee_damage_upper = damage * 5

--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -12,16 +12,19 @@
 	guardian.range = range * 2
 	if (ranged)
 		guardian.ranged = TRUE
-		guardian.ranged_cooldown_time = 20 / speed
+		guardian.ranged_cooldown_time = 20 / speed				//2, 1, 0.66, 0.5, 0.4 second cooldown time
+		guardian.ranged_ammo_max = potential + 1				//2, 3, 4, 5, 6 ammo max
+		guardian.ranged_ammo_regen = max(1, floor(speed / 1.5))	//1, 1, 2, 2, 3 regen speed
+		guardian.ranged_ammo_current = guardian.ranged_ammo_max	//start with full ammo
 	else
-		guardian.melee_damage_lower = damage * 5
+		guardian.melee_damage_lower = damage * 5	//5, 10, 15, 20, 25 damage
 		guardian.melee_damage_upper = damage * 5
-		guardian.obj_damage = damage * 16
-	var/armor = clamp((max(6 - defense, 1)/2.5)/2, 0.25, 1)
+		guardian.obj_damage = damage * 16			//16, 32, 48, 64, 80 damage
+	var/armor = clamp((max(6 - defense, 1)/2.5)/2, 0.25, 1)	//1, 0.8, 0.6, 0.4, 0.25 damage mod
 	guardian.damage_coeff = list(BRUTE = armor, BURN = armor, TOX = armor, CLONE = armor, STAMINA = 0, OXY = armor)
 	if (damage == 5)
 		guardian.environment_smash = ENVIRONMENT_SMASH_WALLS
-	guardian.atk_cooldown = (15 / speed) * 1.5
+	guardian.atk_cooldown = (15 / speed) * 1.5	//2.25, 1.13,  0.75, 0.56, 0.45 second cooldown time
 	if (ability)
 		ability.guardian = guardian
 		ability.Apply()


### PR DESCRIPTION
Ok lets be real, infinite ammo guns are stupid. Infinite ammo guns that do decent damage are also stupid. Infinite ammo guns that do decent damage, are fired by an auto-turret attached to your ass, and have really high AP all while leaving your hands free to do whatever else you want are extra special stupid. As such, they no longer have quite as infinite ammo. Also now they need to care about potential too hahaha

Each shot uses 5 ammo. Maximum ammo is determined by potential (5 + 5*potential, max 30). Charge rate is determined by speed ([1,3,4,6,7] per ~2 seconds). This means the holoparasite at max speed can, when out of ammo, fire at about .7 shot per second, or 1 shot per 1.4 seconds. This is a 3.5x increase in fire delay when out of ammo. Goodbye infinite super high DPS, so long spraying down a hallway constantly forever. Hopefully.

This is clearly an ided pr and not something that has been talked about for a while.
# Document the changes in your pull request

Ranged holoparasites now have a regenerating magazine of ammo. Max ammo based on potential, regen speed based on speed.

# Wiki Documentation

Ranged holoparas have ammo. See breakdown above.

# Changelog

:cl:  

tweak: Ranged holoparasites now have a regenerating magazine to draw upon for firing their stupid crystals
tweak: Ranged holoparasites now actually care about potential
/:cl:
