### PR TITLE
Posiborgs (and shells) are slower than brainborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -985,6 +985,10 @@
 
 /mob/living/silicon/robot/movement_delay()
 	. = ..()
+	if(istype(mmi, /obj/item/mmi/posibrain))
+		. += 0.5
+	if(mainframe)
+		. += 0.25
 	var/hd = maxHealth - health
 	if(hd > 50)
 		if(has_gravity())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -987,8 +987,9 @@
 	. = ..()
 	if(istype(mmi, /obj/item/mmi/posibrain))
 		. += 0.5
-	if(mainframe)
+	else if(mainframe)
 		. += 0.25
+
 	var/hd = maxHealth - health
 	if(hd > 50)
 		if(has_gravity())


### PR DESCRIPTION
# Document the changes in your pull request

Cyborgs with posibrains now suffer 0.5 more slowdown than cyborgs with real brains (like roundstart or borged)

**Respawns should be punished and disadvantaged**

AI shells suffer 0.25 slowdown because it harbors nearly the same problem but the AI is usually more effective as an eye in the sky

# Changelog

:cl:  
tweak: Cyborgs with positronic brains installed now suffer moderate slowdown
tweak: AI shells now suffer small slowdown
/:cl:
