### PR TITLE
criminal status comment log

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -21,7 +21,7 @@
 
 	var/datum/data/record/active_general_record = null
 	var/datum/data/record/active_security_record = null
-	
+
 	//Radio internal
 	var/obj/item/radio/radio
 	var/radio_key = /obj/item/encryptionkey/heads/hos
@@ -769,6 +769,7 @@
 							if("Discharged")
 								active_security_record.fields["criminal"] = WANTED_DISCHARGED
 						investigate_log("[active_general_record.fields["name"]] has been set from [old_field] to [active_security_record.fields["criminal"]] by [key_name(usr)].", INVESTIGATE_RECORDS)
+						active_security_record.fields["comments"] |= GLOB.data_core.createCommentEntry("Criminal status set to [active_security_record.fields["criminal"]].", logged_in)
 						for(var/mob/living/carbon/human/H in GLOB.carbon_list)
 							H.sec_hud_set_security_status()
 
@@ -778,7 +779,7 @@
 					if(!issilicon(usr))
 						if(user.wear_id)
 							var/list/access = user.wear_id.GetAccess()
-							if((ACCESS_KEYCARD_AUTH || ACCESS_CAPTAIN || ACCESS_CHANGE_IDS || ACCESS_HOP || ACCESS_HOS) in access)							
+							if((ACCESS_KEYCARD_AUTH || ACCESS_CAPTAIN || ACCESS_CHANGE_IDS || ACCESS_HOP || ACCESS_HOS) in access)
 								changed_rank = input("Select a rank", "Rank Selection") as null|anything in get_all_jobs()
 							else
 								say("You do not have the required access to do this!")
@@ -854,7 +855,7 @@
 			name = "[ID.registered_name]"
 		else
 			name = "Unknown"
-			
+
 	if(issilicon(user))
 		name = "[user.name]"
 
@@ -866,7 +867,7 @@
 		var/area/A = get_area(loc)
 		radio.talk_into(src, "Alert: security breach alarm triggered in [A.map_name]!! Unauthorized access by [name] of [src]!!", sec_freq)
 		radio.talk_into(src, "Alert: security breach alarm triggered in [A.map_name]!! Unauthorized access by [name] of [src]!!", command_freq)
-	
+
 /obj/machinery/computer/secure_data/emp_act(severity)
 	. = ..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -93,7 +93,7 @@
 			. += ""
 			. += "Chemical Storage: [changeling.chem_charges]/[changeling.chem_storage]"
 			. += "Absorbed DNA: [changeling.absorbedcount]"
-		
+
 		//WS Begin - Display Ethereal Charge
 		if(istype(src))
 			var/datum/species/ethereal/eth_species = src.dna?.species
@@ -427,6 +427,7 @@
 											if(H.canUseHUD())
 												if(istype(H.glasses, /obj/item/clothing/glasses/hud/security) || istype(H.getorganslot(ORGAN_SLOT_HUD), /obj/item/organ/cyberimp/eyes/hud/security))
 													investigate_log("[key_name(src)] has been set from [R.fields["criminal"]] to [setcriminal] by [key_name(usr)].", INVESTIGATE_RECORDS)
+													R.fields["comments"] |= GLOB.data_core.createCommentEntry("Criminal status set to [setcriminal].", allowed_access)
 													R.fields["criminal"] = setcriminal
 													sec_hud_set_security_status()
 									return


### PR DESCRIPTION
# Document the changes in your pull request

Creates a comment that logs the criminal status, author (ID), and time of setting.

`Criminal status set to Arrest.`

This is useful when the crime has not been added to the record (because no one ever does) so you can verify with the person who set the status as to why and for what the criminal should be charged with.

Comments can still be deleted by malicious actors if they so choose.

# Changelog

:cl:  
rscadd: Setting someone's criminal status now logs it in the security record comments
/:cl:
