### PR TITLE
Reinforces Reebe so Clockies cannot escape

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -102,14 +102,6 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"aG" = (
-/obj/effect/clockwork/servant_blocker,
-/obj/structure/lattice/catwalk/clockwork,
-/obj/effect/clockwork/servant_blocker{
-	dir = 1
-	},
-/turf/open/indestructible/reebe_void,
-/area/reebe/city_of_cogs)
 "aH" = (
 /obj/effect/landmark/servant_of_ratvar,
 /turf/open/floor/clockwork/reebe,
@@ -170,16 +162,31 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
+"ef" = (
+/obj/structure/lattice/catwalk/clockwork,
+/obj/effect/clockwork/servant_blocker{
+	dir = 1
+	},
+/turf/open/indestructible/reebe_void,
+/area/reebe/city_of_cogs)
 "er" = (
 /obj/effect/landmark/servant_of_ratvar/scarab,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
 "fi" = (
 /obj/machinery/stasis{
-	dir = 4;
-	color = "#FF8000"
+	color = "#FF8000";
+	dir = 4
 	},
 /turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"hA" = (
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/structure/grille/ratvar,
+/obj/effect/clockwork/servant_blocker{
+	dir = 1
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
 "mj" = (
 /obj/structure/table/reinforced/brass,
@@ -3468,17 +3475,17 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
 ab
 ab
 ab
@@ -3558,8 +3565,8 @@ ab
 ab
 ab
 ab
-aa
-aa
+hA
+hA
 az
 mj
 ai
@@ -3569,8 +3576,8 @@ aj
 ai
 at
 aF
-aa
-aa
+hA
+hA
 ab
 ab
 ab
@@ -3649,7 +3656,7 @@ ab
 ab
 ab
 ab
-aa
+hA
 au
 aj
 aj
@@ -3661,7 +3668,7 @@ aE
 aj
 at
 aF
-aa
+hA
 ab
 ab
 ab
@@ -3738,9 +3745,9 @@ ab
 ab
 ab
 ab
-aa
-aa
-aa
+hA
+hA
+hA
 av
 aj
 aj
@@ -3752,9 +3759,9 @@ ai
 aj
 aj
 aj
-aa
-aa
-aa
+hA
+hA
+hA
 ab
 ab
 ab
@@ -3828,8 +3835,8 @@ ab
 ab
 ab
 ab
-aa
-aa
+hA
+hA
 au
 ax
 aH
@@ -3845,8 +3852,8 @@ aj
 aH
 aj
 ay
-aa
-aa
+hA
+hA
 ab
 ab
 ab
@@ -3919,7 +3926,7 @@ ab
 ab
 ab
 ab
-aa
+hA
 bj
 aj
 aj
@@ -3937,7 +3944,7 @@ aj
 aj
 av
 ay
-aa
+hA
 ab
 ab
 ab
@@ -4010,7 +4017,7 @@ ab
 ab
 ab
 ab
-aa
+hA
 wm
 aj
 aj
@@ -4028,7 +4035,7 @@ ax
 aj
 aj
 av
-aa
+hA
 ab
 ab
 ab
@@ -4087,21 +4094,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
 ai
 ag
 ai
@@ -4119,21 +4126,21 @@ ah
 ai
 aE
 ai
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
+hA
 aa
 aa
 aa
@@ -4178,7 +4185,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -4224,7 +4231,7 @@ aj
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4269,7 +4276,7 @@ aP
 ac
 ac
 ac
-aG
+ef
 aj
 aO
 aj
@@ -4315,7 +4322,7 @@ aj
 aO
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4360,7 +4367,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -4406,7 +4413,7 @@ aj
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4451,7 +4458,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -4497,7 +4504,7 @@ aj
 aj
 aO
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4542,7 +4549,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aO
 aj
@@ -4588,7 +4595,7 @@ aO
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4633,7 +4640,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -4679,7 +4686,7 @@ aj
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4724,8 +4731,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -4769,8 +4776,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -4816,7 +4823,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aO
 aj
@@ -4860,7 +4867,7 @@ aO
 aj
 aO
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4907,7 +4914,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -4951,7 +4958,7 @@ aj
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -4998,8 +5005,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aO
@@ -5041,8 +5048,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5090,7 +5097,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aj
@@ -5132,7 +5139,7 @@ aj
 aj
 aO
 aj
-aG
+ef
 ac
 ac
 ac
@@ -5181,8 +5188,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5222,8 +5229,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5273,7 +5280,7 @@ ah
 ac
 ac
 ac
-aG
+ef
 aj
 aj
 aO
@@ -5313,7 +5320,7 @@ aj
 aj
 aj
 aj
-aG
+ef
 ac
 ac
 ac
@@ -5364,8 +5371,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5403,8 +5410,8 @@ aj
 aO
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5456,8 +5463,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aO
@@ -5493,8 +5500,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5548,8 +5555,8 @@ ah
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5583,8 +5590,8 @@ aj
 aO
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5640,8 +5647,8 @@ ac
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5673,8 +5680,8 @@ aO
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5732,8 +5739,8 @@ ac
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aO
@@ -5763,8 +5770,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5824,8 +5831,8 @@ ac
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5853,8 +5860,8 @@ aO
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -5916,8 +5923,8 @@ ac
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -5943,8 +5950,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -6008,8 +6015,8 @@ ac
 ac
 ac
 ac
-aG
-aG
+ef
+ef
 aj
 aj
 aj
@@ -6033,8 +6040,8 @@ aj
 aj
 aj
 aj
-aG
-aG
+ef
+ef
 ac
 ac
 ac
@@ -6100,9 +6107,9 @@ ac
 ac
 ac
 ac
-aG
-aG
-aG
+ef
+ef
+ef
 aj
 aj
 aj
@@ -6122,9 +6129,9 @@ aj
 aj
 aj
 aj
-aG
-aG
-aG
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6193,9 +6200,9 @@ ac
 ac
 ac
 ac
-aG
-aG
-aG
+ef
+ef
+ef
 aj
 aj
 aj
@@ -6211,9 +6218,9 @@ aj
 aj
 aj
 aj
-aG
-aG
-aG
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6286,10 +6293,10 @@ ac
 ac
 ac
 ac
-aG
-aG
-aG
-aG
+ef
+ef
+ef
+ef
 aj
 aj
 aj
@@ -6299,10 +6306,10 @@ aj
 aj
 aj
 aj
-aG
-aG
-aG
-aG
+ef
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6380,17 +6387,17 @@ ac
 ac
 ac
 ac
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+ef
+ef
+ef
+ef
+ef
+ef
+ef
+ef
+ef
+ef
+ef
 ac
 ac
 ac

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -224,13 +224,6 @@
 /obj/structure/window/reinforced/clockwork/fulltile,
 /turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
-"um" = (
-/obj/effect/clockwork/servant_blocker,
-/obj/structure/grille/ratvar,
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/indestructible/clock_spawn_room,
-/area/reebe/city_of_cogs)
 "wm" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/kitchen/fork{
@@ -4112,7 +4105,7 @@ aa
 aa
 aa
 aa
-um
+ty
 ty
 ty
 ty

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -162,6 +162,13 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
+"ef" = (
+/obj/structure/lattice/catwalk/clockwork,
+/obj/effect/clockwork/servant_blocker{
+	dir = 1
+	},
+/turf/open/indestructible/reebe_void,
+/area/reebe/city_of_cogs)
 "er" = (
 /obj/effect/landmark/servant_of_ratvar/scarab,
 /turf/open/floor/clockwork/reebe,
@@ -172,6 +179,11 @@
 	dir = 4
 	},
 /turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"fT" = (
+/obj/structure/lattice/catwalk/clockwork,
+/obj/effect/clockwork/servant_blocker,
+/turf/open/indestructible/reebe_void,
 /area/reebe/city_of_cogs)
 "mj" = (
 /obj/structure/table/reinforced/brass,
@@ -206,16 +218,18 @@
 /obj/item/paper/servant_primer/infirmarypaper,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"ry" = (
-/obj/structure/lattice/catwalk/clockwork,
+"ty" = (
 /obj/effect/clockwork/servant_blocker,
-/turf/open/indestructible/reebe_void,
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
-"sl" = (
-/obj/structure/lattice/catwalk/clockwork,
+"um" = (
 /obj/effect/clockwork/servant_blocker,
-/obj/effect/clockwork/servant_blocker,
-/turf/open/indestructible/reebe_void,
+/obj/structure/grille/ratvar,
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
 "wm" = (
 /obj/structure/table/reinforced/brass,
@@ -237,19 +251,6 @@
 /obj/structure/table/reinforced/brass,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"An" = (
-/obj/effect/clockwork/servant_blocker,
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/indestructible/clock_spawn_room,
-/area/reebe/city_of_cogs)
-"Bg" = (
-/obj/effect/clockwork/servant_blocker,
-/obj/structure/grille/ratvar,
-/obj/structure/grille/ratvar,
-/obj/structure/window/reinforced/clockwork/fulltile,
-/turf/open/indestructible/clock_spawn_room,
-/area/reebe/city_of_cogs)
 "Ct" = (
 /turf/closed/indestructible/riveted,
 /area/reebe)
@@ -257,6 +258,14 @@
 /obj/item/clockwork/alloy_shards,
 /obj/effect/landmark/servant_of_ratvar/scarab,
 /turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"Qp" = (
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/effect/clockwork/servant_blocker{
+	dir = 1
+	},
+/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
 
 (1,1,1) = {"
@@ -3484,17 +3493,17 @@ ab
 ab
 ab
 ab
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
 ab
 ab
 ab
@@ -3574,8 +3583,8 @@ ab
 ab
 ab
 ab
-An
-An
+ty
+ty
 az
 mj
 ai
@@ -3585,8 +3594,8 @@ aj
 ai
 at
 aF
-An
-An
+Qp
+Qp
 ab
 ab
 ab
@@ -3665,7 +3674,7 @@ ab
 ab
 ab
 ab
-An
+ty
 au
 aj
 aj
@@ -3677,7 +3686,7 @@ aE
 aj
 at
 aF
-An
+Qp
 ab
 ab
 ab
@@ -3754,9 +3763,9 @@ ab
 ab
 ab
 ab
-An
-An
-An
+ty
+ty
+ty
 av
 aj
 aj
@@ -3768,9 +3777,9 @@ ai
 aj
 aj
 aj
-An
-An
-An
+Qp
+Qp
+Qp
 ab
 ab
 ab
@@ -3844,8 +3853,8 @@ ab
 ab
 ab
 ab
-An
-An
+ty
+ty
 au
 ax
 aH
@@ -3861,8 +3870,8 @@ aj
 aH
 aj
 ay
-An
-An
+Qp
+Qp
 ab
 ab
 ab
@@ -3935,7 +3944,7 @@ ab
 ab
 ab
 ab
-An
+ty
 bj
 aj
 aj
@@ -3953,7 +3962,7 @@ aj
 aj
 av
 ay
-An
+Qp
 ab
 ab
 ab
@@ -4026,7 +4035,7 @@ ab
 ab
 ab
 ab
-An
+ty
 wm
 aj
 aj
@@ -4044,7 +4053,7 @@ ax
 aj
 aj
 av
-An
+Qp
 ab
 ab
 ab
@@ -4103,21 +4112,21 @@ aa
 aa
 aa
 aa
-Bg
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
+um
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
 ai
 ag
 ai
@@ -4135,21 +4144,21 @@ ah
 ai
 aE
 ai
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-An
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
+Qp
 aa
 aa
 aa
@@ -4194,7 +4203,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -4240,7 +4249,7 @@ aj
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4285,7 +4294,7 @@ aP
 ac
 ac
 ac
-ry
+fT
 aj
 aO
 aj
@@ -4331,7 +4340,7 @@ aj
 aO
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4376,7 +4385,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -4422,7 +4431,7 @@ aj
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4467,7 +4476,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -4513,7 +4522,7 @@ aj
 aj
 aO
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4558,7 +4567,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aO
 aj
@@ -4604,7 +4613,7 @@ aO
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4649,7 +4658,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -4695,7 +4704,7 @@ aj
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4740,8 +4749,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -4785,8 +4794,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -4832,7 +4841,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aO
 aj
@@ -4876,7 +4885,7 @@ aO
 aj
 aO
 aj
-ry
+ef
 ac
 ac
 ac
@@ -4923,7 +4932,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -4967,7 +4976,7 @@ aj
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -5014,8 +5023,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aO
@@ -5057,8 +5066,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5106,7 +5115,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aj
@@ -5148,7 +5157,7 @@ aj
 aj
 aO
 aj
-ry
+ef
 ac
 ac
 ac
@@ -5197,8 +5206,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5238,8 +5247,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5289,7 +5298,7 @@ ah
 ac
 ac
 ac
-ry
+fT
 aj
 aj
 aO
@@ -5329,7 +5338,7 @@ aj
 aj
 aj
 aj
-ry
+ef
 ac
 ac
 ac
@@ -5380,8 +5389,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5419,8 +5428,8 @@ aj
 aO
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5472,8 +5481,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aO
@@ -5509,8 +5518,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5564,8 +5573,8 @@ ah
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5599,8 +5608,8 @@ aj
 aO
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5656,8 +5665,8 @@ ac
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5689,8 +5698,8 @@ aO
 aj
 aj
 aj
-sl
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5748,8 +5757,8 @@ ac
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aO
@@ -5779,8 +5788,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5840,8 +5849,8 @@ ac
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5869,8 +5878,8 @@ aO
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -5932,8 +5941,8 @@ ac
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -5959,8 +5968,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -6024,8 +6033,8 @@ ac
 ac
 ac
 ac
-ry
-ry
+fT
+fT
 aj
 aj
 aj
@@ -6049,8 +6058,8 @@ aj
 aj
 aj
 aj
-ry
-ry
+ef
+ef
 ac
 ac
 ac
@@ -6116,9 +6125,9 @@ ac
 ac
 ac
 ac
-ry
-ry
-ry
+fT
+fT
+fT
 aj
 aj
 aj
@@ -6138,9 +6147,9 @@ aj
 aj
 aj
 aj
-ry
-ry
-ry
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6209,9 +6218,9 @@ ac
 ac
 ac
 ac
-ry
-ry
-ry
+fT
+fT
+fT
 aj
 aj
 aj
@@ -6227,9 +6236,9 @@ aj
 aj
 aj
 aj
-ry
-ry
-ry
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6302,10 +6311,10 @@ ac
 ac
 ac
 ac
-ry
-ry
-ry
-ry
+fT
+fT
+fT
+fT
 aj
 aj
 aj
@@ -6315,10 +6324,10 @@ aj
 aj
 aj
 aj
-ry
-ry
-ry
-ry
+ef
+ef
+ef
+ef
 ac
 ac
 ac
@@ -6396,17 +6405,17 @@ ac
 ac
 ac
 ac
-ry
-ry
-ry
-ry
-ry
-ry
-ry
-ry
-ry
-ry
-ry
+fT
+fT
+fT
+fT
+fT
+fT
+fT
+fT
+fT
+fT
+fT
 ac
 ac
 ac

--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -162,13 +162,6 @@
 	},
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
-"ef" = (
-/obj/structure/lattice/catwalk/clockwork,
-/obj/effect/clockwork/servant_blocker{
-	dir = 1
-	},
-/turf/open/indestructible/reebe_void,
-/area/reebe/city_of_cogs)
 "er" = (
 /obj/effect/landmark/servant_of_ratvar/scarab,
 /turf/open/floor/clockwork/reebe,
@@ -179,14 +172,6 @@
 	dir = 4
 	},
 /turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
-"hA" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille/ratvar,
-/obj/effect/clockwork/servant_blocker{
-	dir = 1
-	},
-/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
 "mj" = (
 /obj/structure/table/reinforced/brass,
@@ -221,6 +206,17 @@
 /obj/item/paper/servant_primer/infirmarypaper,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
+"ry" = (
+/obj/structure/lattice/catwalk/clockwork,
+/obj/effect/clockwork/servant_blocker,
+/turf/open/indestructible/reebe_void,
+/area/reebe/city_of_cogs)
+"sl" = (
+/obj/structure/lattice/catwalk/clockwork,
+/obj/effect/clockwork/servant_blocker,
+/obj/effect/clockwork/servant_blocker,
+/turf/open/indestructible/reebe_void,
+/area/reebe/city_of_cogs)
 "wm" = (
 /obj/structure/table/reinforced/brass,
 /obj/item/kitchen/fork{
@@ -240,6 +236,19 @@
 "wT" = (
 /obj/structure/table/reinforced/brass,
 /turf/open/floor/clockwork/reebe,
+/area/reebe/city_of_cogs)
+"An" = (
+/obj/effect/clockwork/servant_blocker,
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/indestructible/clock_spawn_room,
+/area/reebe/city_of_cogs)
+"Bg" = (
+/obj/effect/clockwork/servant_blocker,
+/obj/structure/grille/ratvar,
+/obj/structure/grille/ratvar,
+/obj/structure/window/reinforced/clockwork/fulltile,
+/turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
 "Ct" = (
 /turf/closed/indestructible/riveted,
@@ -3475,17 +3484,17 @@ ab
 ab
 ab
 ab
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
 ab
 ab
 ab
@@ -3565,8 +3574,8 @@ ab
 ab
 ab
 ab
-hA
-hA
+An
+An
 az
 mj
 ai
@@ -3576,8 +3585,8 @@ aj
 ai
 at
 aF
-hA
-hA
+An
+An
 ab
 ab
 ab
@@ -3656,7 +3665,7 @@ ab
 ab
 ab
 ab
-hA
+An
 au
 aj
 aj
@@ -3668,7 +3677,7 @@ aE
 aj
 at
 aF
-hA
+An
 ab
 ab
 ab
@@ -3745,9 +3754,9 @@ ab
 ab
 ab
 ab
-hA
-hA
-hA
+An
+An
+An
 av
 aj
 aj
@@ -3759,9 +3768,9 @@ ai
 aj
 aj
 aj
-hA
-hA
-hA
+An
+An
+An
 ab
 ab
 ab
@@ -3835,8 +3844,8 @@ ab
 ab
 ab
 ab
-hA
-hA
+An
+An
 au
 ax
 aH
@@ -3852,8 +3861,8 @@ aj
 aH
 aj
 ay
-hA
-hA
+An
+An
 ab
 ab
 ab
@@ -3926,7 +3935,7 @@ ab
 ab
 ab
 ab
-hA
+An
 bj
 aj
 aj
@@ -3944,7 +3953,7 @@ aj
 aj
 av
 ay
-hA
+An
 ab
 ab
 ab
@@ -4017,7 +4026,7 @@ ab
 ab
 ab
 ab
-hA
+An
 wm
 aj
 aj
@@ -4035,7 +4044,7 @@ ax
 aj
 aj
 av
-hA
+An
 ab
 ab
 ab
@@ -4094,21 +4103,21 @@ aa
 aa
 aa
 aa
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
+Bg
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
 ai
 ag
 ai
@@ -4126,21 +4135,21 @@ ah
 ai
 aE
 ai
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
-hA
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
 aa
 aa
 aa
@@ -4185,7 +4194,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -4231,7 +4240,7 @@ aj
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4276,7 +4285,7 @@ aP
 ac
 ac
 ac
-ef
+ry
 aj
 aO
 aj
@@ -4322,7 +4331,7 @@ aj
 aO
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4367,7 +4376,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -4413,7 +4422,7 @@ aj
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4458,7 +4467,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -4504,7 +4513,7 @@ aj
 aj
 aO
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4549,7 +4558,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aO
 aj
@@ -4595,7 +4604,7 @@ aO
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4640,7 +4649,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -4686,7 +4695,7 @@ aj
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4731,8 +4740,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -4776,8 +4785,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -4823,7 +4832,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aO
 aj
@@ -4867,7 +4876,7 @@ aO
 aj
 aO
 aj
-ef
+ry
 ac
 ac
 ac
@@ -4914,7 +4923,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -4958,7 +4967,7 @@ aj
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -5005,8 +5014,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aO
@@ -5048,8 +5057,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5097,7 +5106,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aj
@@ -5139,7 +5148,7 @@ aj
 aj
 aO
 aj
-ef
+ry
 ac
 ac
 ac
@@ -5188,8 +5197,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5229,8 +5238,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5280,7 +5289,7 @@ ah
 ac
 ac
 ac
-ef
+ry
 aj
 aj
 aO
@@ -5320,7 +5329,7 @@ aj
 aj
 aj
 aj
-ef
+ry
 ac
 ac
 ac
@@ -5371,8 +5380,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5410,8 +5419,8 @@ aj
 aO
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5463,8 +5472,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aO
@@ -5500,8 +5509,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5555,8 +5564,8 @@ ah
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5590,8 +5599,8 @@ aj
 aO
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5647,8 +5656,8 @@ ac
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5680,8 +5689,8 @@ aO
 aj
 aj
 aj
-ef
-ef
+sl
+ry
 ac
 ac
 ac
@@ -5739,8 +5748,8 @@ ac
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aO
@@ -5770,8 +5779,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5831,8 +5840,8 @@ ac
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5860,8 +5869,8 @@ aO
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -5923,8 +5932,8 @@ ac
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -5950,8 +5959,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -6015,8 +6024,8 @@ ac
 ac
 ac
 ac
-ef
-ef
+ry
+ry
 aj
 aj
 aj
@@ -6040,8 +6049,8 @@ aj
 aj
 aj
 aj
-ef
-ef
+ry
+ry
 ac
 ac
 ac
@@ -6107,9 +6116,9 @@ ac
 ac
 ac
 ac
-ef
-ef
-ef
+ry
+ry
+ry
 aj
 aj
 aj
@@ -6129,9 +6138,9 @@ aj
 aj
 aj
 aj
-ef
-ef
-ef
+ry
+ry
+ry
 ac
 ac
 ac
@@ -6200,9 +6209,9 @@ ac
 ac
 ac
 ac
-ef
-ef
-ef
+ry
+ry
+ry
 aj
 aj
 aj
@@ -6218,9 +6227,9 @@ aj
 aj
 aj
 aj
-ef
-ef
-ef
+ry
+ry
+ry
 ac
 ac
 ac
@@ -6293,10 +6302,10 @@ ac
 ac
 ac
 ac
-ef
-ef
-ef
-ef
+ry
+ry
+ry
+ry
 aj
 aj
 aj
@@ -6306,10 +6315,10 @@ aj
 aj
 aj
 aj
-ef
-ef
-ef
-ef
+ry
+ry
+ry
+ry
 ac
 ac
 ac
@@ -6387,17 +6396,17 @@ ac
 ac
 ac
 ac
-ef
-ef
-ef
-ef
-ef
-ef
-ef
-ef
-ef
-ef
-ef
+ry
+ry
+ry
+ry
+ry
+ry
+ry
+ry
+ry
+ry
+ry
 ac
 ac
 ac


### PR DESCRIPTION
# Document the changes in your pull request

Fixed Reebe so that servant_blockers are extended along the glass walls on the western side. Also removed the double-layer of blockers that made up the ring.

# Changelog

:cl:  
bugfix: Fixed double blocker tiles on the main ring
tweak: Added blockers under the western glass wall
/:cl:
