### PR TITLE
[Box] Adds two more RPDs and an atmos holofan creator to SM template

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_sm.dmm
@@ -72,34 +72,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"al" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"am" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ap" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1688,6 +1660,23 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"wt" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 5
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2032,6 +2021,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"Tr" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/pipe_dispenser,
+/obj/item/holosign_creator/atmos,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "Um" = (
 /obj/machinery/power/emitter/anchored{
@@ -2495,7 +2498,7 @@ cl
 "}
 (15,1,1) = {"
 ad
-al
+Tr
 MS
 aN
 bf
@@ -2523,7 +2526,7 @@ aa
 "}
 (16,1,1) = {"
 ad
-am
+wt
 cA
 aO
 bg


### PR DESCRIPTION

# Document the changes in your pull request

Spacing the SM is a nightmare

One RPD is not enough for multiple engineers to work on the SM

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog



:cl:  
mapping: two more rpds and a holofan creator box s m
/:cl:
