### PR TITLE
Makes bluespace vials equivalent to large vials

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -438,7 +438,7 @@
 /obj/item/reagent_containers/glass/bottle/bromine
 	name = "bromine bottle"
 	list_reagents = list(/datum/reagent/bromine = 30)
-	
+
 /obj/item/reagent_containers/glass/woodmug
 	name = "wooden mug"
 	desc = "Style is everything, whether it be an ashtray or a keychain or a kitchen timer, we’re living in an age of design, where the physical contours of an object are paramount. Look at this wooden mug, for instance, and see how much it deviates, in its conception, from the ordinary mug. Not much. It is round, tallish, has a handle just like any coffee mug. But it’s not an ordinary coffee mug. First of all its form is totally different; it’s made of wood, not ceramic or plastic. It’s an object that cannot be used casually and put it away, you would love to possess it."
@@ -452,7 +452,7 @@
 	name = "vial"
 	desc = "A small vial for holding small amounts of reagents."
 	icon_state = "vial"
-	item_state = "atoxinbottle"	
+	item_state = "atoxinbottle"
 	unique_reskin = list("vial" = "vial",
 						"white vial" = "vial_white",
 						"red vial" = "vial_red",
@@ -686,7 +686,7 @@
 /obj/item/reagent_containers/glass/bottle/vial/bluespace
 	name = "bluespace vial"
 	base_name = "bluespace vial"
-	desc = "A small vial powered by experimental bluespace technology capable of holding 60 units."
+	desc = "A small vial powered by experimental bluespace technology capable of holding 30 units."
 	icon_state = "vialbluespace"
 	base_icon_state = "vialbluespace"
 	unique_reskin = list("bluespace vial" = "vialbluespace",
@@ -698,5 +698,5 @@
 						"purple bluespace vial" = "vialbluespace_purple",
 						"black bluespace vial" = "vialbluespace_black"
 						)
-	possible_transfer_amounts = list(5,10,15,30,45)
-	volume = 60
+	possible_transfer_amounts = list(5,10,15,30)
+	volume = 30


### PR DESCRIPTION
# Document the changes in your pull request

Getting an upgrade 30 minutes into the round to usurp one of the deluxe hypospray's main attractions and be *twice as good* feels very silly to me.

It is perfectly reasonable to me to have the tiny-sized vials be upgraded into an equivalent of the large vials, but not surpass them.

As an aside, a "large bluespace vial" for particularly ambitious CMOs could be considered in the future, to allow the deluxe hypospray to upgrade alongside the normal one, but we would need a new sprite for it.

# Changelog

:cl:  
tweak: Bluespace vials now only carry 30 units, like large vials
/:cl:
