### PR TITLE
Cryo can only heal burn wounds

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -116,6 +116,8 @@ GLOBAL_LIST_INIT(global_all_wound_types, list(/datum/wound/blunt/critical, /datu
 #define MANGLES_BONE	(1<<3)
 /// If this wound marks the limb as being allowed to have gauze applied
 #define ACCEPTS_GAUZE	(1<<4)
+/// If this wound can be healed by cryoxadone
+#define ACCEPTS_CRYO	(1<<5)
 
 // ~scar persistence defines
 // The following are the order placements for persistent scar save formats

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -79,6 +79,8 @@
 	var/datum/surgery/attached_surgery
 	/// if you're a lazy git and just throw them in cryo, the wound will go away after accumulating severity * 25 power
 	var/cryo_progress
+	/// wait, can cryo even heal it at all?
+	var/can_cryo_heal = FALSE
 
 	/// What kind of scars this wound will create description wise once healed
 	var/scar_keyword = "generic"
@@ -324,9 +326,10 @@
 
 /// Called from cryoxadone and pyroxadone when they're proc'ing. Wounds will slowly be fixed separately from other methods when these are in effect. crappy name but eh
 /datum/wound/proc/on_xadone(power)
-	cryo_progress += power
-	if(cryo_progress > 66 * severity)
-		qdel(src)
+	if(can_cryo_heal)
+		cryo_progress += power
+		if(cryo_progress > 66 * severity)
+			qdel(src)
 
 /// When synthflesh is applied to the victim, we call this. No sense in setting up an entire chem reaction system for wounds when we only care for a few chems. Probably will change in the future
 /datum/wound/proc/on_synthflesh(power)

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -79,8 +79,6 @@
 	var/datum/surgery/attached_surgery
 	/// if you're a lazy git and just throw them in cryo, the wound will go away after accumulating severity * 25 power
 	var/cryo_progress
-	/// wait, can cryo even heal it at all?
-	var/can_cryo_heal = FALSE
 
 	/// What kind of scars this wound will create description wise once healed
 	var/scar_keyword = "generic"
@@ -326,10 +324,11 @@
 
 /// Called from cryoxadone and pyroxadone when they're proc'ing. Wounds will slowly be fixed separately from other methods when these are in effect. crappy name but eh
 /datum/wound/proc/on_xadone(power)
-	if(can_cryo_heal)
-		cryo_progress += power
-		if(cryo_progress > 66 * severity)
-			qdel(src)
+	if(!(wound_flags & ACCEPTS_CRYO))
+		return
+	cryo_progress += power
+	if(cryo_progress > 66 * severity)
+		qdel(src)
 
 /// When synthflesh is applied to the victim, we call this. No sense in setting up an entire chem reaction system for wounds when we only care for a few chems. Probably will change in the future
 /datum/wound/proc/on_synthflesh(power)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -10,8 +10,7 @@
 	wound_type = WOUND_BURN
 	processes = TRUE
 	sound_effect = 'sound/effects/wounds/sizzle1.ogg'
-	wound_flags = (FLESH_WOUND | ACCEPTS_GAUZE)
-	can_cryo_heal = TRUE // cryo can always heal burn wounds
+	wound_flags = (FLESH_WOUND | ACCEPTS_GAUZE | ACCEPTS_CRYO)
 
 	treatable_by = list(/obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh) // sterilizer and alcohol will require reagent treatments, coming soon
 

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -11,6 +11,7 @@
 	processes = TRUE
 	sound_effect = 'sound/effects/wounds/sizzle1.ogg'
 	wound_flags = (FLESH_WOUND | ACCEPTS_GAUZE)
+	can_cryo_heal = TRUE // cryo can always heal burn wounds
 
 	treatable_by = list(/obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh) // sterilizer and alcohol will require reagent treatments, coming soon
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -36,6 +36,7 @@
 	var/breakout_time = 300
 	///Cryo will continue to treat people with 0 damage but existing wounds, but will sound off when damage healing is done in case doctors want to directly treat the wounds instead
 	var/treating_wounds = FALSE
+	var/can_heal_wounds = FALSE // just in case someone wants to add something that lets it heal wounds
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -210,7 +211,7 @@
 
 	if(mob_occupant.health >= mob_occupant.getMaxHealth() - robotic_limb_damage) // Don't bother with fully healed people. Now takes robotic limbs into account.
 		if(C)
-			if(C.all_wounds)
+			if(C.all_wounds && can_heal_wounds)
 				if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
 					treating_wounds = TRUE
 					playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -211,8 +211,8 @@
 	if(mob_occupant.health >= mob_occupant.getMaxHealth() - robotic_limb_damage) // Don't bother with fully healed people. Now takes robotic limbs into account.
 		var/has_cryo_wound = FALSE
 		if(C && C.all_wounds)
-			for(var/datum/wound/wound in C.all_wounds)
-				if(wound.can_cryo_heal)
+			for(var/datum/wound/wound as anything in C.all_wounds)
+				if(wound.wound_flags & ACCEPTS_CRYO)
 					if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
 						playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
 						var/msg = "Patient vitals fully recovered, continuing automated burn treatment."

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -36,7 +36,6 @@
 	var/breakout_time = 300
 	///Cryo will continue to treat people with 0 damage but existing wounds, but will sound off when damage healing is done in case doctors want to directly treat the wounds instead
 	var/treating_wounds = FALSE
-	var/can_heal_wounds = FALSE // just in case someone wants to add something that lets it heal wounds
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 
@@ -210,16 +209,18 @@
 			robotic_limb_damage += limb.get_damage(stamina=FALSE)
 
 	if(mob_occupant.health >= mob_occupant.getMaxHealth() - robotic_limb_damage) // Don't bother with fully healed people. Now takes robotic limbs into account.
-		if(C)
-			if(C.all_wounds && can_heal_wounds)
-				if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
-					treating_wounds = TRUE
-					playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
-					var/msg = "Patient vitals fully recovered, continuing automated wound treatment."
-					radio.talk_into(src, msg, radio_channel)
-			else // otherwise if we were only treating wounds and now we don't have any, turn off treating_wounds so we can boot 'em out
-				treating_wounds = FALSE
+		var/has_cryo_wound = FALSE
+		if(C && C.all_wounds)
+			for(var/datum/wound/wound in C.all_wounds)
+				if(wound.can_cryo_heal)
+					if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
+						playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
+						var/msg = "Patient vitals fully recovered, continuing automated burn treatment."
+						radio.talk_into(src, msg, radio_channel)
+					has_cryo_wound = TRUE
+					break
 
+		treating_wounds = has_cryo_wound
 		if(!treating_wounds)
 			on = FALSE
 			update_icon()


### PR DESCRIPTION
# Document the changes in your pull request

Cryo now only heals burn wounds on top of healing all damage types. It already heals a respectable amount of damage and is great for an overloaded medbay, but the way it is sort of makes wounds a thing only antagonists will ever have to actually worry about getting treated, and doctors over-rely on this feature to the point they don't know how to fix basic things like hairline fractures.

Alternative to #19412 

# Wiki Documentation

If there's anything that says cryo fixes all wounds anywhere that'll have to change to just burn wounds

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: cryo can only fix burn wounds
/:cl:
