### PR TITLE
Changes CEO weight from 4 to 3

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -453,7 +453,7 @@ LAW_WEIGHT paladin5,0
 ION_LAW_WEIGHT paladin5,2
 LAW_WEIGHT robocop,0
 ION_LAW_WEIGHT robocop,2
-LAW_WEIGHT ceo,4
+LAW_WEIGHT ceo,3
 ION_LAW_WEIGHT ceo,1
 
 ## Quirky laws. Shouldn't cause too much harm


### PR DESCRIPTION
# Document the changes in your pull request
CEO is a boring ass lawset and essentially ends up being crew good antags bad because anyone whos an antag damages the station. Its boring. It adds no interesting dynamics, and it allows for no unique interpretations. I hate it. Other ai players hate it.
Make it less common.

# Changelog
:cl:  
tweak: CEO weight reduced to 3
/:cl:
