### PR TITLE
makes the improvised pneumatic cannon uncraftable

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -337,17 +337,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but
-	name = "Pneumatic Cannon"
-	result = /obj/item/pneumatic_cannon/ghetto
-	tools = list(TOOL_WELDER, TOOL_WRENCH)
-	reqs = list(/obj/item/stack/sheet/metal = 4,
-				/obj/item/stack/packageWrap = 8,
-				/obj/item/pipe = 2)
-	time = 5 SECONDS
-	category = CAT_WEAPONRY
-	subcategory = CAT_WEAPON
-
 // Shank - Makeshift weapon that can embed on throw
 /datum/crafting_recipe/shank
 	name = "Shank"


### PR DESCRIPTION
# Document the changes in your pull request

removes the crafting recipe

current exploit makes this weapon instakill/near-death on direct hit instacrit/nearcrit on near miss on a weapon any crewmember can obtain

get a better gimmick

ided pr

will close if an alternative is merged that sucks less

# Spriting
n/a

# Wiki Documentation

https://wiki.yogstation.net/wiki/Makeshift_weapons

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscdel: pneumatic cannon has been made uncraftable
/:cl:
