### PR TITLE
Cyborgs now have TRAIT_FORCED_STANDING

### DIFF
--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -26,8 +26,6 @@
 
 	. = ..()
 
-	remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED, TRAIT_CRITICAL_CONDITION), STAT_TRAIT) // to remove unwanted traits from living/set_stat
-
 	locked = FALSE //unlock cover
 
 	if(!QDELETED(builtInCamera) && builtInCamera.status)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -26,6 +26,8 @@
 
 	. = ..()
 
+	remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED, TRAIT_CRITICAL_CONDITION), STAT_TRAIT) // to remove unwanted traits from living/set_stat
+
 	locked = FALSE //unlock cover
 
 	if(!QDELETED(builtInCamera) && builtInCamera.status)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -59,6 +59,8 @@
 		diag_hud.add_atom_to_hud(src)
 	diag_hud_set_status()
 	diag_hud_set_health()
+	ADD_TRAIT(src, TRAIT_FORCED_STANDING, "cyborg") // not CYBORG_ITEM_TRAIT because not an item
+
 
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
@@ -506,26 +508,3 @@
 			else
 				jobname = "Silicon"
 			msgr.username = "[newname] ([jobname])"
-
-/mob/living/silicon/robot/set_stat(new_stat)
-	//Don't  want to call parent (mob/living/set_stat) since it adds unwanted traits.
-	//Copied from mob/proc/set_stat:
-	if(new_stat == stat)
-		return
-	. = stat
-	stat = new_stat
-	SEND_SIGNAL(src, COMSIG_MOB_STATCHANGE, new_stat, .)
-
-	//Altered mob/living/set_stat for Cyborgs
-	switch(.) //Previous stat.
-		if(CONSCIOUS || SOFT_CRIT || UNCONSCIOUS)
-			remove_traits(src, list(TRAIT_IMMOBILIZED, TRAIT_INCAPACITATED, TRAIT_HANDS_BLOCKED), STAT_TRAIT)
-		if(DEAD)
-			remove_from_dead_mob_list()
-			add_to_alive_mob_list()
-	switch(stat) //Current stat.
-		if(CONSCIOUS || SOFT_CRIT || UNCONSCIOUS)
-			add_traits(src, list(TRAIT_IMMOBILIZED, TRAIT_INCAPACITATED, TRAIT_HANDS_BLOCKED), STAT_TRAIT)
-		if(DEAD)
-			remove_from_alive_mob_list()
-			add_to_dead_mob_list()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -506,3 +506,26 @@
 			else
 				jobname = "Silicon"
 			msgr.username = "[newname] ([jobname])"
+
+/mob/living/silicon/robot/set_stat(new_stat)
+	//Don't  want to call parent (mob/living/set_stat) since it adds unwanted traits.
+	//Copied from mob/proc/set_stat:
+	if(new_stat == stat)
+		return
+	. = stat
+	stat = new_stat
+	SEND_SIGNAL(src, COMSIG_MOB_STATCHANGE, new_stat, .)
+
+	//Altered mob/living/set_stat for Cyborgs
+	switch(.) //Previous stat.
+		if(CONSCIOUS || SOFT_CRIT || UNCONSCIOUS)
+			remove_traits(src, list(TRAIT_IMMOBILIZED, TRAIT_INCAPACITATED, TRAIT_HANDS_BLOCKED), STAT_TRAIT)
+		if(DEAD)
+			remove_from_dead_mob_list()
+			add_to_alive_mob_list()
+	switch(stat) //Current stat.
+		if(CONSCIOUS || SOFT_CRIT || UNCONSCIOUS)
+			add_traits(src, list(TRAIT_IMMOBILIZED, TRAIT_INCAPACITATED, TRAIT_HANDS_BLOCKED), STAT_TRAIT)
+		if(DEAD)
+			remove_from_alive_mob_list()
+			add_to_dead_mob_list()


### PR DESCRIPTION
# Document the changes in your pull request
Cyborgs now start with ``TRAIT_FORCED_STANDING`` in order to counteract the forced resting that was caused by the #18514. The forced rest caused projectiles to be shot over dead Cyborgs and forced those who dragged any dead Cyborg to be slowed down as if they were dragging someone that was sideways.

Tested in local as dead cyborgs are no longer walk through and you can shoot/throw stuff at their dead body instead of over.
# Changelog
:cl:  
bugfix: Cyborgs are no longer mysteriously lying down even though their sprite appears to be standing up.
/:cl:
