### PR TITLE
Nerfs blazing oil again

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -14,11 +14,11 @@
 	reagent = /datum/reagent/blob/blazing_oil
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1.3, BURN, ENERGY)
+	B.take_damage(2, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BRUTE) 
-		return damage * 1.5
+		return damage * 2
 	if(damage_type == BURN && damage_flag != ENERGY)
 		var/mob/camera/blob/O = overmind
 		O.add_points(damage / 10)//burn damage causes the blob to gain a very small amount of points: the 20 damage of a laser will generate 2 BP.


### PR DESCRIPTION
Despite more nerfs it's still absolutely top-tier with the powers of lighting people on fire (extended damage), dealing burn damage (most species take extra burn damage), and being COMPLETELY IMMUNE to laser fire (and getting free shit from it) so now it takes DOUBLE damage from brute and ~50% more damage from extinguishers. This still may not be enough.


# Wiki Documentation

2x brute modifier

# Changelog

:cl:  

tweak: Blazing oil strain now takes more (1.5x -> 2x) brute damage
tweak: Blazing oil strain now takes ~50% more damage from extinguishers
/:cl:
