### PR TITLE
HFR production and fuel consumption scale with power level

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -140,15 +140,26 @@
 //
 // Explosion flags for use in fuel recipes
 //
+
+/// Causes a light explosion on meltdown
 #define HYPERTORUS_FLAG_BASE_EXPLOSION (1<<0)
+/// Causes a heavy explosion on meltdown
 #define HYPERTORUS_FLAG_MEDIUM_EXPLOSION (1<<1)
+/// Causes a devastating explosion on meltdown
 #define HYPERTORUS_FLAG_DEVASTATING_EXPLOSION (1<<2)
+/// Causes a radiation pulse on meltdown
 #define HYPERTORUS_FLAG_RADIATION_PULSE (1<<3)
+/// Causes an EMP on meltdown
 #define HYPERTORUS_FLAG_EMP (1<<4)
+/// Small radiation/EMP radius
 #define HYPERTORUS_FLAG_MINIMUM_SPREAD (1<<5)
+/// Medium radiation/EMP radius
 #define HYPERTORUS_FLAG_MEDIUM_SPREAD (1<<6)
+/// Large radiation/EMP radius
 #define HYPERTORUS_FLAG_BIG_SPREAD (1<<7)
+/// Very large radiation/EMP radius
 #define HYPERTORUS_FLAG_MASSIVE_SPREAD (1<<8)
+/// Doubles explosion size and radiation/EMP radius
 #define HYPERTORUS_FLAG_CRITICAL_MELTDOWN (1<<9)
 
 ///High power damage

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -237,8 +237,8 @@
  */
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/moderator_fuel_process(delta_time, production_amount, consumption_amount, datum/gas_mixture/internal_output, moderator_list, datum/hfr_fuel/fuel, fuel_list)
 	// Adjust fusion consumption/production based on this recipe's characteristics
-	var/fuel_consumption = consumption_amount * 0.85 * selected_fuel.fuel_consumption_multiplier
-	var/scaled_production = production_amount * selected_fuel.gas_production_multiplier
+	var/fuel_consumption = consumption_amount * 0.85 * selected_fuel.fuel_consumption_multiplier * max(power_level, 1)
+	var/scaled_production = production_amount * selected_fuel.gas_production_multiplier * max(power_level, 1)
 
 	for(var/gas_id in fuel.requirements)
 		internal_fusion.adjust_moles(gas_id, -min(fuel_list[gas_id], fuel_consumption))


### PR DESCRIPTION
# Document the changes in your pull request

HFR will produce more byproducts and consume more fuel at higher fusion levels. Also added comments to a bunch of flags that didn't have them.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: HFR fuel consumption and gas production scales with power level
/:cl:
