### PR TITLE
ports Holymelons are more melon-like

### DIFF
--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -57,6 +57,8 @@
 	filling_color = "#FFD700"
 	dried_type = null
 	w_class = WEIGHT_CLASS_NORMAL
+	foodtype = FRUIT
+	juice_results = list(/datum/reagent/water/holywater = 0)
 	wine_power = 70 //Water to wine, baby.
 	wine_flavor = "divinity"
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/70411

should be fruit as they are melons, and they should be juiced as they are melons. it just makes sense

# Wiki Documentation

possibly somewhere but i doubt it? i'll have a look

:cl:  Melbert
rscadd: Holy melons are now more melon like - they are now fruits (instead of no food type), and can be juiced into holy water
/:cl: