### PR TITLE
Sinful demon Greed summon cursed item spell

### DIFF
--- a/code/game/objects/items/granters/magic/sacred_flame.dm
+++ b/code/game/objects/items/granters/magic/sacred_flame.dm
@@ -12,3 +12,6 @@
 		"No pain, no gain...",
 		"One with the flame...",
 	)
+
+/obj/item/book/granter/action/spell/sacredflame/weak //grants the far weaker version
+	granted_action = /datum/action/cooldown/spell/aoe/sacred_flame/weak

--- a/code/modules/antagonists/demon/demons.dm
+++ b/code/modules/antagonists/demon/demons.dm
@@ -26,6 +26,7 @@
 		/datum/action/cooldown/spell/conjure/summon_mirror,
 		/datum/action/cooldown/spell/touch/mend,
 		/datum/action/cooldown/spell/touch/torment,
+		/datum/action/cooldown/spell/conjure/cursed_item,
 		))
 
 	var/static/list/sinfuldemon_traits = list(
@@ -131,12 +132,15 @@
 			ADD_TRAIT(owner.current, TRAIT_BOTTOMLESS_STOMACH, SINFULDEMON_TRAIT) // nutrition is capped for infinite eating
 			ADD_TRAIT(owner.current, TRAIT_VORACIOUS, SINFULDEMON_TRAIT) // eat and drink faster & eat infinite snacks
 
-		if(SIN_GREED)
+		if(SIN_GREED) 
 			var/datum/action/cooldown/spell/shapeshift/demon/demon_form = new(owner.current)
 			demon_form.Grant(owner.current)
 
 			var/datum/action/cooldown/spell/conjure/summon_greedslots/gambling_addiction = new(owner.current)
 			gambling_addiction.Grant(owner.current)
+
+			var/datum/action/cooldown/spell/conjure/cursed_item/immortal_temptation = new(owner.current)
+			immortal_temptation.Grant(owner.current)
 
 		if(SIN_WRATH)
 			var/datum/action/cooldown/spell/shapeshift/demon/wrath/wrath_demon = new(owner.current)

--- a/code/modules/antagonists/demon/sins/greed.dm
+++ b/code/modules/antagonists/demon/sins/greed.dm
@@ -14,3 +14,78 @@
 	summon_lifespan = 1 MINUTES
 	summon_radius = 0 //spawns on top of us
 	summon_type = list(/obj/structure/cursed_slot_machine/betterchance)
+
+/datum/action/cooldown/spell/conjure/cursed_item //conjure a random unique cursed item, which can impart various benefits, but always at a cost...
+	name = "Summon Cursed Item"
+	desc = "Manifest a random cursed object from hell beneath you. They have powerful applications, though often times with unintended consequences. Perfect for selling, or even using yourself if in a bind. Be aware, many of their effects can harm you too if used."
+	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
+	button_icon_state = "moneybag"
+	background_icon_state = "bg_demon"
+	overlay_icon_state = "bg_demon_border"
+
+	invocation = "Power beyond measure"
+	invocation_type = INVOCATION_WHISPER
+	spell_requirements = NONE
+
+	cooldown_time = 180 SECONDS //no farming a bunch of items
+	summon_radius = 0 //spawns on top of us
+	summon_type = list(
+		/obj/item/katana/greedcursed,
+		/obj/item/reagent_containers/pill/greedcursed,
+		/obj/item/book_of_babel/greedcursed,
+		/obj/item/book/granter/action/spell/sacredflame/weak, //this one isnt actually 'cursed', but its also way weaker than the normal spell, and you're still setting yourself on fire
+		/obj/item/greedcursed_bottle
+	)
+
+/obj/item/katana/greedcursed //quite a bit weaker katana, still deals good damage, but also siphons part of your health every hit.
+	name = "peculiar katana"
+	desc = "The handle seems to dig into your flesh as you swing it..."
+	force = 20
+	block_chance = 25
+	armour_penetration = 15
+	sharpness = SHARP_EDGED
+
+/obj/item/katana/greedcursed/attack(mob/target, mob/living/carbon/human/user)
+	to_chat(user, "<span class ='warning'>[src] digs into your hands...</span>")
+	user.apply_damage(rand(force/4, force/2), BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)) //5-10 damage to one of your arms
+	..()
+
+/obj/item/reagent_containers/pill/greedcursed //has a good amount of healing chems, you just have to deal with being set on fire first
+	name = "strange pill"
+	desc = "It smells of brimstone. Just looking it, you instinctively feel like this might heal you in exchange for something else..."
+	volume = 25
+	list_reagents = list(/datum/reagent/medicine/omnizine = 20, /datum/reagent/hellwater = 3, /datum/reagent/medicine/lavaland_extract = 2)
+	icon_state = "pill21"
+
+/obj/item/book_of_babel/greedcursed
+	desc = "An ancient tome written in countless tongues. It emits an overwhelming odor of sulphur. Reading this may bring you knowledge, if you can handle the price."
+
+/obj/item/book_of_babel/greedcursed/attack_self(mob/living/carbon/human/user)
+	if(!user.can_read(src))
+		return FALSE
+	if(!istype(user))
+		return
+	to_chat(user, span_notice("You flip through the pages as quickly as possible, the overwhelming stench draining seemingly your very being. As you finish, the book suddenly ignites in a flash of hellfire, and turns to dust."))
+	user.grant_all_languages()
+	user.health -= 20
+	user.maxHealth -= 20
+	new /obj/effect/decal/cleanable/ash(get_turf(user))
+	qdel(src)
+
+/obj/item/greedcursed_bottle //recovers a portion of your max health, at the cost of being cursed into a shadowperson
+	name = "bottle of dark blood"
+	desc = "The contents seem to swirl constantly, and shrivel away when faced with bright light. If you drink this, you may just recover a part of yourself, though perhaps at a terrible cost..."
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "vial"
+
+/obj/item/greedcursed_bottle/attack_self(mob/living/carbon/human/user)
+	if(!istype(user))
+		return
+	
+	to_chat(user, span_danger("You feel a bit better for but a moment, like your very life force grew stronger. Then, all of a sudden, your flesh sloughs and darkens, revealing your terrible new form..."))
+	user.set_species(/datum/species/shadow)
+	if(user.maxHealth < 100) //cannot bring you above standard max health
+		user.maxHealth += 20 
+
+	playsound(user.loc,'sound/items/drink.ogg', rand(10,50), 1)
+	qdel(src)

--- a/code/modules/antagonists/demon/sins/wrath.dm
+++ b/code/modules/antagonists/demon/sins/wrath.dm
@@ -16,7 +16,7 @@
 	name = "Ignite"
 	desc = "This ranged spell sets a person on fire."
 	button_icon = 'icons/mob/actions/actions_minor_antag.dmi'
-	base_icon_state = "ignite"
+	button_icon_state = "ignite"
 	active_msg = "You prepare to ignite a target..."
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 	overlay_icon_state = "bg_demon_border"

--- a/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
+++ b/code/modules/spells/spell_types/aoe_spell/sacred_flame.dm
@@ -16,6 +16,13 @@
 	/// The amount of firestacks to put people afflicted.
 	var/firestacks_to_give = 20
 
+/datum/action/cooldown/spell/aoe/sacred_flame/weak //far weaker version, primarily for the greed cursed item
+	cooldown_time = 15 SECONDS
+
+	aoe_radius = 2
+
+	firestacks_to_give = 5
+
 /datum/action/cooldown/spell/aoe/sacred_flame/get_things_to_cast_on(atom/center)
 	var/list/things = list()
 	for(var/mob/living/nearby_mob in view(aoe_radius, center))


### PR DESCRIPTION
Adds a new spell for Greed demon of sin that lets them summon a special cursed item from a list of 5 every 3 minutes. They all have moderately useful applications in return for something. You can't pick which one to summon, and the demon still gets any negative effects if they decide to use them, they're primarily meant to be sold. Spell uses a moneybag as it's icon.

Possible items
(all the ones that impart negative effects are fairly obvious in what they do if you read the item descriptions)
-------------------------

Peculiar Katana: Huge item, looks like a normal katana with a special name. Deals 20 damage, 15 AP, and a 25 block chance. However, every time you swing it, you take 5-10 damage.

Strange pill: Filled with 20 units of omnizine, 3 units of hell water, and 2 units of lavaland extract, it will impart long lasting minor healing effects at the cost of setting you on fire. If you aren't flameproof or have a extinguisher on hard, using it during combat will be incredibly ill advised.

Cursed book of babel: Works like a normal book of babel, granting you all languages, but also takes away 20 max health upon use.

Bottle of dark blood: Gives you back 20 max health (only if you lost any, you cant go above 100) that you might have lost from gambling or something, and in return curses you into a shadow person.

Weak sacred flame spell book: Grants you a weaker version of the sacred flame spell. It has a lower radius for giving people fire stacks, only gives half as many, and has a far longer cooldown. The downside is that you are indeed setting yourself on fire to use this so if you're not fireproof its not very good.

----------------


Don't know how balanced this would actually be, but sin demons only have 5 weight as a midround event and then its a 1 in 5 chance to even get greed, so it wouldn't be seen often.

Good for the game because it gives them more things to try to sell to people than just the slot machine. Also they can use the cursed items themselves too for powerups if they're alright with the consequences, so it gives them more versatility.

this also fixes the ignite spell icon not showing since i noticed it


# Changelog


:cl:  
rscadd: Greed sinful demons now get a spell that lets them summon a random unique cursed item to sell to patrons.
bugfix: Wrath demon ignite spell icon properly shows
/:cl:
