### PR TITLE
Chameleon envirosuit for plasmaman contractors + bugfix

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -436,6 +436,65 @@
 	// Paper guide
 	new /obj/item/paper/contractor_guide(src)
 
+/obj/item/storage/box/syndicate/contract_kit/plasmaman
+	real_name = "Contract Kit"
+	desc = "Supplied to Syndicate contractors."
+	icon_state = "syndiebox"
+	illustration = "writing_syndie"
+	
+/obj/item/storage/box/syndicate/contract_kit/plasmaman/PopulateContents()
+	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
+	new /obj/item/storage/box/syndicate/contractor_loadout/plasmaman(src)
+	new /obj/item/melee/classic_baton/telescopic/contractor_baton(src)
+	new /obj/item/bodybag/environmental/prisoner/syndicate(src)
+	
+	var/list/item_list = list(
+		/obj/item/storage/backpack/duffelbag/syndie/x4,
+		/obj/item/storage/box/syndie_kit/throwing_weapons,
+		/obj/item/gun/syringe/syndicate,
+		/obj/item/pen/edagger,
+		/obj/item/pen/sleepy,
+		/obj/item/flashlight/emp,
+		/obj/item/book/granter/crafting_recipe/weapons,
+		/obj/item/clothing/shoes/chameleon/noslip/syndicate,
+		/obj/item/storage/firstaid/tactical,
+		/obj/item/clothing/shoes/airshoes,
+		/obj/item/clothing/glasses/thermal/syndi,
+		/obj/item/camera_bug,
+		/obj/item/storage/box/syndie_kit/imp_radio,
+		/obj/item/storage/box/syndie_kit/imp_uplink,
+		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
+		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
+		/obj/item/reagent_containers/syringe/stimulants,
+		/obj/item/storage/box/syndie_kit/imp_freedom,
+		/obj/item/storage/belt/chameleon/syndicate
+	)
+	
+	var/obj/item1 = pick_n_take(item_list)
+	var/obj/item2 = pick_n_take(item_list)
+	var/obj/item3 = pick_n_take(item_list)
+
+	new item1(src)
+	new item2(src)
+	new item3(src)
+
+	new /obj/item/paper/contractor_guide(src)
+
+/obj/item/storage/box/syndicate/contractor_loadout/plasmaman
+	real_name = "Standard Loadout"
+	desc = "Supplied to the Syndicate's plasmaman contractors, providing their specialised space suit and chameleon envirosuit."
+	icon_state = "syndiebox"
+	illustration = "writing_syndie"
+	
+/obj/item/storage/box/syndicate/contractor_loadout/plasmaman/PopulateContents()
+	new /obj/item/clothing/head/helmet/space/plasmaman/chameleon/syndicate(src)
+	new /obj/item/clothing/suit/space/syndicate/contract(src)
+	new /obj/item/clothing/under/plasmaman/chameleon/syndicate(src)
+	new /obj/item/clothing/mask/chameleon/syndicate(src)
+	new /obj/item/card/id/syndicate(src)
+	new /obj/item/storage/box/fancy/cigarettes/cigpack_syndicate(src)
+	new /obj/item/lighter(src)
+
 /obj/item/storage/box/syndie_kit
 	name = "box"
 	real_name = "box"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -498,11 +498,11 @@
 
 /obj/item/clothing/head/helmet/space/plasmaman/chameleon/Initialize(mapload)
 	. = ..()
-	chameleon_action = new /datum/action/item_action/chameleon/change
+	chameleon_action = new(src)
 	if(syndicate)
 		chameleon_action.syndicate = TRUE
-	chameleon_action.chameleon_type = /obj/item/clothing/head/helmet/space
-	chameleon_action.chameleon_name = "Hat"
+	chameleon_action.chameleon_type = /obj/item/clothing/head
+	chameleon_action.chameleon_name = "Helmet"
 	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/head/changeling, only_root_path = TRUE)
 	chameleon_action.initialize_disguises()
 	add_item_action(chameleon_action)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -213,6 +213,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	player_minimum = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 
+/datum/uplink_item/bundles_TC/contract_kit/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
+	if(is_species(user, /datum/species/plasmaman))
+		spawn_path = /obj/item/storage/box/syndicate/contract_kit/plasmaman
+	..()
+
 /datum/uplink_item/bundles_TC/bundle_A
 	name = "Syndi-kit Tactical"
 	desc = "Syndicate Bundles, also known as Syndi-Kits, are specialized groups of items that arrive in a plain box. \


### PR DESCRIPTION
# Document the changes in your pull request

Because of an oversight, plasmamen still got the regular chameleon clothes in contract kits (my bad.) They now receive a chameleon envirosuit instead of the jumpsuit, and the contractor spacesuit has its helmet replaced with a chameleon envirohelm.

Also fixed an issue where the chameleon envirohelm couldn't change its appearance, and it can now disguise as whatever headwear instead of being restricted to space helmets because why not.

Closes #19145


# Changelog

:cl:  
bugfix: fixed chameleon envirohelm being unable to change appearance
tweak: plasmamen get chameleon envirosuits in the contract kit
/:cl:
