### PR TITLE
you can remove Jelly Spagh-o-nut from the food cart again

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -140,7 +140,7 @@
 	tastes = list("Spaghetti"= 3, "Carbs" = 2, "Bewilderment" = 1)
 
 /obj/item/reagent_containers/food/snacks/donut/spaghetti/jelly
-	name = "'Jelly' Spagh-o-nut"
+	name = "Jelly Spagh-o-nut"
 	desc = "A Spaghetti Donut stuffed with ketchup."
 	icon_state = "jdonut_spaghetti"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/ketchup = 2)


### PR DESCRIPTION
i cant get it working another way, so just removes the quotations around "'jelly'".

you could add it to the food cart but it was stuck there forever, never able to be dispensed.

:cl:  Ktlwjec
bugfix: You can dispense Jelly Spagh-o-nut from the food cart.
/:cl: