### PR TITLE
[BOX] Makes some changes to new perma to appease a few requests.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -5482,11 +5482,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aMi" = (
-/obj/structure/chair/stool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aMj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21645,6 +21640,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"ePT" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "eQc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -23942,6 +23946,11 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fGa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "fGz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
@@ -30264,6 +30273,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ibF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate,
+/obj/item/storage/box/ingredients/sweets,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/carnivore,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ibH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -36364,16 +36383,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"kxA" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -47116,11 +47125,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"oDX" = (
-/obj/machinery/microwave,
-/obj/structure/table,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "oEg" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -69119,6 +69123,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xeY" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "xfb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -69524,11 +69534,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/psych)
-"xnv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -100455,8 +100460,8 @@ aaa
 aiT
 xer
 vWn
-aMi
-xnv
+fGa
+ibF
 vqB
 aat
 mbY
@@ -100969,8 +100974,8 @@ aaa
 aiT
 elb
 vWn
-oDX
-kxA
+xeY
+ePT
 jWw
 fBv
 uyC

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1417,6 +1417,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"ajy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ajD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -21640,15 +21645,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"ePT" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/microwave,
-/obj/structure/table,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "eQc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -23946,11 +23942,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"fGa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "fGz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
@@ -30273,16 +30264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ibF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/closet/crate,
-/obj/item/storage/box/ingredients/sweets,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/carnivore,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ibH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -35182,26 +35163,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jWw" = (
-/obj/structure/window,
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/book/manual/chef_recipes,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jWx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -43540,6 +43501,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ngK" = (
+/obj/structure/window,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ngZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45717,6 +45684,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"odH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate,
+/obj/item/storage/box/ingredients/sweets,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/carnivore,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "odL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -45831,6 +45808,36 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ogp" = (
+/obj/structure/window,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ogV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -64488,21 +64495,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vqB" = (
-/obj/structure/window,
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "vqP" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
@@ -68401,6 +68393,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"wPs" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "wPt" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -69123,12 +69123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xeY" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/reagent_containers/food/condiment/flour,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xfb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -69388,6 +69382,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"xkV" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "xkZ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -100460,9 +100458,9 @@ aaa
 aiT
 xer
 vWn
-fGa
-ibF
-vqB
+ajy
+odH
+ogp
 aat
 mbY
 mbY
@@ -100974,9 +100972,9 @@ aaa
 aiT
 elb
 vWn
-xeY
-ePT
-jWw
+xkV
+wPs
+ngK
 fBv
 uyC
 iyT

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -23398,13 +23398,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"fwc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/security/prison)
 "fwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -45227,6 +45220,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"nSK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/security/prison)
 "nSQ" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -95057,7 +95059,7 @@ acd
 xGC
 rIv
 lao
-fwc
+nSK
 acd
 xPE
 xFt

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1492,6 +1492,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"akw" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/brown/Tom,
+/turf/open/floor/plating,
+/area/security/prison)
 "akx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -29659,6 +29671,16 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hQY" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/security/prison)
 "hRi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -31294,16 +31316,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"iuZ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/mob/living/simple_animal/mouse/brown/Tom,
-/turf/open/floor/plating,
-/area/security/prison)
 "iva" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -71583,17 +71595,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ydl" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
 "ydI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -98671,7 +98672,7 @@ vnR
 kdm
 gSZ
 acd
-iuZ
+hQY
 oNh
 acd
 fSk
@@ -98929,7 +98930,7 @@ pTP
 alC
 acd
 oqW
-ydl
+akw
 acd
 nMO
 gjk

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -359,6 +359,28 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"abI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/button/door{
+	id = "cell5 blast";
+	name = "Cell 5 Blast Door Control";
+	pixel_x = -28;
+	pixel_y = 8;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door{
+	id = "cell4 blast";
+	name = "Cell 4 Blast Door Control";
+	pixel_x = -28;
+	pixel_y = -8;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "abJ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -516,13 +538,6 @@
 /obj/machinery/armaments_dispenser,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"acV" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory External";
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/space)
 "add" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2340,16 +2355,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
-"aqG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aqO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/med_data/laptop,
@@ -7675,6 +7680,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"bcG" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Showers";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "bcL" = (
 /obj/machinery/light{
 	dir = 8
@@ -7895,6 +7912,16 @@
 "beq" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
+"bex" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "beC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 4
@@ -13635,24 +13662,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cfS" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 6"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "cfY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -13784,6 +13793,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/foyer)
+"cid" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cif" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -15380,16 +15395,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
-"cDl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/security/prison)
 "cDq" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -15825,6 +15830,23 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
+"cKK" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainterior";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cLg" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line,
@@ -16190,18 +16212,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"cPr" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "cPt" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -16907,15 +16917,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ddx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ddA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17326,6 +17327,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"dmA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "dmK" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -17469,6 +17477,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dpa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dpF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17786,6 +17800,22 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"dwA" = (
+/obj/machinery/button/door{
+	id = "permacells2";
+	name = "Privacy Shutters";
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 2";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "dwN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -17889,12 +17919,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dzg" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/turf/open/space/basic,
-/area/space)
 "dzm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19064,6 +19088,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"dUY" = (
+/obj/item/toy/beach_ball/holoball,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dVi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "dVk" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -20043,6 +20085,16 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/mix)
+"end" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/security/prison)
 "enf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -20156,14 +20208,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"epa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Permabrig Maintenance";
-	req_access_txt = "1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
 "epj" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
@@ -20200,18 +20244,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"ero" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 1"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "erw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -20566,6 +20598,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"evO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Security Post";
+	req_access_txt = "2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "ewD" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -22169,11 +22224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"eZr" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
 "eZu" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Treatment";
@@ -22388,6 +22438,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"fes" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "feu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -22979,6 +23039,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
+"foV" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 6"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "cell6 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "fpR" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -24317,19 +24399,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
-"fMY" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fNs" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -26682,21 +26751,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"gPZ" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "gQa" = (
 /obj/machinery/airalarm/tcomms{
 	pixel_y = 24
@@ -27144,6 +27198,19 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gWA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "gWK" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
@@ -27535,6 +27602,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hdy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hdQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -28081,21 +28159,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"hmd" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells4";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hmj" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -28724,6 +28787,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hyG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hyI" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/machinery/airalarm{
@@ -30001,17 +30074,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"hYT" = (
-/obj/machinery/button/door{
-	id = "permacells1";
-	name = "Privacy Shutters";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "hYX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -30146,10 +30208,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
-"iaV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/security/prison)
 "ibh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -31435,6 +31493,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iyT" = (
+/obj/machinery/camera{
+	c_tag = "Prison Cafeteria";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "izo" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 5
@@ -32471,22 +32537,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"iSh" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainterior";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "iSq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33158,6 +33208,28 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jfV" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "cell5 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jfX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -33594,6 +33666,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jpy" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/security/prison)
 "jpK" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -34644,14 +34726,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"jMm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "jMv" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -34947,6 +35021,26 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jTP" = (
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells4";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 4";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jTW" = (
 /obj/machinery/requests_console{
 	department = "Engineering";
@@ -35056,6 +35150,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"jWf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "jWq" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -35069,6 +35170,26 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jWw" = (
+/obj/structure/window,
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jWx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -35279,6 +35400,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"kby" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainterior";
+	name = "Permabrig";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kbJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35349,6 +35478,18 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kdm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kdv" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
@@ -36238,6 +36379,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"kxA" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/item/reagent_containers/food/condiment/rice,
+/obj/item/reagent_containers/food/condiment/flour,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "kxF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -36598,17 +36749,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"kDF" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kDS" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/guncase/shotgun,
@@ -37073,6 +37213,27 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"kNT" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = -6;
+	pixel_y = 36;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kNX" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
@@ -37475,13 +37636,6 @@
 "kVU" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
-"kWb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "kWf" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -37674,6 +37828,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"lbi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "lbD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -38057,16 +38227,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"liQ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/security/prison)
 "liR" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 3";
@@ -38918,24 +39078,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"lxE" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "lxF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -39028,6 +39170,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lAj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Prison Security Post";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lAk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile{
@@ -39821,6 +39984,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"lRX" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 5";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "lSz" = (
 /obj/machinery/air_sensor{
 	id_tag = "o2_sensor"
@@ -40434,14 +40612,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"meK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/security/prison)
 "meN" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -40582,6 +40752,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mhB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "mhE" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -41171,6 +41346,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"mrt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "mrK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -41774,6 +41956,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mCm" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"mCp" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "cell4 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "mCx" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -42624,26 +42835,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mUQ" = (
-/obj/structure/table,
-/obj/structure/window,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "mUU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -43193,6 +43384,18 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"ndz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ndA" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -44054,6 +44257,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"nwI" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nwZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -44213,6 +44425,16 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"nAp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nAZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
@@ -44805,6 +45027,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"nOb" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/security/prison)
 "nOu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -45767,6 +45996,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"okN" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "okO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -46527,16 +46762,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"oxD" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "oxS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -46588,19 +46813,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oyH" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oyI" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -46910,6 +47122,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"oDX" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "oEg" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -48982,9 +49199,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"ptc" = (
-/turf/open/floor/plasteel/dark/side,
-/area/security/prison)
 "pth" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/explab";
@@ -49060,6 +49274,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"puS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "cell1 blast";
+	name = "Cell 1 Blast Door Control";
+	pixel_y = -26;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "puY" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -49986,13 +50218,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"pOe" = (
-/obj/item/toy/beach_ball/holoball,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -50102,11 +50327,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"pQp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/security/prison)
 "pQt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -51220,6 +51440,11 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"qlJ" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/security/prison)
 "qlL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -51599,6 +51824,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"quf" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qum" = (
 /obj/structure/chair{
 	dir = 4
@@ -52062,19 +52295,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qEY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "qFh" = (
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
@@ -52398,6 +52618,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"qJf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "qJt" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -54183,6 +54413,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"rte" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rtl" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -55066,6 +55305,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"rLp" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 3"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "cell3 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "rLw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -55403,6 +55658,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"rRQ" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "rRR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -56581,17 +56842,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"spY" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sqh" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -56639,21 +56889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ssq" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells6";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ssx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -56915,24 +57150,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"syN" = (
-/obj/machinery/button/flasher{
-	id = "visitorflash";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = -6;
-	pixel_y = 36;
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "szt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Robotics Access"
@@ -57040,6 +57257,12 @@
 "sAV" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"sBp" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "sBA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -57909,19 +58132,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sUg" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "sUj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -57957,11 +58167,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sUZ" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "sVu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58519,6 +58724,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"tdh" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "cell2 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tdw" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
@@ -58762,6 +58983,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"thU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = 4;
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "tie" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tanks South";
@@ -58838,6 +59076,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"tjV" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainterior";
+	name = "Permabrig Transfer";
+	req_access_txt = "2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tjY" = (
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006;
@@ -59432,11 +59687,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"twK" = (
-/obj/structure/window,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "txG" = (
 /obj/machinery/light{
 	dir = 1
@@ -59540,18 +59790,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"tyK" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "tyV" = (
 /obj/machinery/light{
 	dir = 4
@@ -60550,6 +60788,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tSN" = (
+/obj/machinery/button/door{
+	id = "permacells1";
+	name = "Privacy Shutters";
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 1";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "tSS" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
@@ -61363,22 +61617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"uke" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainterior";
-	name = "Permabrig Transfer";
-	req_access_txt = "2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "ukK" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -61534,17 +61772,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ai_monitored/security/armory)
-"und" = (
-/obj/machinery/button/door{
-	id = "permacells2";
-	name = "Privacy Shutters";
-	pixel_x = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "uni" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -61702,6 +61929,30 @@
 /obj/item/circuitboard/machine/techfab/department/security,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"urb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Prison Cell Block Central";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "cell3 blast";
+	name = "Cell 3 Blast Door Control";
+	pixel_y = -26;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ure" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -62499,6 +62750,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"uHT" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Permanent Cell 1"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "cell1 blast";
+	name = "blast door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "uHY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62628,18 +62895,6 @@
 /obj/item/stock_parts/micro_laser/high,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"uKj" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 3"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "uKB" = (
 /obj/machinery/meter,
 /obj/structure/sign/warning/nosmoking{
@@ -62660,6 +62915,25 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uLi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "cell2 blast";
+	name = "Cell 2 Blast Door Control";
+	pixel_y = -26;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uLo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
@@ -64099,6 +64373,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"vnR" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vnU" = (
 /obj/machinery/light{
 	dir = 8
@@ -64147,6 +64435,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"vok" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "voH" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -64191,6 +64490,21 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vqB" = (
+/obj/structure/window,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "vqP" = (
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
@@ -64261,13 +64575,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vsm" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/security/prison)
 "vsP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -64835,6 +65142,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"vCL" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vCX" = (
 /obj/structure/janitorialcart,
 /obj/effect/turf_decal/delivery,
@@ -65010,6 +65324,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"vGk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/security/prison)
 "vGx" = (
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
@@ -65253,6 +65571,13 @@
 	dir = 4
 	},
 /area/crew_quarters/theatre)
+"vJi" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "vJk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -65686,17 +66011,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"vSj" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "vTi" = (
 /obj/item/shard,
 /obj/structure/disposalpipe/segment{
@@ -66710,6 +67024,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wlf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wlI" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -66916,6 +67246,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"wpw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "wpR" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot_white,
@@ -67979,6 +68319,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wNb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "cell6 blast";
+	name = "Cell 6 Blast Door Control";
+	pixel_x = 28;
+	pixel_y = 8;
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wNq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -68009,24 +68360,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"wOy" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Permanent Cell 5"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "wOC" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -68335,24 +68668,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"wVG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Cell Block Central";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wVO" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/bridge";
@@ -69045,6 +69360,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"xkE" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_x = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 3";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xkN" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
@@ -70086,6 +70418,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
+"xFt" = (
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells6";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/camera{
+	c_tag = "Prison Cell 6";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xFW" = (
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
@@ -70387,6 +70739,18 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xNM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/security/prison)
 "xOa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -71167,6 +71531,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ycE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "ycG" = (
 /obj/machinery/power/turbine{
 	dir = 4;
@@ -93397,13 +93772,13 @@ hqQ
 hqQ
 syi
 hqQ
-hqQ
+bcG
 acd
 mNH
-oxD
+lRX
 acd
 sps
-hmd
+jTP
 uTh
 rnS
 rnS
@@ -93657,10 +94032,10 @@ acd
 acd
 acd
 npL
-wOy
+jfV
 acd
 cab
-lxE
+mCp
 uTh
 rnS
 rnS
@@ -93915,7 +94290,7 @@ tHq
 jms
 wbe
 lbH
-gJM
+abI
 gJM
 tHj
 uTh
@@ -94172,9 +94547,9 @@ ybf
 fBv
 fBv
 iva
-aat
+wNb
 fBv
-wVG
+urb
 uTh
 uTh
 uTh
@@ -94428,11 +94803,11 @@ acd
 acd
 acd
 caq
-cfS
+foV
 acd
 peW
 pzO
-uKj
+rLp
 vIr
 mko
 acd
@@ -94685,12 +95060,12 @@ lao
 fwc
 acd
 xPE
-ssq
+xFt
 acd
 nMO
 vni
 hSc
-cPr
+xkE
 mYZ
 acd
 isP
@@ -94945,7 +95320,7 @@ wen
 aHl
 acd
 djy
-qEY
+uLi
 acd
 acd
 acd
@@ -95201,9 +95576,9 @@ acd
 acd
 acd
 acd
-aqG
+hyG
 cux
-tyK
+tdh
 vIr
 mko
 acd
@@ -95461,7 +95836,7 @@ pog
 sKN
 elq
 uxi
-und
+dwA
 mYZ
 acd
 dFi
@@ -95716,7 +96091,7 @@ kXP
 acd
 oyL
 dGY
-oyH
+puS
 acd
 acd
 acd
@@ -95974,7 +96349,7 @@ acd
 uVz
 oSb
 juP
-ero
+uHT
 vIr
 oDG
 acd
@@ -96232,7 +96607,7 @@ dsd
 rAx
 sWK
 gVn
-hYT
+tSN
 mYZ
 acd
 cjo
@@ -96744,7 +97119,7 @@ uln
 rsZ
 obK
 gBi
-uke
+cKK
 jdG
 vPF
 oSq
@@ -97001,7 +97376,7 @@ ubP
 acd
 aat
 uEg
-iSh
+tjV
 xsD
 eMU
 tAU
@@ -97503,7 +97878,7 @@ kbU
 pYC
 aBg
 jRq
-sUg
+vok
 hFe
 acd
 ssR
@@ -97760,7 +98135,7 @@ nlE
 aat
 iMs
 kyl
-kWb
+nAp
 qnt
 acd
 phd
@@ -98016,8 +98391,8 @@ aaa
 nlE
 rXV
 iMs
-kyl
-pOe
+nwI
+dUY
 rWa
 acd
 acd
@@ -98272,9 +98647,9 @@ aaa
 aaa
 dgr
 dyx
-jMm
-kDF
-ddx
+lbi
+vnR
+kdm
 gSZ
 acd
 iuZ
@@ -98529,7 +98904,7 @@ aaa
 aaa
 aiT
 rXV
-ptc
+xNM
 iCl
 pTP
 alC
@@ -98786,10 +99161,10 @@ aaa
 aaa
 aiT
 aiT
-epa
+evO
 acd
-acd
-acd
+wpw
+mhB
 acd
 acd
 acd
@@ -99043,12 +99418,12 @@ aaa
 aaa
 aaa
 aiT
-iaV
-lao
-pQp
-rkj
-vsm
-acd
+ndz
+sBp
+hdy
+dpa
+lAj
+dmA
 aHy
 aHy
 wSF
@@ -99300,12 +99675,12 @@ aaa
 aaa
 aaa
 aiT
-meK
-kdv
-iot
-iaV
-eZr
-acd
+thU
+fes
+wlf
+bex
+qJf
+ycE
 qTP
 lQs
 xEK
@@ -99557,12 +99932,12 @@ aaa
 aaa
 aaa
 aiT
-aiT
-aiT
-aiT
-acd
-acd
-acd
+vJi
+nnc
+uyC
+fBv
+rRQ
+mrt
 uNn
 krX
 jVe
@@ -99570,7 +99945,7 @@ iFF
 woN
 krX
 acd
-nyJ
+kNT
 mgJ
 pmx
 tRK
@@ -99813,21 +100188,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aiT
-fVh
-osK
-vWn
-gPZ
-twK
+aiT
+jWf
+gWA
+dVi
+mhB
+vGk
 aat
 aat
 aat
 uyC
 aat
 gQh
-acd
-syN
+kby
+okN
 cHS
 fVu
 lww
@@ -100076,7 +100451,7 @@ xer
 vWn
 aMi
 xnv
-vWn
+vqB
 aat
 mbY
 mbY
@@ -100329,15 +100704,15 @@ aaa
 aaa
 aaa
 aiT
-elb
+fVh
 vWn
-sUZ
-vSj
-mUQ
+vWn
+osK
+vWn
 fBv
 hgL
-spY
-fMY
+cid
+rte
 icL
 fBv
 aiT
@@ -100586,17 +100961,17 @@ aaa
 aaa
 aaa
 aiT
-aiT
-aiT
-aiT
-aiT
-aiT
-cVS
-cDl
-aiT
-aiT
-liQ
-iJe
+elb
+vWn
+oDX
+kxA
+jWw
+fBv
+uyC
+iyT
+vCL
+uyC
+fBv
 aiT
 vxt
 adl
@@ -100842,19 +101217,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gXs
-gXs
-gXs
-gXs
-gXs
-aaZ
+aiT
+aiT
+aiT
+aiT
+aiT
+aiT
+nOb
+jpy
+aiT
+aiT
+end
+qlJ
+aiT
 vQY
 xhI
 llj
@@ -101106,7 +101481,7 @@ aaa
 aaa
 aaa
 aaa
-aKN
+aaa
 aaa
 aaa
 aaa
@@ -101363,11 +101738,11 @@ aaa
 aaa
 aaa
 aaa
-gXs
-gXs
 aaa
 aaa
-dzg
+aaa
+aaa
+mCm
 aaZ
 adl
 adl
@@ -101621,10 +101996,10 @@ aaa
 aaa
 aaa
 aaa
-aKN
 aaa
 aaa
-acV
+aaa
+quf
 aaZ
 dVK
 adl
@@ -101876,8 +102251,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+pEf
+gXs
 aKN
 tgE
 gXs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -7719,11 +7719,6 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/vacant_room)
-"bcX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "bcZ" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
@@ -16549,36 +16544,6 @@
 "cUT" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
-"cVh" = (
-/obj/structure/window,
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "cVx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32115,16 +32080,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iKh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/closet/crate,
-/obj/item/storage/box/ingredients/sweets,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/carnivore,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "iKk" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -33176,12 +33131,6 @@
 "jdO" = (
 /turf/closed/wall,
 /area/medical/storage)
-"jdX" = (
-/obj/structure/window,
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "jec" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -35880,10 +35829,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"kld" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "klD" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -45790,6 +45735,44 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ofi" = (
+/obj/structure/window,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin,
+/obj/item/kitchen/knife{
+	bare_wound_bonus = 0;
+	desc = "A general purpose Chef's Knife made by SpaceCook Incorporated. Guaranteed to stay sharp for years to come - unfortunately, those years have already come and gone.";
+	force = 2;
+	name = "blunt kitchen knife";
+	wound_bonus = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "ofy" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -49919,6 +49902,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pEO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate,
+/obj/item/storage/box/ingredients/sweets,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/carnivore,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "pFb" = (
 /obj/machinery/light{
 	dir = 4
@@ -51005,6 +50998,12 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qdi" = (
+/obj/structure/window,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "qdv" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
@@ -60778,16 +60777,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"tSc" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
-	name = "refrigerator"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "tSu" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
@@ -62455,6 +62444,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"uBq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "uBw" = (
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -65066,6 +65060,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"vAT" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
+	name = "refrigerator"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "vBj" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -66022,6 +66026,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vTm" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "vTB" = (
 /obj/machinery/shower{
 	dir = 4
@@ -100460,9 +100468,9 @@ aaa
 aiT
 xer
 vWn
-bcX
-iKh
-cVh
+uBq
+pEO
+ofi
 aat
 mbY
 mbY
@@ -100974,9 +100982,9 @@ aaa
 aiT
 elb
 vWn
-kld
-tSc
-jdX
+vTm
+vAT
+qdi
 fBv
 uyC
 iyT

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -7675,18 +7675,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"bcG" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Showers";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
 "bcL" = (
 /obj/machinery/light{
 	dir = 8
@@ -93797,7 +93785,7 @@ hqQ
 hqQ
 syi
 hqQ
-bcG
+hqQ
 acd
 mNH
 lRX

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1417,11 +1417,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"ajy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/processor,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ajD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -7724,6 +7719,11 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/vacant_room)
+"bcX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/processor,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "bcZ" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
@@ -16549,6 +16549,36 @@
 "cUT" = (
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness)
+"cVh" = (
+/obj/structure/window,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/storage/box/drinkingglasses,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3.1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/book/manual/chef_recipes,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "cVx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32085,6 +32115,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"iKh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate,
+/obj/item/storage/box/ingredients/sweets,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/carnivore,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "iKk" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -33136,6 +33176,12 @@
 "jdO" = (
 /turf/closed/wall,
 /area/medical/storage)
+"jdX" = (
+/obj/structure/window,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jec" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -35834,6 +35880,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kld" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "klD" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -43501,12 +43551,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ngK" = (
-/obj/structure/window,
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ngZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45684,16 +45728,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"odH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/closet/crate,
-/obj/item/storage/box/ingredients/sweets,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/carnivore,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "odL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -45808,36 +45842,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ogp" = (
-/obj/structure/window,
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/storage/box/drinkingglasses,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3.1;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "ogV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -60774,6 +60778,16 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tSc" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
+	name = "refrigerator"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tSu" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
@@ -68393,14 +68407,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"wPs" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "wPt" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -69382,10 +69388,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"xkV" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "xkZ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -100458,9 +100460,9 @@ aaa
 aiT
 xer
 vWn
-ajy
-odH
-ogp
+bcX
+iKh
+cVh
 aat
 mbY
 mbY
@@ -100972,9 +100974,9 @@ aaa
 aiT
 elb
 vWn
-xkV
-wPs
-ngK
+kld
+tSc
+jdX
 fBv
 uyC
 iyT

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1492,18 +1492,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"akw" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/brown/Tom,
-/turf/open/floor/plating,
-/area/security/prison)
 "akx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -16896,6 +16884,16 @@
 /obj/machinery/papershredder,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"dbM" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/security/prison)
 "dcn" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "permaouter";
@@ -29671,16 +29669,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"hQY" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/security/prison)
 "hRi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -46085,6 +46073,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"olG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "olT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -54200,6 +54193,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rna" = (
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/brown/Tom,
+/turf/open/floor/plating,
+/area/security/prison)
 "rnS" = (
 /turf/template_noop,
 /area/security/execution/transfer)
@@ -96610,7 +96615,7 @@ cVS
 scE
 xfH
 jFw
-aat
+olG
 aat
 uBb
 kNK
@@ -98672,7 +98677,7 @@ vnR
 kdm
 gSZ
 acd
-hQY
+dbM
 oNh
 acd
 fSk
@@ -98930,7 +98935,7 @@ pTP
 alC
 acd
 oqW
-akw
+rna
 acd
 nMO
 gjk

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -18463,6 +18463,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dIg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "dIh" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -27785,14 +27791,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"hgL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "hha" = (
 /obj/machinery/computer/station_alert,
 /obj/item/radio/intercom{
@@ -33456,6 +33454,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"jmq" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
+	name = "refrigerator"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "jms" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -46360,10 +46367,6 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"osK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "osP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47057,6 +47060,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/fore)
+"oCE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "oCZ" = (
 /obj/item/radio/intercom{
 	pixel_x = -25
@@ -47193,6 +47203,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"oHm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oHC" = (
 /obj/structure/railing,
 /obj/structure/table/wood,
@@ -50991,12 +51012,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qdi" = (
-/obj/structure/window,
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "qdv" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
@@ -51825,14 +51840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"quf" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory External";
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "qum" = (
 /obj/structure/chair{
 	dir = 4
@@ -56456,6 +56463,16 @@
 	dir = 4
 	},
 /area/security/prison)
+"sgz" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/security/prison)
 "sgF" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -58758,6 +58775,16 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tdO" = (
+/obj/structure/window,
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tdY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
@@ -65065,16 +65092,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/tcommsat/server)
-"vAT" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance{
-	name = "refrigerator"
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "vBj" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -67075,6 +67092,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wlK" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space)
 "wma" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
@@ -91982,7 +92006,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pEf
 aaa
 aaa
 aaa
@@ -92239,10 +92263,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
-aaa
-aaa
+pEf
 aaa
 aaa
 aaa
@@ -92496,10 +92520,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -92753,10 +92777,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -93010,13 +93034,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -93265,7 +93289,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aiT
 cVS
 esp
@@ -93522,7 +93546,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aiT
 etn
 jda
@@ -93775,11 +93799,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
+gXs
 rRo
 hqQ
 hqQ
@@ -94036,7 +94060,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aiT
 acd
 acd
@@ -94291,9 +94315,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
 qCF
 dyx
 xAJ
@@ -94544,7 +94568,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pEf
 aaa
 aaa
 aaa
@@ -94797,14 +94821,14 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+gXs
+aaa
+gXs
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aiT
 cVS
 esp
@@ -95054,14 +95078,14 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aiT
 lMq
 ebo
@@ -95311,9 +95335,9 @@ aaa
 aaa
 aaa
 aaa
+aKN
 aaa
-aaa
-aaa
+gXs
 aiT
 kbU
 aiT
@@ -95568,9 +95592,9 @@ aaa
 aaa
 aaa
 aaa
+aKN
 aaa
-aaa
-aaa
+gXs
 cVS
 iVt
 cUn
@@ -95825,9 +95849,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
+gXs
 aiT
 jRN
 jOv
@@ -96082,9 +96106,9 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
+gXs
 cVS
 vyo
 oWZ
@@ -96337,11 +96361,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
+gXs
 aiT
 gqA
 peN
@@ -96596,7 +96620,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aaa
 cVS
@@ -96853,7 +96877,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aaa
 aiT
@@ -97110,10 +97134,10 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
-aaa
-aaa
+gXs
 cVS
 vvo
 iAx
@@ -97367,10 +97391,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 aiT
 aiT
 aiT
@@ -97626,7 +97650,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aaa
 aaa
@@ -97883,10 +97907,10 @@ aaa
 aaa
 aaa
 aaa
+aKN
 aaa
 aaa
-aaa
-aaa
+gXs
 kbU
 pYC
 aBg
@@ -98138,12 +98162,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
+gXs
+gXs
 nlE
 aat
 iMs
@@ -98400,7 +98424,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 nlE
 rXV
 iMs
@@ -98654,10 +98678,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
 dgr
 dyx
 lbi
@@ -98913,7 +98937,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aiT
 rXV
@@ -99170,7 +99194,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aiT
 aiT
@@ -99427,7 +99451,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aaa
 aiT
@@ -99683,10 +99707,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
 aiT
 thU
 fes
@@ -99942,7 +99966,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aiT
 vJi
@@ -100199,7 +100223,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aiT
 aiT
@@ -100456,7 +100480,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aKN
 aaa
 aaa
 aiT
@@ -100713,17 +100737,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
 aiT
 fVh
 vWn
 vWn
-osK
-vWn
-fBv
-hgL
+oCE
+dIg
+cid
+oHm
 cid
 rte
 icL
@@ -100972,13 +100996,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aiT
 elb
 vWn
 vTm
-vAT
-qdi
+jmq
+tdO
 fBv
 uyC
 iyT
@@ -101226,15 +101250,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+pEf
+gXs
+gXs
+gXs
 aiT
 aiT
-aiT
-aiT
-aiT
+nOb
+sgz
+jpy
 aiT
 nOb
 jpy
@@ -101489,15 +101513,15 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+gXs
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 gXs
 aaZ
 hOn
@@ -101747,11 +101771,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
+gXs
 aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -102004,15 +102028,15 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
+gXs
+gXs
 aaa
 aaa
-aaa
-aaa
-aaa
-quf
+wlK
 aaZ
 dVK
 adl
@@ -102261,13 +102285,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 pEf
-gXs
+aaa
+aaa
+aaa
+aaa
 aKN
-tgE
+aaa
 gXs
 gXs
 aaZ

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -35393,14 +35393,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"kby" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "permainterior";
-	name = "Permabrig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "kbJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70955,6 +70947,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xRS" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "permainterior";
+	name = "Permabrig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "xSl" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
@@ -100203,7 +100207,7 @@ aat
 uyC
 aat
 gQh
-kby
+xRS
 okN
 cHS
 fVu


### PR DESCRIPTION
# Document the changes in your pull request

Changes are as follows

Adds a camera to every cell as well as a blast door to lock in unruly prisoners (requested numerous times)
Adds a security post if any officers or the warden wish to more closely watch permabrig
Adds a second entrance through the visitation observation
Northern Main entrance doors now no longer have access requirements from the south (requested by THE REEL)
Buffs kitchen by adding a food processor + fridge and a crate w/ ingredient boxes inside. (Food processor requested by Dahlia, other items by me myself and I)
Adds a holopad (citadel didnt have one for some reason)
Adds a recharger for IPC/Ethereal/Preternis
Adds catwalks and lattices outside of perma for navigation purposes.

# Changelog

:cl:  cark
mapping: some more changes to new perma
/:cl:
