### PR TITLE
[Box & Meta] "Unsecures" Psych Backroom

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9942,18 +9942,6 @@
 "bwe" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
-"bwo" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "bwq" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/turf_decal/bot,
@@ -12927,29 +12915,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bXt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "viropen";
-	name = "Monkey Pen Shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
 /area/medical/virology)
 "bXx" = (
 /obj/machinery/door/firedoor/border_only{
@@ -17711,6 +17676,26 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"dsj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "viropen";
+	name = "Monkey Pen Shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/medical/virology)
 "dss" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -22718,18 +22703,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"fju" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "fjz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -27350,6 +27323,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"gWN" = (
+/obj/structure/closet/secure_closet/psych,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "gXs" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -33342,9 +33322,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"jhe" = (
-/turf/closed/wall/r_wall,
-/area/medical/storage)
 "jhp" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -48632,6 +48609,18 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"pkD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "pkF" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -52526,6 +52515,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qIv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "qIz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -69263,13 +69264,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"xou" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/psych,
-/turf/open/floor/wood,
-/area/medical/psych)
 "xoz" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner{
@@ -109175,7 +109169,7 @@ jdO
 qHL
 jdO
 jdO
-jhe
+jdO
 bHk
 cmL
 cmL
@@ -109432,7 +109426,7 @@ mFt
 iTq
 eVb
 nSJ
-jhe
+jdO
 xkZ
 aSI
 bAw
@@ -109689,7 +109683,7 @@ euX
 vbv
 pUL
 pKl
-jhe
+jdO
 oGk
 ghg
 wea
@@ -109946,11 +109940,11 @@ ugf
 nBj
 ngi
 iyt
-jhe
-jxu
-jxu
-jxu
-jxu
+jdO
+aDR
+aDR
+aDR
+aDR
 eoJ
 avy
 avy
@@ -110207,7 +110201,7 @@ jdO
 cQo
 hpd
 gRT
-jxu
+aDR
 bSN
 pYm
 pYm
@@ -110461,10 +110455,10 @@ jdO
 jdO
 jdO
 jdO
-xou
+gWN
 fyq
 tly
-jxu
+aDR
 xpC
 hEv
 bAw
@@ -110719,7 +110713,7 @@ lMs
 cFP
 wfd
 qns
-bwo
+qIv
 vtO
 jxu
 bNd
@@ -110976,7 +110970,7 @@ jyi
 bDB
 gjv
 btY
-fju
+pkD
 pxM
 jxu
 qYx
@@ -111491,9 +111485,9 @@ wwp
 xnn
 aDR
 aDR
-aDR
 jxu
-bXt
+jxu
+dsj
 xWw
 bNd
 vzb
@@ -111748,7 +111742,7 @@ mOU
 hxw
 hxw
 kua
-xGG
+bNd
 eHY
 tpA
 nUI

--- a/_maps/map_files/Yogsmeta/Yogsmeta.dmm
+++ b/_maps/map_files/Yogsmeta/Yogsmeta.dmm
@@ -52983,36 +52983,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
-"fDL" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/taperecorder{
-	pixel_x = 5
-	},
-/obj/item/lighter{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/flashlight/pen{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/laser_pointer{
-	pixel_x = 4;
-	pixel_y = -10
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet,
-/area/medical/psych)
 "fEQ" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -55988,19 +55958,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hJz" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	name = "Filing Room";
-	req_access_txt = "77"
-	},
-/turf/open/floor/wood,
-/area/medical/psych)
 "hJW" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -58402,13 +58359,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"jng" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/psych,
-/turf/open/floor/wood,
-/area/medical/psych)
 "jnh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -60151,6 +60101,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"krj" = (
+/obj/structure/closet/secure_closet/psych,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "kro" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring medbay to ensure patient safety.";
@@ -64556,9 +64513,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/security/prison/hallway)
-"mWz" = (
-/turf/closed/wall/r_wall,
-/area/medical/psych)
 "mWK" = (
 /obj/effect/landmark/start/mime,
 /turf/open/floor/carpet,
@@ -71012,6 +70966,36 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"rbS" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/taperecorder{
+	pixel_x = 5
+	},
+/obj/item/lighter{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/laser_pointer{
+	pixel_x = 4;
+	pixel_y = -10
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "rbU" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medbay Backroom";
@@ -78135,6 +78119,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"vvo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	name = "Filing Room";
+	req_access_txt = "77"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/medical/psych)
 "vvN" = (
 /obj/machinery/space_heater,
 /obj/structure/sign/warning/vacuum/external{
@@ -78182,16 +78179,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vyf" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/carpet,
-/area/medical/psych)
 "vzb" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
@@ -78566,6 +78553,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"vOf" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/medical/psych)
 "vOg" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -106840,7 +106837,7 @@ cCe
 qHu
 cCe
 auQ
-hJz
+vvo
 fQD
 cdG
 tXA
@@ -107098,10 +107095,10 @@ ecc
 bPc
 auQ
 gLq
-vyf
-fDL
-jng
-mWz
+vOf
+rbS
+krj
+auQ
 bUs
 cLa
 cMI
@@ -107615,7 +107612,7 @@ mTn
 bSe
 qGP
 qMu
-mWz
+auQ
 qkN
 cZr
 qbF
@@ -107870,9 +107867,9 @@ tFJ
 auQ
 auQ
 bSm
-mWz
-mWz
-mWz
+auQ
+auQ
+auQ
 vrg
 hTx
 lsu


### PR DESCRIPTION
# Document the changes in your pull request

Removes reinforced walls and tinted glass walls in psych office. They're no longer needed with no chem machine back there for people to abuse.

![image](https://github.com/yogstation13/Yogstation/assets/70451213/e520c5ae-1b09-439d-96b5-bcbf118ec1bb)

![image](https://github.com/yogstation13/Yogstation/assets/70451213/197d1e5f-534b-4d55-bb56-f9218c6e4639)

# Wiki Documentation

Images probably.

# Changelog

:cl:
mapping: Removes rwalls and tinted windows for box/meta (rwalls remaining on box are the ones that touch virology)
experimental: Asteroid to come after medbay PR merged (if I can't get airlines to do it for me) -- DONE
/:cl:
