### PR TITLE
Ratvar can now spawn from the weapon vendor

### DIFF
--- a/code/modules/vending/security_armaments.dm
+++ b/code/modules/vending/security_armaments.dm
@@ -62,6 +62,9 @@
 					new mag(loc)
 			else
 				return FALSE
+			if(prob(0.1)) //Easteregg of the exploit that allowed you to buy an actual real ratvar mob
+				playsound(src, 'sound/magic/clockwork/ark_activation.ogg', 50, 0)
+				new /obj/item/toy/plush/plushvar(loc)
 			C.registered_account.sec_weapon_claimed = TRUE
 			return TRUE
 	return FALSE

--- a/code/modules/vending/security_armaments.dm
+++ b/code/modules/vending/security_armaments.dm
@@ -64,6 +64,7 @@
 				return FALSE
 			if(prob(0.1)) //Easteregg of the exploit that allowed you to buy an actual real ratvar mob
 				playsound(src, 'sound/magic/clockwork/ark_activation.ogg', 50, 0)
+				visible_message(message = "<span class='big_brass'>Ratvar has risen! ...from the vendor?</span>")
 				new /obj/item/toy/plush/plushvar(loc)
 			C.registered_account.sec_weapon_claimed = TRUE
 			return TRUE


### PR DESCRIPTION
# Document the changes in your pull request
Adds a miniature chance for the Ratvar plush to appear out of the vendor, with clockie sounds playing with it.

This is a reference to the glorious Ratvar spawning exploit of 2023

# Changelog
:cl:  
rscadd: Ratvar might return to station using other means
/:cl:
