### PR TITLE
Blowgun Tweak

### DIFF
--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -60,3 +60,25 @@
 		S.forceMove(D)
 		D.injector = S
 	..()
+
+/obj/item/ammo_casing/blowgun
+	name = "blow gun spring"
+	desc = "A low-power spring that throws syringes a short distance." // how does a blowgun have a spring
+	projectile_type = /obj/item/projectile/bullet/reusable/dart/syringe/blowgun
+	firing_effect_type = null
+
+/obj/item/ammo_casing/blowgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
+	if(!BB)
+		return
+	if(istype(loc, /obj/item/gun/syringe/blowgun))
+		var/obj/item/gun/syringe/BG = loc
+		var/obj/item/projectile/bullet/reusable/dart/D = BB
+		if(!BG.syringes.len)
+			return
+
+		var/obj/item/reagent_containers/syringe/S = BG.syringes[1]
+
+		S.reagents.trans_to(BB, S.reagents.total_volume, transfered_by = user)
+		D.add_dart(S, S.proj_piercing)
+		BG.syringes.Remove(S)
+	..()

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -133,16 +133,20 @@
 
 /obj/item/gun/syringe/blowgun
 	name = "blowgun"
-	desc = "Fire syringes at a short distance."
+	desc = "Fire syringes a short distance."
 	icon_state = "blowgun"
 	item_state = "blowgun"
 	fire_sound = 'sound/items/syringeproj.ogg'
 	no_pin_required = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL //it's a fucking blowgun it shouldn't even have a triggerguard
 
+/obj/item/gun/syringe/blowgun/Initialize(mapload)
+	. = ..()
+	update_icon()
+	chambered = new /obj/item/ammo_casing/blowgun(src)
+
+
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	visible_message(span_danger("[user] starts aiming with a blowgun!"))
-	if(do_after(user, 2.5 SECONDS, src))
-		user.adjustStaminaLoss(20)
-		user.adjustOxyLoss(20)
-		..()
+	user.adjustStaminaLoss(25)
+	user.adjustOxyLoss(25)
+	..()

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -29,6 +29,11 @@
 	name = "syringe"
 	icon_state = "syringeproj"
 
+/obj/item/projectile/bullet/reusable/dart/syringe/blowgun
+	name = "syringe"
+	icon_state = "syringeproj"
+	range = 2
+
 /obj/item/projectile/bullet/reusable/dart/hidden
 	name = "beanbag slug"
 	icon_state = "bullet" //So it doesn't look like a goddamned syringe


### PR DESCRIPTION
# Document the changes in your pull request
Blowgun no longer requires you to stand still for 2.5 seconds. To compensate, it does not have infinite range anymore and has a range of 2 which means it must be used up close instead of across the hallway (where it is safer). It also deals 5 more oxygen and 5 more stamina damage to a total of 25 oxygen and stamina damage.

Technically fixes a bug where you can abuse/stack the 2.5 second stand still to put yourself into unconsciousness via oxygen damage (by removing the stand still entirely).

Works fine in local.

# Wiki Documentation
Change Blowgun in [Guide to Combat](https://wiki.yogstation.net/wiki/Guide_to_Combat) to indicate there is no need to stand still, no alert, and increase values from 20 to 25 for both Oxygen and Stamina.

# Changelog
:cl:  
tweak: Blowgun now shoots instantly, but only has a range of 2.
tweak: Blowgun causes 25 oxygen and 25 stamina damage per usage to user instead of 20.
/:cl:
