### PR TITLE
Adds the remote signaling button

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -114,6 +114,11 @@
 
 
 /obj/item/assembly/attack_self(mob/user)
+	if(HAS_TRAIT(user, TRAIT_NOINTERACT))
+		to_chat(user, span_notice("You can't use things!"))
+		return
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user) & COMPONENT_NO_INTERACT)
+		return
 	if(!user)
 		return FALSE
 	user.set_machine(src)
@@ -121,6 +126,7 @@
 	return TRUE
 
 /obj/item/assembly/interact(mob/user)
+	add_fingerprint(user)
 	return ui_interact(user)
 
 /obj/item/assembly/ui_host(mob/user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -251,6 +251,7 @@
 /obj/item/assembly/signaler/button
 	name = "remote signaling button"
 	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Configured via multitool. Can't be attached to wires."
+	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "radio"
 	item_state = "radio"
 	attachable = FALSE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -240,3 +240,27 @@
 	if(ispAI(user))
 		return TRUE
 	. = ..()
+
+/// Button signaler
+/// Activated by attack_self instead of UI
+/// UI is instead opened by multitool
+/obj/item/assembly/signaler/button
+	name = "remote signaling button"
+	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Can't be attached to wires."
+	attachable = FALSE
+
+/obj/item/assembly/signaler/button/attack_self(mob/user)
+	if(HAS_TRAIT(user, TRAIT_NOINTERACT))
+		to_chat(user, span_notice("You can't use things!"))
+		return
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF, user) & COMPONENT_NO_INTERACT)
+		return
+	if(!user)
+		return FALSE
+	activate()
+	return TRUE
+
+/obj/item/assembly/signaler/button/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	user.set_machine(src)
+	interact(user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -250,11 +250,10 @@
  */
 /obj/item/assembly/signaler/button
 	name = "remote signaling button"
-	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Configured via multitool. Can't be attached to wires."
+	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Configured via multitool. Cannot receive signals."
 	icon = 'icons/obj/assemblies/new_assemblies.dmi'
 	icon_state = "radio"
 	item_state = "radio"
-	attachable = FALSE
 
 /obj/item/assembly/signaler/button/attack_self(mob/user)
 	if(HAS_TRAIT(user, TRAIT_NOINTERACT))
@@ -265,9 +264,13 @@
 	if(!user)
 		return FALSE
 	activate()
+	pulse()
 	return TRUE
 
 /obj/item/assembly/signaler/button/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
 	user.set_machine(src)
 	interact(user)
+
+/obj/item/assembly/signaler/button/receive_signal(datum/signal/signal)
+	return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -241,12 +241,16 @@
 		return TRUE
 	. = ..()
 
-/// Button signaler
-/// Activated by attack_self instead of UI
-/// UI is instead opened by multitool
+/**
+ * Button signaler
+ *
+ * Activated by attack_self instead of UI
+ *
+ * UI is instead opened by multitool
+ */
 /obj/item/assembly/signaler/button
 	name = "remote signaling button"
-	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Can't be attached to wires."
+	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Configured via multitool. Can't be attached to wires."
 	icon_state = "radio"
 	item_state = "radio"
 	attachable = FALSE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -248,6 +248,7 @@
 	name = "remote signaling button"
 	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Can't be attached to wires."
 	icon_state = "radio"
+	item_state = "radio"
 	attachable = FALSE
 
 /obj/item/assembly/signaler/button/attack_self(mob/user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -247,6 +247,7 @@
 /obj/item/assembly/signaler/button
 	name = "remote signaling button"
 	desc = "A modern design of the remote signaling device, for when you need to signal NOW. Can't be attached to wires."
+	icon_state = "radio"
 	attachable = FALSE
 
 /obj/item/assembly/signaler/button/attack_self(mob/user)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -661,6 +661,15 @@
 	category = list("initial", "T-Comm", "Assemblies")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/signalbutton
+	name = "Remote Signaling Button"
+	id = "signalbutton"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 400, /datum/material/glass = 120)
+	build_path = /obj/item/assembly/signaler/button
+	category = list("initial", "T-Comm", "Assemblies")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/mousetrap
 	name = "Mousetrap"
 	id = "mousetrap"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -10,7 +10,7 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "desttagger", "handlabel", "packagewrap",
 	"destructive_analyzer", "circuit_imprinter", "rack_creator", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand", "ticket_machine", "ticket_remote", "light_tube", "light_bulb",
 	"space_heater", "beaker", "large_beaker", "vial", "large_vial", "bucket", "fork", "tray","plate", "bowl", "mixing_bowl", "drinking_glass", "shot_glass", "shaker", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_38", "sec_38_lethal", "apc_control", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "blastdoorcontroller", "aac_electronics", "mousetrap",
-	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","wallframe/flasher", "rsf", "oven_tray", "bounced_radio", "signaler", "inspector_booth", "intercom_frame", "infrared_emitter", "health_sensor", "timer", "voice_analyser", "camera_assembly", "newscaster_frame", "prox_sensor", "flashlight", "extinguisher", "pocketfireextinguisher")
+	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","wallframe/flasher", "rsf", "oven_tray", "bounced_radio", "signaler", "signalbutton", "inspector_booth", "intercom_frame", "infrared_emitter", "health_sensor", "timer", "voice_analyser", "camera_assembly", "newscaster_frame", "prox_sensor", "flashlight", "extinguisher", "pocketfireextinguisher")
 
 /datum/techweb_node/mmi
 	id = "mmi"
@@ -1266,4 +1266,4 @@
 		var/datum/techweb_node/TN = i
 		TW.add_point_list(TN.research_costs)
 	return TW.printout_points()
-	
+

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -2,6 +2,7 @@
 	products = list(/obj/item/assembly/prox_sensor = 5,
 					/obj/item/assembly/igniter = 3,
 					/obj/item/assembly/signaler = 4,
+					/obj/item/assembly/signaler/button = 2,
 					/obj/item/wirecutters = 1,
 					/obj/item/cartridge/signal = 4)
 	premium = list(/obj/item/laserlevel = 1)

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -3,7 +3,7 @@
 	icon = 'yogstation/icons/obj/clothing/suits.dmi'
 	name = "network admin's winter coat"
 	icon_state = "coatsignaltech"
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/radio, /obj/item/analyzer, /obj/item/multitool, /obj/item/assembly/signaler, /obj/item/tank/internals/plasmaman, /obj/item/tank/internals/ipc_coolant)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/radio, /obj/item/analyzer, /obj/item/multitool, /obj/item/assembly/signaler, /obj/item/assembly/signaler/button, /obj/item/tank/internals/plasmaman, /obj/item/tank/internals/ipc_coolant)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/tcomms
 
 /obj/item/clothing/head/hooded/winterhood/engineering/tcomms
@@ -371,7 +371,7 @@
 	icon_state = "northern"
 	item_state = "northern"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/northern
-	
+
 /obj/item/clothing/head/hooded/winterhood/northern
 	name = "northern hat"
 	desc = "only this, and nothing more."


### PR DESCRIPTION
# Document the changes in your pull request

Activates on attack_self instead of being forced to use UI

For when you need to blow up NOW

Configured via multitool

Can be attached to another assembly to pulse that aswell

# Changelog

:cl:  
rscadd: Added the remote signaling button, now available Vendomats, autolathes, and engi/sci protolathes
/:cl:
