### PR TITLE
Adds grep for mapped associative lists

### DIFF
--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -10,7 +10,7 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
-if grep -REl 'list\(.*[^ ]=' --include='*.dmm' _maps;    then
+if grep -REl 'list\(.*[^ ]=' --include='*.dmm' _maps; then
     echo "ERROR: Associative list missing leading and trailing space. Update your mapping tool!"
     st=1
 fi;

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -1,3 +1,5 @@
+set -x
+
 #!/bin/bash
 set -euo pipefail
 

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -12,7 +12,7 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
-if grep -REl '([^ ])=([^ ])' --include='*.dmm' _maps;    then
+if grep -REl '"=' --include='*.dmm' _maps;    then
     echo "ERROR: Associative list missing leading and trailing space. Update your mapping tool!"
     st=1
 fi;

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -12,7 +12,7 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
-if grep -REl '"=' --include='*.dmm' _maps;    then
+if grep -REl 'list\(.*[^ ]=' --include='*.dmm' _maps;    then
     echo "ERROR: Associative list missing leading and trailing space. Update your mapping tool!"
     st=1
 fi;

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -10,6 +10,10 @@ if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
+if grep -REl '([^ ])=([^ ])' --include='*.dmm' _maps;    then
+    echo "ERROR: Associative list missing leading and trailing space. Update your mapping tool!"
+    st=1
+fi;
 if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\) code/**/*.dm'; then
     echo "ERROR: changed files contains proc argument starting with 'var'"
     st=1

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -1,5 +1,3 @@
-set -x
-
 #!/bin/bash
 set -euo pipefail
 


### PR DESCRIPTION
# Document the changes in your pull request

With StrongDMM matching fastdmm and dream maker on the proper way to save varedited associative lists as of https://github.com/SpaiR/StrongDMM/pull/195, we will now force everyone to upgrade to the new strongdmm version so we dont get constant line changes. Nothing player facing.
