### PR TITLE
Fixes some instances of improper init args

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -219,7 +219,7 @@
 		return
 	if(!has_buckled_mobs() && do_after(user, 5 SECONDS, src))
 		for(var/I in 1 to 5)
-			var/obj/item/grown/log/L = new /obj/item/grown/log(src.loc)
+			var/obj/item/grown/log/L = new /obj/item/grown/log(loc)
 			L.pixel_x += rand(1,4)
 			L.pixel_y += rand(1,4)
 		if(can_buckle || grill)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -36,7 +36,7 @@
 	var/weed_rate = 1 //If the chance below passes, then this many weeds sprout during growth
 	var/weed_chance = 5 //Percentage chance per tray update to grow weeds
 
-/obj/item/seeds/Initialize(mapload, loc, nogenes = 0)
+/obj/item/seeds/Initialize(mapload, nogenes = 0)
 	. = ..()
 	pixel_x = rand(-8, 8)
 	pixel_y = rand(-8, 8)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -267,7 +267,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	if(istype(F, /obj/item/reagent_containers/food/snacks/royalcheese))
 		evolve()
 	if(istype(F, /obj/item/grown/bananapeel/bluespace))
-		var/obj/item/grown/bananapeel/bluespace/B
+		var/obj/item/grown/bananapeel/bluespace/B = F
 		var/teleport_radius = max(round(B.seed.potency / 10), 1)
 		var/turf/T = get_turf(src)
 		do_teleport(src, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -14,7 +14,7 @@
 	var/obj/pipe_type = /obj/structure/disposalpipe/segment
 	var/pipename
 
-/obj/structure/disposalconstruct/Initialize(mapload, loc, _pipe_type, _dir = SOUTH, flip = FALSE, obj/make_from)
+/obj/structure/disposalconstruct/Initialize(mapload, _pipe_type, _dir = SOUTH, flip = FALSE, obj/make_from)
 	. = ..()
 	if(make_from)
 		pipe_type = make_from.type

--- a/yogstation/code/game/objects/items/crayons.dm
+++ b/yogstation/code/game/objects/items/crayons.dm
@@ -83,7 +83,7 @@
 	pre_noise = FALSE
 	post_noise = TRUE
 
-/obj/item/toy/crayon/spraycan/gang/Initialize(mapload, loc, datum/team/gang/G)
+/obj/item/toy/crayon/spraycan/gang/Initialize(mapload, datum/team/gang/G)
 	.=..()
 	if(G)
 		gang = G

--- a/yogstation/code/game/objects/items/implants/implant_gang.dm
+++ b/yogstation/code/game/objects/items/implants/implant_gang.dm
@@ -3,7 +3,7 @@
 	desc = "Makes you a gangster."
 	var/datum/team/gang/gang
 
-/obj/item/implant/gang/Initialize(mapload, loc, setgang)
+/obj/item/implant/gang/Initialize(mapload, setgang)
 	.=..()
 	gang = setgang
 
@@ -53,7 +53,7 @@
 /obj/item/implanter/gang
 	name = "implanter (gang)"
 
-/obj/item/implanter/gang/Initialize(mapload, loc, gang)
+/obj/item/implanter/gang/Initialize(mapload, gang)
 	if(!gang)
 		return INITIALIZE_HINT_QDEL
 	imp = new /obj/item/implant/gang(src,gang)


### PR DESCRIPTION
# Document the changes in your pull request

Some Initializes already had mapload into account in their args, they just did not have it named 'mapload'. This meant that when I added it, there were 2 mapload args, so things after it would not be put in order (see: disposals).

In basic terms: fixes disposals, gang tags, and nogene'd seeds.

![image](https://github.com/yogstation13/Yogstation/assets/53777086/9877a51e-a073-49ab-b8b3-f1da0818156a)

Closes https://github.com/yogstation13/Yogstation/issues/19306
Closes https://github.com/yogstation13/Yogstation/issues/19400
Closes https://github.com/yogstation13/Yogstation/issues/19425

# Changelog

:cl:  
fix: You can now build disposals again.
/:cl:
