### PR TITLE
IPC tweaks

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -91,9 +91,6 @@
 	/// Internals box. Will be inserted at the start of backpack_contents
 	var/box
 
-	/// Special internals box for IPCs.
-	var/ipc_box = /obj/item/storage/box/ipc
-
 	/** 
 	  * Any implants the mob should start implanted with
 	  *

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -192,17 +192,6 @@
 	new /obj/item/gps/mining(src)
 	new /obj/item/reagent_containers/autoinjector/medipen(src)
 
-// IPC survival box
-/obj/item/storage/box/ipc/PopulateContents()
-	new /obj/item/tank/internals/ipc_coolant(src)
-	new /obj/item/reagent_containers/autoinjector/medipen(src)
-
-/obj/item/storage/box/ipc/miner/PopulateContents() //IPC mining box
-	new /obj/item/tank/internals/ipc_coolant(src)
-	new /obj/item/crowbar/red(src)
-	new /obj/item/gps/mining(src)
-	new /obj/item/reagent_containers/autoinjector/medipen(src)
-
 /obj/item/storage/box/gloves
 	name = "box of latex gloves"
 	desc = "Contains sterile latex gloves."

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -252,7 +252,6 @@
 	back = /obj/item/storage/backpack
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	box = /obj/item/storage/box/survival
-	ipc_box = /obj/item/storage/box/ipc
 
 	preload = TRUE // These are used by the prefs ui, and also just kinda could use the extra help at roundstart
 
@@ -292,8 +291,6 @@
 
 	if (isplasmaman(H) && !(visualsOnly)) //this is a plasmaman fix to stop having two boxes
 		box = null
-	if (isipc(H) && !(visualsOnly)) // IPCs get their own box with special internals in it
-		box = ipc_box
 
 	if((DIGITIGRADE in H.dna.species.species_traits) && digitigrade_shoes) 
 		shoes = digitigrade_shoes

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -63,7 +63,6 @@
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	duffelbag = /obj/item/storage/backpack/duffelbag
 	box = /obj/item/storage/box/survival_mining
-	ipc_box = /obj/item/storage/box/ipc/miner
 
 	chameleon_extras = /obj/item/gun/energy/kinetic_accelerator
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -95,6 +95,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/toxmod = 1
 	/// multiplier for stun duration
 	var/staminamod = 1
+	/// multiplier for pressure damage
+	var/pressuremod = 1
 	/// multiplier for money paid at payday, species dependent
 	var/payday_modifier = 1
 	///Type of damage attack does
@@ -2048,7 +2050,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	switch(adjusted_pressure)
 		if(HAZARD_HIGH_PRESSURE to INFINITY)
 			if(!HAS_TRAIT(H, TRAIT_RESISTHIGHPRESSURE))
-				H.adjustBruteLoss(min(((adjusted_pressure / HAZARD_HIGH_PRESSURE) -1 ) * PRESSURE_DAMAGE_COEFFICIENT, MAX_HIGH_PRESSURE_DAMAGE) * H.physiology.pressure_mod)
+				H.adjustBruteLoss(min(((adjusted_pressure / HAZARD_HIGH_PRESSURE) -1 ) * PRESSURE_DAMAGE_COEFFICIENT, MAX_HIGH_PRESSURE_DAMAGE) * H.physiology.pressure_mod * H.dna.species.pressuremod)
 				H.throw_alert("pressure", /atom/movable/screen/alert/highpressure, 2)
 			else
 				H.clear_alert("pressure")
@@ -2062,7 +2064,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			if(HAS_TRAIT(H, TRAIT_RESISTLOWPRESSURE))
 				H.clear_alert("pressure")
 			else
-				H.adjustBruteLoss(LOW_PRESSURE_DAMAGE * H.physiology.pressure_mod)
+				H.adjustBruteLoss(LOW_PRESSURE_DAMAGE * H.physiology.pressure_mod * H.dna.species.pressuremod)
 				H.throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 2)
 
 //////////

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -35,9 +35,9 @@
 	staminamod = 0.8
 	siemens_coeff = 1.75
 	action_speed_coefficient = 0.8 // designed for labor, they should be good at it
-	punchdamagelow = 3 // much more consistent with their punches due to being a robot
-	punchdamagehigh = 7 // however their limbs aren't built to hit quite as hard
-	punchstunthreshold = 7 // you're still gonna feel it though
+	punchdamagelow = 2 // much more consistent with their punches due to being a robot
+	punchdamagehigh = 8 // however their limbs aren't built to hit quite as hard
+	punchstunthreshold = 8 // you're still gonna feel it though
 	reagent_tag = PROCESS_SYNTHETIC
 	species_gibs = "robotic"
 	attack_sound = 'sound/items/trayhit1.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -34,10 +34,7 @@
 	clonemod = 0
 	staminamod = 0.8
 	siemens_coeff = 1.75
-	action_speed_coefficient = 0.8 // designed for labor, they should be good at it
-	punchdamagelow = 2 // much more consistent with their punches due to being a robot
-	punchdamagehigh = 8 // however their limbs aren't built to hit quite as hard
-	punchstunthreshold = 8 // you're still gonna feel it though
+	action_speed_coefficient = 0.9 // designed for labor, they should be good at it
 	reagent_tag = PROCESS_SYNTHETIC
 	species_gibs = "robotic"
 	attack_sound = 'sound/items/trayhit1.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -25,8 +25,10 @@
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
 	payday_modifier = 0.3 //Mass producible labor + robot, lucky to be paid at all
-	burnmod = 1.35 // easily cut by laser cutters and welding tools to speed up manufacturing
-	tempmod = 1.5 // metal is more thermally conductive than flesh, heats up more when on fire
+	pressuremod = 0.5 // from the moment i understood the weakness of my flesh it disgusted me
+	heatmod = 0.5 // and i yearned for the certainty of steel
+	burnmod = 1.25 // easily cut by laser cutters and welding tools to speed up manufacturing
+	tempmod = 2 // metal is more thermally conductive than flesh, heats up more when on fire
 	acidmod = 2 // go look up "acid etching"
 	brutemod = 1
 	oxymod = 0 // what the fuck?
@@ -69,8 +71,6 @@
 		change_screen = new
 		change_screen.Grant(C)
 	for(var/obj/item/bodypart/O in C.bodyparts)
-		O.brute_reduction = 1 // made of metal, tiny amount of flat reduction (same as preternis)
-		O.burn_reduction = 2
 		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		var/chassis = C.dna.features["ipc_chassis"]
 		var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.ipc_chassis_list[chassis]
@@ -82,10 +82,6 @@
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	. = ..()
-	for(var/obj/item/bodypart/O in C.bodyparts)
-		O.brute_reduction = initial(O.brute_reduction) // no you don't get to keep it
-		O.burn_reduction = initial(O.burn_reduction)
-		O.render_like_organic = initial(O.render_like_organic)
 	QDEL_NULL(C.particles)
 	if(change_screen)
 		change_screen.Remove(C)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -6,7 +6,7 @@
 	say_mod = "states" //inherited from a user's real species
 	sexes = FALSE
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,NOHUSK,AGENDER,NOBLOOD,NO_UNDERWEAR)
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_COLDBLOODED,TRAIT_LIMBATTACHMENT,TRAIT_EASYDISMEMBER,TRAIT_NOCRITDAMAGE,TRAIT_GENELESS,TRAIT_MEDICALIGNORE,TRAIT_NOCLONE,TRAIT_TOXIMMUNE,TRAIT_EASILY_WOUNDED,TRAIT_NODEFIB)
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_NOBREATH,TRAIT_LIMBATTACHMENT,TRAIT_EASYDISMEMBER,TRAIT_NOCRITDAMAGE,TRAIT_GENELESS,TRAIT_MEDICALIGNORE,TRAIT_NOCLONE,TRAIT_TOXIMMUNE,TRAIT_EASILY_WOUNDED,TRAIT_NODEFIB)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutantbrain = /obj/item/organ/brain/positron
 	mutantheart = /obj/item/organ/heart/cybernetic/ipc
@@ -24,14 +24,20 @@
 	exotic_blood = /datum/reagent/oil
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
-	payday_modifier = 0.5 //Mass producible labor + robot
-	burnmod = 1.5
-	heatmod = 1
+	payday_modifier = 0.3 //Mass producible labor + robot, lucky to be paid at all
+	burnmod = 1.35 // easily cut by laser cutters and welding tools to speed up manufacturing
+	tempmod = 1.5 // metal is more thermally conductive than flesh, heats up more when on fire
+	acidmod = 2 // go look up "acid etching"
 	brutemod = 1
+	oxymod = 0 // what the fuck?
 	toxmod = 0
 	clonemod = 0
 	staminamod = 0.8
 	siemens_coeff = 1.75
+	action_speed_coefficient = 0.8 // designed for labor, they should be good at it
+	punchdamagelow = 3 // much more consistent with their punches due to being a robot
+	punchdamagehigh = 7 // however their limbs aren't built to hit quite as hard
+	punchstunthreshold = 7 // you're still gonna feel it though
 	reagent_tag = PROCESS_SYNTHETIC
 	species_gibs = "robotic"
 	attack_sound = 'sound/items/trayhit1.ogg'
@@ -66,6 +72,8 @@
 		change_screen = new
 		change_screen.Grant(C)
 	for(var/obj/item/bodypart/O in C.bodyparts)
+		O.brute_reduction = 1 // made of metal, tiny amount of flat reduction (same as preternis)
+		O.burn_reduction = 2
 		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		var/chassis = C.dna.features["ipc_chassis"]
 		var/datum/sprite_accessory/ipc_chassis/chassis_of_choice = GLOB.ipc_chassis_list[chassis]
@@ -77,6 +85,10 @@
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	. = ..()
+	for(var/obj/item/bodypart/O in C.bodyparts)
+		O.brute_reduction = initial(O.brute_reduction) // no you don't get to keep it
+		O.burn_reduction = initial(O.burn_reduction)
+		O.render_like_organic = initial(O.render_like_organic)
 	QDEL_NULL(C.particles)
 	if(change_screen)
 		change_screen.Remove(C)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -309,15 +309,6 @@
 	category = list("hacked","Miscellaneous","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
-/datum/design/ipc_coolant_tank
-	name = "IPC Coolant Tank"
-	id = "ipc_coolant_tank"
-	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 800)
-	build_path = /obj/item/tank/internals/ipc_coolant/empty
-	category = list("hacked","Miscellaneous","Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
-
 /datum/design/metal
 	name = "Metal"
 	id = "metal"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1047,15 +1047,6 @@
 	construction_time = 100
 	category = list("IPC Components")
 
-/datum/design/ipc_lungs
-	name = "Cooling Radiator"
-	id = "ipc_lungs"
-	build_type = MECHFAB
-	build_path = /obj/item/organ/lungs/ipc
-	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
-	construction_time = 100
-	category = list("IPC Components")
-
 /datum/design/power_cord
 	name = "Recharging Electronics"
 	id = "power_cord"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -155,7 +155,7 @@
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"cell_charger", "stack_console", "stack_machine", "conveyor_belt", "conveyor_switch",
-	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "ipc_coolant_tank", "electrolyzer", "floorigniter", "crystallizer", "suit_storage_unit")
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "electrolyzer", "floorigniter", "crystallizer", "suit_storage_unit")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/adv_engi
@@ -504,7 +504,7 @@
 	display_name = "IPC Parts"
 	description = "We have the technology to replace him."
 	prereq_ids = list("cyber_organs","robotics")
-	design_ids = list("robotic_liver", "robotic_eyes", "robotic_tongue", "robotic_stomach", "robotic_ears", "power_cord", "ipc_lungs", "blankipc")
+	design_ids = list("robotic_liver", "robotic_eyes", "robotic_tongue", "robotic_stomach", "robotic_ears", "power_cord", "blankipc")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
 /datum/techweb_node/cyber_implants

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -64,5 +64,4 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	box = /obj/item/storage/box/survival_mining
-	ipc_box = /obj/item/storage/box/ipc/miner
 	pda_slot = ITEM_SLOT_LPOCKET


### PR DESCRIPTION
# Document the changes in your pull request

There have been a lot of nerfs to IPCs since they were first added and are at this point probably the weakest roundstart race, so this PR attempts to rebalance them a bit to be less bad without making them too strong.

IPCs no longer need to "breathe", have had their burn damage multiplier decreased from 1.5x to 1.25x, can use tools a bit faster, and take half damage from pressure and heat.

However, they heat up more when on fire or in a hot room, are much more vulnerable to acid, and get paid 30% of what a human would.

# Wiki Documentation

On the page for IPCs, remove "overheats in low pressure" from racial weaknesses, change "take 50% more burn damage" with 25%, add that they take twice as much damage from acid and overheat more easily to their weaknesses, and add to their strengths that they don't breathe, take half damage from heat and pressure, and can use tools 20% faster. Also remove any mentions of IPC coolant tanks and radiator "lungs," and change their paycheck modifier to 0.3x.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: IPC burn damage multiplier reduced
tweak: IPC heat up twice as much when on fire or in a hot room
tweak: IPC no longer need to "breathe"
tweak: IPC take more damage from acid
tweak: IPC take half damage from pressure and heat
tweak: IPC can use tools slightly faster
tweak: IPC "lungs" and coolant tank are no longer obtainable due to being unnecessary
bugfix: fixed IPCs taking oxygen damage sometimes
/:cl:
