### PR TITLE
People (me) can no longer make infinite error sprites with a stamp, paper, and some toner.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -46,6 +46,7 @@
 	var/contact_poison // Reagent ID to transfer on contact
 	var/contact_poison_volume = 0
 	var/next_write_time = 0 // prevent crash exploit
+	var/timesstamped = 0 //prevent error exploit
 
 
 /obj/item/paper/pickup(user)
@@ -299,7 +300,8 @@
 			return
 
 	else if(istype(P, /obj/item/stamp))
-
+		if(timesstamped > 25)
+			return
 		if(!in_range(src, user))
 			return
 
@@ -315,6 +317,7 @@
 		add_overlay(stampoverlay)
 
 		to_chat(user, span_notice("You stamp the paper with your rubber stamp."))
+		timesstamped += 1
 
 	if(P.is_hot())
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10))

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -72,11 +72,6 @@
 	if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))
 		to_chat(user, span_notice("You should unfold [src] before changing it."))
 		return
-
-	else if(istype(P, /obj/item/stamp)) 	//we don't randomize stamps on a paperplane
-		internalPaper.attackby(P, user) //spoofed attack to update internal paper.
-		update_icon()
-
 	else if(P.is_hot())
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10))
 			user.visible_message(span_warning("[user] accidentally ignites [user.p_them()]self!"), \

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -72,6 +72,11 @@
 	if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))
 		to_chat(user, span_notice("You should unfold [src] before changing it."))
 		return
+
+	else if(istype(P, /obj/item/stamp)) 	//we don't randomize stamps on a paperplane
+		internalPaper.attackby(P, user) //spoofed attack to update internal paper.
+		update_icon()
+
 	else if(P.is_hot())
 		if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10))
 			user.visible_message(span_warning("[user] accidentally ignites [user.p_them()]self!"), \

--- a/yogstation/code/_globalvars/lists/maintenance_loot.dm
+++ b/yogstation/code/_globalvars/lists/maintenance_loot.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST_INIT(maintenance_loot_makeshift,list(
 	/obj/item/stack/medical/gauze/improvised = W_UNCOMMON,
 	/obj/item/stack/medical/poultice = W_RARE,
 	/obj/item/stack/medical/suture/emergency/makeshift = W_UNCOMMON,
-	/obj/item/stamp/syndi = W_MYTHICAL,
+	/obj/item/stamp/syndiround = W_MYTHICAL,
 	/obj/item/storage/bag/trash = W_COMMON,
 	/obj/item/storage/bag/tray = W_UNCOMMON,
 	/obj/item/storage/belt/military/snack = W_RARE,

--- a/yogstation/code/_globalvars/lists/maintenance_loot.dm
+++ b/yogstation/code/_globalvars/lists/maintenance_loot.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST_INIT(maintenance_loot_makeshift,list(
 	/obj/item/stack/medical/gauze/improvised = W_UNCOMMON,
 	/obj/item/stack/medical/poultice = W_RARE,
 	/obj/item/stack/medical/suture/emergency/makeshift = W_UNCOMMON,
-	/obj/item/stamp/syndiround = W_RARE,
+	/obj/item/stamp/syndiround = W_MYTHICAL,
 	/obj/item/storage/bag/trash = W_COMMON,
 	/obj/item/storage/bag/tray = W_UNCOMMON,
 	/obj/item/storage/belt/military/snack = W_RARE,

--- a/yogstation/code/_globalvars/lists/maintenance_loot.dm
+++ b/yogstation/code/_globalvars/lists/maintenance_loot.dm
@@ -509,7 +509,7 @@ GLOBAL_LIST_INIT(maintenance_loot_makeshift,list(
 	/obj/item/stack/medical/gauze/improvised = W_UNCOMMON,
 	/obj/item/stack/medical/poultice = W_RARE,
 	/obj/item/stack/medical/suture/emergency/makeshift = W_UNCOMMON,
-	/obj/item/stamp/syndiround = W_MYTHICAL,
+	/obj/item/stamp/syndiround = W_RARE,
 	/obj/item/storage/bag/trash = W_COMMON,
 	/obj/item/storage/bag/tray = W_UNCOMMON,
 	/obj/item/storage/belt/military/snack = W_RARE,


### PR DESCRIPTION
# Document the changes in your pull request
If a paper had enough stamps overlayed ontop of it, it would give an errorsprite.
Now it is capped at 25 stamps on a single piece of paper, should be more than enough really.

Also unrelated but changes the mythical maint syndicate stamp loot to syndiround, since its supposed to be incredibly rare, the normal syndi stamp is available on the station on every round by default.

# Changelog
:cl:  
bugfix: you can no longer make infinite error signs out of paper
tweak: syndiround is now available in maintloot instead of non round syndi stamp
/:cl:
