### PR TITLE
HFR can now remove fuel mix (transfer to waste)

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -51,6 +51,8 @@
 	var/list/moderator_scrubbing = list()
 	///Set the amount of moles per tick should be removed from the moderator by filtering
 	var/moderator_filtering_rate = 100
+	///Set the amount of moles per tick should be removed from the fuel by filtering
+	var/fuel_filtering_rate = 100
 	///Stores the current fuel mix that the user has selected
 	var/datum/hfr_fuel/selected_fuel
 
@@ -95,6 +97,8 @@
 
 	///Check if the user want to remove the waste gases
 	var/waste_remove = FALSE
+	///Check if the user want to remove the fuel gases
+	var/fuel_remove = FALSE
 	///User controlled variable to control the flow of the fusion by changing the contact of the material
 	var/heating_conductor = 100
 	///User controlled variable to control the flow of the fusion by changing the volume of the gasmix by controlling the power of the magnetic fields

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -28,6 +28,7 @@
 		check_alert()
 	if (start_power)
 		remove_waste(delta_time)
+		remove_fuel(delta_time)
 	update_pipenets()
 
 	check_deconstructable()
@@ -50,6 +51,7 @@
 		magnetic_constrictor = 100
 		current_damper = 0
 		waste_remove = FALSE
+		fuel_remove = FALSE
 		iron_content += 0.02 * power_level * delta_time
 
 	update_temperature_status(delta_time)
@@ -481,6 +483,15 @@
 		if(alive_mob.z != z || get_dist(alive_mob, src) > grav_range || alive_mob.mob_negates_gravity())
 			continue
 		step_towards(alive_mob, loc)
+
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/remove_fuel(delta_time)
+	if(!fuel_remove)
+		return
+
+	for(var/gas in internal_fusion.get_gases())
+		var/gas_removed = min(internal_fusion.get_moles(gas), fuel_filtering_rate/2 * delta_time)
+		internal_fusion.adjust_moles(gas, -gas_removed)
+		linked_output.airs[1].adjust_moles(gas, gas_removed)
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/remove_waste(delta_time)
 	//Gases can be removed from the moderator internal by using the interface.

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -310,6 +310,7 @@
 	data["temperature_period"] = connected_core.temperature_period
 
 	data["waste_remove"] = connected_core.waste_remove
+	data["fuel_remove"] = connected_core.fuel_remove
 	data["filter_types"] = list()
 	for(var/path in GLOB.meta_gas_info)
 		var/list/gas = GLOB.meta_gas_info[path]
@@ -317,6 +318,7 @@
 
 	data["cooling_volume"] = connected_core.airs[1].return_volume()
 	data["mod_filtering_rate"] = connected_core.moderator_filtering_rate
+	data["fl_filtering_rate"] = connected_core.fuel_filtering_rate
 
 	return data
 
@@ -366,6 +368,9 @@
 		if("waste_remove")
 			connected_core.waste_remove = !connected_core.waste_remove
 			. = TRUE
+		if("fuel_remove")
+			connected_core.fuel_remove = !connected_core.fuel_remove
+			. = TRUE
 		if("filter")
 			connected_core.moderator_scrubbing ^= gas_id2path(params["mode"])
 			. = TRUE
@@ -373,6 +378,11 @@
 			var/mod_filtering_rate = text2num(params["mod_filtering_rate"])
 			if(mod_filtering_rate != null)
 				connected_core.moderator_filtering_rate = clamp(mod_filtering_rate, 5, 200)
+				. = TRUE
+		if("fl_filtering_rate")
+			var/fl_filtering_rate = text2num(params["fl_filtering_rate"])
+			if(fl_filtering_rate != null)
+				connected_core.fuel_filtering_rate = clamp(fl_filtering_rate, 5, 200)
 				. = TRUE
 		if("fuel")
 			connected_core.selected_fuel = null

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -162,6 +162,45 @@ export const HypertorusWasteRemove = (props, context) => {
             <>
               <HoverHelp
                 content={
+                  'Remove fuel gases from Fusion,' +
+                  ' and any selected gases from the Fuel.'
+                }
+              />
+              Fuel remove:
+            </>
+          }>
+          <Button
+            icon={data.fuel_remove ? 'power-off' : 'times'}
+            content={data.fuel_remove ? 'On' : 'Off'}
+            selected={data.fuel_remove}
+            onClick={() => act('fuel_remove')}
+          />
+        </LabeledList.Item>
+        <LabeledList.Item
+          label={
+            <>
+              <HelpDummy />
+              Fuel filtering rate:
+            </>
+          }>
+          <NumberInput
+            animated
+            value={parseFloat(data.fl_filtering_rate)}
+            unit="mol/s"
+            minValue={5}
+            maxValue={200}
+            onDrag={(e, value) =>
+              act('fl_filtering_rate', {
+                fl_filtering_rate: value,
+              })
+            }
+          />
+        </LabeledList.Item>
+        <LabeledList.Item
+          label={
+            <>
+              <HoverHelp
+                content={
                   'Remove waste gases from Fusion,' +
                   ' and any selected gases from the Moderator.'
                 }


### PR DESCRIPTION
Good for stopping a meltdown 
# Document the changes in your pull request
You can now transfer the fuel mix to waste (200L/s max)


# Wiki Documentation
You can now transfer the fuel mix to waste (200L/s max)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: You can now transfer the fuel mix to waste (200L/s max)
/:cl:
