### PR TITLE
Lowers the price of Horror-in-a-box traitor item

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2471,7 +2471,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	Either a failed experiment or otherworldly monster, this creature has been trained to aid whoever wakes it up. If you aren't afraid of it entering your head, it can prove a useful ally. \
 	We take no responsibility for your newfound madness and accept no refunds."
 	item = /obj/item/horrorspawner
-	cost = 16
+	cost = 14
 	surplus = 0
 	restricted_roles = list("Curator")
 	player_minimum = 20


### PR DESCRIPTION

# Document the changes in your pull request

Lower price of horror in the box to 14 tc, so you can buy something nice on the side, and because eldrich horror is just simply not powerful enough to be worth 16 tc.

Did not test it, but it's a simple change so i hope this works (first time doing this)

# Wiki Documentation
Lower the price on the item from 16 to 14

# Changelog
:cl:  
tweak: Lowers the price of horror in a box  
/:cl:
