### PR TITLE
Remove nitrous oxide from nitrium formation requirement

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -382,7 +382,6 @@ nobliumformation = 1001
 		/datum/gas/nitrogen = 50,
 		/datum/gas/plasma = 20,
 		/datum/gas/bz = 20,
-		/datum/gas/nitrous_oxide = 5,
 		"TEMP" = NITRIUM_FORMATION_MIN_TEMP,
 	)
 


### PR DESCRIPTION
At temperatures exceeding 800°C, nitrous oxide breaks down into O2 and N2, and subsequently, the O2 reacts with plasma to produce a burn that emits CO2 and trit. Additionally, the trit reacts with plasma or O2, resulting in a strong tritburn that makes it challenging to obtain any nitrium. Moreover, N2O acts as a catalyst for the reaction, and only a small quantity of it is required. Therefore, removing it will not significantly change much to the reaction.


# Document the changes in your pull request
remove nitrous oxide from the nitrium requirement 


# Wiki Documentation
remove nitrous oxide from the nitrium requirement 

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

rscdel:removed nitrous oxide from the nitrium requirement 
/:cl:
