### PR TITLE
Cyborg hugging module now reduce status effects like carbon hugs.

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -114,6 +114,7 @@
 			if(M.health >= 0)
 				if(ishuman(M))
 					if(!(M.mobility_flags & MOBILITY_STAND))
+						M.adjust_status_effects_on_shake_up()
 						user.visible_message(span_notice("[user] shakes [M] trying to get [M.p_them()] up!"), \
 										span_notice("You shake [M] trying to get [M.p_them()] up!"))
 					else if(user.zone_selected == BODY_ZONE_HEAD)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -113,8 +113,8 @@
 		if(1)
 			if(M.health >= 0)
 				if(ishuman(M))
+					M.adjust_status_effects_on_shake_up()
 					if(!(M.mobility_flags & MOBILITY_STAND))
-						M.adjust_status_effects_on_shake_up()
 						user.visible_message(span_notice("[user] shakes [M] trying to get [M.p_them()] up!"), \
 										span_notice("You shake [M] trying to get [M.p_them()] up!"))
 					else if(user.zone_selected == BODY_ZONE_HEAD)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -209,7 +209,7 @@
 		affecting = bodyparts[1]
 	SEND_SIGNAL(I, COMSIG_ITEM_ATTACK_ZONE, src, user, affecting)
 	send_item_attack_message(I, user, affecting.name, affecting)
-	if(I.force)		
+	if(I.force)
 		var/attack_direction = get_dir(user, src)
 		apply_damage(I.force, I.damtype, affecting, wound_bonus = I.wound_bonus, bare_wound_bonus = I.bare_wound_bonus, sharpness = I.sharpness, attack_direction = attack_direction)
 		if(I.damtype == BRUTE && affecting.status == BODYPART_ORGANIC)
@@ -467,12 +467,8 @@
 		else if(averagestacks < -1)
 			to_chat(src, span_notice("The hug [M] gave you was a little wet..."))
 
-	AdjustStun(-6 SECONDS)
-	AdjustKnockdown(-6 SECONDS)
-	AdjustUnconscious(-6 SECONDS)
-	AdjustSleeping(-10 SECONDS)
-	AdjustParalyzed(-6 SECONDS)
-	AdjustImmobilized(-6 SECONDS)
+	adjust_status_effects_on_shake_up()
+
 //	adjustStaminaLoss(-10) if you want hugs to recover stamina damage, uncomment this
 	if(dna && dna.check_mutation(ACTIVE_HULK))
 		if(prob(30))

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -335,6 +335,16 @@
 			S = apply_status_effect(STATUS_EFFECT_SLEEPING, amount, updating)
 		return S
 
+///////////////////////// CLEAR STATUS /////////////////////////
+
+/mob/living/proc/adjust_status_effects_on_shake_up()
+	AdjustStun(-6 SECONDS)
+	AdjustKnockdown(-6 SECONDS)
+	AdjustUnconscious(-6 SECONDS)
+	AdjustSleeping(-10 SECONDS)
+	AdjustParalyzed(-6 SECONDS)
+	AdjustImmobilized(-6 SECONDS)
+
 ///////////////////////////////// FROZEN /////////////////////////////////////
 
 /mob/living/proc/IsFrozen()


### PR DESCRIPTION
# Document the changes in your pull request
This is a bugfix port from [tgstation](https://github.com/tgstation/tgstation/pull/62468). 

The empowered hug from cyborg hugging module now adjusts/reduces status effects similar to how carbon's hugs do.

Tested in local with the usage of flash bang smite.

# Wiki Documentation
Include in all the entries at [Cyborg's The Latest Models](https://wiki.yogstation.net/wiki/Cyborg#The_Latest_Models) for hugging module that an empowered hug will act similar to a carbon hug.

# Changelog
:cl:  
bugfix: Cyborg's hugging module no longer lies to you as it now adjusts status effects similar to a carbon hug.
/:cl:
