### PR TITLE
Earmuffs Counters Resonant Shriek

### DIFF
--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -16,6 +16,10 @@
 		return FALSE
 	for(var/mob/living/M in get_hearers_in_view(4, user))
 		if(iscarbon(M))
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(istype(H.ears, /obj/item/clothing/ears/earmuffs))
+					continue
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)


### PR DESCRIPTION
# Document the changes in your pull request
Resonant Shriek is now countered by wearing earmuffs, similar to how it blocks Honk Blaster.

# Wiki Documentation
Mention how Resonant Shriek is blocked by earmuffs in the Changeling page.

# Changelog
:cl:  
tweak: Wearing earmuffs now prevents the effects of Resonant Shriek.
/:cl:
