### PR TITLE
Stops Accidental Overdosing for Cyborg Hyposprays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,5 +218,3 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 
 #KDIFF3 files
 *.orig
-/.vs
-/tools/LinuxOneShot/SetupProgram/obj

--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 
 #KDIFF3 files
 *.orig
+/.vs
+/tools/LinuxOneShot/SetupProgram/obj

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -113,7 +113,7 @@ Borg Hypospray
 		return
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
-			for(var/datum/reagent/RG in R.reagent_list)
+			for(var/datum/reagent/RG as anything in R.reagent_list)
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
 					if( MRG.overdosed == 1 )

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -105,34 +105,34 @@ Borg Hypospray
 					RG.add_reagent(reagent_ids[i], 5)		//And fill hypo with reagent.
 
 /obj/item/reagent_containers/borghypo/attack(mob/living/carbon/M, mob/user)
-	var/datum/reagents/R = reagent_list[mode]
-	if(!R.total_volume)
+	var/datum/reagents/hyporeagent = reagent_list[mode]
+	if(!hyporeagent.total_volume)
 		to_chat(user, span_notice("The injector is empty."))
 		return
 	if(!istype(M))
 		return
-	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
+	if(hyporeagent.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
-			for(var/datum/reagent/RG as anything in R.reagent_list)
-				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold )
-					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
-					if(MRG.overdosed)
-						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))
+			for(var/datum/reagent/reagent as anything in hyporeagent.reagent_list)
+				if(M.reagents.has_reagent(reagent.type) && !reagent.overdose_threshold )
+					var/datum/reagent/mobreagent = M.reagents.get_reagent(reagent.type)
+					if(mobreagent.overdosed)
+						to_chat(user, span_warning("Injecting [M] with more [reagent] would further their overdose."))
 						return
-					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
-						to_chat(user, span_warning("Injecting [M] with more [RG] would overdose them."))
+					if(((M.reagents.get_reagent_amount(reagent.type)) + amount_per_transfer_from_this > reagent.overdose_threshold))
+						to_chat(user, span_warning("Injecting [M] with more [reagent] would overdose them."))
 						return
 		to_chat(M, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [M] with the injector."))
-		var/fraction = min(amount_per_transfer_from_this/R.total_volume, 1)
-		R.reaction(M, INJECT, fraction)
+		var/fraction = min(amount_per_transfer_from_this/hyporeagent.total_volume, 1)
+		hyporeagent.reaction(M, INJECT, fraction)
 		if(M.reagents)
-			var/trans = R.trans_to(M, amount_per_transfer_from_this, transfered_by = user)
-			to_chat(user, span_notice("[trans] unit\s injected.  [R.total_volume] unit\s remaining."))
+			var/trans = hyporeagent.trans_to(M, amount_per_transfer_from_this, transfered_by = user)
+			to_chat(user, span_notice("[trans] unit\s injected.  [hyporeagent.total_volume] unit\s remaining."))
 
 	var/list/injected = list()
-	for(var/datum/reagent/RG in R.reagent_list)
-		injected += RG.name
+	for(var/datum/reagent/reagent in hyporeagent.reagent_list)
+		injected += reagent.name
 	log_combat(user, M, "injected", src, "(CHEMICALS: [english_list(injected)])")
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -120,7 +120,7 @@ Borg Hypospray
 						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))
 						return
 					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
-						to_chat(user, span_warning("Injecting [M] with more [RG] would overdose them.") )
+						to_chat(user, span_warning("Injecting [M] with more [RG] would overdose them."))
 						return
 		to_chat(M, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [M] with the injector."))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -112,7 +112,7 @@ Borg Hypospray
 	if(!istype(M))
 		return
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
-		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people unless on harm intent
+		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
 			for(var/datum/reagent/RG in R.reagent_list)
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -117,7 +117,7 @@ Borg Hypospray
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
 					if( MRG.overdosed == 1 )
-						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose.") )
+						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))
 						return
 					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
 						to_chat(user, span_warning("Injecting [M] with more [RG] would overdose them.") )

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -116,7 +116,7 @@ Borg Hypospray
 			for(var/datum/reagent/RG as anything in R.reagent_list)
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
-					if( MRG.overdosed == 1 )
+					if(MRG.overdosed)
 						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))
 						return
 					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -115,12 +115,12 @@ Borg Hypospray
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people unless on harm intent
 			for(var/datum/reagent/RG in R.reagent_list)
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
-					var/datum/reagent/O = M.reagents.get_reagent(RG.type)
-					if( O.overdosed == 1 )
-						to_chat(user, "<span class='warning'>Injecting [M] with more [RG] would further their overdose.</span>")
+					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
+					if( MRG.overdosed == 1 )
+						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose.") )
 						return
 					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
-						to_chat(user, "<span class='warning'>Injecting [M] with more [RG] would overdose them.</span>")
+						to_chat(user, span_warning("Injecting [M] with more [RG] would overdose them.") )
 						return
 		to_chat(M, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [M] with the injector."))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -112,9 +112,13 @@ Borg Hypospray
 	if(!istype(M))
 		return
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
-		if(user.a_intent == INTENT_HELP) //Prevents mediborgs from OD'ing people unless on harm intent
+		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people unless on harm intent
 			for(var/datum/reagent/RG in R.reagent_list)
 				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
+					var/datum/reagent/O = M.reagents.get_reagent(RG.type)
+					if( O.overdosed == 1 )
+						to_chat(user, "<span class='warning'>Injecting [M] with more [RG] would further their overdose.</span>")
+						return
 					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
 						to_chat(user, "<span class='warning'>Injecting [M] with more [RG] would overdose them.</span>")
 						return

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -114,7 +114,7 @@ Borg Hypospray
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
 			for(var/datum/reagent/RG as anything in R.reagent_list)
-				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold )
+				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold)
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
 					if(MRG.overdosed)
 						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -114,7 +114,7 @@ Borg Hypospray
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
 			for(var/datum/reagent/RG as anything in R.reagent_list)
-				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
+				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold )
 					var/datum/reagent/MRG = M.reagents.get_reagent(RG.type)
 					if(MRG.overdosed)
 						to_chat(user, span_warning("Injecting [M] with more [RG] would further their overdose."))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -112,6 +112,12 @@ Borg Hypospray
 	if(!istype(M))
 		return
 	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
+		if(user.a_intent == INTENT_HELP) //Prevents mediborgs from OD'ing people unless on harm intent
+			for(var/datum/reagent/RG in R.reagent_list)
+				if(M.reagents.has_reagent(RG.type) && !RG.overdose_threshold == 0)
+					if(((M.reagents.get_reagent_amount(RG.type)) + amount_per_transfer_from_this > RG.overdose_threshold))
+						to_chat(user, "<span class='warning'>Injecting [M] with more [RG] would overdose them.</span>")
+						return
 		to_chat(M, span_warning("You feel a tiny prick!"))
 		to_chat(user, span_notice("You inject [M] with the injector."))
 		var/fraction = min(amount_per_transfer_from_this/R.total_volume, 1)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -114,7 +114,7 @@ Borg Hypospray
 	if(hyporeagent.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
 		if(user.a_intent == INTENT_HELP) // Prevents mediborgs from OD'ing people if they're on help intent
 			for(var/datum/reagent/reagent as anything in hyporeagent.reagent_list)
-				if(M.reagents.has_reagent(reagent.type) && !reagent.overdose_threshold )
+				if(M.reagents.has_reagent(reagent.type) && reagent.overdose_threshold )
 					var/datum/reagent/mobreagent = M.reagents.get_reagent(reagent.type)
 					if(mobreagent.overdosed)
 						to_chat(user, span_warning("Injecting [M] with more [reagent] would further their overdose."))


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request
This is a [port from Citadel](https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13811) and adds a bit more.

On help intent, Cyborg hyposprays now warn and prevent the user from injecting their target if it would overdose them. In addition, it prevents injection if they are currently overdosing while on help intent.

# Wiki Documentation
Mention that there is a safety feature for accidentally and continually overdosing in all of the [Cyborg's Modules](https://wiki.yogstation.net/wiki/Cyborg#The_Latest_Models) that use a hypospray that have a chemical capable of overdosing. If that is too much, just mention that this is a thing in the [Tips](https://wiki.yogstation.net/wiki/Cyborg#Tips).
# Changelog
:cl:  
tweak: Cyborg hyposprays stop the user from injecting chemicals if it would cause a overdose or would further it while on help intent.
/:cl:
