### PR TITLE
Hardlight Bow & Xray bolt tweak

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -269,6 +269,7 @@
 
 /obj/item/projectile/energy/arrow/xray/Move(atom/newloc, dir)
 	. = ..()
+	if(isclosedturf(get_turf(src)))
 		damage -= wall_damage_falloff
 	if(damage <=0)
 		qdel(src)

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -261,7 +261,7 @@
 	light_color = LIGHT_COLOR_GREEN
 	damage = 30
 	wound_bonus = -30
-	irradiate = 500
+	irradiate = 300
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINES | PASSSTRUCTURE | PASSDOOR
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/xray

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -255,7 +255,7 @@
 		else
 			SSexplosions.medturf += target
 
-/obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.
+/obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Reasonable irradiation on hit.
 	name = "X-ray bolt"
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
@@ -265,6 +265,13 @@
 	range = 20
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINES | PASSSTRUCTURE | PASSDOOR
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/xray
+	var/wall_damage_falloff = 5
+
+/obj/item/projectile/energy/arrow/xray/Move(atom/newloc, dir)
+	. = ..()
+		damage -= wall_damage_falloff
+	if(damage <=0)
+		qdel(src)
 
 /obj/item/projectile/energy/arrow/shock //Hardlight projectile. Replicable tasers are fair and balanced.
 	name = "shock bolt"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -609,7 +609,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Hardlight Bow"
 	desc = "A modern bow that can fabricate hardlight arrows, designed for silent takedowns of targets."
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
-	cost = 6
+	cost = 10
 	surplus = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -609,7 +609,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Hardlight Bow"
 	desc = "A modern bow that can fabricate hardlight arrows, designed for silent takedowns of targets."
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
-	cost = 10
+	cost = 7
 	surplus = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
# Document the changes in your pull request

We fucked up, we made hardlight bow too cheap and the xray arrows go through everything now whilst rading you, your family, your friends and your ancestors.

The current meta with hardlight bows as an antag is, get thermals sit in a room and fire into your victim till they get ruined by the 30 damage it does and the 500 rads. Two shots makes rads basically incurable and by the time you can react you're alreadyt slowed, mutated and dead.

So all in all, rads for the xray arrow (hardlight bow only) have been reduced to 300, so it takes 2 shots to start causing damage, I've increased the TC price since it is stupidly cheap for a good sniper weapon and added damage falloff to prevent people from sitting at the max range for the arrow and shooting through everything with no care.

@SapphicOverload helped with finding the code with the damage falloff and suggesting the idea of damage falloff.

# Changelog

:cl:  
tweak: Reduced rad damage from 500 to 300 for the xray arrow for the Syndie Hardlight bow
tweak: Increased TC cost from 6TC to 7TC
rscadd: damage falloff of 5 for every wall it passes again for the xray arrow type
/:cl:
