### PR TITLE
New Chem, Frigorific Mixture

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -293,3 +293,24 @@
 		M.adjust_fire_stacks(-reac_volume)
 		M.extinguish_mob()
 	..()
+
+datum/reagent/frigorific_mixture
+	name = "Frigorific Mixture"
+	description = "Comes into existence at 20K. As long as there is sufficient water for it to react with, frigorific mixture slowly cools all other reagents in the container 0K."
+	color = "#a2ccf3"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	taste_description = "bitterness"
+	self_consuming = TRUE
+	process_flags = ORGANIC | SYNTHETIC
+
+
+/datum/reagent/frigorific_mixture/on_mob_life(mob/living/carbon/M) //TODO: code freezing into an ice cube
+	if(M.reagents.has_reagent(/datum/reagent/water))
+		M.reagents.remove_reagent(/datum/reagent/water, 1)
+		M.adjust_bodytemperature(-15)
+	..()
+
+/datum/reagent/frigorific_mixture/reaction_turf(turf/T, reac_volume)
+	if(reac_volume >= 5)
+		for(var/mob/living/simple_animal/slime/M in T)
+			M.adjustToxLoss(rand(15,30))

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -477,3 +477,23 @@
 	strengthdiv = 1
 	noblium_suppression = FALSE
 	mob_react = FALSE // no
+
+/datum/chemical_reaction/frigorific_mixture
+	name = /datum/reagent/frigorific_mixture
+	id = /datum/reagent/frigorific_mixture
+	results = list(/datum/reagent/frigorific_mixture = 2)
+	required_reagents = list(/datum/reagent/consumable/sodiumchloride = 1, /datum/reagent/consumable/ice = 1)
+
+/datum/chemical_reaction/frigorific_mixture/on_reaction(datum/reagents/holder, created_volume)
+	holder.chem_temp = 20 // cools the fuck down
+	return
+
+/datum/chemical_reaction/frigorific_mixture_water
+	name = "ephemeral salty reaction"
+	id = "frigorific_mixture_water"
+	results = list(/datum/reagent/frigorific_mixture = 1)
+	required_reagents = list(/datum/reagent/frigorific_mixture = 1, /datum/reagent/water = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/frigorific_mixture_water/on_reaction(datum/reagents/holder, created_volume)
+	holder.chem_temp = max(holder.chem_temp - 10*created_volume,0)


### PR DESCRIPTION
Reopen of [#18887] by Dahlia
# Document the changes in your pull request

Allows ghetto chemists to cool mixtures with salty ice water.

Currently, Cryostylane allows you to also do this but is practically useless as it is only easily made in a lab setting where heating/cooling mixtures is done by a roundstart machine.
Wiki Documentation

# Wiki Documentation

Frigorific Mixture is made with 1 part sodium-chloride and 1 part ice. It reacts with water rather than oxygen, but most other variables from cryostylane can be put in its description.
Changelog

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Added salty ice water that makes mixtures cold
/:cl:
