### PR TITLE
Slightly reworks Holy Light sect

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -68,6 +68,7 @@
 	var/treatment_virus = /datum/reagent/medicine/spaceacillin
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
+	var/holy = FALSE //if it gives the chaplain favour on injection (holy light sect)
 
 /mob/living/simple_animal/bot/medbot/mysterious
 	name = "\improper Mysterious Medibot"
@@ -655,6 +656,8 @@
 				else
 					patient.reagents.add_reagent(reagent_id,injection_amount)
 					log_combat(src, patient, "injected", "internal synthesizer", "[reagent_id]:[injection_amount]")
+					if(holy)
+						GLOB.religious_sect.adjust_favor(20)
 				C.visible_message(span_danger("[src] injects [patient] with its syringe!"), \
 					span_userdanger("[src] injects you with its syringe!"))
 			else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -231,7 +231,7 @@
 
 /datum/reagent/water/holywater/on_mob_life(mob/living/carbon/M)
 	if(healing)
-		if(ishuman(M))
+		if(ishuman(M) && M.client)
 			var/mob/living/carbon/human/H = M
 			var/heal_amt = healing
 			var/favor = 2

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -424,7 +424,11 @@
 	desc = "A sect dedicated to healing."
 	convert_opener = "Welcome to the Holy Light, disciple. Use holy water to heal and generate favor over time. Use your bible to heal for large amounts instantly, costing favor."
 	alignment = ALIGNMENT_GOOD // literally the only good sect besides default lol
-	rites_list = list(/datum/religion_rites/medibot, /datum/religion_rites/holysight, /datum/religion_rites/healrod, /datum/religion_rites/suffusion)
+	rites_list = list(/datum/religion_rites/medibot, 
+					/datum/religion_rites/holysight, 
+					/datum/religion_rites/healrod, 
+					/datum/religion_rites/suffusion, 
+					/datum/religion_rites/holyrevival)
 	altar_icon_state = "convertaltar-heal"
 	COOLDOWN_DECLARE(last_heal)
 	var/heal_amt = 40 //this is also the favour requirement
@@ -442,7 +446,7 @@
 	if(!L.client)
 		return FALSE
 
-	if(favor < heal_amt)
+	if(favor < heal_amt * 2)
 		user.visible_message(span_notice("You don't have enough favour to heal in this manner."))
 		return FALSE
 
@@ -456,7 +460,7 @@
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
 
 		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-		adjust_favor(-round(amount_healed/2), user)//costs favour to use
+		adjust_favor(-amount_healed, user)//costs favour to use
 
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -427,7 +427,7 @@
 	rites_list = list(/datum/religion_rites/medibot, /datum/religion_rites/holysight, /datum/religion_rites/healrod, /datum/religion_rites/suffusion)
 	altar_icon_state = "convertaltar-heal"
 	COOLDOWN_DECLARE(last_heal)
-	var/heal_amt = 40 //double this is also the favour requirement
+	var/heal_amt = 40 //this is also the favour requirement
 	var/water_heal = 0.2 //how much holy water heals
 
 /datum/religion_sect/holylight/on_conversion(mob/living/L)
@@ -442,7 +442,7 @@
 	if(!L.client)
 		return FALSE
 
-	if(favor < heal_amt * 2)
+	if(favor < heal_amt)
 		user.visible_message(span_notice("You don't have enough favour to heal in this manner."))
 		return FALSE
 
@@ -456,7 +456,7 @@
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
 
 		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-		adjust_favor(-amount_healed, user)//costs favour to use
+		adjust_favor(-amount_healed/2, user)//costs favour to use
 
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -456,7 +456,7 @@
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
 
 		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-		adjust_favor(-amount_healed/2, user)//costs favour to use
+		adjust_favor(-round(amount_healed/2), user)//costs favour to use
 
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -652,7 +652,7 @@
 	"...that I shall impart upon the water I bless...",
 	)
 	invoke_msg = "So that light may fill all!"
-	favor_cost = 600
+	favor_cost = 400
 
 /datum/religion_rites/suffusion/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	if(GLOB.religious_sect)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -662,3 +662,57 @@
 	var/altar_turf = get_turf(religious_tool)
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 100, TRUE)
 	return TRUE
+
+/datum/religion_rites/holyrevival
+	name = "Rebirth"
+	desc = "Regenerates a being to its once pure state."
+	ritual_length = 60 SECONDS
+	ritual_invocations = list(
+	"This being is in dire need of your assistance...",
+	"...As they have been inflicted with great ailment...",
+	"...Please, grant us the unbridled power of the Holy Light...",
+	"...We will channel our power in your name...",
+	)
+	invoke_msg = "So that this being may be reborn in your image!"
+	favor_cost = 650
+
+/datum/religion_rites/holyrevival/perform_rite(mob/living/user, atom/religious_tool)
+	if(!ismovable(religious_tool))
+		to_chat(user, span_warning("This rite requires a religious device that individuals can be buckled to."))
+		return FALSE
+	var/atom/movable/movable_reltool = religious_tool
+	if(!movable_reltool)
+		return FALSE
+	if(!LAZYLEN(movable_reltool.buckled_mobs))
+		. = FALSE
+		if(!movable_reltool.can_buckle)
+			to_chat(user, span_warning("This rite requires a religious device that individuals can be buckled to."))
+			return
+		to_chat(user, span_warning("This rite requires an individual to be buckled to [movable_reltool]."))
+		return
+	return ..()
+
+/datum/religion_rites/holyrevival/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	if(!ismovable(religious_tool))
+		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
+	var/atom/movable/movable_reltool = religious_tool
+	if(!movable_reltool?.buckled_mobs?.len)
+		return FALSE
+	var/mob/living/carbon/human/man_to_revive
+	for(var/i in movable_reltool.buckled_mobs)
+		if(istype(i,/mob/living/carbon/human))
+			man_to_revive = i
+			break
+	if(!man_to_revive)
+		return FALSE
+	var/was_dead = man_to_revive.stat == DEAD
+	man_to_revive.revive(TRUE)
+	if(was_dead) // aheal needs downside
+		man_to_revive.adjustCloneLoss(75) // can be slowly healed with the rod of asclepius anyways
+	man_to_revive.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+	to_chat(man_to_revive, span_userdanger("As you rise anew, you forget all that had previously harmed you!"))
+	man_to_revive.emote("smile")
+	man_to_revive.visible_message(span_notice("[man_to_revive] rises, reborn in the Holy Light!"))
+	var/altar_turf = get_turf(religious_tool)
+	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 100, TRUE)
+	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -607,8 +607,10 @@
 
 /datum/religion_rites/medibot/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)
-	var/atom/newitem = new /mob/living/simple_animal/bot/medbot (altar_turf)
+	var/mob/living/simple_animal/bot/medbot/newitem = new (altar_turf)
 	newitem.name = "\improper Holy Medibot"
+	newitem.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+	newitem.holy = TRUE
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 50, TRUE)
 	return TRUE
 
@@ -640,56 +642,23 @@
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 75, TRUE)
 	return TRUE
 
-/datum/religion_rites/holyrevival
-	name = "Rebirth"
-	desc = "Regenerates a being to its once pure state."
-	ritual_length = 60 SECONDS
+/datum/religion_rites/suffusion
+	name = "Suffusion of Light"
+	desc = "Make holy water heal more."
+	ritual_length = 20 SECONDS
 	ritual_invocations = list(
-	"This being is in dire need of your assistance...",
-	"...As they have been inflicted with great ailment...",
-	"...Please, grant us the unbridled power of the Holy Light...",
-	"...We will channel our power in your name...",
+	"To radiate the grace of light...",
+	"...Please, grant unto me the unbridled power of the Holy Light...",
+	"...that I shall impart upon the water I bless...",
 	)
-	invoke_msg = "So that this being may be reborn in your image!"
-	favor_cost = 650
+	invoke_msg = "So that light may fill all!"
+	favor_cost = 400
 
-/datum/religion_rites/holyrevival/perform_rite(mob/living/user, atom/religious_tool)
-	if(!ismovable(religious_tool))
-		to_chat(user, span_warning("This rite requires a religious device that individuals can be buckled to."))
-		return FALSE
-	var/atom/movable/movable_reltool = religious_tool
-	if(!movable_reltool)
-		return FALSE
-	if(!LAZYLEN(movable_reltool.buckled_mobs))
-		. = FALSE
-		if(!movable_reltool.can_buckle)
-			to_chat(user, span_warning("This rite requires a religious device that individuals can be buckled to."))
-			return
-		to_chat(user, span_warning("This rite requires an individual to be buckled to [movable_reltool]."))
-		return
-	return ..()
-
-/datum/religion_rites/holyrevival/invoke_effect(mob/living/user, atom/movable/religious_tool)
-	if(!ismovable(religious_tool))
-		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
-	var/atom/movable/movable_reltool = religious_tool
-	if(!movable_reltool?.buckled_mobs?.len)
-		return FALSE
-	var/mob/living/carbon/human/man_to_revive
-	for(var/i in movable_reltool.buckled_mobs)
-		if(istype(i,/mob/living/carbon/human))
-			man_to_revive = i
-			break
-	if(!man_to_revive)
-		return FALSE
-	var/was_dead = man_to_revive.stat == DEAD
-	man_to_revive.revive(TRUE)
-	if(was_dead) // aheal needs downside
-		man_to_revive.adjustCloneLoss(75) // can be slowly healed with the rod of asclepius anyways
-	man_to_revive.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
-	to_chat(man_to_revive, span_userdanger("As you rise anew, you forget all that had previously harmed you!"))
-	man_to_revive.emote("smile")
-	man_to_revive.visible_message(span_notice("[man_to_revive] rises, reborn in the Holy Light!"))
+/datum/religion_rites/suffusion/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	if(GLOB.religious_sect)
+		var/datum/religion_sect/holylight/sect = GLOB.religious_sect
+		if(istype(sect))
+			sect.water_heal += 0.2
 	var/altar_turf = get_turf(religious_tool)
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 100, TRUE)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -652,7 +652,7 @@
 	"...that I shall impart upon the water I bless...",
 	)
 	invoke_msg = "So that light may fill all!"
-	favor_cost = 400
+	favor_cost = 600
 
 /datum/religion_rites/suffusion/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	if(GLOB.religious_sect)


### PR DESCRIPTION
Doctors hate holy light because chaplains with it just sit outside medbay and steal gameplay from them
Changes how the sect generates and uses favor

Holy water will slowly heal with this sect (0.2 brute and 0.2 burn) and generate favour as it heals
The healing and favour generation is doubled if the person with it is inside the chapel

Bible now consumes favour rather than generating it (so if you want a burst heal, you need to spent favor)

Holy Medbot now also generates favor so there's no anti-synergy with spawning them

Gives them a ritual that increases the healing that holy water does


These changes should mean that chaplain will want to spread holy water around rather than just sitting next to medbay and spamming their bible
It should also mean that they want to spend time in their chapel as it generates more favor if the injured are there

:cl:  
tweak: Holy light bible now costs favour instead of generating it
tweak: Holy light makes holy water heal for small amounts and generate favor (doubled in chapel)
tweak: Holy medbot generates favor upon injecting chems
rscadd: Added Suffusion of Light rite that increases holy water healing
/:cl:
