### PR TITLE
Dead Cyborgs now emit a GPS location.

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -68,6 +68,10 @@
 		R.mind.grab_ghost()
 		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
 
+	var/obj/item/gps/internal/G = R.internal
+	if(G)
+		QDEL_NULL(G)
+
 	R.revive()
 	R.logevent("WARN -- System recovered from unexpected shutdown.")
 	R.logevent("System brought online.")

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -68,10 +68,6 @@
 		R.mind.grab_ghost()
 		playsound(loc, 'sound/voice/liveagain.ogg', 75, 1)
 
-	var/obj/item/gps/internal/G = R.internal
-	if(G)
-		QDEL_NULL(G)
-
 	R.revive()
 	R.logevent("WARN -- System recovered from unexpected shutdown.")
 	R.logevent("System brought online.")

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -27,6 +27,7 @@
 		logevent("FATAL -- SYSTEM HALT")
 		modularInterface.shutdown_computer()
 		internal = new /obj/item/gps/internal/cyborg(src)
+		internal.gpstag += " ([real_name])"
 
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -13,6 +13,9 @@
 /mob/living/silicon/robot/dust_animation()
 	new /obj/effect/temp_visual/dust_animation(loc, "dust-r")
 
+/obj/item/gps/internal/cyborg
+	gpstag = "Cyborg Distress Signal"
+
 /mob/living/silicon/robot/death(gibbed)
 	if(stat == DEAD)
 		return
@@ -23,6 +26,7 @@
 	if(!gibbed)
 		logevent("FATAL -- SYSTEM HALT")
 		modularInterface.shutdown_computer()
+		internal = new /obj/item/gps/internal/cyborg(src)
 
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -112,6 +112,9 @@
 	buckle_lying = FALSE
 	var/static/list/can_ride_typecache = typecacheof(/mob/living/carbon/human)
 
+	var/obj/item/gps/internal // GPS location for when they die
+
+
 /mob/living/silicon/robot/get_cell()
 	return cell
 
@@ -1074,6 +1077,9 @@
 		toggle_headlamp(TRUE)
 		if(admin_revive)
 			locked = TRUE
+		if(internal)
+			QDEL_NULL(internal)
+
 		notify_ai(NEW_BORG)
 		. = 1
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -112,7 +112,8 @@
 	buckle_lying = FALSE
 	var/static/list/can_ride_typecache = typecacheof(/mob/living/carbon/human)
 
-	var/obj/item/gps/internal // GPS location for when they die
+	///Contains GPS location. Does not exist until the Cyborg is dead.
+	var/obj/item/gps/internal
 
 
 /mob/living/silicon/robot/get_cell()


### PR DESCRIPTION
# Document the changes in your pull request
Dead Cyborgs will emit a GPS location that can be used to locate their dead body.
They no longer broadcast their GPS location if they are revived or lose their body.

Tested in local and works fine.

# Wiki Documentation
Mention somewhere in either [Roboticist's Tips](https://wiki.yogstation.net/wiki/Roboticist#Tips) or [Cyborg's Tips](https://wiki.yogstation.net/wiki/Cyborg#Tips) that dead cyborgs emit a GPS location.

# Changelog
:cl:  
rscadd: Dead Cyborgs now broadcast a location on the GPS to encourage finding their body.
/:cl:
