### PR TITLE
Handles an oversight with delayed injections from syringe guns that caused acid to deal significantly more damage than expected

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -866,7 +866,7 @@
 		return
 	if(methods & INJECT)
 		if(!HAS_TRAIT(C, TRAIT_ACIDBLOOD))
-			C.adjustBruteLoss(1.5 * min(6*toxpwr, reac_volume * toxpwr))
+			C.adjustBruteLoss(1.5 * min(2*toxpwr, reac_volume * toxpwr))
 		return
 	C.acid_act(acidpwr, reac_volume)
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Acid contsct damage from syringe gun used to be capped at 6 units, now syringe gun syringes inject in smaller increments, allowing this damage to be double dipped

To handle this, I reduce the cap of acid damage on inject to 2 rather than 6, causing sulphuric acid to deal 3 damage per injection, and fluoroacid to deal 6 (totals 9 and 18 for default syringe, as was before delayed injection syringes)
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

Sulphuric acid inject damage capped at 2 units rather than 6, for 3 damage per injection
Fluorosulphuric acid inject damage capped at 2 units rather than 6, for 6 damage per injection
<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: acid injection damage cap reduced from 6 units to 2 units
/:cl:
