### PR TITLE
You can reload utensils into the dinnerware vendor

### DIFF
--- a/code/modules/vending/dinnerware.dm
+++ b/code/modules/vending/dinnerware.dm
@@ -15,13 +15,13 @@
 					/obj/item/clothing/suit/apron/chef = 2,
 					/obj/item/kitchen/rollingpin = 2,
 					/obj/item/kitchen/knife = 2,
-					/obj/item/reagent_containers/glass/mixbowl = 3, // Yogs -- chef's mixing bowl 
+					/obj/item/reagent_containers/glass/mixbowl = 3, // Yogs -- chef's mixing bowl
 					/obj/item/reagent_containers/food/condiment/cinnamon = 5, // Yogs -- cinnamon shakers!
-					/obj/item/plate = 10) 
+					/obj/item/plate = 10)
 	contraband = list(/obj/item/kitchen/knife/butcher = 2,
 					  /obj/item/melee/fryingpan = 2,	// Yogs -- Pan
 					  /obj/item/twohanded/bigspoon = 2, // Yogs -- Big spoon
-					  ) 
+					  )
 	refill_canister = /obj/item/vending_refill/dinnerware
 	default_price = 5
 	extra_price = 50
@@ -30,3 +30,9 @@
 /obj/item/vending_refill/dinnerware
 	machine_name = "Plasteel Chef's Dinnerware Vendor"
 	icon_state = "refill_smoke"
+
+/obj/machinery/vending/dinnerware/canLoadItem(obj/item/I,mob/user)
+	if(I.type in products)
+		if(istype(I, /obj/item/reagent_containers/food/condiment)) //feels weird to put food back
+			return FALSE
+		return TRUE


### PR DESCRIPTION
qol, it's really annoying when you vend too many of something by mistake, or upgrade your knife to a cleaver and now you have two, use a tray for one task and want it put back, etc. Removed condiments because why would you put food back, seems off to me.

:cl:  Ktlwjec
rscadd: You can reload utensils into the dinnerware (kitchen) vendor
/:cl: