### PR TITLE
Codergun the slaughter demon that killed my friends

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -18,6 +18,7 @@
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1
 	status_flags = CANPUSH
+	move_resist = MOVE_FORCE_STRONG
 	attack_sound = 'sound/magic/demon_attack1.ogg'
 	var/feast_sound = 'sound/magic/demon_consume.ogg'
 	deathsound = 'sound/magic/demon_dies.ogg'

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -52,6 +52,7 @@
 	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
 	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, PROC_REF(on_jaunt_exited))
 	spell_requirements |= SPELL_CASTABLE_WHILE_PHASED
+	ADD_TRAIT(jaunter, TRAIT_MUTE, REF(src))
 	ADD_TRAIT(jaunter, TRAIT_MAGICALLY_PHASED, REF(src))
 	// Don't do the feedback until we have runechat hidden.
 	// Otherwise the text will follow the jaunt holder, which reveals where our caster is travelling.
@@ -97,6 +98,7 @@
 /datum/action/cooldown/spell/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	SHOULD_CALL_PARENT(TRUE)
 	spell_requirements &= ~SPELL_CASTABLE_WHILE_PHASED
+	REMOVE_TRAIT(unjaunter, TRAIT_MUTE, REF(src))
 	REMOVE_TRAIT(unjaunter, TRAIT_MAGICALLY_PHASED, REF(src))
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -52,7 +52,6 @@
 	var/obj/effect/dummy/phased_mob/jaunt = new jaunt_type(loc_override || get_turf(jaunter), jaunter)
 	RegisterSignal(jaunt, COMSIG_MOB_EJECTED_FROM_JAUNT, PROC_REF(on_jaunt_exited))
 	spell_requirements |= SPELL_CASTABLE_WHILE_PHASED
-	ADD_TRAIT(jaunter, TRAIT_MUTE, REF(src))
 	ADD_TRAIT(jaunter, TRAIT_MAGICALLY_PHASED, REF(src))
 	// Don't do the feedback until we have runechat hidden.
 	// Otherwise the text will follow the jaunt holder, which reveals where our caster is travelling.
@@ -98,7 +97,6 @@
 /datum/action/cooldown/spell/jaunt/proc/on_jaunt_exited(obj/effect/dummy/phased_mob/jaunt, mob/living/unjaunter)
 	SHOULD_CALL_PARENT(TRUE)
 	spell_requirements &= ~SPELL_CASTABLE_WHILE_PHASED
-	REMOVE_TRAIT(unjaunter, TRAIT_MUTE, REF(src))
 	REMOVE_TRAIT(unjaunter, TRAIT_MAGICALLY_PHASED, REF(src))
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(unjaunter, COMSIG_MOB_AFTER_EXIT_JAUNT, src)

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -15,7 +15,7 @@
 	spell_requirements = NONE
 
 	/// The time it takes to enter blood
-	var/enter_blood_time = 0 SECONDS
+	var/enter_blood_time = 1 SECONDS
 	/// The time it takes to exit blood
 	var/exit_blood_time = 2 SECONDS
 	/// The radius around us that we look for blood in

--- a/yogstation/code/datums/components/crawl.dm
+++ b/yogstation/code/datums/components/crawl.dm
@@ -10,7 +10,7 @@
 
 /obj/effect/dummy/crawling/relaymove(mob/user, direction)
 	forceMove(get_step(src,direction))
-	
+
 /obj/effect/dummy/crawling/ex_act()
 	return
 /obj/effect/dummy/crawling/bullet_act()
@@ -53,6 +53,8 @@
 		start_crawling(target, M)
 
 /datum/component/crawl/proc/can_start_crawling(atom/target, mob/living/user)
+	if(!do_after(user, 1 SECONDS, target))
+		return FALSE
 	if(!user.Adjacent(target))
 		return FALSE
 	return !user.notransform


### PR DESCRIPTION
# Document the changes in your pull request

Slaughter demons (and other bloodcrawlers) now have a 1 second entry time on bloodcrawling, forcing them to commit to crawl exits and not be able to instantly eat or flee from a situation by clicking a blood tile.

To prevent crew-side cheese, the slaughter demon is now un-pullable and un-pushable by crew member hands.

Also, you can no longer speak while jaunted.

# Changelog

:cl:  
tweak: Bloodcrawling now takes 1 second to enter blood
tweak: Slaughter and laughter demons can no longer be pulled with your bare hands or pushed by walking
/:cl:
