### PR TITLE
Posibrains can only be used once per person per round

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -27,6 +27,8 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/recharge_message = span_warning("The positronic brain isn't ready to activate again yet! Give it some time to recharge.")
 	var/list/possible_names //If you leave this blank, it will use the global posibrain names
 	var/picked_name
+	/// list of people who have already taken a posibrain, preventing them from taking another
+	var/static/list/brain_users = list()
 
 /obj/item/mmi/posibrain/Topic(href, href_list)
 	if(href_list["activate"])
@@ -97,6 +99,9 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(user.suiciding) //if they suicided, they're out forever.
 		to_chat(user, span_warning("[src] fizzles slightly. Sadly it doesn't take those who suicided!"))
 		return
+	if(user.ckey in brain_users) //no double dipping
+		to_chat(user, span_warning("[src] fizzles slightly. You have already used a positronic brain!"))
+		return
 	var/playtime = SSjob.GetJob("Cyborg").required_playtime_remaining(user.client)
 	if(playtime)
 		to_chat(user, span_warning("Positronic brains are beyond your knowledge to control."))
@@ -145,6 +150,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	brainmob.set_stat(CONSCIOUS)
 	brainmob.remove_from_dead_mob_list()
 	brainmob.add_to_alive_mob_list()
+	LAZYADD(brain_users, brainmob.ckey)
 	ADD_TRAIT(brainmob, TRAIT_PACIFISM, POSIBRAIN_TRAIT)
 
 	visible_message(new_mob_message)


### PR DESCRIPTION
# Document the changes in your pull request

oh no!! I died!! I gues I'll have to ghost and click one more of the 200 spare squares in robotics!!
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

unlikely to be documented, posibrains now cannot be used by the same person to respawn more than once
<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: you can no longer respawn as a posibrain after already having respawned as a posibrain. Use your cyborg life wisely.
/:cl:
