### PR TITLE
IPC charging implant is now installed in the chest

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -29,7 +29,9 @@
 		if(BODY_ZONE_R_ARM)
 			slot = ORGAN_SLOT_RIGHT_ARM_AUG
 		else
-			CRASH("Invalid zone for [type]")
+			stack_trace("Invalid zone for [type]")
+			return FALSE
+	return TRUE
 
 /obj/item/organ/cyberimp/arm/update_icon()
 	if(zone == BODY_ZONE_R_ARM)
@@ -45,14 +47,16 @@
 	. = ..()
 	if(.)
 		return TRUE
-	I.play_tool_sound(src)
 	if(zone == BODY_ZONE_R_ARM)
 		zone = BODY_ZONE_L_ARM
-	else
+	else if(zone == BODY_ZONE_L_ARM)
 		zone = BODY_ZONE_R_ARM
-	SetSlotFromZone()
-	to_chat(user, span_notice("You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."))
-	update_icon()
+	if(SetSlotFromZone())
+		I.play_tool_sound(src)
+		update_icon()
+		to_chat(user, span_notice("You modify [src] to be installed on the [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."))
+	else
+		to_chat(user, span_warning("[src] cannot be modified!"))
 
 /obj/item/organ/cyberimp/arm/Remove(mob/living/carbon/M, special = 0)
 	Retract()
@@ -419,7 +423,10 @@
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
 	contents = newlist(/obj/item/apc_powercord)
 	slot = ORGAN_SLOT_STOMACH_AID //so ipcs don't get shafted for nothing
-	zone = "l_arm"
+	zone = BODY_ZONE_CHEST
+
+/obj/item/organ/cyberimp/arm/power_cord/SetSlotFromZone() // don't swap the zone
+	return FALSE
 
 /obj/item/organ/cyberimp/arm/flash/rev
 	name = "revolutionary brainwashing implant"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Having an organ you rely on inside your arm when you lose limbs easily is not a good combination. Functions the exact same as before but is installed in the chest, which makes sense because that's where their battery is.

Also fixes a bug where using a screwdriver on the implant made it take up the wrong organ slot.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:    
bugfix: using a screwdriver no longer permanently locks IPC charging cable implant into taking up the wrong organ slot 
tweak: IPC recharging cable is now installed in the chest 
/:cl:
