### PR TITLE
Makes legion cores also heal robotic limbs

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -515,8 +515,8 @@
 		ADD_TRAIT(owner, TRAIT_REDUCED_DAMAGE_SLOWDOWN, id)
 	else
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)
-	owner.adjustBruteLoss(-25)
-	owner.adjustFireLoss(-25)
+	owner.adjustBruteLoss(-25, TRUE, FALSE, BODYPART_ANY)
+	owner.adjustFireLoss(-25, TRUE, FALSE, BODYPART_ANY)
 	owner.remove_CC()
 	owner.bodytemperature = BODYTEMP_NORMAL
 	return TRUE


### PR DESCRIPTION
They work via some sort of lavaland tendril fuckery, no reason it can't hold metal together just like it can flesh
Should make mining as an ipc/preternis not quite as miserable (still can't use medipens)
Also a buff to the seismic arm

:cl:  
tweak: legion cores also heal robotic limbs
/:cl:
