### PR TITLE
Water will now wake you up when splashed

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -186,6 +186,15 @@
 	if(!istype(M))
 		return
 	if(methods & TOUCH)
+		// some nice cold water to WAKE THE FUCK UP
+		// 20 units of water = 1 hug of antistun
+		M.AdjustStun(-reac_volume*0.3 SECONDS)
+		M.AdjustKnockdown(-reac_volume*0.3 SECONDS)
+		M.AdjustUnconscious(-reac_volume*0.3 SECONDS)
+		M.AdjustSleeping(-reac_volume*0.5 SECONDS)
+		M.AdjustParalyzed(-reac_volume*0.3 SECONDS)
+		M.AdjustImmobilized(-reac_volume*0.3 SECONDS)
+
 		M.adjust_fire_stacks(-(reac_volume / 10) * M.get_permeability(null, TRUE))
 		M.extinguish_mob() // permeability affects the negative fire stacks but not the extinguishing
 	..()
@@ -635,7 +644,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/ethereal
 	mutationtext = span_danger("The pain subsides. You feel... ecstatic.")
-	
+
 /datum/reagent/mutationtoxin/preternis
 	name = "Preternis Mutation Toxin"
 	description = "A metallic precursor toxin."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -187,13 +187,9 @@
 		return
 	if(methods & TOUCH)
 		// some nice cold water to WAKE THE FUCK UP
-		// 20 units of water = 1 hug of antistun
-		M.AdjustStun(-reac_volume*0.3 SECONDS)
-		M.AdjustKnockdown(-reac_volume*0.3 SECONDS)
+		// 20 units of water = 1 hug of antisleep
 		M.AdjustUnconscious(-reac_volume*0.3 SECONDS)
 		M.AdjustSleeping(-reac_volume*0.5 SECONDS)
-		M.AdjustParalyzed(-reac_volume*0.3 SECONDS)
-		M.AdjustImmobilized(-reac_volume*0.3 SECONDS)
 
 		M.adjust_fire_stacks(-(reac_volume / 10) * M.get_permeability(null, TRUE))
 		M.extinguish_mob() // permeability affects the negative fire stacks but not the extinguishing


### PR DESCRIPTION
# Document the changes in your pull request

Water now has anti-sleep capabilities when splashed (touch method) on a mob, similar to hugging them up

20 units of water is equivalent to 1 hug

This means splashing your friend with a bucket of water will get them up from sleeping/unconscious

This also means that the medbay shower will wake people up fairly quickly

#

Seriously people do this every single round

# Changelog

:cl:  
tweak: Water now wakes people up when you splash them with it
/:cl:
