### PR TITLE
tiny cook vendor changes

### DIFF
--- a/code/modules/vending/dinnerware.dm
+++ b/code/modules/vending/dinnerware.dm
@@ -12,7 +12,6 @@
 					/obj/item/reagent_containers/food/condiment/pack/astrotame = 5,
 					/obj/item/reagent_containers/food/condiment/saltshaker = 5,
 					/obj/item/reagent_containers/food/condiment/peppermill = 5,
-					/obj/item/clothing/suit/apron/chef = 2,
 					/obj/item/kitchen/rollingpin = 2,
 					/obj/item/kitchen/knife = 2,
 					/obj/item/reagent_containers/glass/mixbowl = 3, // Yogs -- chef's mixing bowl

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -331,10 +331,10 @@
 					/obj/item/storage/box/mousetraps = 2,
 					/obj/item/circuitboard/machine/dish_drive = 1,
 					/obj/item/clothing/suit/toggle/chef = 1,
-					/obj/item/clothing/under/rank/chef = 1,
+					/obj/item/clothing/under/rank/chef = 2,
 					/obj/item/clothing/under/rank/chef/skirt = 2,
 					/obj/item/clothing/head/chefhat = 1,
-					/obj/item/reagent_containers/glass/rag = 1,
+					/obj/item/reagent_containers/glass/rag = 2,
 					/obj/item/clothing/suit/hooded/wintercoat = 2,
 					/obj/item/clothing/accessory/armband/service = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chef_wardrobe


### PR DESCRIPTION
Removes apron from utensils vendor (they have a drobe with them in), ups damp rag+jumpsuit to 2 in vendors since there's 2 cooks. Just makes sense I guess.


# Wiki Documentation

vending machines page i can do this

:cl:  Ktlwjec
rscdel: Chef's apron from Dinnerware vendor (this is  still in the ChefDrobe).
tweak: ChefDrobe has 2 damp rags and jumpsuits (up from 1).
/:cl: