### PR TITLE
Increases Worldbreaker tankiness while reducing the damage

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -8,7 +8,7 @@
 #define PLATE_CAP 15 //hard cap of plates to prevent station wide fuckery with worldstomp
 #define PLATE_INTERVAL 15 SECONDS //how often a plate grows
 #define PLATE_REDUCTION 10 //how much armour per plate
-#define PLATE_BREAK 25 //How much damage it takes to break a plate
+#define PLATE_BREAK 15 //How much damage it takes to break a plate
 
 #define COOLDOWN_STOMP 30 SECONDS
 #define STOMP_WINDUP 2 SECONDS //this gets doubled if heavy

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -7,7 +7,7 @@
 #define MAX_PLATES 10 //maximum number of plates that factor into armour (speed decrease scales infinitely)
 #define PLATE_CAP 15 //hard cap of plates to prevent station wide fuckery with worldstomp
 #define PLATE_INTERVAL 15 SECONDS //how often a plate grows
-#define PLATE_REDUCTION 10 //how much DR per plate
+#define PLATE_REDUCTION 10 //how much armour per plate
 #define PLATE_BREAK 25 //How much damage it takes to break a plate
 
 #define COOLDOWN_STOMP 30 SECONDS

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -8,7 +8,7 @@
 #define PLATE_CAP 15 //hard cap of plates to prevent station wide fuckery with worldstomp
 #define PLATE_INTERVAL 15 SECONDS //how often a plate grows
 #define PLATE_REDUCTION 10 //how much DR per plate
-#define PLATE_BREAK 30 //How much damage it takes to break a plate
+#define PLATE_BREAK 25 //How much damage it takes to break a plate
 
 #define COOLDOWN_STOMP 30 SECONDS
 #define STOMP_WINDUP 2 SECONDS //this gets doubled if heavy


### PR DESCRIPTION
I want you to FEEL like an unstoppable juggernaut
even if you don't do much damage

:cl:  
tweak: Worldbreaker Tweaks
tweak: max 100% armour instead of 80%
tweak: removed all AP from every attack (still does 50/50 melee and bomb damage)
tweak: initial part of throw attack does 4 damage instead of 10
tweak: throw collision does 4 damage instead of 5
tweak: leap does 10 damage, increased to 15 if heavy instead of 15/25
tweak: pummel does 10/15 instead of 12/18
tweak: stomp does 10/15 instead of 10/20
tweak: stomp multiplier for direct hit reduced to x2 instead of x4, but applies the heavy multiplier a second time if heavy
tweak: regular punch no longer gets +5 damage
/:cl:
