### PR TITLE
You can now change the freezer/heater mode on the thermomachine interface

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/5x4/5x4_oldcryoroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x4/5x4_oldcryoroom.dmm
@@ -31,7 +31,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "l" = (
-/obj/item/circuitboard/machine/thermomachine/freezer,
+/obj/item/circuitboard/machine/thermomachine,
 /turf/open/floor/plasteel/showroomfloor,
 /area/template_noop)
 "n" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -364,7 +364,7 @@
 /obj/item/circuitboard/machine/thermomachine
 	name = "Thermomachine (Machine Board)"
 	icon_state = "engineering"
-	desc = "You can use a screwdriver to switch between heater and freezer."
+	build_path = /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 	var/pipe_layer = PIPING_LAYER_DEFAULT
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
@@ -372,56 +372,15 @@
 		/obj/item/stack/cable_coil = 1,
 		/obj/item/stack/sheet/glass = 1)
 
-#define PATH_FREEZER /obj/machinery/atmospherics/components/unary/thermomachine/freezer
-#define PATH_HEATER  /obj/machinery/atmospherics/components/unary/thermomachine/heater
-
-/obj/item/circuitboard/machine/thermomachine/Initialize(mapload)
+/obj/item/circuitboard/machine/thermomachine/multitool_act(mob/living/user, obj/item/multitool/I)
 	. = ..()
-	if(!build_path)
-		if(prob(50))
-			name = "Freezer (Machine Board)"
-			build_path = PATH_FREEZER
-		else
-			name = "Heater (Machine Board)"
-			build_path = PATH_HEATER
-
-/obj/item/circuitboard/machine/thermomachine/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		var/obj/item/circuitboard/new_type
-		var/new_setting
-		switch(build_path)
-			if(PATH_FREEZER)
-				new_type = /obj/item/circuitboard/machine/thermomachine/heater
-				new_setting = "Heater"
-			if(PATH_HEATER)
-				new_type = /obj/item/circuitboard/machine/thermomachine/freezer
-				new_setting = "Freezer"
-		name = initial(new_type.name)
-		build_path = initial(new_type.build_path)
-		I.play_tool_sound(src)
-		to_chat(user, span_notice("You change the circuitboard setting to \"[new_setting]\"."))
-		return
-
-	if(I.tool_behaviour == TOOL_MULTITOOL)
+	if(istype(I))
 		pipe_layer = (pipe_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (pipe_layer + 1)
 		to_chat(user, "<span class='notice'>You change the circuitboard to layer [pipe_layer].</span>")
-		return
-
-	. = ..()
 
 /obj/item/circuitboard/machine/thermomachine/examine()
 	. = ..()
 	. += "<span class='notice'>It is set to layer [pipe_layer].</span>"
-
-
-/obj/item/circuitboard/machine/thermomachine/heater
-	name = "Heater (Machine Board)"
-	build_path = PATH_HEATER
-
-/obj/item/circuitboard/machine/thermomachine/freezer
-	name = "Freezer (Machine Board)"
-	build_path = PATH_FREEZER
-
 /obj/item/circuitboard/machine/crystallizer
 	name = "Crystallizer (Machine Board)"
 	icon_state = "engineering"
@@ -430,9 +389,6 @@
 		/obj/item/stack/cable_coil = 10,
 		/obj/item/stack/sheet/glass = 10,
 		/obj/item/stack/sheet/plasteel = 5)
-
-#undef PATH_FREEZER
-#undef PATH_HEATER
 
 /obj/item/circuitboard/machine/HFR_fuel_input
 	name = "HFR Fuel Input (Machine Board)"

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -227,7 +227,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer
-	name = "freezer"
+	name = "Thermomachine"
 	icon_state = "freezer"
 	icon_state_off = "freezer"
 	icon_state_on = "freezer_1"
@@ -244,13 +244,13 @@
 		target_temperature = min_temperature
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom
-	name = "cold room freezer"
+	name = "Thermomachine"
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom/Initialize(mapload)
 	. = ..()
 	target_temperature = T0C-80
 /obj/machinery/atmospherics/components/unary/thermomachine/heater
-	name = "heater"
+	name = "Thermomachine"
 	icon_state = "heater"
 	icon_state_off = "heater"
 	icon_state_on = "heater_1"

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -89,11 +89,11 @@
 	if(cooling)
 		target_temperature = min_temperature
 		investigate_log("was set to [target_temperature] K by [key_name(user)]", INVESTIGATE_ATMOS)
-		to_chat(user, "<span class='notice'>You minimize the target temperature on [src] to [target_temperature] K.</span>")
+		balloon_alert(user, "You minimize the target temperature on [src] to [target_temperature] K.")
 	else
 		target_temperature = max_temperature
 		investigate_log("was set to [target_temperature] K by [key_name(user)]", INVESTIGATE_ATMOS)
-		to_chat(user, "<span class='notice'>You maximize the target temperature on [src] to [target_temperature] K.</span>")
+		balloon_alert(user, "You maximize the target temperature on [src] to [target_temperature] K.d")
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_nopipes()
 	cut_overlays()
@@ -112,13 +112,6 @@
 		on = !on
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 		update_icon()
-	return ..()
-
-/obj/machinery/atmospherics/components/unary/thermomachine/AltClick(mob/living/user)
-	if(can_interact(user))
-		target_temperature = T20C
-		investigate_log("was set to [target_temperature] K by [key_name(user)]", INVESTIGATE_ATMOS)
-		balloon_alert(user, "temperature reset to [target_temperature] K")
 	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/process_atmos()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -2,7 +2,7 @@
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
 	icon_state = "freezer"
 
-	name = "thermomachine"
+	name = "Thermomachine"
 	desc = "Heats or cools gas in connected pipes."
 
 	density = TRUE
@@ -17,27 +17,59 @@
 	var/icon_state_on = "freezer_1"
 	var/icon_state_open = "freezer-o"
 
-	var/min_temperature = 0
-	var/max_temperature = 0
+	var/min_temperature = T20C //actual temperature will be defined by RefreshParts() and by the cooling var
+	var/max_temperature = T20C //actual temperature will be defined by RefreshParts() and by the cooling var
 	var/target_temperature = T20C
 	var/heat_capacity = 0
 	var/interactive = TRUE // So mapmakers can disable interaction.
+	var/cooling = TRUE
+	var/base_heating = 140
+	var/base_cooling = 170
 
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize(mapload)
 	. = ..()
 	initialize_directions = dir
+	RefreshParts()
+	update_icon()
+
+/obj/machinery/atmospherics/components/unary/thermomachine/proc/swap_function()
+	cooling = !cooling
+	if(cooling)
+		icon_state_off = "freezer"
+		icon_state_on = "freezer_1"
+		icon_state_open = "freezer-o"
+	else
+		icon_state_off = "heater"
+		icon_state_on = "heater_1"
+		icon_state_open = "heater-o"
+	target_temperature = T20C
+	RefreshParts()
+	update_icon()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/on_construction()
 	var/obj/item/circuitboard/machine/thermomachine/board = circuit
 	if(board)
 		piping_layer = board.pipe_layer
 	..(dir, piping_layer)
+	return ..(dir, piping_layer)
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()
-	var/B
-	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
-		B += M.rating
-	heat_capacity = 5000 * ((B - 1) ** 2)
+	var/calculated_bin_rating
+	for(var/obj/item/stock_parts/matter_bin/bin in component_parts)
+		calculated_bin_rating += bin.rating
+	heat_capacity = 5000 * ((calculated_bin_rating - 1) ** 2)
+	min_temperature = T20C
+	max_temperature = T20C
+	if(cooling)
+		var/calculated_laser_rating
+		for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
+			calculated_laser_rating += laser.rating
+		min_temperature = max(T0C - (base_cooling + calculated_laser_rating * 15), TCMB) //73.15K with T1 stock parts
+	else
+		var/calculated_laser_rating
+		for(var/obj/item/stock_parts/micro_laser/laser in component_parts)
+			calculated_laser_rating += laser.rating
+		max_temperature = T20C + (base_heating * calculated_laser_rating) //573.15K with T1 stock parts
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon()
 	cut_overlays()
@@ -51,6 +83,17 @@
 
 	add_overlay(getpipeimage(icon, "pipe", dir, , piping_layer))
 
+/obj/machinery/atmospherics/components/unary/thermomachine/AltClick(mob/living/user)
+	if(!can_interact(user))
+		return
+	if(cooling)
+		target_temperature = min_temperature
+		investigate_log("was set to [target_temperature] K by [key_name(user)]", INVESTIGATE_ATMOS)
+		to_chat(user, "<span class='notice'>You minimize the target temperature on [src] to [target_temperature] K.</span>")
+	else
+		target_temperature = max_temperature
+		investigate_log("was set to [target_temperature] K by [key_name(user)]", INVESTIGATE_ATMOS)
+		to_chat(user, "<span class='notice'>You maximize the target temperature on [src] to [target_temperature] K.</span>")
 
 /obj/machinery/atmospherics/components/unary/thermomachine/update_icon_nopipes()
 	cut_overlays()
@@ -144,6 +187,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/ui_data(mob/user)
 	var/list/data = list()
 	data["on"] = on
+	data["cooling"] = cooling
 
 	data["min"] = min_temperature
 	data["max"] = max_temperature
@@ -165,6 +209,10 @@
 			on = !on
 			use_power = on ? ACTIVE_POWER_USE : IDLE_POWER_USE
 			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
+			. = TRUE
+		if("cooling")
+			swap_function()
+			investigate_log("was changed to [cooling ? "cooling" : "heating"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 		if("target")
 			var/target = params["target"]
@@ -191,9 +239,7 @@
 	icon_state_off = "freezer"
 	icon_state_on = "freezer_1"
 	icon_state_open = "freezer-o"
-	max_temperature = T20C
-	min_temperature = 170 //actual minimum temperature is defined by RefreshParts()
-	circuit = /obj/item/circuitboard/machine/thermomachine/freezer
+	cooling = TRUE
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on
 	on = TRUE
@@ -210,41 +256,14 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom/Initialize(mapload)
 	. = ..()
 	target_temperature = T0C-80
-
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/RefreshParts()
-	..()
-	var/L
-	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		L += M.rating
-	min_temperature = max(T0C - (initial(min_temperature) + L * 15), TCMB) //73.15K with T1 stock parts
-
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
-		return
-	target_temperature = min_temperature
-
 /obj/machinery/atmospherics/components/unary/thermomachine/heater
 	name = "heater"
 	icon_state = "heater"
 	icon_state_off = "heater"
 	icon_state_on = "heater_1"
 	icon_state_open = "heater-o"
-	max_temperature = 140 //actual maximum temperature is defined by RefreshParts()
-	min_temperature = T20C
-	circuit = /obj/item/circuitboard/machine/thermomachine/heater
+	cooling = FALSE
 
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on
 	on = TRUE
 	icon_state = "heater_1"
-
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/RefreshParts()
-	..()
-	var/L
-	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		L += M.rating
-	max_temperature = T20C + (initial(max_temperature) * L) //573.15K with T1 stock parts
-
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/AltClick(mob/living/user)
-	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
-		return
-	target_temperature = max_temperature

--- a/tgui/packages/tgui/interfaces/ThermoMachine.js
+++ b/tgui/packages/tgui/interfaces/ThermoMachine.js
@@ -8,7 +8,7 @@ export const ThermoMachine = (props, context) => {
   return (
     <Window
       width={300}
-      height={230}>
+      height={250}>
       <Window.Content>
         <Section title="Status">
           <LabeledList>
@@ -36,6 +36,13 @@ export const ThermoMachine = (props, context) => {
               onClick={() => act('power')} />
           )}>
           <LabeledList>
+            <LabeledList.Item label="Setting">
+              <Button
+                icon={data.cooling ? 'cooling' : 'heating'}
+                content={data.cooling ? 'Cooling' : 'Heating'}
+                selected={data.cooling}
+                onClick={() => act('cooling')} />
+            </LabeledList.Item>
             <LabeledList.Item label="Target Temperature">
               <NumberInput
                 animated

--- a/tgui/packages/tgui/interfaces/ThermoMachine.js
+++ b/tgui/packages/tgui/interfaces/ThermoMachine.js
@@ -38,7 +38,7 @@ export const ThermoMachine = (props, context) => {
           <LabeledList>
             <LabeledList.Item label="Setting">
               <Button
-                icon={data.cooling ? 'cooling' : 'heating'}
+                icon={data.cooling ? 'snowflake' : 'fire'}
                 content={data.cooling ? 'Cooling' : 'Heating'}
                 selected={data.cooling}
                 onClick={() => act('cooling')} />


### PR DESCRIPTION
* port https://github.com/tgstation/tgstation/pull/55345
You can now change the freezer/heater mode on the thermomachine interface instead decontrust and screwdriver it

https://github.com/yogstation13/Yogstation/assets/89688125/5396ee37-83cb-463c-baa7-1c6f1daa6bc8


# Document the changes in your pull request
You can now change the freezer/heater mode on the thermomachine interface


# Wiki Documentation
You can now change the freezer/heater mode on the thermomachine interface




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: You can now change the freezer/heater mode on the thermomachine interface
rscdel: You can no longer use screwdriver on freezer/heater board to change mode
/:cl:
