### PR TITLE
Robotic healing tweaks

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1079,16 +1079,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 //specifically for "suture" type robotic healing items
 //amount is either the fuel of a welding tool, or the number of wires consumed
 //volume is how loud the sound of the item is
-#define ROBO_LIMB_HEAL_SELF 6 SECONDS
-#define ROBO_LIMB_HEAL_OTHER 2 SECONDS
-/obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
-	var/used_delay
-	if(H != user)
-		used_delay = ROBO_LIMB_HEAL_OTHER
-	else
-		used_delay = ROBO_LIMB_HEAL_SELF
 
-	if(I.use_tool(H, user, used_delay, amount, volume, null, TRUE))
+#define ROBO_LIMB_HEAL_SELF 3 SECONDS
+#define ROBO_LIMB_HEAL_OTHER 1 SECONDS
+
+/obj/item/proc/heal_robo_limb(obj/item/I, mob/living/carbon/human/H,  mob/user, brute_heal = 0, burn_heal = 0, amount = 0, volume = 0)
+	if(I.use_tool(H, user, (H == user) ? ROBO_LIMB_HEAL_SELF : ROBO_LIMB_HEAL_OTHER, amount, volume, null, TRUE))
 		if(item_heal_robotic(H, user, brute_heal, burn_heal))
 			return heal_robo_limb(I, H, user, brute_heal, burn_heal, amount, volume)
 		return TRUE

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -118,7 +118,7 @@
 			playsound(src, 'sound/items/lighter/light.ogg', 50, 2)
 			return TRUE
 
-	if(isOn() && user.a_intent == INTENT_HELP && ishuman(M))
+	if(user.a_intent == INTENT_HELP && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 		if(affecting?.status == BODYPART_ROBOTIC)
@@ -127,9 +127,11 @@
 				return FALSE
 			if(INTERACTING_WITH(user, H))
 				return FALSE
+			if(!tool_start_check(user, 1))
+				return FALSE
 			user.changeNext_move(CLICK_CD_MELEE)
 			user.visible_message(span_notice("[user] starts to fix some of the dents on [M]'s [affecting.name]."), span_notice("You start fixing some of the dents on [M == user ? "your" : "[M]'s"] [affecting.name]."))
-			heal_robo_limb(src, H, user, 15, 0, 1, 50)
+			heal_robo_limb(src, H, user, 10, 0, 1, 50)
 			user.visible_message(span_notice("[user] fixes some of the dents on [M]'s [affecting.name]."), span_notice("You fix some of the dents on [M == user ? "your" : "[M]'s"] [affecting.name]."))
 			return TRUE
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -557,7 +557,7 @@ By design, d1 is the smallest direction and d2 is the highest
 		if(INTERACTING_WITH(user, H))
 			return FALSE
 		user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.name]."), span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.name]."))
-		heal_robo_limb(src, H, user, 0, 15, 1)
+		heal_robo_limb(src, H, user, 0, 10, 1)
 		user.visible_message(span_notice("[user] fixes the wires in [H]'s [affecting.name]."), span_notice("You fix the wires in [H == user ? "your" : "[H]'s"] [affecting.name]."))
 		return
 	return ..()

--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -47,7 +47,7 @@
 				return FALSE
 			user.changeNext_move(CLICK_CD_MELEE)
 			user.visible_message(span_notice("[user] starts to fix some of the dents on [M]'s [affecting.name]."), span_notice("You start fixing some of the dents on [M == user ? "your" : "[M]'s"] [affecting.name]."))
-			heal_robo_limb(src, H, user, 15, 0, 0, 50)
+			heal_robo_limb(src, H, user, 10, 0, 0, 50)
 			user.visible_message(span_notice("[user] fixes some of the dents on [M]'s [affecting.name]."), span_notice("You fix some of the dents on [M == user ? "your" : "[M]'s"] [affecting.name]."))
 			return TRUE
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

The last PR about this made robotic healing painfully slow, so this makes robotic healing twice as fast but only heals 66% as much each time, making them the same speed and healing amount as sutures. This means that while robotic healing is overall slightly faster than before, it requires 50% more welding fuel and cables to heal the same amount of damage.

This also fixes a bug where using a welder to repair yourself only required sunglasses-level flash protection instead of the intended amount of protection for that specific welding tool.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: welding yourself requires the correct amount of flash protection
tweak: robotic healing is faster but heals less each time
/:cl:
