### PR TITLE
Rebalances the ultra violence revolver

### DIFF
--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -180,10 +180,14 @@
 		var/mob/living/carbon/human/H = target
 		H.add_splatter_floor(H.loc, TRUE)//janitors everywhere cry when they hear that an ipc is going off
 	ricochets = ricochets_max // so you can't shoot through someone to ricochet and hit them twice for 70 damage in one shot
+	damage -= 20
+	if(damage <= 0)
+		qdel(src)
 
 /obj/item/projectile/bullet/ipcmartial/on_ricochet(atom/A)
 	damage += 10 // more damage if you ricochet it, good luck hitting it consistently though
 	speed *= 0.5 // faster so it can hit more reliably
+	penetrating = FALSE
 	return ..()
 
 /obj/item/projectile/bullet/ipcmartial/check_ricochet()

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -179,7 +179,7 @@
 	if(ishuman(target) && !blocked)
 		var/mob/living/carbon/human/H = target
 		H.add_splatter_floor(H.loc, TRUE)//janitors everywhere cry when they hear that an ipc is going off
-	ricochets++ // so you can't shoot through someone to ricochet and hit them twice for 70 damage in one shot
+	ricochets = ricochets_max // so you can't shoot through someone to ricochet and hit them twice for 70 damage in one shot
 
 /obj/item/projectile/bullet/ipcmartial/on_ricochet(atom/A)
 	damage += 10 // more damage if you ricochet it, good luck hitting it consistently though

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -4,6 +4,7 @@
 #define BLOOD_BURST "HH"
 #define MAX_DASH_DIST 4
 #define DASH_SPEED 2
+
 #define STYLE_REVOLVER "revolver"
 #define STYLE_SHOTGUN "shotgun"
 #define STYLE_PUNCH "punch"
@@ -135,6 +136,7 @@
 	var/mob/gun_owner
 	spread = 0
 	semi_auto_spread = 0
+	slot_flags = 0 // so it doesn't get stuck on your belt
 
 /obj/item/ammo_box/magazine/internal/cylinder/ipcmartial
 	name = "\improper Piercer cylinder"
@@ -143,18 +145,20 @@
 	max_ammo = 3
 
 /obj/item/ammo_casing/ipcmartial
-	name = ".357 piercer bullet casing"
-	desc = "A .357 piercer bullet casing."
+	name = ".357 sharpshooter bullet casing"
+	desc = "A .357 sharpshooter bullet casing."
 	caliber = "357"
 	projectile_type = /obj/item/projectile/bullet/ipcmartial
 	click_cooldown_override = 0.1 //this gun shoots faster
 
 /obj/item/projectile/bullet/ipcmartial //literally just default 357 with mob piercing
-	name = ".357 piercer bullet"
-	damage = 40
+	name = ".357 sharpshooter bullet"
+	damage = 30 // can't 3-shot against sec armor
 	armour_penetration = 15
 	wound_bonus = -45
 	wound_falloff_tile = -2.5
+	ricochets_max = 1 // so you can't use it in a small room to obliterate everyone inside
+	ricochet_chance = INFINITY // ALWAYS ricochet
 	penetrating = TRUE
 
 /obj/item/projectile/bullet/ipcmartial/on_hit(atom/target, blocked)
@@ -171,13 +175,22 @@
 			if(ricochets) // the most powerful weapon: coins
 				UV.handle_style(H, 1)
 				H.balloon_alert(H, "+RICOSHOT")
-			UV.handle_style(H, 0.2 * damage / initial(damage), STYLE_REVOLVER)
-
-/obj/item/projectile/bullet/ipcmartial/on_hit(atom/target, blocked)
-	. = ..()
+			UV.handle_style(H, 0.1 * damage / initial(damage), STYLE_REVOLVER)
 	if(ishuman(target) && !blocked)
 		var/mob/living/carbon/human/H = target
 		H.add_splatter_floor(H.loc, TRUE)//janitors everywhere cry when they hear that an ipc is going off
+	ricochets++ // so you can't shoot through someone to ricochet and hit them twice for 70 damage in one shot
+
+/obj/item/projectile/bullet/ipcmartial/on_ricochet(atom/A)
+	damage += 10 // more damage if you ricochet it, good luck hitting it consistently though
+	speed *= 0.5 // faster so it can hit more reliably
+	return ..()
+
+/obj/item/projectile/bullet/ipcmartial/check_ricochet()
+	return TRUE
+
+/obj/item/projectile/bullet/ipcmartial/check_ricochet_flag(atom/A)
+	return !ismob(A) // don't ricochet off of mobs, that would be weird
 
 /obj/item/gun/ballistic/revolver/ipcmartial/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Reworks the ultra violence revolver bullets to be less damaging and give less style bonus, but gives them the ability to ricochet. They can still pierce mobs, but if they do so they lose their ability to ricochet off of walls. The bullets will do more damage and move faster if you ricochet them first, encouraging users to take their time to line up a shot instead of spamming the projectile.

Specifics:
-30 damage (from 40)
-0.1x damage style bonus (from 0.2x damage)
-can ricochet once unless it pierced a mob
-can pierce mobs unless it has ricocheted before
-gains +10 damage and increased speed on ricochet
-loses 20 damage after each mob pierced

Effects on balance:
-Armor is now a more viable counter
-Ultra Violence revolver is less effective when spamming it
-Adds incentive to use the revolver in a more fun and skill-based way

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: ultra violence revolver damage reduced to 30 and gives less style per damage
tweak: ultra violence revolver can ricochet off of any wall once, unless it pierced a mob first
tweak: ultra violence revolver bullet gains some damage and speed on ricochet, but loses damage after piercing a mob
bugfix: fixed a duplicate definition in ultra_violence.dm
bugfix: fixed ultra violence revolver getting stuck to your belt
/:cl:
