### PR TITLE
Renames bluespace launchpad to telecrystal launchpad

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -1,6 +1,6 @@
 /obj/machinery/launchpad
-	name = "bluespace launchpad"
-	desc = "A bluespace pad able to thrust matter through bluespace, teleporting it to or from nearby locations."
+	name = "telecrystal launchpad"
+	desc = "A telecrystal launchpad able to thrust matter through bluespace, teleporting it to or from nearby locations."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "lpad-idle"
 	use_power = TRUE


### PR DESCRIPTION
# Document the changes in your pull request
the syndicate make telecrystals not bluespace crystals

# Changelog
:cl:  
tweak: Bluespace launchpad renamed to telecrystal launchpad
/:cl:
