### PR TITLE
Rod of white no longer heals dead people

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -468,11 +468,9 @@
 					continue
 				var/total_healing = (min(L.getBruteLoss(), 3.5*efficiency) + min(L.getFireLoss(), 3.5*efficiency) + min(L.getOxyLoss(), 3.5*efficiency) + min(L.getToxLoss(), 3.5 * efficiency))
 				GLOB.religious_sect.adjust_favor(total_healing * 0.2)
-			if(ispath(rod_type, /obj/item/rod_of_asclepius/white) && L.stat == DEAD)
-				continue
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
-			if(iscarbon(L))	
+			if(iscarbon(L))
 				L.adjustBruteLoss(-3.5 * efficiency)
 				L.adjustFireLoss(-3.5 * efficiency)
 				L.adjustToxLoss(-3.5 * efficiency, forced = TRUE) //Because Slime People are people too

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -464,11 +464,15 @@
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
 			if(ispath(rod_type, /obj/item/rod_of_asclepius/white)) //Used for adjusting the Holy Light Sect Favor from white rod healing.
+				if(L.stat == DEAD)
+					continue
 				var/total_healing = (min(L.getBruteLoss(), 3.5*efficiency) + min(L.getFireLoss(), 3.5*efficiency) + min(L.getOxyLoss(), 3.5*efficiency) + min(L.getToxLoss(), 3.5 * efficiency))
 				GLOB.religious_sect.adjust_favor(total_healing * 0.2)
+			if(ispath(rod_type, /obj/item/rod_of_asclepius/white) && L.stat == DEAD)
+				continue
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
-			if(iscarbon(L))
+			if(iscarbon(L))	
 				L.adjustBruteLoss(-3.5 * efficiency)
 				L.adjustFireLoss(-3.5 * efficiency)
 				L.adjustToxLoss(-3.5 * efficiency, forced = TRUE) //Because Slime People are people too


### PR DESCRIPTION

# Document the changes in your pull request
Basically, some chaps got savvy and decided to stack 10 burning corpses in a room to gain favor instead of healing people as they SHOULD be. While that is really cool and ritualistic, it goes against the design of Holy Light.

Normal rod still heals all the same, so lava land loot isn't nerfed, and the only change from this is that chappies white rod should force medbay out of their role a bit less while still not making the rod of white a neverpick since it nerfs your favor gain.
Tested the changes. Pinky Winky Promise.


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Rod of white can no longer heal dead people.
/:cl:
