### PR TITLE
fixes an atmos bug in Syndicate Lavaland (oops!)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -650,7 +650,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/syndicate_lava_base/engineering)
 "ev" = (
@@ -970,7 +970,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered/syndicate_lava_base/engineering)
 "fr" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -132,9 +132,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/syndicate_lava_base/testlab)
-"aL" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/testlab)
 "aM" = (
 /obj/machinery/vending/syndichem,
 /obj/effect/turf_decal/siding/purple{
@@ -660,9 +657,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered/syndicate_lava_base/virology)
-"ex" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/engineering)
 "ey" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -744,9 +738,6 @@
 	},
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
-"eK" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/powered/syndicate_lava_base/medbay)
 "eN" = (
 /obj/structure/flora/tree/jungle/small,
@@ -1683,9 +1674,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/syndicate_lava_base/virology)
-"hO" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/dormitories)
 "hP" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -7636,7 +7624,7 @@ eC
 yl
 gw
 gX
-eK
+kQ
 hX
 Jv
 eh
@@ -8185,7 +8173,7 @@ MN
 RC
 eT
 zq
-aL
+ae
 as
 Om
 dU
@@ -8375,7 +8363,7 @@ jq
 hz
 gE
 lR
-hO
+hz
 JV
 hg
 hz
@@ -8474,7 +8462,7 @@ as
 ju
 ju
 ju
-ex
+ju
 ju
 ju
 ju

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -437,9 +437,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/syndicate_lava_base/virology)
-"dP" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/cargo)
 "dQ" = (
 /obj/structure/sink{
 	pixel_y = 23
@@ -2072,9 +2069,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/syndicate_lava_base/virology)
-"iN" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/vault)
 "iP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -7866,7 +7860,7 @@ kp
 Cg
 Lg
 Je
-dP
+dy
 jq
 Sr
 iV
@@ -7985,7 +7979,7 @@ iV
 ab
 FN
 ha
-iN
+ha
 ha
 FN
 ab
@@ -8095,7 +8089,7 @@ Hn
 oP
 iV
 dS
-iN
+ha
 Gv
 it
 dE
@@ -8209,7 +8203,7 @@ iV
 ab
 FN
 ha
-iN
+ha
 ha
 FN
 ab
@@ -8390,10 +8384,10 @@ lR
 hO
 JV
 hg
-hO
+hz
 dQ
 TY
-hO
+hz
 Yn
 FB
 mT

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2513,9 +2513,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/ruin/powered/syndicate_lava_base/virology)
-"jP" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/bar)
 "jQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3438,9 +3435,6 @@
 /area/ruin/powered/syndicate_lava_base/cargo)
 "mn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/telecomms)
-"mo" = (
-/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/powered/syndicate_lava_base/telecomms)
 "mq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -7762,7 +7756,7 @@ zN
 Nq
 Nq
 ed
-jP
+jy
 ZV
 ov
 jZ
@@ -8098,7 +8092,7 @@ TA
 IC
 Ib
 jo
-hO
+hz
 KZ
 kf
 hz
@@ -8157,7 +8151,7 @@ da
 hz
 ft
 hz
-hO
+hz
 hz
 no
 hz
@@ -8298,7 +8292,7 @@ ab
 ab
 ab
 ab
-aL
+ae
 kw
 ae
 mJ
@@ -8486,7 +8480,7 @@ ju
 ju
 ie
 mn
-mo
+mn
 mn
 Hi
 mn
@@ -8877,7 +8871,7 @@ hA
 hl
 hU
 mH
-mo
+vl
 iJ
 qB
 kY


### PR DESCRIPTION
turns out the heater and freezer that maintain air temperature were misconfigured since the freezer started cooling to 73 kelvin instead of 293 like i intended. instead of making changes i'll turn them off.

also this
<img width="479" alt="image" src="https://github.com/yogstation13/Yogstation/assets/80979251/285d0a32-1546-4bcf-857e-7edaa44b0b7f">


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: woops i misconfigured syndie lavaland atmos its fixed now
bugfix: it also doesn't freeze the server anymore as an act of revenge whenever it is destroyed
/:cl:
