### PR TITLE
Lavaland wizard den fish don't wander anymore so they won't just walk outside and kill innocent miners who are passing by

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
@@ -60,22 +60,9 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
 /area/ruin/powered)
-"j" = (
-/mob/living/simple_animal/hostile/carp/ranged/chaos{
-	name = "Blossom"
-	},
-/turf/open/floor/wood,
-/area/ruin/powered)
 "k" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered)
-"l" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/carp/ranged/chaos{
-	name = "Buttercup"
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -155,11 +142,10 @@
 /turf/open/floor/wood,
 /area/ruin/powered)
 "D" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp/ranged/chaos{
-	name = "Bubbles"
+	name = "Buttercup";
+	wander = 0
 	},
 /turf/open/floor/wood,
 /area/ruin/powered)
@@ -168,6 +154,23 @@
 	dir = 8
 	},
 /turf/open/floor/wood/lavaland,
+/area/ruin/powered)
+"K" = (
+/mob/living/simple_animal/hostile/carp/ranged/chaos{
+	name = "Blossom";
+	wander = 0
+	},
+/turf/open/floor/wood,
+/area/ruin/powered)
+"N" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/carp/ranged/chaos{
+	name = "Bubbles";
+	wander = 0
+	},
+/turf/open/floor/wood,
 /area/ruin/powered)
 "P" = (
 /obj/effect/decal/cleanable/dirt,
@@ -227,7 +230,7 @@ a
 a
 x
 e
-l
+D
 p
 x
 U
@@ -276,7 +279,7 @@ a
 x
 h
 h
-D
+N
 h
 g
 h
@@ -298,7 +301,7 @@ a
 (10,1,1) = {"
 a
 x
-j
+K
 n
 x
 s


### PR DESCRIPTION

# Document the changes in your pull request

I believe this is a better alternative, most of the times I/other people have died to the fair and balanced fishies it's because they have wandered out and death bolted yo ass

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: lavaland wizard den fish no longer wander
/:cl:
