### PR TITLE
Buff gas production from HFR

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -238,7 +238,7 @@
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/moderator_fuel_process(delta_time, production_amount, consumption_amount, datum/gas_mixture/internal_output, moderator_list, datum/hfr_fuel/fuel, fuel_list)
 	// Adjust fusion consumption/production based on this recipe's characteristics
 	var/fuel_consumption = consumption_amount * 0.85 * selected_fuel.fuel_consumption_multiplier
-	var/scaled_production = production_amount * selected_fuel.gas_production_multiplier
+	var/scaled_production = production_amount * 20 * selected_fuel.gas_production_multiplier
 
 	for(var/gas_id in fuel.requirements)
 		internal_fusion.adjust_moles(gas_id, -min(fuel_list[gas_id], fuel_consumption))


### PR DESCRIPTION
Currently HFR gas production is very slow, people would rather make gases in open tile than this.

also i have tested this and it did make gas a bit faster than usual

# Document the changes in your pull request

Buff gas production from HFR by 20x ~~it wont be making thousands mole per second~~



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Buff gas production from HFR by 20x
/:cl:
