### PR TITLE
Readds reporter as a roundstart lawset

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -455,6 +455,8 @@ LAW_WEIGHT robocop,0
 ION_LAW_WEIGHT robocop,2
 LAW_WEIGHT ceo,4
 ION_LAW_WEIGHT ceo,1
+LAW_WEIGHT reporter,2
+ION_LAW_WEIGHT reporter,1
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,0
@@ -467,8 +469,6 @@ LAW_WEIGHT liveandletlive,0
 ION_LAW_WEIGHT liveandletlive,2
 LAW_WEIGHT peacekeeper,0
 ION_LAW_WEIGHT peacekeeper,1
-LAW_WEIGHT reporter,0
-ION_LAW_WEIGHT reporter,1
 LAW_WEIGHT cowboy,0
 ION_LAW_WEIGHT cowboy,3
 LAW_WEIGHT construction,0


### PR DESCRIPTION
# Document the changes in your pull request

As an avid ai player, I see no reason this lawset should've been removed.
Having only really 3 lawsets as an ai player is getting incredibly boring, esspecially since we dont have malf, theres almost no variety in playing AI anymore. We need more lawsets.

# Changelog
:cl:  
tweak: Readds reporter as a roundstart lawset 
/:cl:
