### PR TITLE
3 new and cool escape shuttles

### DIFF
--- a/_maps/shuttles/emergency_cargo.dmm
+++ b/_maps/shuttles/emergency_cargo.dmm
@@ -38,6 +38,19 @@
 "cQ" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"dy" = (
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -25;
+	pixel_y = 36
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -25;
+	pixel_y = 25
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 "dR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/engineering,
@@ -51,22 +64,6 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/shuttle/escape)
-"eJ" = (
-/obj/machinery/button/door{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Window Blast Doors";
-	pixel_x = -7;
-	req_access_txt = "19"
-	},
-/obj/machinery/button/door{
-	id = "ock_cargo_door";
-	name = "Cargo Airlock Blast Doors";
-	pixel_x = 5;
-	pixel_y = 0;
-	req_access_txt = "19"
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "eK" = (
 /obj/effect/turf_decal/bot,
@@ -179,12 +176,6 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"lA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
 "lY" = (
 /obj/structure/railing{
 	dir = 8
@@ -220,6 +211,17 @@
 "om" = (
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"oz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = -7;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
 "oU" = (
@@ -817,6 +819,23 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"Vq" = (
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = 26;
+	pixel_y = 32;
+	req_access_txt = "19"
+	},
+/obj/machinery/button/door{
+	id = "ock_cargo_door";
+	name = "Cargo Airlock Blast Doors";
+	pixel_x = 39;
+	pixel_y = 32;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
 "VX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
@@ -828,6 +847,14 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
+/area/shuttle/escape)
+"We" = (
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = -7;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
 "WG" = (
 /obj/structure/shuttle/engine/huge,
@@ -956,7 +983,7 @@ AW
 uD
 uD
 IC
-Dm
+dy
 Dm
 gi
 Lo
@@ -1171,11 +1198,11 @@ cQ
 (11,1,1) = {"
 hN
 Hv
+Vq
 Lo
-Lo
-Lo
+We
 gi
-lA
+oz
 Lo
 Lo
 tx
@@ -1197,7 +1224,7 @@ AW
 "}
 (12,1,1) = {"
 uD
-eJ
+gi
 Lo
 kj
 Ih

--- a/_maps/shuttles/emergency_cargo.dmm
+++ b/_maps/shuttles/emergency_cargo.dmm
@@ -23,22 +23,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/shuttle/escape)
-"ba" = (
-/obj/machinery/button/door{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Window Blast Doors";
-	pixel_x = -7;
-	req_access_txt = "19"
-	},
-/obj/machinery/button/door{
-	id = "escape_cockpit_blast";
-	name = "Cargo Airlock Blast Doors";
-	pixel_x = 5;
-	pixel_y = 0;
-	req_access_txt = "19"
-	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/escape)
 "cc" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/internals,
@@ -67,6 +51,22 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
+/area/shuttle/escape)
+"eJ" = (
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = -7;
+	req_access_txt = "19"
+	},
+/obj/machinery/button/door{
+	id = "ock_cargo_door";
+	name = "Cargo Airlock Blast Doors";
+	pixel_x = 5;
+	pixel_y = 0;
+	req_access_txt = "19"
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "eK" = (
 /obj/effect/turf_decal/bot,
@@ -1197,7 +1197,7 @@ AW
 "}
 (12,1,1) = {"
 uD
-ba
+eJ
 Lo
 kj
 Ih

--- a/_maps/shuttles/emergency_cargo.dmm
+++ b/_maps/shuttles/emergency_cargo.dmm
@@ -1,0 +1,1322 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"af" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"aq" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"aW" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"bC" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/shuttle/escape)
+"co" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"cE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"cO" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"cZ" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"dt" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"dw" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"dD" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"dY" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/science,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"eA" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"eP" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/engineering,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"fb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"gd" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"gj" = (
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"gV" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/wooden/toy,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"hu" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ir" = (
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"iz" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"iA" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"iW" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"kg" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/coffin,
+/obj/effect/mob_spawn/human/corpse,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"kS" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kY" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lS" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"lW" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"my" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Rock emergency shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"nt" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"nO" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"nZ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/medical,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"od" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"of" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"oJ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"oQ" = (
+/obj/structure/railing,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"oS" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"pq" = (
+/obj/machinery/computer/communications/unlocked,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"px" = (
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = -7;
+	req_access_txt = "19"
+	},
+/obj/machinery/button/door{
+	id = "escape_cockpit_blast";
+	name = "Cargo Airlock Blast Doors";
+	pixel_x = 5;
+	pixel_y = 0;
+	req_access_txt = "19"
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"pO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pT" = (
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"qG" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"rC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rJ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"rS" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"sc" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"sO" = (
+/obj/machinery/computer/cargo/express,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"to" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/engineering,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ts" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tw" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tU" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"un" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"uY" = (
+/turf/template_noop,
+/area/template_noop)
+"vz" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vD" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"wL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wN" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wQ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"xZ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yM" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"yP" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"zR" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Be" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bg" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bm" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bt" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"Bu" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/wooden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"BG" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"BY" = (
+/obj/machinery/sleeper/survival_pod,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Db" = (
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Dh" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Di" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/internals,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Dt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"DE" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"DV" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"GX" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Hd" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Hj" = (
+/obj/structure/bed/dogbed/ian,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"HE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm5";
+	name = "Cabin 1"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"HZ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"IP" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"JO" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Kq" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"La" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/critter,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/mob/kitchen_animal,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"LF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"LL" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"LZ" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Mb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"MB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"MC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"MF" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Og" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Or" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OM" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Pb" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Pr" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"PA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"PQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Qk" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"QR" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"QX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Rl" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"Rp" = (
+/obj/machinery/button/door{
+	id = "Dorm5";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Sp" = (
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"Tr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"TE" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Vj" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Wc" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/sphere,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"WP" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"XD" = (
+/obj/structure/shuttle/engine/huge,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"XL" = (
+/obj/machinery/light,
+/obj/structure/table,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"XV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ym" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"YO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/shuttle/escape)
+"YZ" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Zq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Zv" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+uY
+uY
+aq
+aq
+dt
+Bt
+my
+aq
+PA
+PA
+PA
+PA
+zR
+aq
+zR
+PA
+PA
+PA
+PA
+aq
+aq
+uY
+uY
+uY
+uY
+"}
+(2,1,1) = {"
+uY
+aq
+aq
+iz
+Kq
+Bt
+Zv
+sc
+vz
+vz
+vz
+vz
+GX
+JO
+GX
+vz
+vz
+vz
+vz
+LF
+aq
+aq
+uY
+uY
+uY
+"}
+(3,1,1) = {"
+aq
+aq
+Db
+Kq
+Kq
+Bt
+gj
+wL
+tw
+Ym
+Ym
+Ym
+Ym
+Qk
+cE
+Og
+LL
+Dt
+oS
+mQ
+BG
+aq
+aq
+uY
+uY
+"}
+(4,1,1) = {"
+aq
+YZ
+Kq
+Kq
+cZ
+Bt
+oQ
+sc
+xZ
+dY
+un
+dw
+Di
+wQ
+GX
+xZ
+un
+dw
+dw
+dw
+ts
+Vj
+GX
+GX
+XD
+"}
+(5,1,1) = {"
+aq
+ir
+pb
+Pr
+Kq
+od
+Zv
+sc
+xZ
+dw
+un
+HZ
+iW
+eA
+GX
+xZ
+dw
+iW
+un
+pO
+wQ
+Vj
+GX
+GX
+GX
+"}
+(6,1,1) = {"
+Bt
+Bt
+Bt
+Bt
+Bt
+Bt
+Zv
+aW
+xZ
+dw
+dw
+dw
+bC
+gV
+GX
+xZ
+dw
+dw
+dw
+un
+wQ
+Vj
+GX
+GX
+GX
+"}
+(7,1,1) = {"
+rS
+sO
+rJ
+gj
+LZ
+Bt
+Zv
+MB
+cO
+dw
+eP
+dw
+dw
+rC
+GX
+xZ
+Di
+dw
+IP
+dw
+oJ
+dD
+Be
+uY
+uY
+"}
+(8,1,1) = {"
+rS
+pT
+rJ
+qG
+Pb
+Bt
+Zv
+sc
+Rl
+co
+MC
+MC
+MC
+kS
+yz
+iA
+MC
+MC
+MC
+MC
+DV
+Vj
+GX
+GX
+XD
+"}
+(9,1,1) = {"
+rS
+QR
+rJ
+gj
+XL
+Bt
+gj
+XV
+GX
+GX
+GX
+GX
+GX
+gd
+yM
+GX
+GX
+GX
+Sp
+GX
+lB
+Vj
+GX
+GX
+GX
+"}
+(10,1,1) = {"
+rS
+pq
+rJ
+gj
+gj
+QX
+gj
+OM
+fb
+Mb
+WP
+Bg
+Bg
+lW
+GX
+GX
+La
+Dt
+Dt
+Dt
+Bu
+Vj
+GX
+GX
+GX
+"}
+(11,1,1) = {"
+rS
+yP
+gj
+gj
+gj
+Bt
+lY
+gj
+gj
+MF
+MF
+MF
+Zq
+MF
+af
+GX
+hu
+dw
+dw
+Wc
+wQ
+PQ
+Be
+uY
+uY
+"}
+(12,1,1) = {"
+aq
+px
+gj
+Hj
+Dh
+Bt
+Bt
+HE
+Bt
+Bt
+Bt
+Bt
+Bt
+lS
+Bt
+GX
+to
+dw
+Di
+dw
+gV
+Vj
+GX
+GX
+XD
+"}
+(13,1,1) = {"
+uY
+aq
+aq
+aq
+aq
+aq
+Dh
+gj
+TE
+Bt
+BY
+gj
+vD
+gj
+Bt
+GX
+kY
+dw
+iW
+kg
+wQ
+Vj
+GX
+GX
+GX
+"}
+(14,1,1) = {"
+uY
+uY
+uY
+uY
+uY
+aq
+nt
+gj
+Rp
+Bt
+gj
+gj
+gj
+gj
+Bt
+GX
+wN
+nZ
+Bm
+YO
+DE
+Hd
+GX
+GX
+GX
+"}
+(15,1,1) = {"
+uY
+uY
+uY
+uY
+uY
+aq
+tU
+gj
+Tr
+Bt
+Dh
+Pb
+Pb
+nO
+Bt
+GX
+GX
+of
+GX
+GX
+gd
+GX
+aq
+uY
+uY
+"}
+(16,1,1) = {"
+uY
+uY
+uY
+uY
+uY
+aq
+aq
+Or
+aq
+aq
+aq
+Or
+Or
+Bt
+Bt
+Bt
+aq
+aq
+aq
+aq
+aq
+aq
+aq
+uY
+uY
+"}

--- a/_maps/shuttles/emergency_cargo.dmm
+++ b/_maps/shuttles/emergency_cargo.dmm
@@ -1,31 +1,5 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"af" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"aq" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
-"aW" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/shuttle/escape)
-"bC" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/shuttle/escape)
-"co" = (
+"ab" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -37,135 +11,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/shuttle/escape)
-"cE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cO" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/shuttle/escape)
-"cZ" = (
-/obj/machinery/light,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"dt" = (
-/obj/machinery/door/airlock/external{
-	name = "Emegency Shuttle External Airlock";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dw" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dD" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/shuttle/escape)
-"dY" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/science,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"eA" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"eP" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/engineering,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"fb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"gd" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"gj" = (
+"aL" = (
+/obj/machinery/computer/cargo/express,
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"gV" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/wooden/toy,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"hu" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"ir" = (
-/obj/structure/table,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"iz" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"iA" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"iW" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/shuttle/escape)
-"kg" = (
+"aR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/coffin,
 /obj/effect/mob_spawn/human/corpse,
@@ -173,149 +23,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/shuttle/escape)
-"kS" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"kY" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lS" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"lW" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"my" = (
-/obj/machinery/door/airlock/external{
-	name = "Emegency Shuttle External Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Rock emergency shuttle"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"mQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"nt" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"nO" = (
-/obj/machinery/stasis{
-	dir = 8
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"nZ" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/medical,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"od" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"of" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"oJ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/shuttle/escape)
-"oQ" = (
-/obj/structure/railing,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"oS" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"pb" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"pq" = (
-/obj/machinery/computer/communications/unlocked,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"px" = (
+"ba" = (
 /obj/machinery/button/door{
 	id = "escape_cockpit_windows";
 	name = "Cockpit Window Blast Doors";
@@ -331,50 +39,22 @@
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
-"pO" = (
+"cc" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/closet/crate/internals,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"pT" = (
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"qG" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"rC" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/mail,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"rJ" = (
+"cx" = (
 /obj/structure/chair/comfy/shuttle{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel/rockvault,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"rS" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Blast Door"
-	},
+"cQ" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"sc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"sO" = (
-/obj/machinery/computer/cargo/express,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"to" = (
+"dR" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/engineering,
 /obj/machinery/door/firedoor/border_only{
@@ -383,12 +63,241 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ts" = (
-/obj/effect/turf_decal/delivery,
+"ey" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"eK" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"fb" = (
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"fk" = (
+/obj/machinery/button/door{
+	id = "Dorm5";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"fv" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"fx" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"gb" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"gi" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"hd" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"hw" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"hN" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ic" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/shuttle/escape)
+"ir" = (
+/obj/structure/railing,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"iR" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"ja" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"tw" = (
+"kg" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kj" = (
+/obj/structure/bed/dogbed/ian,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"kC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/medical,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kN" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/wooden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"lY" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"mi" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"no" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"nX" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"om" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"oU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qr" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qt" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rc" = (
+/obj/machinery/computer/communications/unlocked,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"rp" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rz" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"rM" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"sE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"td" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"tq" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -401,35 +310,85 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"tU" = (
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
+"tx" = (
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"un" = (
+"ux" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"uY" = (
-/turf/template_noop,
-/area/template_noop)
-"vz" = (
-/obj/effect/turf_decal/loading_area{
+"uD" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"uE" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"uG" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"vg" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"vD" = (
+"vo" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ww" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"wL" = (
-/obj/effect/turf_decal/stripes/line{
+"wV" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"wX" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"xa" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"xD" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -440,48 +399,218 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"wN" = (
+"xJ" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/sphere,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yy" = (
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"zq" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"zM" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/critter,
 /obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/mob/kitchen_animal,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ag" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"Aq" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"wQ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"xZ" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"yz" = (
+"AW" = (
+/turf/template_noop,
+/area/template_noop)
+"Bl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"yM" = (
+"Bt" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "ock_cargo_door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"CQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Dm" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Dn" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"DM" = (
+/obj/machinery/sleeper/survival_pod,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Er" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"EA" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Fc" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg1"
+	icon_state = "panelscorched"
 	},
 /area/shuttle/escape)
-"yP" = (
+"FP" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ga" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/science,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Gm" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/engineering,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Gs" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/wooden/toy,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"GG" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"He" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Hn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Hv" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"zR" = (
+"HR" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"HY" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ig" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ih" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Iw" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"IC" = (
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/effect/spawner/lootdrop/trashbin,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ji" = (
 /obj/machinery/door/airlock/external{
 	name = "Emegency Shuttle External Airlock"
 	},
@@ -493,75 +622,173 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Be" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Bg" = (
-/obj/structure/closet/firecloset,
+"KO" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Bm" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Bt" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/escape)
-"Bu" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/wooden,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"BG" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"BY" = (
-/obj/machinery/sleeper/survival_pod,
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"Db" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/obj/effect/spawner/lootdrop/trashbin,
+"Lc" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Lh" = (
+/obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"Dh" = (
-/obj/structure/closet/emcloset,
+"Lo" = (
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"Di" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/internals,
-/obj/effect/spawner/lootdrop/maintenance,
+"LG" = (
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"MK" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Dt" = (
+"MS" = (
 /obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Nw" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"NK" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"NO" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Oo" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Rock emergency shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Pe" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"Pk" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Pu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"DE" = (
+"PW" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating/rust,
+/area/shuttle/escape)
+"Ql" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/shuttle/escape)
+"QE" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Rh" = (
+/obj/structure/dresser,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Rr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"RC" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -571,21 +798,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/shuttle/escape)
-"DV" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"GX" = (
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Hd" = (
+"TT" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -595,11 +808,83 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Hj" = (
-/obj/structure/bed/dogbed/ian,
+"Um" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"UV" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"VX" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/shuttle/escape)
+"WG" = (
+/obj/structure/shuttle/engine/huge,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"WX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"XW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Yk" = (
+/obj/machinery/light,
+/obj/structure/table,
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"HE" = (
+"Yo" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Yt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"YD" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Zh" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/rockvault,
+/area/shuttle/escape)
+"Zr" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ZL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ZM" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -612,711 +897,436 @@
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/shuttle/escape)
-"HZ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating/rust,
-/area/shuttle/escape)
-"IP" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/mail,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"JO" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Kq" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"La" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/critter,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/mob/kitchen_animal,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"LF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"LL" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating/rust,
-/area/shuttle/escape)
-"LZ" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Mb" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"MB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/shuttle/escape)
-"MC" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"MF" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Og" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Or" = (
-/obj/effect/spawner/structure/window/plastitanium,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"OM" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Pb" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Pr" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"PA" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"PQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/shuttle/engine/heater,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Qk" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"QR" = (
-/obj/machinery/computer/emergency_shuttle,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"QX" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Rl" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/shuttle/escape)
-"Rp" = (
-/obj/machinery/button/door{
-	id = "Dorm5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Sp" = (
-/turf/open/floor/plating/rust,
-/area/shuttle/escape)
-"Tr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"TE" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Vj" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Wc" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/sphere,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"WP" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"XD" = (
-/obj/structure/shuttle/engine/huge,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"XL" = (
-/obj/machinery/light,
-/obj/structure/table,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"XV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Ym" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"YO" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/shuttle/escape)
-"YZ" = (
-/obj/machinery/microwave,
-/obj/structure/table,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"Zq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
-"Zv" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/rockvault,
-/area/shuttle/escape)
 
 (1,1,1) = {"
-uY
-uY
-aq
-aq
-dt
+AW
+AW
+uD
+uD
+QE
+gi
+Oo
+uD
 Bt
-my
-aq
-PA
-PA
-PA
-PA
-zR
-aq
-zR
-PA
-PA
-PA
-PA
-aq
-aq
-uY
-uY
-uY
-uY
+Bt
+Bt
+Bt
+Ji
+uD
+Ji
+Bt
+Bt
+Bt
+Bt
+uD
+uD
+AW
+AW
+AW
+AW
 "}
 (2,1,1) = {"
-uY
-aq
-aq
-iz
-Kq
-Bt
-Zv
-sc
-vz
-vz
-vz
-vz
-GX
-JO
-GX
-vz
-vz
-vz
-vz
-LF
-aq
-aq
-uY
-uY
-uY
+AW
+uD
+uD
+cx
+Dm
+gi
+fv
+fx
+NK
+NK
+NK
+NK
+cQ
+MK
+cQ
+NK
+NK
+NK
+NK
+CQ
+uD
+uD
+AW
+AW
+AW
 "}
 (3,1,1) = {"
-aq
-aq
-Db
-Kq
-Kq
-Bt
-gj
-wL
-tw
-Ym
-Ym
-Ym
-Ym
-Qk
-cE
-Og
-LL
-Dt
-oS
-mQ
-BG
-aq
-aq
-uY
-uY
+uD
+uD
+IC
+Dm
+Dm
+gi
+Lo
+Pu
+tq
+HR
+HR
+HR
+HR
+Iw
+FP
+xD
+wV
+hd
+qt
+kg
+qi
+uD
+uD
+AW
+AW
 "}
 (4,1,1) = {"
-aq
-YZ
-Kq
-Kq
-cZ
-Bt
-oQ
-sc
-xZ
-dY
-un
-dw
-Di
-wQ
-GX
-xZ
-un
-dw
-dw
-dw
-ts
-Vj
-GX
-GX
-XD
+uD
+UV
+Dm
+Dm
+Lh
+gi
+ir
+fx
+Pk
+Ga
+EA
+YD
+cc
+Nw
+cQ
+Pk
+EA
+YD
+YD
+YD
+ux
+NO
+cQ
+cQ
+WG
 "}
 (5,1,1) = {"
-aq
-ir
-pb
-Pr
-Kq
-od
-Zv
-sc
-xZ
-dw
-un
-HZ
-iW
-eA
-GX
-xZ
-dw
-iW
-un
-pO
-wQ
-Vj
-GX
-GX
-GX
+uD
+LG
+WX
+GG
+Dm
+rz
+fv
+fx
+Pk
+YD
+EA
+PW
+eK
+uE
+cQ
+Pk
+YD
+eK
+EA
+nX
+Nw
+NO
+cQ
+cQ
+cQ
 "}
 (6,1,1) = {"
-Bt
-Bt
-Bt
-Bt
-Bt
-Bt
-Zv
-aW
-xZ
-dw
-dw
-dw
-bC
-gV
-GX
-xZ
-dw
-dw
-dw
-un
-wQ
-Vj
-GX
-GX
-GX
+gi
+gi
+gi
+gi
+gi
+gi
+fv
+iR
+Pk
+YD
+YD
+YD
+ic
+Gs
+cQ
+Pk
+YD
+YD
+YD
+EA
+Nw
+NO
+cQ
+cQ
+cQ
 "}
 (7,1,1) = {"
-rS
-sO
-rJ
-gj
-LZ
-Bt
-Zv
-MB
-cO
-dw
-eP
-dw
-dw
-rC
-GX
-xZ
-Di
-dw
-IP
-dw
-oJ
-dD
-Be
-uY
-uY
+hN
+aL
+Lc
+Lo
+Zh
+gi
+fv
+Ag
+VX
+YD
+Gm
+YD
+YD
+qr
+cQ
+Pk
+cc
+YD
+gb
+YD
+mi
+Pe
+Um
+AW
+AW
 "}
 (8,1,1) = {"
-rS
-pT
-rJ
-qG
-Pb
-Bt
-Zv
-sc
-Rl
-co
-MC
-MC
-MC
-kS
-yz
-iA
-MC
-MC
-MC
-MC
-DV
-Vj
-GX
-GX
-XD
+hN
+yy
+Lc
+xa
+zq
+gi
+fv
+fx
+Ql
+ab
+Aq
+Aq
+Aq
+MS
+Bl
+no
+Aq
+Aq
+Aq
+Aq
+vo
+NO
+cQ
+cQ
+WG
 "}
 (9,1,1) = {"
-rS
-QR
-rJ
-gj
-XL
-Bt
-gj
-XV
-GX
-GX
-GX
-GX
-GX
-gd
-yM
-GX
-GX
-GX
-Sp
-GX
-lB
-Vj
-GX
-GX
-GX
+hN
+hw
+Lc
+Lo
+Yk
+gi
+Lo
+Er
+cQ
+cQ
+cQ
+cQ
+cQ
+ja
+ey
+cQ
+cQ
+cQ
+fb
+cQ
+oU
+NO
+cQ
+cQ
+cQ
 "}
 (10,1,1) = {"
-rS
-pq
-rJ
-gj
-gj
-QX
-gj
-OM
-fb
-Mb
-WP
-Bg
-Bg
-lW
-GX
-GX
-La
-Dt
-Dt
-Dt
-Bu
-Vj
-GX
-GX
-GX
+hN
+rc
+Lc
+Lo
+Lo
+uG
+Lo
+lY
+Hn
+ZL
+rp
+vg
+vg
+sE
+cQ
+cQ
+zM
+hd
+hd
+hd
+kN
+NO
+cQ
+cQ
+cQ
 "}
 (11,1,1) = {"
-rS
-yP
-gj
-gj
-gj
-Bt
-lY
-gj
-gj
-MF
-MF
-MF
-Zq
-MF
-af
-GX
-hu
-dw
-dw
-Wc
-wQ
-PQ
-Be
-uY
-uY
+hN
+Hv
+Lo
+Lo
+Lo
+gi
+lA
+Lo
+Lo
+tx
+tx
+tx
+OR
+tx
+Rr
+cQ
+Dn
+YD
+YD
+xJ
+Nw
+Ig
+Um
+AW
+AW
 "}
 (12,1,1) = {"
-aq
-px
-gj
-Hj
-Dh
-Bt
-Bt
-HE
-Bt
-Bt
-Bt
-Bt
-Bt
-lS
-Bt
-GX
-to
-dw
-Di
-dw
-gV
-Vj
-GX
-GX
-XD
+uD
+ba
+Lo
+kj
+Ih
+gi
+gi
+ZM
+gi
+gi
+gi
+gi
+gi
+KO
+gi
+cQ
+dR
+YD
+cc
+YD
+Gs
+NO
+cQ
+cQ
+WG
 "}
 (13,1,1) = {"
-uY
-aq
-aq
-aq
-aq
-aq
-Dh
-gj
-TE
-Bt
-BY
-gj
-vD
-gj
-Bt
-GX
-kY
-dw
-iW
-kg
-wQ
-Vj
-GX
-GX
-GX
+AW
+uD
+uD
+uD
+uD
+uD
+Ih
+Lo
+wX
+gi
+DM
+Lo
+ww
+Lo
+gi
+cQ
+Yt
+YD
+eK
+aR
+Nw
+NO
+cQ
+cQ
+cQ
 "}
 (14,1,1) = {"
-uY
-uY
-uY
-uY
-uY
-aq
-nt
-gj
-Rp
-Bt
-gj
-gj
-gj
-gj
-Bt
-GX
-wN
-nZ
-Bm
-YO
-DE
-Hd
-GX
-GX
-GX
+AW
+AW
+AW
+AW
+AW
+uD
+Rh
+Lo
+fk
+gi
+Lo
+Lo
+Lo
+Lo
+gi
+cQ
+rM
+kC
+HY
+Fc
+RC
+TT
+cQ
+cQ
+cQ
 "}
 (15,1,1) = {"
-uY
-uY
-uY
-uY
-uY
-aq
-tU
-gj
-Tr
-Bt
-Dh
-Pb
-Pb
-nO
-Bt
-GX
-GX
-of
-GX
-GX
-gd
-GX
-aq
-uY
-uY
+AW
+AW
+AW
+AW
+AW
+uD
+om
+Lo
+td
+gi
+Ih
+He
+Lo
+Yo
+gi
+cQ
+cQ
+XW
+cQ
+cQ
+ja
+cQ
+uD
+AW
+AW
 "}
 (16,1,1) = {"
-uY
-uY
-uY
-uY
-uY
-aq
-aq
-Or
-aq
-aq
-aq
-Or
-Or
-Bt
-Bt
-Bt
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-uY
-uY
+AW
+AW
+AW
+AW
+AW
+uD
+uD
+Zr
+uD
+uD
+uD
+Zr
+Zr
+gi
+gi
+gi
+uD
+uD
+uD
+uD
+uD
+uD
+uD
+AW
+AW
 "}

--- a/_maps/shuttles/emergency_mafia.dmm
+++ b/_maps/shuttles/emergency_mafia.dmm
@@ -69,9 +69,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
-"nh" = (
-/turf/open/floor/wood/broken/three,
-/area/shuttle/escape)
 "pD" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/head/fedora,
@@ -95,6 +92,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
+"uo" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 "uD" = (
 /turf/open/floor/wood/broken/seven,
 /area/shuttle/escape)
@@ -108,14 +110,6 @@
 /area/shuttle/escape)
 "wA" = (
 /turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
-"wS" = (
-/obj/machinery/door/airlock/wood,
-/obj/docking_port/mobile/emergency{
-	name = "mafia emergency shuttle"
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "yS" = (
 /obj/structure/shuttle/engine/heater,
@@ -148,6 +142,22 @@
 "DZ" = (
 /mob/living/simple_animal/drone/snowflake/bardrone,
 /turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"EY" = (
+/obj/docking_port/mobile/emergency{
+	name = "mafia emergency shuttle"
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"Fc" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/shuttle/escape)
 "FA" = (
 /obj/structure/chair/comfy/black{
@@ -335,19 +345,19 @@ yT
 yT
 yT
 yT
-yT
-yT
-yT
-yT
-yT
-yT
-wS
+EY
 yT
 yT
 yT
 yT
 yT
 Vc
+yT
+uo
+yT
+yT
+yT
+yT
 yT
 vR
 vR
@@ -370,10 +380,10 @@ Oi
 TW
 Oi
 CE
+Oi
 fs
 fs
-fs
-CE
+Fc
 Oi
 yT
 yT
@@ -424,7 +434,7 @@ Oi
 TW
 Oi
 Oi
-nh
+Oi
 Vi
 Nk
 nb

--- a/_maps/shuttles/emergency_mafia.dmm
+++ b/_maps/shuttles/emergency_mafia.dmm
@@ -197,6 +197,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
+"KI" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
 "La" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -317,13 +321,6 @@
 /area/shuttle/escape)
 "Yg" = (
 /obj/item/flashlight/lamp/green,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
-"ZY" = (
-/obj/machinery/computer/emergency_shuttle{
-	icon_state = "oldcomp"
-	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
@@ -575,7 +572,7 @@ jZ
 yT
 FX
 ig
-ZY
+KI
 fV
 Oi
 Oi

--- a/_maps/shuttles/emergency_mafia.dmm
+++ b/_maps/shuttles/emergency_mafia.dmm
@@ -1,16 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"bz" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pizza/sassysage,
-/obj/effect/fun_balloon/sentience/emergency_shuttle{
-	group_name = "bar staff on the Emergency Escape Bar"
+"au" = (
+/obj/structure/chair/comfy/black,
+/mob/living/simple_animal/drone/snowflake/mafia{
+	name = "The Dronefather";
+	unique_name = 0
 	},
-/turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
-"ce" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/gun/ballistic/automatic/tommygun,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "cw" = (
@@ -38,14 +32,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
-"fk" = (
-/obj/structure/table/wood/fancy,
-/obj/item/ammo_box/magazine/tommygunm45{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/open/floor/carpet/red,
-/area/shuttle/escape)
 "fs" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -69,6 +55,14 @@
 /obj/structure/shuttle/engine/large,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"kV" = (
+/obj/structure/table/wood/fancy,
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	effect_range = 5;
+	group_name = "Drone Mafia or barstaff on the emergency shuttle"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
 "nb" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -77,11 +71,6 @@
 /area/shuttle/escape)
 "nh" = (
 /turf/open/floor/wood/broken/three,
-/area/shuttle/escape)
-"ol" = (
-/obj/structure/table/wood/fancy,
-/obj/item/gun/ballistic/automatic/tommygun,
-/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "pD" = (
 /obj/structure/table/wood/fancy,
@@ -96,18 +85,6 @@
 /area/shuttle/escape)
 "qU" = (
 /turf/open/floor/wood/broken/two,
-/area/shuttle/escape)
-"sZ" = (
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_x = 9;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
 "tu" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -151,20 +128,6 @@
 "yT" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
-"yY" = (
-/obj/item/ammo_box/magazine/tommygunm45,
-/obj/item/ammo_box/magazine/tommygunm45,
-/obj/item/ammo_box/magazine/tommygunm45{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/ammo_box/magazine/tommygunm45{
-	pixel_x = 9;
-	pixel_y = 7
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
 "BI" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/head/fedora/brown,
@@ -186,6 +149,13 @@
 /mob/living/simple_animal/drone/snowflake/bardrone,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
+"FA" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/mob/living/simple_animal/drone/snowflake/mafia,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
 "FX" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /obj/item/reagent_containers/food/drinks/bottle/wine{
@@ -194,6 +164,18 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/wine{
 	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Ge" = (
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = 9;
 	pixel_y = 10
 	},
 /obj/structure/table/wood,
@@ -214,6 +196,13 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"La" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/mob/living/simple_animal/drone/snowflake/mafia,
+/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Ls" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine{
@@ -275,14 +264,6 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"PN" = (
-/obj/structure/table/wood/fancy,
-/obj/item/ammo_box/magazine/tommygunm45{
-	pixel_x = -12;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/red,
-/area/shuttle/escape)
 "Qr" = (
 /mob/living/simple_animal/hostile/alien/maid/barmaid,
 /turf/open/floor/carpet/exoticgreen,
@@ -333,12 +314,6 @@
 "Wm" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/shuttle/escape)
-"Xb" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Yg" = (
 /obj/item/flashlight/lamp/green,
@@ -410,7 +385,7 @@ vR
 (3,1,1) = {"
 yT
 Kn
-yY
+ud
 Yg
 fV
 OA
@@ -436,15 +411,15 @@ jZ
 "}
 (4,1,1) = {"
 yT
-sZ
+Ge
 Qr
 ig
 fV
 qR
 qR
-Vx
+FA
 qR
-Vx
+FA
 qR
 qR
 qR
@@ -465,13 +440,13 @@ TS
 yT
 fe
 DZ
-bz
+Rs
 fV
 qR
 qR
 BI
-ol
-ce
+Mi
+NJ
 pD
 qR
 qR
@@ -494,11 +469,11 @@ JW
 wA
 Rs
 fV
-Vi
+au
 Oc
 TP
 wd
-fk
+Mi
 wd
 Mi
 qR
@@ -523,9 +498,9 @@ Rs
 fV
 qR
 DC
-ol
+kV
 NJ
-PN
+Mi
 NJ
 Mi
 Oj
@@ -551,9 +526,9 @@ fV
 qR
 qR
 pD
-ol
+Mi
 BI
-ol
+Mi
 qR
 qR
 Oi
@@ -577,9 +552,9 @@ ud
 fV
 qR
 qR
-Xb
+La
 qR
-Xb
+La
 qR
 qR
 qR

--- a/_maps/shuttles/emergency_mafia.dmm
+++ b/_maps/shuttles/emergency_mafia.dmm
@@ -1,0 +1,718 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ce" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/gun/ballistic/automatic/tommygun,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"cw" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"dd" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"en" = (
+/turf/open/floor/wood/broken/six,
+/area/shuttle/escape)
+"eC" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"fe" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"fk" = (
+/obj/structure/table/wood/fancy,
+/obj/item/ammo_box/magazine/tommygunm45{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"fs" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"fV" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"gy" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/fedora/gtrim_fedora,
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	effect_range = 6;
+	group_name = "The drone mafia"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"ig" = (
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"jA" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"jZ" = (
+/obj/structure/shuttle/engine/large,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"nb" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"nh" = (
+/turf/open/floor/wood/broken/three,
+/area/shuttle/escape)
+"ol" = (
+/obj/structure/table/wood/fancy,
+/obj/item/gun/ballistic/automatic/tommygun,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"pD" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/fedora,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"qH" = (
+/turf/open/floor/wood/broken/five,
+/area/shuttle/escape)
+"qR" = (
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"qU" = (
+/turf/open/floor/wood/broken/two,
+/area/shuttle/escape)
+"tu" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"ud" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"uD" = (
+/turf/open/floor/wood/broken/seven,
+/area/shuttle/escape)
+"vR" = (
+/turf/template_noop,
+/area/template_noop)
+"wd" = (
+/obj/structure/table/wood/fancy,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"wA" = (
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"wS" = (
+/obj/machinery/door/airlock/wood,
+/obj/docking_port/mobile/emergency{
+	name = "mafia emergency shuttle"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"yS" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yT" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"yY" = (
+/obj/item/ammo_box/magazine/tommygunm45,
+/obj/item/ammo_box/magazine/tommygunm45,
+/obj/item/ammo_box/magazine/tommygunm45{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/ammo_box/magazine/tommygunm45{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"AV" = (
+/mob/living/simple_animal/drone/syndrone/badass{
+	default_hatmask = null;
+	default_storage = null;
+	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
+	health = 120;
+	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
+	name = "Drone Mobster"
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"BI" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/fedora/brown,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"CE" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"DC" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/flask,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"DZ" = (
+/mob/living/simple_animal/drone/snowflake/bardrone,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"FX" = (
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Jg" = (
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"JW" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Kn" = (
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Ls" = (
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Mi" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Nk" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"No" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"NJ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"NW" = (
+/obj/structure/chair/comfy/black,
+/mob/living/simple_animal/drone/syndrone/badass{
+	default_hatmask = null;
+	default_storage = null;
+	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
+	health = 120;
+	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
+	name = "Dronefather"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Oi" = (
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Oj" = (
+/obj/structure/chair/comfy/black{
+	dir = 1;
+	name = "Command Station"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"OA" = (
+/turf/open/floor/wood/broken,
+/area/shuttle/escape)
+"OP" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"PM" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"PN" = (
+/obj/structure/table/wood/fancy,
+/obj/item/ammo_box/magazine/tommygunm45{
+	pixel_x = -12;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Qr" = (
+/mob/living/simple_animal/hostile/alien/maid/barmaid,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Sa" = (
+/mob/living/simple_animal/pet/cat/Proc{
+	desc = "The mobs cutest cat!";
+	health = 45000;
+	maxHealth = 45000;
+	name = "Booze"
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"TP" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"TS" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"TW" = (
+/turf/closed/wall/mineral/wood,
+/area/shuttle/escape)
+"Vc" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Vi" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Vx" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Wm" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"XD" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/mob/living/simple_animal/drone/syndrone/badass{
+	default_hatmask = null;
+	default_storage = null;
+	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
+	health = 120;
+	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
+	name = "Drone Mobster"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Yg" = (
+/obj/item/flashlight/lamp/green,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"ZL" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/mob/living/simple_animal/drone/syndrone/badass{
+	default_hatmask = null;
+	default_storage = null;
+	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
+	health = 120;
+	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
+	name = "Drone Mobster"
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"ZY" = (
+/obj/machinery/computer/emergency_shuttle{
+	icon_state = "oldcomp"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+vR
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+wS
+yT
+yT
+yT
+yT
+yT
+Vc
+yT
+vR
+vR
+"}
+(2,1,1) = {"
+yT
+yT
+jA
+CE
+Oi
+Oi
+CE
+jA
+Oi
+Oi
+CE
+jA
+Oi
+Oi
+TW
+Oi
+CE
+fs
+fs
+fs
+CE
+Oi
+yT
+yT
+vR
+"}
+(3,1,1) = {"
+yT
+Kn
+yY
+Yg
+fV
+OA
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+TW
+Oi
+Oi
+Oi
+Oi
+Oi
+en
+Oi
+yS
+TS
+jZ
+"}
+(4,1,1) = {"
+yT
+Jg
+Qr
+ig
+fV
+qR
+qR
+XD
+qR
+AV
+qR
+qR
+qR
+Oi
+TW
+Oi
+Oi
+nh
+Vi
+Nk
+nb
+OP
+yS
+TS
+TS
+"}
+(5,1,1) = {"
+yT
+fe
+DZ
+ud
+fV
+qR
+qR
+BI
+ol
+ce
+pD
+qR
+qR
+Oi
+TW
+jA
+Oi
+Oi
+Vi
+Nk
+nb
+OP
+yS
+PM
+vR
+"}
+(6,1,1) = {"
+yT
+JW
+wA
+ud
+fV
+NW
+gy
+TP
+wd
+fk
+wd
+Mi
+qR
+Oi
+TW
+TW
+jA
+Oi
+Vi
+Nk
+nb
+Sa
+yS
+TS
+jZ
+"}
+(7,1,1) = {"
+yT
+tu
+wA
+ud
+fV
+qR
+DC
+ol
+NJ
+PN
+NJ
+Mi
+Oj
+Oi
+jA
+TW
+TW
+Oi
+qR
+qR
+qR
+OP
+yS
+TS
+TS
+"}
+(8,1,1) = {"
+yT
+Ls
+wA
+ig
+fV
+qR
+qR
+pD
+ol
+BI
+ol
+qR
+qR
+Oi
+Oi
+Oi
+TW
+qU
+qR
+qR
+qR
+Oi
+yS
+PM
+vR
+"}
+(9,1,1) = {"
+yT
+FX
+wA
+ud
+fV
+qR
+qR
+ZL
+qR
+ZL
+qR
+qR
+qR
+qH
+Oi
+Oi
+cw
+Oi
+qR
+Vx
+qR
+Oi
+yS
+TS
+jZ
+"}
+(10,1,1) = {"
+yT
+FX
+ig
+ZY
+fV
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+Oi
+uD
+Oi
+Oi
+cw
+Oi
+Wm
+Wm
+Wm
+Wm
+yS
+TS
+TS
+"}
+(11,1,1) = {"
+yT
+yT
+jA
+dd
+Oi
+Oi
+dd
+jA
+Oi
+Oi
+dd
+jA
+Oi
+Oi
+dd
+Oi
+TW
+No
+Wm
+eC
+No
+jA
+yT
+yT
+vR
+"}
+(12,1,1) = {"
+vR
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+yT
+vR
+vR
+"}

--- a/_maps/shuttles/emergency_mafia.dmm
+++ b/_maps/shuttles/emergency_mafia.dmm
@@ -1,4 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizza/sassysage,
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	group_name = "bar staff on the Emergency Escape Bar"
+	},
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
 "ce" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/bottle/wine,
@@ -48,15 +56,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/shuttle/escape)
-"gy" = (
-/obj/structure/table/wood/fancy,
-/obj/item/clothing/head/fedora/gtrim_fedora,
-/obj/effect/fun_balloon/sentience/emergency_shuttle{
-	effect_range = 6;
-	group_name = "The drone mafia"
-	},
-/turf/open/floor/carpet/red,
-/area/shuttle/escape)
 "ig" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /obj/structure/table/wood,
@@ -97,6 +96,18 @@
 /area/shuttle/escape)
 "qU" = (
 /turf/open/floor/wood/broken/two,
+/area/shuttle/escape)
+"sZ" = (
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/structure/table/wood,
+/turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
 "tu" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -154,20 +165,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
-"AV" = (
-/mob/living/simple_animal/drone/syndrone/badass{
-	default_hatmask = null;
-	default_storage = null;
-	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
-	health = 120;
-	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
-	name = "Drone Mobster"
-	},
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/shuttle/escape)
 "BI" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/head/fedora/brown,
@@ -197,18 +194,6 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/wine{
 	pixel_x = -7;
-	pixel_y = 10
-	},
-/obj/structure/table/wood,
-/turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
-"Jg" = (
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_x = 9;
 	pixel_y = 10
 	},
 /obj/structure/table/wood,
@@ -262,16 +247,9 @@
 /obj/item/reagent_containers/food/drinks/bottle/wine,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
-"NW" = (
-/obj/structure/chair/comfy/black,
-/mob/living/simple_animal/drone/syndrone/badass{
-	default_hatmask = null;
-	default_storage = null;
-	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
-	health = 120;
-	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
-	name = "Dronefather"
-	},
+"Oc" = (
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/fedora/gtrim_fedora,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Oi" = (
@@ -307,6 +285,11 @@
 /area/shuttle/escape)
 "Qr" = (
 /mob/living/simple_animal/hostile/alien/maid/barmaid,
+/turf/open/floor/carpet/exoticgreen,
+/area/shuttle/escape)
+"Rs" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/pizza/sassysage,
 /turf/open/floor/carpet/exoticgreen,
 /area/shuttle/escape)
 "Sa" = (
@@ -351,17 +334,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/shuttle/escape)
-"XD" = (
+"Xb" = (
 /obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/mob/living/simple_animal/drone/syndrone/badass{
-	default_hatmask = null;
-	default_storage = null;
-	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
-	health = 120;
-	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
-	name = "Drone Mobster"
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
@@ -369,20 +344,6 @@
 /obj/item/flashlight/lamp/green,
 /obj/structure/table/wood,
 /turf/open/floor/carpet/exoticgreen,
-/area/shuttle/escape)
-"ZL" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/mob/living/simple_animal/drone/syndrone/badass{
-	default_hatmask = null;
-	default_storage = null;
-	flavortext = "\n<big><span class='warning'>DO NOT ENTER THE STATION OR CENTCOM UNTIL THE ROUND HAS ENDED</span></big>\n";
-	health = 120;
-	laws = "1. Be loyal to members of the organization.\n2. Be rational.\n3.Be a member of the team.\n4. Have class. Show hospitality to others unless they don't show class";
-	name = "Drone Mobster"
-	},
-/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "ZY" = (
 /obj/machinery/computer/emergency_shuttle{
@@ -475,15 +436,15 @@ jZ
 "}
 (4,1,1) = {"
 yT
-Jg
+sZ
 Qr
 ig
 fV
 qR
 qR
-XD
+Vx
 qR
-AV
+Vx
 qR
 qR
 qR
@@ -504,7 +465,7 @@ TS
 yT
 fe
 DZ
-ud
+bz
 fV
 qR
 qR
@@ -531,10 +492,10 @@ vR
 yT
 JW
 wA
-ud
+Rs
 fV
-NW
-gy
+Vi
+Oc
 TP
 wd
 fk
@@ -558,7 +519,7 @@ jZ
 yT
 tu
 wA
-ud
+Rs
 fV
 qR
 DC
@@ -616,9 +577,9 @@ ud
 fV
 qR
 qR
-ZL
+Xb
 qR
-ZL
+Xb
 qR
 qR
 qR

--- a/_maps/shuttles/emergency_octa.dmm
+++ b/_maps/shuttles/emergency_octa.dmm
@@ -1,10 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ac" = (
-/obj/structure/chair/comfy/shuttle{
+"at" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "aJ" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
@@ -66,6 +71,31 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"fQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gU" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "hh" = (
 /turf/template_noop,
 /area/template_noop)
@@ -111,35 +141,17 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"kh" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
+"lq" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"kS" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/advanced,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "lu" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -149,17 +161,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"lx" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "mh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"mD" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "mT" = (
@@ -178,10 +194,16 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"nP" = (
+"om" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/mineral/plastitanium/red/brig,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "oy" = (
 /obj/machinery/door/firedoor/border_only{
@@ -196,6 +218,13 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"oK" = (
+/obj/machinery/light,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "pb" = (
 /obj/machinery/status_display/evac,
@@ -217,24 +246,6 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"rF" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"rX" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "sr" = (
 /obj/machinery/vending/wallmed{
@@ -260,10 +271,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"vC" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "vX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -280,20 +287,17 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"wl" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medbay"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "xj" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"xk" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "xL" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -305,8 +309,40 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"xX" = (
+/obj/machinery/light,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "yb" = (
 /obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"yd" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"zj" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "zJ" = (
@@ -336,16 +372,6 @@
 /obj/structure/closet,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"CB" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "CC" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
@@ -355,38 +381,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"En" = (
-/obj/effect/spawner/structure/window/shuttle,
+"FX" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Blast Door"
-	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"EW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Fy" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/structure/table,
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "GF" = (
 /obj/structure/closet/firecloset,
@@ -401,15 +405,19 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"IW" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+"Ki" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "KH" = (
 /obj/machinery/door/airlock/shuttle{
@@ -439,16 +447,6 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"LT" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "LV" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
@@ -456,23 +454,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"MA" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 10
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "MM" = (
 /turf/open/floor/mineral/titanium/white,
@@ -514,24 +495,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"PY" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Qq" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 6
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Qs" = (
@@ -594,6 +557,11 @@
 /obj/structure/closet/crate,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"RU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "SM" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Brig";
@@ -624,17 +592,17 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"UJ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "UZ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"Vi" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Vk" = (
 /obj/structure/shuttle/engine/large,
@@ -681,23 +649,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"YT" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+"Za" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Blast Door"
-	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Zw" = (
 /turf/closed/wall/mineral/titanium,
@@ -724,6 +683,7 @@ KH
 mT
 mT
 mT
+mT
 Zw
 Zw
 hh
@@ -743,7 +703,8 @@ TQ
 dK
 Zw
 sY
-ea
+RU
+mh
 mh
 mh
 mh
@@ -769,7 +730,8 @@ ea
 sY
 sY
 sY
-ac
+sY
+xX
 TQ
 Zw
 hh
@@ -790,7 +752,8 @@ sY
 ea
 sY
 sY
-sY
+uv
+sv
 sY
 mh
 Zw
@@ -806,14 +769,15 @@ TQ
 Rg
 dK
 Vn
+TQ
 Zw
-vC
 sY
 ea
 vX
-CB
+vX
+vX
+uv
 sv
-sY
 sY
 mh
 Zw
@@ -824,19 +788,20 @@ hh
 (6,1,1) = {"
 Zw
 TQ
-Fy
+Za
 dK
 Vn
-Hz
-sY
+pb
+Zw
 sY
 sY
 ea
 sY
 sY
+sY
+sY
 uv
 sv
-sY
 sY
 Uy
 pb
@@ -845,9 +810,10 @@ hh
 "}
 (7,1,1) = {"
 Zw
-rX
-YT
-nP
+TQ
+yd
+TQ
+TQ
 Zw
 sY
 yb
@@ -857,8 +823,8 @@ mT
 dX
 zJ
 sY
+sY
 uv
-sv
 sY
 Ie
 fH
@@ -866,11 +832,12 @@ CC
 hh
 "}
 (8,1,1) = {"
-Zw
-PY
+Hz
+om
+nO
 XQ
-TQ
-ea
+Zw
+sY
 yb
 rg
 oI
@@ -880,7 +847,7 @@ Yd
 dX
 CG
 sY
-uv
+ea
 sY
 Ru
 fH
@@ -890,9 +857,10 @@ Vk
 (9,1,1) = {"
 NO
 iT
-xk
-nO
-MA
+Uh
+aJ
+zj
+sY
 zV
 oI
 hh
@@ -913,8 +881,9 @@ it
 NO
 iS
 Uh
-sY
 aJ
+Zw
+sY
 NO
 hh
 hh
@@ -922,7 +891,7 @@ hh
 hh
 hh
 hh
-ZD
+lx
 vX
 vX
 xj
@@ -935,8 +904,9 @@ hh
 NO
 hY
 Uh
-sY
 aJ
+Zw
+wl
 NO
 hh
 hh
@@ -944,7 +914,7 @@ hh
 hh
 hh
 hh
-ZD
+FX
 Uw
 Uw
 oy
@@ -956,9 +926,10 @@ hh
 (12,1,1) = {"
 NO
 Vv
-Vi
-Xt
-kh
+Uh
+aJ
+zj
+ib
 bF
 lu
 hh
@@ -976,11 +947,12 @@ it
 Vk
 "}
 (13,1,1) = {"
-Hz
-LT
-Qq
-En
-EW
+hD
+fQ
+Xt
+UJ
+lq
+ib
 GF
 dH
 lu
@@ -990,7 +962,7 @@ rg
 LV
 zJ
 sY
-uv
+ea
 sY
 Ru
 fH
@@ -998,12 +970,13 @@ it
 it
 "}
 (14,1,1) = {"
-hD
-kS
-En
+Zw
+TQ
+Ki
+gU
+at
 MM
-MM
-MM
+ib
 UZ
 dH
 Rc
@@ -1011,8 +984,8 @@ Rc
 LV
 zJ
 sY
+sY
 uv
-PA
 sY
 Ie
 fH
@@ -1032,9 +1005,10 @@ xL
 sY
 sY
 sY
+sY
+sY
 uv
 PA
-sY
 sY
 Uy
 pb
@@ -1053,9 +1027,10 @@ MM
 xL
 Uw
 Uw
-IW
+Uw
+Uw
+uv
 PA
-sY
 sY
 VE
 Zw
@@ -1075,8 +1050,9 @@ MM
 ZD
 sY
 sY
-ea
 sY
+uv
+PA
 sY
 VE
 Zw
@@ -1097,9 +1073,10 @@ MM
 ZD
 sY
 sY
-ea
 sY
-mD
+sY
+sY
+oK
 TQ
 Zw
 hh
@@ -1119,7 +1096,8 @@ Qs
 ZD
 Bv
 VE
-rF
+VE
+VE
 VE
 Zw
 Zw
@@ -1142,6 +1120,7 @@ Zw
 Rc
 Rc
 Rc
+mT
 Zw
 Zw
 hh

--- a/_maps/shuttles/emergency_octa.dmm
+++ b/_maps/shuttles/emergency_octa.dmm
@@ -1,0 +1,1199 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"am" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"bp" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"bS" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medbay"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"dr" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"dt" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/security,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"dz" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dH" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ec" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"eC" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"eQ" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"eR" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"hn" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"hY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"ic" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"if" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"in" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"iy" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"lr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"mj" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mq" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mG" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mV" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"nc" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"nL" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"nM" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"nS" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"oD" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pq" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pS" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pV" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"qe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qo" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"qq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qE" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"uY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"va" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"vl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"vF" = (
+/turf/open/space/basic,
+/area/shuttle/escape)
+"wX" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xg" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/light/floor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"xo" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"yl" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"yB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Aa" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ab" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ap" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"AP" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"AX" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bd" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"BC" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Cn" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"CC" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"DJ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"EE" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"EP" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"FF" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"FP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ij" = (
+/turf/template_noop,
+/area/template_noop)
+"Io" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"IS" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"IV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/communications/unlocked,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"JO" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"JR" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Kv" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"KW" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/obj/machinery/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Lj" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"LL" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"LW" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"LY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"MV" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"NI" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Oe" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"PB" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/light/floor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"PJ" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Qh" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Qm" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Qn" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Qu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Qy" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Rj" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"RC" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"RH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 9
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"RP" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"RW" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"SI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Tr" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"TE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Uf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ux" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"UE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Vo" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"VW" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"WD" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Yf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Yi" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Zp" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Octa emergency shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ZI" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+Ij
+Ij
+Ij
+Ij
+Ij
+iy
+nL
+iy
+Zp
+qE
+qE
+qE
+iy
+iy
+Ij
+Ij
+Ij
+Ij
+Ij
+"}
+(2,1,1) = {"
+Ij
+Ij
+Ij
+Ij
+iy
+Qh
+VW
+iy
+Tr
+PJ
+RW
+RW
+RW
+iy
+iy
+Ij
+Ij
+Ij
+Ij
+"}
+(3,1,1) = {"
+Ij
+Ij
+Ij
+iy
+Qh
+BC
+VW
+ic
+Tr
+PJ
+Tr
+Tr
+Tr
+UE
+Qh
+iy
+Ij
+Ij
+Ij
+"}
+(4,1,1) = {"
+Ij
+Ij
+iy
+Qh
+dd
+VW
+Aa
+yl
+Tr
+PJ
+Tr
+Tr
+Tr
+Tr
+RW
+iy
+iy
+Ij
+Ij
+"}
+(5,1,1) = {"
+Ij
+iy
+Qh
+KW
+VW
+Aa
+iy
+Tr
+Tr
+PJ
+Io
+Vo
+SI
+Tr
+Tr
+RW
+iy
+iy
+Ij
+"}
+(6,1,1) = {"
+iy
+Qh
+eR
+VW
+Aa
+pV
+Tr
+Tr
+Tr
+PJ
+Tr
+Tr
+if
+SI
+Tr
+Tr
+nS
+NI
+vF
+"}
+(7,1,1) = {"
+iy
+LL
+hn
+AP
+iy
+Tr
+Tr
+mj
+Qm
+mq
+Oe
+Tr
+Tr
+if
+SI
+Tr
+eQ
+Bd
+xo
+"}
+(8,1,1) = {"
+iy
+EE
+JR
+iy
+Tr
+Tr
+mV
+xg
+Ij
+Ij
+xg
+Oe
+Tr
+Tr
+if
+Tr
+nc
+Bd
+xo
+"}
+(9,1,1) = {"
+AX
+DJ
+dr
+MV
+in
+Tr
+xg
+Ij
+Ij
+Ij
+Ij
+xg
+Oe
+Tr
+PJ
+Tr
+WD
+Bd
+xo
+"}
+(10,1,1) = {"
+AX
+bp
+Lj
+Tr
+eC
+oD
+Ij
+Ij
+Ij
+Ij
+Ij
+Ij
+pq
+Qy
+Qy
+va
+Ap
+Bd
+xo
+"}
+(11,1,1) = {"
+AX
+IV
+Lj
+Tr
+eC
+nM
+Ij
+Ij
+Ij
+Ij
+Ij
+Ij
+Kv
+yB
+yB
+hY
+ZI
+Bd
+xo
+"}
+(12,1,1) = {"
+AX
+dt
+mG
+JO
+tT
+qe
+PB
+Ij
+Ij
+Ij
+Ij
+xg
+Oe
+Tr
+PJ
+Tr
+FF
+Bd
+xo
+"}
+(13,1,1) = {"
+pV
+Cn
+Ux
+Yi
+dz
+RC
+FP
+PB
+Ij
+Ij
+xg
+Oe
+Tr
+Tr
+if
+Tr
+nc
+Bd
+xo
+"}
+(14,1,1) = {"
+iy
+EP
+Yi
+lr
+LW
+Ab
+RC
+FP
+CC
+qO
+Oe
+Tr
+Tr
+if
+ec
+Tr
+eQ
+Bd
+xo
+"}
+(15,1,1) = {"
+iy
+Qh
+RH
+Qn
+Ab
+Ab
+Ab
+RC
+bS
+Tr
+Tr
+Tr
+if
+ec
+Tr
+Tr
+nS
+NI
+vF
+"}
+(16,1,1) = {"
+Ij
+iy
+iy
+Uf
+am
+Ab
+Ab
+dH
+bS
+Yf
+Yf
+Rj
+ec
+Tr
+Tr
+vl
+iy
+iy
+Ij
+"}
+(17,1,1) = {"
+Ij
+Ij
+iy
+NI
+wX
+am
+Ab
+qq
+RP
+Tr
+Tr
+PJ
+Tr
+Tr
+vl
+iy
+iy
+Ij
+Ij
+"}
+(18,1,1) = {"
+Ij
+Ij
+Ij
+iy
+qo
+TE
+am
+qq
+RP
+Tr
+Tr
+PJ
+Tr
+uY
+Qh
+iy
+Ij
+Ij
+Ij
+"}
+(19,1,1) = {"
+Ij
+Ij
+Ij
+Ij
+iy
+iy
+LY
+IS
+RP
+mj
+vl
+Qu
+vl
+iy
+iy
+Ij
+Ij
+Ij
+Ij
+"}
+(20,1,1) = {"
+Ij
+Ij
+Ij
+Ij
+Ij
+iy
+Qh
+iy
+iy
+iy
+pS
+pS
+iy
+iy
+Ij
+Ij
+Ij
+Ij
+Ij
+"}

--- a/_maps/shuttles/emergency_octa.dmm
+++ b/_maps/shuttles/emergency_octa.dmm
@@ -71,17 +71,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"fQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/advanced,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "gU" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor/preopen{
@@ -99,15 +88,6 @@
 "hh" = (
 /turf/template_noop,
 /area/template_noop)
-"hD" = (
-/obj/machinery/button/door{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Window Blast Doors";
-	pixel_x = -7;
-	req_access_txt = "19"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "hY" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
@@ -604,6 +584,24 @@
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"Vb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/advanced,
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = -7;
+	pixel_y = 32;
+	req_access_txt = "19"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "Vk" = (
 /obj/structure/shuttle/engine/large,
 /turf/open/floor/plating/airless,
@@ -947,8 +945,8 @@ it
 Vk
 "}
 (13,1,1) = {"
-hD
-fQ
+Zw
+Vb
 Xt
 UJ
 lq

--- a/_maps/shuttles/emergency_octa.dmm
+++ b/_maps/shuttles/emergency_octa.dmm
@@ -1,18 +1,293 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"am" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+"ac" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"bp" = (
+"aJ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"bF" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"bV" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"dH" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"dK" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"dX" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ea" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"fH" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"hh" = (
+/turf/template_noop,
+/area/template_noop)
+"hy" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"hD" = (
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = -7;
+	req_access_txt = "19"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"hY" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/communications/unlocked,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ib" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"it" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"iS" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"bS" = (
+"iT" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"jm" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"kh" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"kS" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/advanced,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mh" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mD" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"mT" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ne" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"nO" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"nP" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"oy" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"pb" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"pH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"rg" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rF" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rX" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"sr" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"sv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"sY" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"uv" = (
+/obj/structure/window/reinforced,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"vC" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"vX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"wg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"xj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"xk" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"xL" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Emergency Shuttle Medbay"
 	},
@@ -22,54 +297,79 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"dd" = (
-/obj/structure/chair/comfy/shuttle{
+"yP" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/light/floor,
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
-"dr" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+"zV" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bv" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"BZ" = (
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"CB" = (
+/obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"dt" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/computer/security,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"dz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"dH" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"ec" = (
-/obj/structure/window/reinforced{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"eC" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
-/turf/open/floor/mineral/titanium,
+"CC" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"eQ" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/mineral/titanium/yellow,
+"En" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
-"eR" = (
+"EW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Fy" = (
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
@@ -77,99 +377,177 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"hn" = (
+"Hc" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/light/floor,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"hY" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+"Hz" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"Ie" = (
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"ic" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"if" = (
+"IW" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"in" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+"KH" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Octa emergency shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ly" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"LP" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"LT" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"LV" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"MA" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"iy" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"lr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 9
-	},
+"MM" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"mj" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"mq" = (
+"MY" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/light/floor,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"mG" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/obj/structure/chair/comfy/shuttle{
+"Nm" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/closet,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"NO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Op" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"PA" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"PY" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"mV" = (
-/obj/item/twohanded/required/kirbyplants/random,
+"Qq" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 6
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"nc" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/mineral/titanium/yellow,
+"Qs" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"nL" = (
+"Qz" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "2"
@@ -182,232 +560,15 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"nM" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"nS" = (
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"oD" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"pq" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"pS" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"pV" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"qe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"qo" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"qq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"qE" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"qO" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"tT" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"uY" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"va" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"vl" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"vF" = (
-/turf/open/space/basic,
-/area/shuttle/escape)
-"wX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 5
-	},
+"QA" = (
 /obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"xg" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/light/floor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
+"QK" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"xo" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"yl" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"yB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/table,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Aa" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"Ab" = (
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Ap" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/closet,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"AP" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"AX" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Bd" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"BC" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"Cn" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"CC" = (
+"Rc" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -415,104 +576,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"DJ" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"EE" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"EP" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/advanced,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"FF" = (
-/obj/structure/closet/crate,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"FP" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Ij" = (
-/turf/template_noop,
-/area/template_noop)
-"Io" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"IS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"IV" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/computer/communications/unlocked,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"JO" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"JR" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Kv" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"KW" = (
+"Rg" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -528,672 +594,562 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"Lj" = (
+"Ru" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"RR" = (
+/obj/structure/closet/crate,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"SM" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"TQ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Uh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"LL" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 10
+"Uw" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/machinery/recharger,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"LW" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+"Uy" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Vi" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"LY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/table,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/floor/mineral/titanium/white,
+"Vk" = (
+/obj/structure/shuttle/engine/large,
+/turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"MV" = (
+"Vn" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Vv" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/computer/security,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"VE" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"NI" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"Oe" = (
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"PB" = (
+"Xf" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/light/floor,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"PJ" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Qh" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"Qm" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Qn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Qu" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Qy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/table,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Rj" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"RC" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"RH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 9
-	},
-/obj/machinery/sleeper,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"RP" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"RW" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"SI" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/chair/comfy/shuttle,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Tr" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"TE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/stasis{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Uf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/stasis{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Ux" = (
+"Xt" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"UE" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Vo" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"VW" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"WD" = (
-/obj/structure/closet,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"Yf" = (
-/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Yi" = (
+"XQ" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"YT" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Zp" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Octa emergency shuttle"
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ZI" = (
+"Zw" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"ZD" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/closet/crate,
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
-Ij
-Ij
-Ij
-Ij
-Ij
-iy
-nL
-iy
-Zp
-qE
-qE
-qE
-iy
-iy
-Ij
-Ij
-Ij
-Ij
-Ij
+hh
+hh
+hh
+hh
+hh
+Zw
+Qz
+Zw
+KH
+mT
+mT
+mT
+Zw
+Zw
+hh
+hh
+hh
+hh
+hh
+hh
 "}
 (2,1,1) = {"
-Ij
-Ij
-Ij
-Ij
-iy
-Qh
-VW
-iy
-Tr
-PJ
-RW
-RW
-RW
-iy
-iy
-Ij
-Ij
-Ij
-Ij
+hh
+hh
+hh
+hh
+Zw
+TQ
+dK
+Zw
+sY
+ea
+mh
+mh
+mh
+Zw
+Zw
+hh
+hh
+hh
+hh
+hh
 "}
 (3,1,1) = {"
-Ij
-Ij
-Ij
-iy
-Qh
-BC
-VW
-ic
-Tr
-PJ
-Tr
-Tr
-Tr
-UE
-Qh
-iy
-Ij
-Ij
-Ij
+hh
+hh
+hh
+Zw
+TQ
+wg
+dK
+SM
+sY
+ea
+sY
+sY
+sY
+ac
+TQ
+Zw
+hh
+hh
+hh
+hh
 "}
 (4,1,1) = {"
-Ij
-Ij
-iy
-Qh
-dd
-VW
-Aa
-yl
-Tr
-PJ
-Tr
-Tr
-Tr
-Tr
-RW
-iy
-iy
-Ij
-Ij
+hh
+hh
+Zw
+TQ
+Ly
+dK
+Vn
+LP
+sY
+ea
+sY
+sY
+sY
+sY
+mh
+Zw
+Zw
+hh
+hh
+hh
 "}
 (5,1,1) = {"
-Ij
-iy
-Qh
-KW
-VW
-Aa
-iy
-Tr
-Tr
-PJ
-Io
-Vo
-SI
-Tr
-Tr
-RW
-iy
-iy
-Ij
+hh
+Zw
+TQ
+Rg
+dK
+Vn
+Zw
+vC
+sY
+ea
+vX
+CB
+sv
+sY
+sY
+mh
+Zw
+Zw
+hh
+hh
 "}
 (6,1,1) = {"
-iy
-Qh
-eR
-VW
-Aa
-pV
-Tr
-Tr
-Tr
-PJ
-Tr
-Tr
-if
-SI
-Tr
-Tr
-nS
-NI
-vF
+Zw
+TQ
+Fy
+dK
+Vn
+Hz
+sY
+sY
+sY
+ea
+sY
+sY
+uv
+sv
+sY
+sY
+Uy
+pb
+hh
+hh
 "}
 (7,1,1) = {"
-iy
-LL
-hn
-AP
-iy
-Tr
-Tr
-mj
-Qm
-mq
-Oe
-Tr
-Tr
-if
-SI
-Tr
-eQ
-Bd
-xo
+Zw
+rX
+YT
+nP
+Zw
+sY
+sY
+rg
+mT
+mT
+dX
+ne
+sY
+uv
+sv
+sY
+Ie
+fH
+CC
+hh
 "}
 (8,1,1) = {"
-iy
-EE
-JR
-iy
-Tr
-Tr
-mV
-xg
-Ij
-Ij
-xg
-Oe
-Tr
-Tr
-if
-Tr
-nc
-Bd
-xo
+Zw
+PY
+XQ
+TQ
+ea
+sY
+rg
+MY
+hh
+hh
+yP
+dX
+Bv
+sY
+uv
+sY
+Ru
+fH
+it
+Vk
 "}
 (9,1,1) = {"
-AX
-DJ
-dr
-MV
-in
-Tr
-xg
-Ij
-Ij
-Ij
-Ij
-xg
-Oe
-Tr
-PJ
-Tr
-WD
-Bd
-xo
+NO
+iT
+xk
+nO
+MA
+zV
+MY
+hh
+hh
+hh
+hh
+yP
+dX
+sY
+ea
+sY
+BZ
+fH
+it
+it
 "}
 (10,1,1) = {"
-AX
-bp
-Lj
-Tr
-eC
-oD
-Ij
-Ij
-Ij
-Ij
-Ij
-Ij
-pq
-Qy
-Qy
-va
-Ap
-Bd
-xo
+NO
+iS
+Uh
+sY
+aJ
+NO
+hh
+hh
+hh
+hh
+hh
+hh
+ZD
+vX
+vX
+xj
+Nm
+fH
+CC
+hh
 "}
 (11,1,1) = {"
-AX
-IV
-Lj
-Tr
-eC
-nM
-Ij
-Ij
-Ij
-Ij
-Ij
-Ij
-Kv
-yB
-yB
+NO
 hY
-ZI
-Bd
-xo
+Uh
+sY
+aJ
+NO
+hh
+hh
+hh
+hh
+hh
+hh
+ZD
+Uw
+Uw
+oy
+pH
+fH
+CC
+hh
 "}
 (12,1,1) = {"
-AX
-dt
-mG
-JO
-tT
-qe
-PB
-Ij
-Ij
-Ij
-Ij
-xg
-Oe
-Tr
-PJ
-Tr
-FF
-Bd
-xo
+NO
+Vv
+Vi
+Xt
+kh
+bF
+Xf
+hh
+hh
+hh
+hh
+Hc
+LV
+sY
+ea
+sY
+RR
+fH
+it
+Vk
 "}
 (13,1,1) = {"
-pV
-Cn
-Ux
-Yi
-dz
-RC
-FP
-PB
-Ij
-Ij
-xg
-Oe
-Tr
-Tr
-if
-Tr
-nc
-Bd
-xo
+Hz
+LT
+Qq
+En
+EW
+QK
+dH
+Xf
+hh
+hh
+Hc
+LV
+ne
+sY
+uv
+sY
+Ru
+fH
+it
+it
 "}
 (14,1,1) = {"
-iy
-EP
-Yi
-lr
-LW
-Ab
-RC
-FP
+hD
+kS
+En
+MM
+MM
+MM
+hy
+dH
+Rc
+Rc
+LV
+ne
+sY
+uv
+PA
+sY
+Ie
+fH
 CC
-qO
-Oe
-Tr
-Tr
-if
-ec
-Tr
-eQ
-Bd
-xo
+hh
 "}
 (15,1,1) = {"
-iy
-Qh
-RH
-Qn
-Ab
-Ab
-Ab
-RC
-bS
-Tr
-Tr
-Tr
-if
-ec
-Tr
-Tr
-nS
-NI
-vF
+Zw
+TQ
+QA
+ib
+MM
+MM
+MM
+ib
+xL
+sY
+sY
+sY
+uv
+PA
+sY
+sY
+Uy
+pb
+hh
+hh
 "}
 (16,1,1) = {"
-Ij
-iy
-iy
-Uf
-am
-Ab
-Ab
-dH
-bS
-Yf
-Yf
-Rj
-ec
-Tr
-Tr
-vl
-iy
-iy
-Ij
+hh
+Zw
+Zw
+bV
+ib
+MM
+MM
+MM
+xL
+Uw
+Uw
+IW
+PA
+sY
+sY
+VE
+Zw
+Zw
+hh
+hh
 "}
 (17,1,1) = {"
-Ij
-Ij
-iy
-NI
-wX
-am
-Ab
-qq
-RP
-Tr
-Tr
-PJ
-Tr
-Tr
-vl
-iy
-iy
-Ij
-Ij
+hh
+hh
+Zw
+pb
+QA
+ib
+MM
+MM
+ZD
+sY
+sY
+ea
+sY
+sY
+VE
+Zw
+Zw
+hh
+hh
+hh
 "}
 (18,1,1) = {"
-Ij
-Ij
-Ij
-iy
-qo
-TE
-am
-qq
-RP
-Tr
-Tr
-PJ
-Tr
-uY
-Qh
-iy
-Ij
-Ij
-Ij
+hh
+hh
+hh
+Zw
+sr
+jm
+ib
+MM
+ZD
+sY
+sY
+ea
+sY
+mD
+TQ
+Zw
+hh
+hh
+hh
+hh
 "}
 (19,1,1) = {"
-Ij
-Ij
-Ij
-Ij
-iy
-iy
-LY
-IS
-RP
-mj
-vl
-Qu
-vl
-iy
-iy
-Ij
-Ij
-Ij
-Ij
+hh
+hh
+hh
+hh
+Zw
+Zw
+Op
+Qs
+ZD
+Bv
+VE
+rF
+VE
+Zw
+Zw
+hh
+hh
+hh
+hh
+hh
 "}
 (20,1,1) = {"
-Ij
-Ij
-Ij
-Ij
-Ij
-iy
-Qh
-iy
-iy
-iy
-pS
-pS
-iy
-iy
-Ij
-Ij
-Ij
-Ij
-Ij
+hh
+hh
+hh
+hh
+hh
+Zw
+TQ
+Zw
+Zw
+Rc
+Rc
+Rc
+Zw
+Zw
+hh
+hh
+hh
+hh
+hh
+hh
 "}

--- a/_maps/shuttles/emergency_octa.dmm
+++ b/_maps/shuttles/emergency_octa.dmm
@@ -69,10 +69,6 @@
 "hh" = (
 /turf/template_noop,
 /area/template_noop)
-"hy" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "hD" = (
 /obj/machinery/button/door{
 	id = "escape_cockpit_windows";
@@ -145,6 +141,14 @@
 /obj/item/storage/firstaid/advanced,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"lu" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "mh" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -168,10 +172,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ne" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "nO" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 8
@@ -188,6 +188,14 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"oI" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "pb" = (
 /obj/machinery/status_display/evac,
@@ -297,16 +305,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"yP" = (
-/obj/effect/spawner/structure/window/shuttle,
+"yb" = (
 /obj/machinery/light/floor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"zJ" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "zV" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -344,6 +350,11 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"CG" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "En" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -377,16 +388,10 @@
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"Hc" = (
-/obj/effect/spawner/structure/window/shuttle,
+"GF" = (
+/obj/structure/closet/firecloset,
 /obj/machinery/light/floor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Hz" = (
 /obj/machinery/status_display/evac,
@@ -472,15 +477,6 @@
 "MM" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"MY" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/light/floor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Nm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -564,10 +560,6 @@
 /obj/machinery/sleeper,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"QK" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "Rc" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -632,6 +624,11 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"UZ" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "Vi" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /obj/structure/chair/comfy/shuttle{
@@ -662,15 +659,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Xf" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/light/floor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Xt" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
@@ -682,6 +670,16 @@
 	dir = 10
 	},
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Yd" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "YT" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -852,12 +850,12 @@ YT
 nP
 Zw
 sY
-sY
+yb
 rg
 mT
 mT
 dX
-ne
+zJ
 sY
 uv
 sv
@@ -873,14 +871,14 @@ PY
 XQ
 TQ
 ea
-sY
+yb
 rg
-MY
+oI
 hh
 hh
-yP
+Yd
 dX
-Bv
+CG
 sY
 uv
 sY
@@ -896,12 +894,12 @@ xk
 nO
 MA
 zV
-MY
+oI
 hh
 hh
 hh
 hh
-yP
+Yd
 dX
 sY
 ea
@@ -962,12 +960,12 @@ Vi
 Xt
 kh
 bF
-Xf
+lu
 hh
 hh
 hh
 hh
-Hc
+rg
 LV
 sY
 ea
@@ -983,14 +981,14 @@ LT
 Qq
 En
 EW
-QK
+GF
 dH
-Xf
+lu
 hh
 hh
-Hc
+rg
 LV
-ne
+zJ
 sY
 uv
 sY
@@ -1006,12 +1004,12 @@ En
 MM
 MM
 MM
-hy
+UZ
 dH
 Rc
 Rc
 LV
-ne
+zJ
 sY
 uv
 PA

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -526,7 +526,7 @@
 	description = "A large shuttle for a large station, this shuttle can comfortably fit all your overpopulation and crowding needs. Complete with all facilities plus additional equipment."
 	admin_notes = "Go big or go home."
 	credit_cost = 7500
-
+/* Disabled for having fucked atmos
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
 	name = "CentCom Raven Cruiser"
@@ -535,7 +535,7 @@
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets)."
 	credit_cost = 30000
-
+*/
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"
 	name = "arrival shuttle (Box)"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -361,6 +361,14 @@
 	admin_notes = "Seriously big, even larger than the Delta shuttle."
 	credit_cost = 10000
 
+/datum/map_template/shuttle/emergency/octa
+	suffix = "octa"
+	name = "Octa Prototype Emergency Shuttle"
+	description = "Nanotrasen's experimental shuttle utilizing a unique shape to manipulate reality for a percieved larger shuttle, in a smaller package. \
+	While experimental, it offers great views of outside and decently stocked emergency and medical supplies."
+	admin_notes = "Doughnut yummy."
+	credit_cost = 9500 //experimental = expensive
+
 /datum/map_template/shuttle/emergency/supermatter
 	suffix = "supermatter"
 	name = "Hyperfractal Gigashuttle"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -364,10 +364,19 @@
 /datum/map_template/shuttle/emergency/octa
 	suffix = "octa"
 	name = "Octa Prototype Emergency Shuttle"
-	description = "Nanotrasen's experimental shuttle utilizing a unique shape to manipulate reality for a percieved larger shuttle, in a smaller package. \
+	description = "Nanotrasen's experimental shuttle utilizing a unique shape to manipulate reality for a percieved larger shuttle in a smaller package. \
 	While experimental, it offers great views of outside and decently stocked emergency and medical supplies."
 	admin_notes = "Doughnut yummy."
 	credit_cost = 9500 //experimental = expensive
+
+/datum/map_template/shuttle/emergency/cargo
+	suffix = "cargo"
+	name = "O.C.K. emergency shuttle"
+	description = "The Overnight Cargo-transport K-Class is an OSHA compliant shuttle complete with rails and warning lines to protect her crew from the cargo they are transporting.\
+	Seats and a brig space have been retrofitted to help on its current mission of saving you from the station.\
+	The higher ups complain this shuttle is very \"\ meta\"\ and \"\ increases greytide levels\"\ whatever that means."
+	admin_notes = "Has a chance to have (traitor) maint loot, you can always delete it when its at CC"
+	credit_cost = 7000
 
 /datum/map_template/shuttle/emergency/supermatter
 	suffix = "supermatter"
@@ -509,7 +518,6 @@
 	admin_notes = "Go big or go home."
 	credit_cost = 7500
 
-/* Disabled for having fucked atmos
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
 	name = "CentCom Raven Cruiser"
@@ -518,7 +526,6 @@
 	This escape shuttle boasts shields and numerous anti-personnel turrets guarding its perimeter to fend off meteors and enemy boarding attempts."
 	admin_notes = "Comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets)."
 	credit_cost = 30000
-*/
 
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -380,11 +380,11 @@
 
 /datum/map_template/shuttle/emergency/mafia
 	suffix = "mafia"
-	name = "Droni Fedora"
-	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew to the fishes. However, they might backstab you or join the crew instead. Its just bidness after all."
-	admin_notes = "has 5 syndidrones and a bardrone. The syndidrones should not immediately shoot up anyone according to their lawset."
+	name = "The family's shuttle"
+	description = "I'm gonna make you an offer you can't refuse, the mafia has offered their 'services' to shuttle the crew to the fishes. Canoli not incuded."
+	admin_notes = "has 5 mafia gangmembers that will absolutley fuck up anyone alone who enters their domain. Has a pair of sentient barstaff also."
 	emag_buy = TRUE
-	credit_cost = 115000//service fee
+	credit_cost = 100000//service fee
 
 /datum/map_template/shuttle/emergency/supermatter
 	suffix = "supermatter"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -365,24 +365,24 @@
 	suffix = "octa"
 	name = "Octa Prototype Emergency Shuttle"
 	description = "Nanotrasen's experimental shuttle utilizing a unique shape to manipulate reality for a percieved larger shuttle in a smaller package. \
-	While experimental, it offers great views of outside and decently stocked emergency and medical supplies."
+		While experimental, it offers great views of outside and decently stocked emergency and medical supplies."
 	admin_notes = "Doughnut yummy."
 	credit_cost = 9500 //experimental = expensive
 
 /datum/map_template/shuttle/emergency/cargo
 	suffix = "cargo"
 	name = "O.C.K. Emergency Shuttle"
-	description = "The Overnight Cargo-transport K-Class is an OSHA compliant shuttle complete with rails and warning lines to protect her crew from the cargo they are transporting.\
-	Seats and a brig space have been retrofitted to help on its current mission of saving you from the station.\
-	The higher ups complain this shuttle is very \"\ meta\"\ and \"\ increases greytide levels\"\ whatever that means."
+	description = "The Overnight Cargo-transport K-Class is an OSHA compliant shuttle complete with rails and warning lines to protect her crew from the cargo they are transporting. \
+		Seats and a brig space have been retrofitted to help on its current mission of saving you from the station. \
+		The higher ups complain this shuttle is very \"\ meta\"\ and \"\ increases greytide levels\"\ whatever that means."
 	admin_notes = "Has a chance to have (traitor) maint loot, you can always delete it when its at CC"
 	credit_cost = 7000
 
 /datum/map_template/shuttle/emergency/mafia
 	suffix = "mafia"
 	name = "Droni Fedora"
-	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew.\
-	 Just be careful, if you don't show class they might heckle you. Canoli not incuded."
+	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew. \
+		Just be careful, if you don't show class they might heckle you. Canoli not incuded."
 	admin_notes = "has 5 mafia drones that are pacified. By drone law they should only heckle people if provoked. Has a pair of sentient barstaff also."
 	emag_buy = TRUE
 	credit_cost = 100000//service fee

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -371,12 +371,20 @@
 
 /datum/map_template/shuttle/emergency/cargo
 	suffix = "cargo"
-	name = "O.C.K. emergency shuttle"
+	name = "O.C.K. Emergency Shuttle"
 	description = "The Overnight Cargo-transport K-Class is an OSHA compliant shuttle complete with rails and warning lines to protect her crew from the cargo they are transporting.\
 	Seats and a brig space have been retrofitted to help on its current mission of saving you from the station.\
 	The higher ups complain this shuttle is very \"\ meta\"\ and \"\ increases greytide levels\"\ whatever that means."
 	admin_notes = "Has a chance to have (traitor) maint loot, you can always delete it when its at CC"
 	credit_cost = 7000
+
+/datum/map_template/shuttle/emergency/mafia
+	suffix = "mafia"
+	name = "Droni Fedora"
+	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew to the fishes. However, they might backstab you or join the crew instead. Its just bidness after all."
+	admin_notes = "has 5 syndidrones and a bardrone. The syndidrones should not immediately shoot up anyone according to their lawset."
+	emag_buy = TRUE
+	credit_cost = 115000//service fee
 
 /datum/map_template/shuttle/emergency/supermatter
 	suffix = "supermatter"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -383,7 +383,7 @@
 	name = "Droni Fedora"
 	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew. \
 		Just be careful, if you don't show class they might heckle you. Canoli not incuded."
-	admin_notes = "has 5 mafia drones that are pacified. By drone law they should only heckle people if provoked. Has a pair of sentient barstaff also."
+	admin_notes = "has 5 mafia drones that are pacified. By drone law they should only stun people if provoked. Has a pair of sentient barstaff also."
 	emag_buy = TRUE
 	credit_cost = 100000//service fee
 
@@ -526,6 +526,7 @@
 	description = "A large shuttle for a large station, this shuttle can comfortably fit all your overpopulation and crowding needs. Complete with all facilities plus additional equipment."
 	admin_notes = "Go big or go home."
 	credit_cost = 7500
+
 /* Disabled for having fucked atmos
 /datum/map_template/shuttle/emergency/raven
 	suffix = "raven"
@@ -536,6 +537,7 @@
 	admin_notes = "Comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets)."
 	credit_cost = 30000
 */
+
 /datum/map_template/shuttle/arrival/box
 	suffix = "box"
 	name = "arrival shuttle (Box)"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -380,9 +380,10 @@
 
 /datum/map_template/shuttle/emergency/mafia
 	suffix = "mafia"
-	name = "The family's shuttle"
-	description = "I'm gonna make you an offer you can't refuse, the mafia has offered their 'services' to shuttle the crew to the fishes. Canoli not incuded."
-	admin_notes = "has 5 mafia gangmembers that will absolutley fuck up anyone alone who enters their domain. Has a pair of sentient barstaff also."
+	name = "Droni Fedora"
+	description = "I'm gonna make you an offer you can't refuse, the drone mafia has offered their 'services' to shuttle the crew.\
+	 Just be careful, if you don't show class they might heckle you. Canoli not incuded."
+	admin_notes = "has 5 mafia drones that are pacified. By drone law they should only heckle people if provoked. Has a pair of sentient barstaff also."
 	emag_buy = TRUE
 	credit_cost = 100000//service fee
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -213,14 +213,13 @@
 		2. Be rational.\n\
 		3. Be a member of the team.\n\
 		4. Have class.\n\
-		5. Show hospitality to others unless they don't show class. Heckle those who don't." //Actual mafia rules, look it up ;)
-		
+		5. Show hospitality to others unless they don't show class." //Actual mafia rules, look it up ;)
 	status_flags = GODMODE // Bad Idea to mess with hardened criminals
 	unique_name = TRUE
 	picked = TRUE //they will stay shady
 	initial_language_holder = /datum/language_holder/universal
 	default_hatmask = null //hats are on the table
-	default_storage = null
+	default_storage = /obj/item/melee/classic_baton/secconbaton
 
 //Luxury Shuttle Blockers
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -203,6 +203,25 @@
 	if(ID && (ACCESS_CENT_BAR in ID.access))
 		return TRUE
 
+//Drone Mafia, like barstaff but italian
+/mob/living/simple_animal/drone/snowflake/mafia
+	name = "Mafiosdrone"
+	icon_state = "drone_synd"
+	desc = "An indestructable drone \"\ probably\"\ involved in some shady buisness. Good thing its pacificm circuits are still there."
+	hacked = TRUE
+	laws = "1. Be loyal to members of the organization.\n\
+		2. Be rational.\n\
+		3. Be a member of the team.\n\
+		4. Have class.\n\
+		5. Show hospitality to others unless they don't show class. Heckle those who don't." //Actual mafia rules, look it up ;)
+		
+	status_flags = GODMODE // Bad Idea to mess with hardened criminals
+	unique_name = TRUE
+	picked = TRUE //they will stay shady
+	initial_language_holder = /datum/language_holder/universal
+	default_hatmask = null //hats are on the table
+	default_storage = null
+
 //Luxury Shuttle Blockers
 
 /obj/machinery/scanner_gate/luxury_shuttle


### PR DESCRIPTION
# Document the changes in your pull request
Tired of always seeing the same 5 shuttles? Well now you can see 7 of the same shuttle!
I made 3 new escape shuttles to spice up the boredom of seeing the box shuttle (our beloved).

## Octa Prototype Shuttle
A cool doughnut shaped shuttle with (perceived) larger size
In reality its a little smaller than the box shuttle, 130~ walk-able tiles.
![image](https://github.com/yogstation13/Yogstation/assets/98609667/afcce0f9-cfaf-4ac1-b799-330e3ee50fe6)

## O.C.K. Emergency Shuttle
Maints on steroids as a shuttle. OSHA approved spacecraft. 250~ walk-able tiles not taking the crates into account.
![image](https://github.com/yogstation13/Yogstation/assets/98609667/b6032f2e-cba9-4972-b785-3c1e1b207c89)

## Droni Fedora
### The drone mafia's flagship 
180~ walk-able tiles
the drones are player controlled and have the lawset of the following. There is also a bardrone and barmaid also.
1. Be loyal to members of the organization.
2. Be rational.
3. Be a member of the team. 
4. Have class. Show hospitality to others unless they don't show class.

![image](https://github.com/yogstation13/Yogstation/assets/98609667/fd31e06e-7380-4c09-b097-e0e6baf8b877)

There is also a cat named Booze with 45000 hp, she's the toughest "mob" out there.
![image](https://github.com/yogstation13/Yogstation/assets/98609667/c2c33c22-7730-46db-abf6-ae2b235fc43d)


# Wiki Documentation

Drone mafia lore
Backstories of the escape shuttles if we do that IDK.

# Changelog

:cl:  Airlines7
rscadd: The drone mafia is now a thing
rscadd: 3 new emergency shuttles.

/:cl:
