### PR TITLE
Partially Revert "Metallic hydrogen production now requires EFFORT (#15333)" and few adjustments

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -677,8 +677,8 @@ nobliumformation = 1001
 
 /datum/gas_reaction/metalhydrogen/init_reqs()
 	min_requirements = list(
-		/datum/gas/hydrogen = 1000,
-		/datum/gas/bz		= 50,
+		/datum/gas/hydrogen = 100,
+		/datum/gas/bz		= 5,
 		"TEMP" = METAL_HYDROGEN_MINIMUM_HEAT
 		)
 
@@ -688,18 +688,18 @@ nobliumformation = 1001
 	if(!isturf(holder))
 		return NO_REACTION
 	var/turf/open/location = holder
-	///More heat means higher chance to react but less efficiency, i.e. higher speed lower yield
-	var/increase_factor = min(log(10 , (temperature / METAL_HYDROGEN_MINIMUM_HEAT)), 5)	//e7-e12 range
+	///the more heat you use the higher is this factor
+	var/increase_factor = min((temperature / METAL_HYDROGEN_MINIMUM_HEAT), 5)
 	///the more moles you use and the higher the heat, the higher is the efficiency
-	var/heat_efficency = air.get_moles(/datum/gas/hydrogen)* 0.01 * increase_factor	//This variable name is dumb but I can't be assed to change it
+	var/heat_efficency = air.get_moles(/datum/gas/hydrogen)* 0.01 * increase_factor
 	var/pressure = air.return_pressure()
 	var/energy_used = heat_efficency * METAL_HYDROGEN_FORMATION_ENERGY
 
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
-		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.05))	//0.0005-0.0025 x mols of present hydrogen as BZ consumed, something about it decomposing
+		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.01))
 		if (prob(20 * increase_factor))
-			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 14))	//14-70% of present hydrogen consumed.
-			if (prob(25 / increase_factor))
+			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 3.5))
+			if (prob(100 / increase_factor))
 				new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
 				SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -677,8 +677,8 @@ nobliumformation = 1001
 
 /datum/gas_reaction/metalhydrogen/init_reqs()
 	min_requirements = list(
-		/datum/gas/hydrogen = 400,
-		/datum/gas/bz		= 40,
+		/datum/gas/hydrogen = 300,
+		/datum/gas/bz		= 50,
 		"TEMP" = METAL_HYDROGEN_MINIMUM_HEAT
 		)
 
@@ -689,7 +689,7 @@ nobliumformation = 1001
 		return NO_REACTION
 	var/turf/open/location = holder
 	///the more heat you use the higher is this factor
-	var/increase_factor = min((temperature / METAL_HYDROGEN_MINIMUM_HEAT), 5)
+	var/increase_factor = min(log(10 , (temperature / METAL_HYDROGEN_MINIMUM_HEAT)), 5) //e7-e12 range
 	///the more moles you use and the higher the heat, the higher is the efficiency
 	var/heat_efficency = air.get_moles(/datum/gas/hydrogen)* 0.01 * increase_factor
 	var/pressure = air.return_pressure()
@@ -697,7 +697,7 @@ nobliumformation = 1001
 
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
 		air.adjust_moles(/datum/gas/bz, -(heat_efficency)) //About 70% the amount of BZ requirement consumed
-		if (prob(20 * increase_factor))
+		if (prob(25 * increase_factor))
 			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 10)) //Still consume about 70% of the hydrogen present
 			new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
 			SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -696,7 +696,7 @@ nobliumformation = 1001
 	var/energy_used = heat_efficency * METAL_HYDROGEN_FORMATION_ENERGY
 
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
-		air.adjust_moles(/datum/gas/bz, -(heat_efficency)) //About half the amount of BZ requirement consumed
+		air.adjust_moles(/datum/gas/bz, -(heat_efficency)) //About 70% the amount of BZ requirement consumed
 		if (prob(20 * increase_factor))
 			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 10)) //Still consume about 70% of the hydrogen present
 			new /obj/item/stack/sheet/mineral/metal_hydrogen(location)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -677,7 +677,7 @@ nobliumformation = 1001
 
 /datum/gas_reaction/metalhydrogen/init_reqs()
 	min_requirements = list(
-		/datum/gas/hydrogen = 300,
+		/datum/gas/hydrogen = 300, //same crystallizer recipe
 		/datum/gas/bz		= 50,
 		"TEMP" = METAL_HYDROGEN_MINIMUM_HEAT
 		)
@@ -691,7 +691,7 @@ nobliumformation = 1001
 	///the more heat you use the higher is this factor
 	var/increase_factor = min(log(10 , (temperature / METAL_HYDROGEN_MINIMUM_HEAT)), 5) //e7-e12 range
 	///the more moles you use and the higher the heat, the higher is the efficiency
-	var/heat_efficency = air.get_moles(/datum/gas/hydrogen)* 0.01 * increase_factor
+	var/heat_efficency = air.get_moles(/datum/gas/hydrogen)* 0.01 * increase_factor //This variable name is dumb but I can't be assed to change it
 	var/pressure = air.return_pressure()
 	var/energy_used = heat_efficency * METAL_HYDROGEN_FORMATION_ENERGY
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -697,9 +697,9 @@ nobliumformation = 1001
 	var/energy_used = heat_efficency * METAL_HYDROGEN_FORMATION_ENERGY
 
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
-		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.01))
+		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.05))
 		if (prob(20 * increase_factor))
-			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 3.5))
+			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 4.5))
 			if (prob(100 / increase_factor))
 				new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
 				SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -677,9 +677,8 @@ nobliumformation = 1001
 
 /datum/gas_reaction/metalhydrogen/init_reqs()
 	min_requirements = list(
-		//same requirement as crystallizer metal h2 recipe
-		/datum/gas/hydrogen = 300,
-		/datum/gas/bz		= 50,
+		/datum/gas/hydrogen = 400,
+		/datum/gas/bz		= 40,
 		"TEMP" = METAL_HYDROGEN_MINIMUM_HEAT
 		)
 
@@ -700,9 +699,8 @@ nobliumformation = 1001
 		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.05))
 		if (prob(20 * increase_factor))
 			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 4.5))
-			if (prob(100 / increase_factor))
-				new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
-				SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))
+			new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
+			SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))
 
 	if(energy_used > 0)
 		var/new_heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -698,7 +698,7 @@ nobliumformation = 1001
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
 		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.05))
 		if (prob(20 * increase_factor))
-			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 4.5))
+			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 10)) //Still consume about 70% of the hydrogen present
 			new /obj/item/stack/sheet/mineral/metal_hydrogen(location)
 			SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((heat_efficency * increase_factor * 0.5), METAL_HYDROGEN_RESEARCH_MAX_AMOUNT))
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -696,7 +696,7 @@ nobliumformation = 1001
 	var/energy_used = heat_efficency * METAL_HYDROGEN_FORMATION_ENERGY
 
 	if(pressure >= METAL_HYDROGEN_MINIMUM_PRESSURE && temperature >= METAL_HYDROGEN_MINIMUM_HEAT)
-		air.adjust_moles(/datum/gas/bz, -(heat_efficency * 0.05))
+		air.adjust_moles(/datum/gas/bz, -(heat_efficency)) //About half the amount of BZ requirement consumed
 		if (prob(20 * increase_factor))
 			air.adjust_moles(/datum/gas/hydrogen, -(heat_efficency * 10)) //Still consume about 70% of the hydrogen present
 			new /obj/item/stack/sheet/mineral/metal_hydrogen(location)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -677,8 +677,9 @@ nobliumformation = 1001
 
 /datum/gas_reaction/metalhydrogen/init_reqs()
 	min_requirements = list(
-		/datum/gas/hydrogen = 100,
-		/datum/gas/bz		= 5,
+		//same requirement as crystallizer metal h2 recipe
+		/datum/gas/hydrogen = 300,
+		/datum/gas/bz		= 50,
 		"TEMP" = METAL_HYDROGEN_MINIMUM_HEAT
 		)
 


### PR DESCRIPTION
# This is still a nerf to it but less painful than the old nerf PR


The open tile methal hydrogen formation got nerfed so hard (nearly removing it at this point because no one tries this anymore) that you need approximately 2000-3000 h2 moles to get a single bar out of it which is so painful that atmosian has to used crystallizer instead. The reason to nerf this was to stop metal h2 golem spam (and also to nerf the production) but there was already a pr removing it from the metal h2 recipe #15295, so why making this even worse. It already required much efforts already: spending half hour into shift getting preparing the burn chamber, collecting water vapor, bz and getting the required temperature for the reaction to start

# Document the changes in your pull request
* Metallic hydrogen production now requires ~1/2 as many mols to start
* Metallic hydrogen production hydrogen consumption is still about 70% of the total hydrogen required
* Metallic hydrogen production BZ consumption now consume about 70% of the total bz required
* Hydrogen min requirement is is reduced by 700 moles (Now the same as crystallizer recipe)
* No more rng to metal h2 generation


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Metallic hydrogen production now requires ~1/2 as many mols to start
tweak: Metallic hydrogen production hydrogen consumption is still about 70% of the total hydrogen required
tweak: Metallic hydrogen production BZ consumption now consume about 70% of the total bz required
tweak: Hydrogen min requirement is is reduced by 700 moles (Now the same as crystallizer recipe)
tweak: No more rng to metal h2 generation
/:cl:
