### PR TITLE
Wizard robes now protect against needles

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -6,7 +6,7 @@
 	armor = list(MELEE = 30, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 20, BIO = 100, RAD = 20, FIRE = 100, ACID = 100, WOUND = 20)
 	strip_delay = 50
 	equip_delay_other = 50
-	resistance_flags = FIRE_PROOF | ACID_PROOF
+	resistance_flags = FIRE_PROOF | ACID_PROOF | THICKMATERIAL
 	dog_fashion = /datum/dog_fashion/head/blue_wizard
 	hattable = FALSE
 


### PR DESCRIPTION
The Archmages of the Wizard Federation have noticed that many of their wayward apprentices and errant spellblades getting decimated by simple syringe guns and the occasional thorny plant.

NO MORE.
Master Artificer Joey has now imbuded these magical robes with additional padding and runic improvements. Preventing the robes from being pierced by weak syringes and silly plants.
:cl:  
tweak: True wizard robes now have thick material.
/:cl:
