### PR TITLE
Replace ambiguous IAA boxes with actual items

### DIFF
--- a/yogstation/code/game/objects/items/implants/implant_dusting.dm
+++ b/yogstation/code/game/objects/items/implants/implant_dusting.dm
@@ -73,7 +73,7 @@
 		// Reward
 		var/list/item_list = list( // Contract kit random items
 			/obj/item/storage/backpack/duffelbag/syndie/x4,
-			/obj/item/storage/box/syndie_kit/throwing_weapons,
+			/obj/item/restraints/legcuffs/bola/tactical,
 			/obj/item/gun/syringe/syndicate,
 			/obj/item/pen/edagger,
 			/obj/item/pen/sleepy,
@@ -84,12 +84,12 @@
 			/obj/item/clothing/shoes/airshoes,
 			/obj/item/clothing/glasses/thermal/syndi,
 			/obj/item/camera_bug,
-			/obj/item/storage/box/syndie_kit/imp_radio,
-			/obj/item/storage/box/syndie_kit/imp_uplink,
+			/obj/item/implanter/radio/syndicate,
+			/obj/item/implanter/uplink,
 			/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 			// /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 			/obj/item/reagent_containers/syringe/stimulants,
-			/obj/item/storage/box/syndie_kit/imp_freedom,
+			/obj/item/implanter/freedom,
 			/obj/item/storage/belt/chameleon/syndicate,
 			// From here is extra items
 			/obj/item/storage/belt/military/shadowcloak,

--- a/yogstation/code/game/objects/items/implants/implant_dusting.dm
+++ b/yogstation/code/game/objects/items/implants/implant_dusting.dm
@@ -72,7 +72,7 @@
 	if(is_syndicate(user))
 		// Reward
 		var/list/item_list = list( // Contract kit random items
-			/obj/item/storage/backpack/duffelbag/syndie/x4,
+			/obj/item/grenade/plastic/x4,
 			/obj/item/restraints/legcuffs/bola/tactical,
 			/obj/item/gun/syringe/syndicate,
 			/obj/item/pen/edagger,


### PR DESCRIPTION
# Document the changes in your pull request

Boxes and duffel bags had no hint of their contents when viewed in the selection panel.

All implanter boxes now give you the implant instead

Throwing kit has been replaced with a single reinforced bola, which should be less cluttery for a player anyways

X4 duffel bag has been replaced with a single X4, which should be less cluttery for a player anyways

# Changelog
:cl:  
tweak: IAA reward duffel bags and boxes have been replaced with actual (single) items
/:cl:
