### PR TITLE
Fixes being unable to put tanks in pneumatic cannons

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -83,6 +83,8 @@
 				to_chat(user, span_warning("\The [IT] is too small for \the [src]."))
 				return
 			updateTank(W, 0, user)
+		else
+			load_item(W, user) // if there's already a tank attached, load it instead
 	else if(W.type == type)
 		to_chat(user, span_warning("You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption."))
 	else if(W.tool_behaviour == TOOL_WRENCH)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a bug caused by a recent PR that prevented being able to load tanks into pneumatic cannons

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed being unable to load tanks into pneumatic cannons
/:cl:
