### PR TITLE
Chapel-alt doorfix

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
@@ -269,25 +269,6 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/carpet/red,
 /area/chapel/main)
-"mM" = (
-/obj/machinery/door/airlock{
-	name = "Crematorium";
-	req_access_txt = "27"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "oG" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/railing{
@@ -723,6 +704,25 @@
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"Jj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -1366,7 +1366,7 @@ Zp
 Zw
 GD
 Cw
-mM
+Jj
 Gs
 ED
 by


### PR DESCRIPTION
Replaces the door "crematorium" in chapel2.dmm with "chapel office" in chapel1.dmm
access for the door should now allow seccies to enter as seen in the issue #19539 

### Before
![image](https://github.com/yogstation13/Yogstation/assets/98609667/a652a9fd-8e2a-4739-aaf1-ca7fe7413c71)

### After
![image](https://github.com/yogstation13/Yogstation/assets/98609667/c59131fb-9df9-40ae-bfee-53c869b1613d)


:cl:  Airlines7
bugfix: fixed a door
/:cl:
