### PR TITLE
Ultra-Violence IPC heads are no longer damage immune after being roughed up a bit

### DIFF
--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -409,6 +409,8 @@
 	add_verb(H, recalibration)
 	usr.click_intercept = src //probably breaks something, don't know what though
 	H.dna.species.GiveSpeciesFlight(H)//because... c'mon
+	var/obj/item/bodypart/head/ipc/V = H.get_bodypart(BODY_ZONE_HEAD)
+	V.max_damage = 200	//Since their heads don't pop off like they normally would
 
 /datum/martial_art/ultra_violence/on_remove(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

IPC heads now have 200 max damage when they learn the ultra violence martial art. This is because, since they are now immune to dismembering, the normal IPC downside of having lower max health on their head is actually an upside because anyone aiming at their head to kill them ends up doing zero damage after a certain point. Additionally, since IPCs don't have wounds, their head being at max damage essentially has no downside at all, other than the damage itself being present.

# Changelog

:cl:  

tweak: Ultra-violent IPCs now can actually die from their head being smashed in enough

/:cl:
