### PR TITLE
attempts to make the Syndicate Toolbox relevant

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -177,6 +177,12 @@
 	for(var/obj/item/I in contents)
 		I.toolspeed = 0.5
 
+/obj/item/storage/toolbox/syndicate/real/PopulateContents()
+	. = ..()
+	for(var/obj/item/I in contents)
+		I.toolspeed = 0.33
+		I.name = "syndicate [I.name]"
+
 /obj/item/storage/toolbox/drone
 	name = "mechanical toolbox"
 	icon_state = "blue"
@@ -284,7 +290,8 @@
 							/obj/item/storage/toolbox/electrical,
 							/obj/item/storage/toolbox/mechanical,
 							/obj/item/storage/toolbox/artistic,
-							/obj/item/storage/toolbox/syndicate)
+							/obj/item/storage/toolbox/syndicate,
+							/obj/item/storage/toolbox/syndicate/real)
 
 	if(!istype(T, /obj/item/stack/tile/plasteel))
 		..()
@@ -307,6 +314,8 @@
 			if(/obj/item/storage/toolbox/artistic)
 				B.toolbox_color = "g"
 			if(/obj/item/storage/toolbox/syndicate)
+				B.toolbox_color = "s"
+			if(/obj/item/storage/toolbox/syndicate/real)
 				B.toolbox_color = "s"
 		user.put_in_hands(B)
 		B.update_icon()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -91,13 +91,13 @@
 			new /obj/item/implanter/explosive(src) //2 TC, nukies only
 			new /obj/item/implanter/storage(src) //8 TC
 
-		if("hacker") //28 TC cost
+		if("hacker") //29 TC cost
 			new /obj/item/aiModule/syndicate(src) //4 TC
 			new /obj/item/card/emag(src) //6 TC
 			new /obj/item/encryptionkey/binary(src) //2 TC
 			new /obj/item/aiModule/toyAI(src) //Um, free...?
 			new /obj/item/multitool/ai_detect(src) //1 TC
-			new /obj/item/storage/toolbox/syndicate(src) //1 TC
+			new /obj/item/storage/toolbox/syndicate/real(src) //2 TC
 			new /obj/item/camera_bug(src) //1 TC
 			new /obj/item/card/id/syndicate(src) //2 TC
 			new /obj/item/flashlight/emp(src) //2 TC
@@ -105,7 +105,7 @@
 			new /obj/item/clothing/glasses/hud/diagnostic/sunglasses(src) //RD glasses. 1 TC, if that
 			new /obj/item/pen/edagger(src) //2 TC
 
-		if("sabotage") //Maybe 29 TC?
+		if("sabotage") //Maybe 30 TC?
 			new /obj/item/grenade/plastic/c4 (src) //1 TC
 			new /obj/item/grenade/plastic/c4 (src) //1 TC
 			new /obj/item/doorCharge(src) //2 TC
@@ -113,7 +113,7 @@
 			new /obj/item/camera_bug(src) //1 TC
 			new /obj/item/sbeacondrop/powersink(src) //8 TC
 			new /obj/item/computer_hardware/hard_drive/portable/syndicate/bomberman(src) //6 TC
-			new /obj/item/storage/toolbox/syndicate(src) //1 TC
+			new /obj/item/storage/toolbox/syndicate/real(src) //2 TC
 			new /obj/item/pizzabox/bomb(src) //6 TC
 			new /obj/item/storage/box/syndie_kit/emp(src) //2 TC
 
@@ -199,7 +199,7 @@
 			new /obj/item/carpcaller(src) //to spawn carps in space, making the place safer for you and dangerous for everyone else, you should get at least 20 carps per use so 60  carps
 			new /obj/item/toy/plush/carpplushie/dehy_carp //1 carp but guaranteed complete loyalty and cuddliness
 
-		if("mad_scientist") // ~21 tc
+		if("mad_scientist") // ~22 tc
 			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
 			new /obj/item/megaphone(src) // 0 tc (because how else are they to know you're mad?)
@@ -211,7 +211,7 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
-			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
+			new /obj/item/storage/toolbox/syndicate/real(src) // 2 tc
 			new /obj/item/pen/edagger(src) // 2 tc
 			new /obj/item/gun/energy/wormhole_projector/upgraded(src) // ~2 tc
 			new /obj/item/gun/energy/decloner/unrestricted(src) // these shots do 9 damage. 1 tc
@@ -441,13 +441,13 @@
 	desc = "Supplied to Syndicate contractors."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
-	
+
 /obj/item/storage/box/syndicate/contract_kit/plasmaman/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
 	new /obj/item/storage/box/syndicate/contractor_loadout/plasmaman(src)
 	new /obj/item/melee/classic_baton/telescopic/contractor_baton(src)
 	new /obj/item/bodybag/environmental/prisoner/syndicate(src)
-	
+
 	var/list/item_list = list(
 		/obj/item/storage/backpack/duffelbag/syndie/x4,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
@@ -469,7 +469,7 @@
 		/obj/item/storage/box/syndie_kit/imp_freedom,
 		/obj/item/storage/belt/chameleon/syndicate
 	)
-	
+
 	var/obj/item1 = pick_n_take(item_list)
 	var/obj/item2 = pick_n_take(item_list)
 	var/obj/item3 = pick_n_take(item_list)
@@ -485,7 +485,7 @@
 	desc = "Supplied to the Syndicate's plasmaman contractors, providing their specialised space suit and chameleon envirosuit."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
-	
+
 /obj/item/storage/box/syndicate/contractor_loadout/plasmaman/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/plasmaman/chameleon/syndicate(src)
 	new /obj/item/clothing/suit/space/syndicate/contract(src)

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -189,7 +189,7 @@
 	shoes = /obj/item/clothing/shoes/chameleon/noslip
 	ears = /obj/item/radio/headset/chameleon
 	id = /obj/item/card/id/syndicate
-	r_hand = /obj/item/storage/toolbox/syndicate
+	r_hand = /obj/item/storage/toolbox/syndicate/real
 
 	backpack_contents = list(/obj/item/storage/box/survival, /obj/item/implanter/uplink, /obj/item/clothing/mask/chameleon,  /obj/item/lighter)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1752,8 +1752,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A suspicious black and red syndicate toolbox. It comes loaded with a full tool set including a \
 			multitool and combat gloves that are resistant to shocks and heat. It is very compact and will \
 			fit in any standard Nanotrasen backpack."
-	item = /obj/item/storage/toolbox/syndicate
-	cost = 1
+	item = /obj/item/storage/toolbox/syndicate/real
+	cost = 2
 
 /datum/uplink_item/device_tools/tactical_gloves
 	name = "Tactical Fingerless Gloves"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1749,9 +1749,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"
-	desc = "A suspicious black and red syndicate toolbox. It comes loaded with a full tool set including a \
+	desc = "A suspicious black and red syndicate toolbox. It comes loaded with a full speedy tool set including a \
 			multitool and combat gloves that are resistant to shocks and heat. It is very compact and will \
 			fit in any standard Nanotrasen backpack."
+	item = /obj/item/storage/toolbox/syndicate
+	cost = 1
+
+/datum/uplink_item/device_tools/toolboxreal
+	name = "Deluxe Syndicate Toolbox"
+	desc = "A syndicate toolbox that comes stocked with ultra-fast syndicate tools. Be careful, as \
+			these tools are more obviously marked and will be easily spotted by anyone observant."
 	item = /obj/item/storage/toolbox/syndicate/real
 	cost = 2
 


### PR DESCRIPTION
# Document the changes in your pull request

Syndicate toolboxes have been split between this deluxe one and regular

The only way to get the deluxe toolbox is through the uplink, an uplink kit, or contractor support unit

All tools now have 0.33x speed instead of 0.5x speed (3x faster instead of 2x)

All items in the toolbox get prefixed with "syndicate" for extra sus

Deluxe Syndicate Toolbox costs 2TC

For reference
- alien tools have 0.1x (10x)
- caravan tools have 0.3x (3.33x)
- these tools will have 0.33x (3x)
- cyborg/syndie tools have 0.5x (2x)
- advanced tools have 0.7x (1.43x)

# Changelog

:cl:  
tweak: The word "speedy" has been added to the syndicate toolbox uplink description to indicate that the tools are and have always been faster
rscadd: Added the Deluxe Syndicate Toolbox to the uplink. Faster tools at a slightly higher price, but also more obvious!
/:cl:
