### PR TITLE
Trays now only hold food/kitchen items and no longer HARDSTUN PEOPLE ON HIT

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -208,7 +208,7 @@
 	STR.set_holdable(list(/obj/item/gem))
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 48
-	STR.max_items = 48 
+	STR.max_items = 48
 
 /obj/item/storage/bag/gem/equipped(mob/user)
 	. = ..()
@@ -358,6 +358,15 @@
 /obj/item/storage/bag/tray/Initialize(mapload)
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 8 // Can hold two plates!
+	STR.set_holdable(list(
+		/obj/item/kitchen,
+		/obj/item/plate,
+		/obj/item/reagent_containers/food, // Includes drinking glasses, as they are a subtype
+		/obj/item/trash
+	), list(
+		/obj/item/plate/oven_tray
+	))
 	STR.insert_preposition = "on"
 
 /obj/item/storage/bag/tray/attack(mob/living/M, mob/living/user)
@@ -379,9 +388,6 @@
 	else
 		playsound(M, 'sound/items/trayhit2.ogg', 50, 1)
 
-	if(ishuman(M) || ismonkey(M))
-		if(prob(10))
-			M.Paralyze(40)
 	update_icon()
 
 /obj/item/storage/bag/tray/update_icon()
@@ -464,7 +470,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 1000
 	STR.max_items = 100
-	
+
 /obj/item/storage/bag/construction/admin/full/PopulateContents()
 	new /obj/item/stack/cable_coil(src,MAXCOIL,"red")
 	for(var/i in 1 to 10)


### PR DESCRIPTION
# Document the changes in your pull request

Trays can now only hold kitchen items like food, drinks, plates, and trash.

Trays no longer have a 10% chance to paralyze for 4 seconds on-hit.

# Changelog

:cl:  
tweak: Trays now only hold kitchen stuff
tweak: Trays no longer stun on-hit
/:cl:
