### PR TITLE
Attacking a limb at its damage cap applies some damage to the chest

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -254,8 +254,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define BODY_ZONE_PRECISE_L_FOOT	"l_foot"
 #define BODY_ZONE_PRECISE_R_FOOT	"r_foot"
 
-//We will round to this value in damage calculations.
+/// We will round to this value in damage calculations.
 #define DAMAGE_PRECISION 0.1
+/// Damage transferred to the chest when hitting a limb that has reached the damage cap
+#define DAMAGE_TRANSFER_COEFFICIENT 0.33
 
 //bullet_act() return values
 /// It's a successful hit, whatever that means in the context of the thing it's hitting.

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -293,13 +293,23 @@
 	//back to our regularly scheduled program, we now actually apply damage if there's room below limb damage cap
 	var/can_inflict = max_damage - get_damage()
 	var/total_damage = brute + burn
+	var/surplus_damage = total_damage - can_inflict
+
+	// If the limb is at its maximum damage, apply some of the surplus damage to the chest
+	if(owner && surplus_damage > 0)
+		var/obj/item/bodypart/chest/chest = owner.get_bodypart(BODY_ZONE_CHEST)
+		chest.receive_damage(surplus_damage * DAMAGE_TRANSFER_COEFFICIENT) // the chest should always be there unless something fucked up
+
+	// End early if the limb is at its maximum damage
+	if(can_inflict <= 0)
+		return FALSE
+
+	// Set the damage applied to as much as the limb can handle
 	if(total_damage > can_inflict && total_damage > 0) // TODO: the second part of this check should be removed once disabling is all done
 		brute = round(brute * (can_inflict / total_damage),DAMAGE_PRECISION)
 		burn = round(burn * (can_inflict / total_damage),DAMAGE_PRECISION)
 
-	if(can_inflict <= 0)
-		return FALSE
-
+	// And finally, apply that damage to the limb
 	if(brute)
 		set_brute_dam(brute_dam + brute)
 	if(burn)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Attacking a limb that has reached its damage cap will deal 33% of the damage to the chest instead. Mainly so that attacking a limb will still cause some damage instead of just being invincible as long as only that limb is hit.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: hitting limbs at their damage cap applies some damage to the chest
/:cl:
