### PR TITLE
New Chem Recipes for Traitors only

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -135,7 +135,7 @@
 	mix_message = span_danger("The mixture suddenly flashes a brilliant red, leaving behind a sickening mass of foul green and orange chunks.")
 	required_temp = 380
 
-	/datum/chemical_reaction/initropidril
+/datum/chemical_reaction/initropidril
 	name = "Initropidril"
 	id = /datum/reagent/toxin/initropidril
 	results = list(/datum/reagent/toxin/initropidril = 3)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -119,3 +119,26 @@
 	results = list(/datum/reagent/toxin/plasma = 12) //One sheet of hot ice makes 200m of plasma
 	required_reagents = list(/datum/reagent/toxin/hot_ice = 1)
 	required_temp = T0C + 30 //Don't burst into flames when you melt
+
+/datum/chemical_reaction/polonium
+	name = "Polonium"
+	id = /datum/reagent/toxin/polonium
+	results = list(/datum/reagent/toxin/polonium = 1)
+	required_reagents = list(/datum/reagent/redspace = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/uranium= 1)
+	mix_message = span_danger("The mixture suddenly flashes a brilliant red, leaving behind a slurry of pale green glowing slush.")
+
+/datum/chemical_reaction/spewium
+	name = "Spewium"
+	id = /datum/reagent/toxin/spewium
+	results = list(/datum/reagent/toxin/spewium = 1)
+	required_reagents = list(/datum/reagent/liquidgibs = 1, /datum/reagent/consumable/milk = 1, /datum/reagent/redspace = 1)
+	mix_message = span_danger("The mixture suddenly flashes a brilliant red, leaving behind a sickening mass of foul green and orange chunks.")
+	required_temp = 380
+
+	/datum/chemical_reaction/initropidril
+	name = "Initropidril"
+	id = /datum/reagent/toxin/initropidril
+	results = list(/datum/reagent/toxin/initropidril = 3)
+	required_reagents = list(/datum/reagent/medicine/corazone = 1, /datum/reagent/toxin/cyanide = 1, /datum/reagent/redspace = 4)
+	mix_message = span_danger("The mixture suddenly flashes a brilliant red, leaving behind a swirling mixture of smoking purple liquid.")
+	required_temp = 670


### PR DESCRIPTION
Adds recipes for 3 previously uncraftable chems that requires ground telecrystals to make.

# This adds recipes for 3 chems, spewium, polonium, and initropidril. All of these were previously not craftable due to being very powerful but with the addition of redspace (ground telecrystals), I posit that this is a system that allows truly powerful chems to be crafted while still limiting the amount that can be crafted. 

1tc gives 20u of redspace, the ratios of the recipes determine that 1tc gives 20u of polonium and spewium and 15u of initropidril. Currently, the poison kit is 5tc and gives 330u worth of poisons and unique larger 30u syringes. In comparison, 5tc or 100u worth of redspace would only get you 75u of initropidril. Thus it has serious diminishing returns the more tc you spend and if you're planning on using them for ammo in a syringe gun, you're probably better off still using the kit. 

The intention of this is really to give people who have 1 or 2tc left, something that is genuinely useful rather than going to waste. More than the chemist using this to kill all of sec, the intention of the pr is to say allow the chef to poison a single target's meal. 


# Wiki Documentation

polonium - 1 part Redspace, 1 part Nuka Cola, and 1 part Uranium results in 1 unit of Polonium 
initropidril - 1 part Corazon, 1 part Cyanide, and 4 parts Redspace results in 3 units of Initropidril once heated to 670k 
spewium - 1 part Milk, 1 part Liquid Gibs, and 1 part Redspace results in 1 unit of Spewium once heated to 380k
# Changelog
adds a recipe for polonium, initropidril, and spewium that uses telecrystals to create

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: adds recipes for traitors to make previously the uncraftable chems polonium, initropidril, and spewium
/:cl:
