### PR TITLE
Changes Harm Alarm's Misleading Text about Confusing Cyborgs

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -325,7 +325,7 @@
 
 	if(safety == TRUE)
 		user.visible_message("<font color='red' size='2'>[user] blares out a near-deafening siren from its speakers!</font>", \
-			span_userdanger("The siren pierces your hearing and confuses you!"), \
+			span_userdanger("Your siren blares around [iscyborg(user) ? "you" : "and confuses you"]!"), \
 			span_danger("The siren pierces your hearing!"))
 		for(var/mob/living/carbon/M in get_hearers_in_view(9, user))
 			if(M.get_ear_protection() == FALSE)


### PR DESCRIPTION
# Document the changes in your pull request
[This is a port from tgstation.](https://github.com/tgstation/tgstation/pull/74235)

Activating the harm alarm no longer lies to you about being confused too as it does not affect cyborgs.

# Changelog
:cl:   
bugfix: Harm alarm no longer lies to you about being confused too, if you're a cyborg.
/:cl:
