### PR TITLE
Fixes wacky living death signal

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -10,5 +10,5 @@
 	return
 
 /mob/proc/death(gibbed)
-	SEND_SIGNAL(src, COMSIG_GLOB_MOB_DEATH, gibbed)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src , gibbed)
+	SEND_SIGNAL(src, COMSIG_LIVING_DEATH, gibbed)
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src, gibbed)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -92,7 +92,6 @@ GLOBAL_VAR_INIT(permadeath, FALSE)
 		addtimer(CALLBACK(src, PROC_REF(med_hud_set_status)), (DEFIB_TIME_LIMIT) + 1)
 	stop_pulling()
 
-	SEND_SIGNAL(src, COMSIG_LIVING_DEATH, gibbed)
 	. = ..()
 
 	if (client)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes global death signal being sent as a non-global signal, and being sent twice.
This is just a thing I need for devil affairs, but fixes

# Changelog

:cl:  
fix: People no longer die twice.
/:cl:
