### PR TITLE
neckerchief text is correct

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -19,7 +19,7 @@
 /obj/item/clothing/mask/muzzle/tape
 	name = "tape muzzle"
 	icon_state = "tape"
-	
+
 /obj/item/clothing/mask/muzzle/tape/attack_self(mob/user)
 	..()
 	user.visible_message(span_notice("You take apart [src]."), span_notice("[user] takes apart [src]."))
@@ -284,7 +284,7 @@ GLOBAL_LIST_INIT(cursed_animal_masks, list(
 			var/currentHandIndex = user.get_held_index_of_item(src)
 			user.transferItemToLoc(src, null)
 			user.put_in_hand(nk, currentHandIndex)
-			user.visible_message(span_notice("You tie [src] up like a neckerchief."), span_notice("[user] ties [src] up like a neckerchief."))
+			user.visible_message(span_notice("[user] ties [src] up like a neckerchief."), span_notice("You tie [src] up like a neckerchief."))
 			qdel(src)
 		else
 			to_chat(user, span_warning("You must be holding [src] in order to tie it!"))

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -229,7 +229,7 @@
 			var/oldName = src.name
 			qdel(src)
 			user.put_in_hand(newBand, currentHandIndex)
-			user.visible_message("You untie [oldName] back into a [newBand.name]", "[user] unties [oldName] back into a [newBand.name]")
+			user.visible_message("[user] unties [oldName] back into a [newBand.name]", "You untie [oldName] back into a [newBand.name]")
 		else
 			to_chat(user, span_warning("You must be holding [src] in order to untie it!"))
 
@@ -411,7 +411,7 @@
 /obj/item/clothing/neck/cloak/ranger/Destroy()
 	set_cloak(0)
 	. = ..()
-	
+
 /obj/item/clothing/neck/cloak/ranger/proc/update_signals(user)
 	if((!user || (current_user == user)) && current_user == loc && istype(current_user) && current_user.get_item_by_slot(ITEM_SLOT_NECK) == src)
 		return TRUE
@@ -441,7 +441,7 @@
 		return
 	var/mob/user = loc
 	if(!istype(user) || !user.get_item_by_slot(ITEM_SLOT_NECK) == src)
-		
+
 		return
 	set_cloak(cloak + (cloak_charge_rate * delta_time))
 

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -229,7 +229,7 @@
 			var/oldName = src.name
 			qdel(src)
 			user.put_in_hand(newBand, currentHandIndex)
-			user.visible_message("[user] unties [oldName] back into a [newBand.name]", "You untie [oldName] back into a [newBand.name]")
+			user.visible_message("[user] unties [oldName] back into a [newBand.name].", "You untie [oldName] back into a [newBand.name].")
 		else
 			to_chat(user, span_warning("You must be holding [src] in order to untie it!"))
 


### PR DESCRIPTION
![image](https://github.com/yogstation13/Yogstation/assets/122807629/042e022e-16d3-4c9e-8898-584b4432d616)
it'd show "you tie" to others and "name ties" to you, funny.

:cl:  Ktlwjec
bugfix: Neckerchief tying text is now correct.
/:cl: