### PR TITLE
Fixes Obliterate (ascended Brawn) shadow overlay not removing

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -530,7 +530,7 @@
 
 /datum/status_effect/the_shadow/Destroy()
 	if(owner)
-		owner.cut_overlay(shadow)
+		owner.overlays -= shadow
 	QDEL_NULL(shadow)
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

I ded

# Changelog

:cl:  
bugfix: Fixed Obliterate (ascended Brawn) shadow overlay not removing
/:cl:
