### PR TITLE
Gives syndie bow a pop requirement

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -615,6 +615,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A modern bow that can fabricate hardlight arrows, designed for silent takedowns of targets."
 	item = /obj/item/gun/ballistic/bow/energy/syndicate
 	cost = 6
+	player_minimum = 25
 	surplus = 25
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
# Document the changes in your pull request

Understaffed crew and security teams do not have the means to deal with someone that is not in their face when attacking them. Syndie bow can be countered with coordination and maneuvering which is not possible with low-pop teams or ghost-town crew.

# Changelog

:cl:  
tweak: Syndie bow now has a 25 pop requirement
/:cl:
