### PR TITLE
Adds "Wander, My Friends" from the Battlestar Galactica soundtrack to the lobby music list

### DIFF
--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -64,7 +64,8 @@
 		"https://www.youtube.com/watch?v=0-CLAPJ1PLs",						// Pizza Tower OST - Tunnely Shimbers
 		"https://www.youtube.com/watch?v=4JkIs37a2JE",						// Jamiroquai - Virtual Insanity
 		"https://www.youtube.com/watch?v=z01VlftkqY8",						// PilotRedSun - The Grinch's Ultimatum
-		"https://www.youtube.com/watch?v=rcmQefeyPBs"						// Nightmargin - IT'S TIME TO FIGHT CRIME
+		"https://www.youtube.com/watch?v=rcmQefeyPBs",						// Nightmargin - IT'S TIME TO FIGHT CRIME
+		"https://www.youtube.com/watch?v=OGcMPp7TNo4"						// Bear McCreary - Wander My Friends
 		)						
 	selected_lobby_music = pick(songs)
 


### PR DESCRIPTION
# Document the changes in your pull request

Adds [Wander My Friends](https://www.youtube.com/watch?v=OGcMPp7TNo4) to the list of lobby music.

Imagine listening to this as roundend music after an hour-and-a-half long traitor round.

Lyrics are Irish Gaelic, which translates to:

Wander my friends, wander with me

Like the mist on the green mountain, moving eternally
Despite our weariness
We'll follow the road
Over hill and valleys
To the end of the journey

Come on my friends and sing with me
Fill the night with joy and sport
Here's a toast to the friends who have gone from us
Like the mist of the green mountain
Gone forever.

# Spriting

N/A

# Wiki Documentation

N/A

# Changelog

:cl:  
rscadd: Adds another battlestar galactica reference in the form of a new lobby music track
/:cl:
