### PR TITLE
Fixes create_new_traitor() making traitors into traitors^2

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -131,6 +131,8 @@
 			continue
 		if(!applicant.mind)
 			continue
+		if(is_syndicate(applicant))
+			continue
 		if(applicant.stat != CONSCIOUS)
 			continue
 		if(applicant.mind.assigned_role in protected_jobs)


### PR DESCRIPTION
# Document the changes in your pull request

is_syndicate() check

# Changelog

:cl:  
bugfix: IAA buttons no longer make IAA into IAA^2
/:cl:
