### PR TITLE
Explicitly specify extools in SpacemanDMM configuration

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,2 +1,5 @@
 [langserver]
 dreamchecker = true
+
+[debugger]
+engine = "extools"


### PR DESCRIPTION
I want to make auxtools the default in SpacemanDMM, to avoid confusing new users. This of course will require remaining users of extools to specify such explicitly. Yogstation appears to be the largest holdout.

I would like to someday remove extools support entirely, but that is for another time.