### PR TITLE
Fixes prosthetic limb quirk

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -301,13 +301,15 @@
 			prosthetic = new/obj/item/bodypart/r_arm/robot/surplus(quirk_holder)
 			slot_string = "right arm"
 		if(BODY_ZONE_L_LEG)
-			if(DIGITIGRADE in H.dna.species.species_traits)
+			var/obj/item/bodypart/l_leg/L = H.get_bodypart(BODY_ZONE_L_LEG)
+			if(L.use_digitigrade)
 				prosthetic = new/obj/item/bodypart/l_leg/robot/surplus/digitigrade(quirk_holder)
 			else
 				prosthetic = new/obj/item/bodypart/l_leg/robot/surplus(quirk_holder)
 			slot_string = "left leg"
 		if(BODY_ZONE_R_LEG)
-			if(DIGITIGRADE in H.dna.species.species_traits)
+			var/obj/item/bodypart/r_leg/R = H.get_bodypart(BODY_ZONE_R_LEG)
+			if(R.use_digitigrade)
 				prosthetic = new/obj/item/bodypart/r_leg/robot/surplus/digitigrade(quirk_holder)
 			else
 				prosthetic = new/obj/item/bodypart/r_leg/robot/surplus(quirk_holder)


### PR DESCRIPTION
# Document the changes in your pull request

Prosthetic legs are now digitigrade when they're supposed to be, as intended.


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed prosthetic legs not being digitigrade when they're supposed to be
/:cl:
