### PR TITLE
Remove "Sheltered" trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -230,7 +230,6 @@
 #define TRAIT_UNINTELLIGIBLE_SPEECH "unintelligible-speech"
 #define TRAIT_UNSTABLE			"unstable"
 #define TRAIT_OIL_FRIED			"oil_fried"
-#define TRAIT_SHELTERED			"sheltered"
 #define TRAIT_RANDOM_ACCENT		"random_accent"
 #define TRAIT_MEDICALIGNORE     "medical_ignore"
 #define TRAIT_PASSTABLE			"passtable"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -626,28 +626,6 @@
 	lose_text = span_notice("Your mind finally feels calm.")
 	medical_record_text = "Patient's mind is in a vulnerable state, and cannot recover from traumatic events."
 
-/datum/quirk/sheltered
-	name = "Sheltered"
-	desc = "You never learned to speak galactic common."
-	icon = "comment-dots"
-	value = -2
-	mob_trait = TRAIT_SHELTERED
-	gain_text = span_danger("You do not speak galactic common.")
-	lose_text = span_notice("You start to put together how to speak galactic common.")
-	medical_record_text = "Patient looks perplexed when questioned in galactic common."
-
-/datum/quirk/sheltered/on_clone(data)
-	var/mob/living/carbon/human/H = quirk_holder
-	H.remove_language(/datum/language/common, FALSE, TRUE)
-	if(!H.get_selected_language())
-		H.grant_language(/datum/language/japanese)
-
-/datum/quirk/sheltered/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	H.remove_language(/datum/language/common, FALSE, TRUE)
-	if(!H.get_selected_language())
-		H.grant_language(/datum/language/japanese)
-
 /datum/quirk/allergic
 	name = "Allergic Reaction"
 	desc = "You have had an allergic reaction to medicine in the past. Better stay away from it!"


### PR DESCRIPTION
# Document the changes in your pull request

This pull request removes the sheltered quirk from the codebase.

My justification for this is twofold:

1:
I do not think it adds much to the game, to have a group of people who can only speak to one another. I think that role should belong only to the mime, who is already unable to speak. This is ultimately a value judgement, and I happen to believe that this really does not add much value. 
I believe it actively takes value away, in that it adds disabilities which can be not just the user's problem. For example, a head of staff having this quirk enabled messes with everyone else as well, not just this person.

2:
I think they should not know *Japanese*. This doesn't necessarily require the quirk to be deleted, but I'm unsure what else to replace the language which. I'd be happy with another language taking its place, but I'm not really that fond of *ninjas* and people with a "negative" quirk speaking the same language. Especially not when that language was meant to make it so the *ninja* couldn't communicate.

# Wiki Documentation

https://wiki.yogstation.net/wiki/Quirks should be updated

# Changelog

:cl:  
rscdel: Removed "Sheltered" trait
/:cl:
