### PR TITLE
another attempt at fixing cult

### DIFF
--- a/code/datums/actions/items/cult_dagger.dm
+++ b/code/datums/actions/items/cult_dagger.dm
@@ -10,7 +10,7 @@
 	default_button_position = "6:157,4:-2"
 
 /datum/action/item_action/cult_dagger/Grant(mob/grant_to)
-	if(!iscultist(M))
+	if(!iscultist(grant_to))
 		return
 
 	return ..()

--- a/code/datums/actions/items/cult_dagger.dm
+++ b/code/datums/actions/items/cult_dagger.dm
@@ -9,10 +9,11 @@
 
 	default_button_position = "6:157,4:-2"
 
-/datum/action/item_action/cult_dagger/Grant(mob/M)
-	if(iscultist(M))
-		return ..()
-	Remove(owner)
+/datum/action/item_action/cult_dagger/Grant(mob/grant_to)
+	if(!iscultist(M))
+		return
+
+	return ..()
 
 /datum/action/item_action/cult_dagger/Trigger(trigger_flags)
 	for(var/obj/item/held_item as anything in owner.held_items) // In case we were already holding a dagger

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -104,7 +104,10 @@
 	return ..()
 
 /datum/game_mode/cult/check_finished(force_ending)
-	if (..())
+	if(!SSticker.setup_done || !gamemode_ready)
+		return FALSE
+	. = ..()
+	if (.)
 		return TRUE
 
 	return !main_cult.check_sacrifice_status() //we should remove this any time soon

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -34,14 +34,15 @@ GLOBAL_VAR(antag_prototypes)
 	var/command_part = commands.Join(" | ")
 	var/data_part = antag_panel_data()
 	var/objective_part = antag_panel_objectives()
+	var/team_objective_part = antag_panel_team_objectives()
 	var/memory_part = antag_panel_memory()
 
-	var/list/parts = listtrim(list(command_part,data_part,objective_part,memory_part))
+	var/list/parts = listtrim(list(command_part, data_part, objective_part, team_objective_part, memory_part))
 
 	return parts.Join("<br>")
 
 /datum/antagonist/proc/antag_panel_objectives()
-	var/result = "<i><b>Objectives</b></i>:<br>"
+	var/result = "<i><b>Personal Objectives</b></i>:<br>"
 	if (objectives.len == 0)
 		result += "EMPTY<br>"
 	else
@@ -51,6 +52,20 @@ GLOBAL_VAR(antag_prototypes)
 			obj_count++
 	result += "<a href='?src=[REF(owner)];obj_add=1;target_antag=[REF(src)]'>Add objective</a><br>"
 	result += "<a href='?src=[REF(owner)];obj_announce=1'>Announce objectives</a><br>"
+	return result
+
+/datum/antagonist/proc/antag_panel_team_objectives()
+	var/datum/team/antag_team = get_team()
+	if(!antag_team)
+		return
+	var/result = "<i><b>Team Objectives</b></i>:<br>"
+	if (antag_team.objectives.len == 0)
+		result += "EMPTY<br>"
+	else
+		var/obj_count = 1
+		for(var/datum/objective/objective in antag_team.objectives)
+			result += "<B>[obj_count]</B>: <font color=[objective.check_completion() ? "green" : "red"]>[objective.explanation_text][objective.check_completion() ? " (COMPLETED)" : ""]</font> <a href='?src=[REF(owner)];obj_edit=[REF(objective)]'>Edit</a> <a href='?src=[REF(owner)];obj_delete=[REF(objective)]'>Delete</a> <a href='?src=[REF(owner)];obj_completed=[REF(objective)]'><font color=[objective.completed ? "green" : "red"]>[objective.completed ? "Mark as incomplete" : "Mark as complete"]</font></a><br>"
+			obj_count++
 	return result
 
 /datum/antagonist/proc/antag_panel_memory()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 //Returns the team antagonist belongs to if any.
 /datum/antagonist/proc/get_team()
-	return
+	return null
 
 //Individual roundend report
 /datum/antagonist/proc/roundend_report()
@@ -401,8 +401,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/get_objectives()
 	var/objective_count = 1
 	var/list/objective_data = list()
+	var/datum/team/antag_team = get_team()
 	//all obj
-	for(var/datum/objective/objective in objectives)
+	for(var/datum/objective/objective in objectives + antag_team?.objectives)
 		objective_data += list(list(
 			"count" = objective_count,
 			"name" = objective.objective_name,

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -64,7 +64,6 @@
 /datum/antagonist/abductor/on_gain()
 	owner.special_role = "[name] [sub_role]"
 	owner.assigned_role = "[name] [sub_role]"
-	objectives += team.objectives
 	finalize_abductor()
 	ADD_TRAIT(owner.current, TRAIT_ABDUCTOR_TRAINING, ABDUCTOR_ANTAGONIST) // Yogs -- Fixes abductors having their traits associated with their mind instead of their mob
 	return ..()

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -14,7 +14,6 @@
 /datum/antagonist/ashwalker/create_team(datum/team/team)
 	if(team)
 		ashie_team = team
-		objectives |= ashie_team.objectives
 	else
 		ashie_team = new
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -20,7 +20,6 @@
 
 /datum/antagonist/brother/on_gain()
 	SSticker.mode.brothers += owner
-	objectives += team.objectives
 	owner.special_role = special_role
 	if(owner.current)
 		give_pinpointer()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -40,9 +40,6 @@
 		stack_trace("Wrong team type passed to [type] initialization.")
 	cult_team = new_team
 
-/datum/antagonist/cult/proc/add_objectives()
-	objectives |= cult_team.objectives
-
 /datum/antagonist/cult/Destroy()
 	QDEL_NULL(communion)
 	QDEL_NULL(vote)
@@ -71,7 +68,6 @@
 
 /datum/antagonist/cult/on_gain()
 	. = ..()
-	add_objectives()
 	var/mob/living/current = owner.current
 	if(ishuman(current))
 		var/mob/living/carbon/human/H = current
@@ -480,12 +476,6 @@
 	var/sacced = FALSE
 	var/sac_image
 
-/datum/objective/sacrifice/is_valid_target(possible_target)
-	. = ..()
-	var/datum/mind/M = possible_target
-	if(istype(M) && isipc(M.current))
-		return FALSE
-
 /// Unregister signals from the old target so it doesn't cause issues when sacrificed of when a new target is found.
 /datum/objective/sacrifice/proc/clear_sacrifice()
 	if(!target)
@@ -502,13 +492,29 @@
 	var/datum/team/cult/cult = team
 	var/list/target_candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && !is_convertable_to_cult(player) && player.stat != DEAD)
-			target_candidates += player.mind
+		if(!player.mind)
+			continue
+		if(player.mind.has_antag_datum(/datum/antagonist/cult))
+			continue
+		if(is_convertable_to_cult(player))
+			continue
+		if(isipc(player))
+			continue
+		if(player.stat == DEAD)
+			continue
+		target_candidates += player.mind
 	if(target_candidates.len == 0)
 		message_admins("Cult Sacrifice: Could not find unconvertible target, checking for convertible target.")
 		for(var/mob/living/carbon/human/player in GLOB.player_list)
-			if(player.mind && !player.mind.has_antag_datum(/datum/antagonist/cult) && player.stat != DEAD)
-				target_candidates += player.mind
+			if(!player.mind)
+				continue
+			if(player.mind.has_antag_datum(/datum/antagonist/cult))
+				continue
+			if(isipc(player))
+				continue
+			if(player.stat == DEAD)
+				continue
+			target_candidates += player.mind
 	listclearnulls(target_candidates)
 	if(LAZYLEN(target_candidates))
 		target = pick(target_candidates)
@@ -580,7 +586,7 @@
 	update_explanation_text()
 
 /datum/objective/eldergod/update_explanation_text()
-	explanation_text = "Summon Nar'sie by invoking the rune 'Summon Nar'sie'. <b>The summoning can only be accomplished in [english_list(summon_spots)] - where the veil is weak enough for the ritual to begin.</b>"
+	explanation_text = "Summon Nar'sie by invoking the rune 'Summon Nar'sie'. The summoning can only be accomplished in [english_list(summon_spots)] - where the veil is weak enough for the ritual to begin."
 
 /datum/objective/eldergod/check_completion()
 	if(killed)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -70,7 +70,6 @@
 	owner.announce_objectives()
 
 /datum/antagonist/cult/on_gain()
-//	add_objectives() figure it out sometime later (remove cult the gamemode in favor of dynamic ruleset)
 	. = ..()
 	add_objectives()
 	var/mob/living/current = owner.current

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -62,7 +62,6 @@
 
 /datum/antagonist/ert/on_gain()
 	update_name()
-	forge_objectives()
 	equipERT()
 	. = ..()
 
@@ -252,10 +251,6 @@
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))
 		ert_team = new_team
-
-/datum/antagonist/ert/proc/forge_objectives()
-	if(ert_team)
-		objectives |= ert_team.objectives
 
 /datum/antagonist/ert/proc/equipERT()
 	var/mob/living/carbon/human/H = owner.current

--- a/code/modules/antagonists/monkey/monkey.dm
+++ b/code/modules/antagonists/monkey/monkey.dm
@@ -72,9 +72,6 @@
 		stack_trace("Wrong team type passed to [type] initialization.")
 	monkey_team = new_team
 
-/datum/antagonist/monkey/proc/forge_objectives()
-	objectives |= monkey_team.objectives
-
 /datum/antagonist/monkey/admin_remove(mob/admin)
 	var/mob/living/carbon/human/M = owner.current
 	if(ismonkey(M))

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -41,7 +41,6 @@
 
 /datum/antagonist/nukeop/on_gain()
 	give_alias()
-	forge_objectives()
 	. = ..()
 	equip_op()
 	memorize_code()
@@ -93,10 +92,6 @@
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
 	else
 		to_chat(owner, "Unfortunately the syndicate was unable to provide you with nuclear authorization code.")
-
-/datum/antagonist/nukeop/proc/forge_objectives()
-	if(nuke_team)
-		objectives |= nuke_team.objectives
 
 /datum/antagonist/nukeop/proc/move_to_spawnpoint()
 	var/team_number = 1

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -30,9 +30,7 @@
 		ert_team = new_team
 
 /datum/antagonist/centcom/proc/forge_objectives()
-	if (ert_team)
-		objectives |= ert_team.objectives
-	else if (!mission)
+	if(!ert_team && !mission)
 		var/datum/objective/missionobj = new
 		missionobj.owner = owner
 		missionobj.explanation_text = "Conduct a routine performance review of [station_name()] and its Captain."

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -46,13 +46,8 @@
 
 /datum/antagonist/rev/on_gain()
 	. = ..()
-	create_objectives()
 	equip_rev()
 	owner.current.log_message("has been converted to the revolution!", LOG_ATTACK, color="red")
-
-/datum/antagonist/rev/on_removal()
-	remove_objectives()
-	return ..()
 
 /datum/antagonist/rev/greet()
 	to_chat(owner, span_userdanger("You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. You can identify your comrades by the red \"R\" icons, and your leaders by the blue \"R\" icons. Help them kill the heads to win the revolution!"))
@@ -77,12 +72,6 @@
 
 /datum/antagonist/rev/get_team()
 	return rev_team
-
-/datum/antagonist/rev/proc/create_objectives()
-	objectives |= rev_team.objectives
-
-/datum/antagonist/rev/proc/remove_objectives()
-	objectives -= rev_team.objectives
 
 //Bump up to head_rev
 /datum/antagonist/rev/proc/promote()

--- a/code/modules/antagonists/zombie/zombie.dm
+++ b/code/modules/antagonists/zombie/zombie.dm
@@ -63,9 +63,6 @@
 		stack_trace("Wrong team type passed to [type] initialization.")
 	team = new_team
 
-/datum/antagonist/zombie/proc/add_objectives()
-	objectives |= team.objectives
-
 ///datum/antagonist/zombie/Destroy()
 //	QDEL_NULL(zombify)
 //	return ..()
@@ -80,7 +77,6 @@
 /datum/antagonist/zombie/on_gain()
 	. = ..()
 	var/mob/living/current = owner.current
-	add_objectives()
 	GLOB.zombies += owner
 	current.log_message("has been made a zombie!", LOG_ATTACK, color="#960000")
 

--- a/yogstation/code/modules/antagonists/infiltrator/infiltrator.dm
+++ b/yogstation/code/modules/antagonists/infiltrator/infiltrator.dm
@@ -37,7 +37,6 @@
 			H.fully_replace_character_name(H.real_name, new_name)
 			H.equipOutfit(/datum/outfit/infiltrator)
 	owner.store_memory("Do <B>NOT</B> kill or destroy needlessly, as this defeats the purpose of an 'infiltration'!")
-	objectives |= infiltrator_team.objectives
 	. = ..()
 	if(send_to_spawnpoint)
 		move_to_spawnpoint()


### PR DESCRIPTION
# Document the changes in your pull request

The error we get is that they physically cannot find the objective, which should never be the case as it seems to be given just fine, so my assumption is that it's being checked before the round even starts. This is a problem in other gamemodes but theyve been fixed because they respect parent, cult doesn't seem to.

# Changelog

:cl:  
bugfix: Cult works now... for real.
bugfix: Cult's antag info button now starts with the objectives, rather than having to close and reopen it to see them.
bugfix: Admins can now see Cult objectives in their TP
bugfix: IPCs can no longer roll cult target
bugfix: Cult's objective text no longer has a random <b
/:cl:
