### PR TITLE
Janitor Holosign QoL

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -1,6 +1,6 @@
 /obj/item/holosign_creator
 	name = "holographic sign projector"
-	desc = "A handy-dandy holographic projector that displays a janitorial sign."
+	desc = "You shouldn't see this."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker"
 	item_state = "electronic"
@@ -63,8 +63,8 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
-	creation_time = 2 SECONDS
-	max_signs = 12
+	creation_time = 0.5 SECONDS
+	max_signs = 25
 
 /obj/item/holosign_creator/security
 	name = "security holobarrier projector"

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -84,6 +84,18 @@
 	desc = "When it says walk it means walk."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "holosign"
+	var/turf/slippery_floor
+
+/obj/structure/holosign/barrier/wetsign/Initialize(mapload)
+	. = ..()
+	slippery_floor = get_turf(src)
+	if(!slippery_floor?.GetComponent(/datum/component/slippery))
+		return INITIALIZE_HINT_QDEL
+	RegisterSignal(slippery_floor.GetComponent(/datum/component/slippery), COMSIG_PARENT_QDELETING, PROC_REF(del_self))
+
+/obj/structure/holosign/barrier/wetsign/proc/del_self()
+	SIGNAL_HANDLER
+	qdel(src)
 
 /obj/structure/holosign/barrier/wetsign/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -147,7 +147,7 @@
 	build_path = /obj/item/bikehorn/airhorn
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL			//HONK!
-	
+
 /datum/design/clownshot
 	name = "Clownshot Shell"
 	desc = "A tactical round used by the clown planet's finest soldiers."
@@ -356,7 +356,7 @@
 	build_path = /obj/item/ticket_machine_remote
 	category = list ("Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_MEDICAL
-	
+
 /datum/design/wallframe/flasher
 	name = "Mounted Flash Frame"
 	id =  "wallframe/flasher"
@@ -425,22 +425,12 @@
 /////////////////////////////////////////
 
 /datum/design/holosign
-	name = "Holographic Sign Projector"
-	desc = "A holograpic projector used to project various warning signs."
-	id = "holosign"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/plastic = 500)
-	build_path = /obj/item/holosign_creator
-	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
-/datum/design/holobarrier_jani
 	name = "Custodial Holobarrier Projector"
 	desc = "A holograpic projector used to project hard light wet floor barriers."
-	id = "holobarrier_jani"
+	id = "holosign"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/silver = 1000, /datum/material/plastic = 500)
-	build_path = /obj/structure/holosign/barrier/wetsign
+	build_path = /obj/item/holosign_creator/janibarrier
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 


### PR DESCRIPTION
# Document the changes in your pull request

Buffing my role ![image](https://github.com/yogstation13/Yogstation/assets/28408322/5d031d6a-a342-4dcf-95af-150bee1ca6ec)

custodial holobarrier projectors
- capacity: 12 -> 25 holosigns
- deployment time: 2 -> 0.5 seconds

wet floor holobarriers now refuse to place on dry tiles and automatically vanish when a tile becomes dry

default "holosign projectors" are not used anywhere besides the erroneous lathe entry

fixed custodial holobarrier projectors being unprintable

# Changelog

:cl:  
tweak: custodial holobarrier projectors now have doubled capacity and deploy much faster
tweak: wet floor holobarriers now automatically vanish when the floor is no longer wet
bugfix: fixed custodial holobarrier projectors being unprintable
/:cl:
