### PR TITLE
Laser pointer no longer uses %chance to recharge and horribly explain it's charge

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -221,4 +221,4 @@
 		
 /obj/item/laser_pointer/proc/RefreshParts()
 	///The rate at which the laser regenerates charge. Clamped between 30 seconds and basically instantly just in case of weirdness. Knock off 5 seconds per diode rating
-	recharge_rate =  clamp((30 SECONDS - (5 SECONDS * diode.rating)), 1, 30 SECONDS)
+	recharge_rate = clamp((30 SECONDS - (5 SECONDS * diode.rating)), 1, 30 SECONDS)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -14,7 +14,6 @@
 	var/charges = 5
 	var/max_charges = 5
 	var/effectchance = 33
-	var/recharge_locked = FALSE
 	///The diode is what determines the effectiveness and recharge rate of the laser pointer. Higher tier part means stronger pointer
 	var/obj/item/stock_parts/micro_laser/diode 
 	var/diode_type = /obj/item/stock_parts/micro_laser

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -198,9 +198,6 @@
 	
 	if(charges <= max_charges)
 		START_PROCESSING(SSobj, src)
-		if(charges <= 0)
-			to_chat(user, span_warning("[src]'s battery is drained, it needs time to recharge!"))
-			//recharge_locked = TRUE
 
 	flick_overlay_view(I, targloc, 10)
 	icon_state = "pointer"


### PR DESCRIPTION
# Document the changes in your pull request

Old code was confusing in that it seemed to imply the battery would burn out and be unusable by calling it "recharge locked" but would actually recharge with a 5% chance of gaining a charge per tick, but remain unusable until completely recharged. However you would have no indication of the recharge chance, percent complete, or if charges were even coming back.

Now you can see exactly how many charges a laser pointer has when you're close enough to hold it in your hand, and the rate at which it recharges. Also it doesn't burn out and lock up anymore. if you regenerate 1 charge from being at 0/5, go ahead and use it.
![image](https://github.com/yogstation13/Yogstation/assets/46236974/9ad0e9d0-f826-466e-841c-29827a18c157)



# Wiki Documentation
laser pointer is no longer rng, doesn't lock you out of using it if you use up all the charges down to 0

recharge rate determined by:
`recharge_rate = clamp((30 SECONDS - (5 SECONDS * diode.rating)), 1, 30 SECONDS)`

so at most it'll ever be 30 seconds and if an admin var edits your laser rating to 100 for whatever reason it'll recharge basically instantly

# Changelog

:cl:  
rscadd: Laser pointer examine text now shows you the number of charges it has and can have, as well as the recharge rate in seconds  
rscadd: Laser pointer generates a charge every 30-5*diode rating seconds. so 25 seconds at base, 10 seconds at tier 4 part
rscdel: Laser pointer batteries don't "burn out" anymore and lock you out of using them until fully recharged, and the recharge process is no longer % based chance
bugfix: The laser pointer process would kill itself on every run because it called the parent proc which specifically says "never do this" 

/:cl:
