### PR TITLE
disable infinite AA validhunter borgs (secborgs)

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -332,7 +332,7 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
-#DISABLE_SECBORG
+DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen


### PR DESCRIPTION
# Document the changes in your pull request
Disables secborgs in config
robotics being able to print infinite, AA, stun and wound immune borgs is not a fun mechanic when 4 salty validhunter ghosts become secborgs and then use metaknowledge to validhunt the antag. Antags shouldnt have to waste TC or resources on getting a EMP soley because ghosts want to be salty validhunters
# Wiki Documentation
note somewhere that secborgs are disabled
# Changelog
:cl:  
rscdel: Secborgs have been disabled
/:cl:
