### PR TITLE
IAA no longer has the capacity to drop multiple syndicate buttons

### DIFF
--- a/yogstation/code/game/objects/items/implants/implant_dusting.dm
+++ b/yogstation/code/game/objects/items/implants/implant_dusting.dm
@@ -53,6 +53,8 @@
 		. = ..()
 
 /obj/item/implant/dusting/iaa/activate(cause)
+	if(active)
+		return
 	. = ..()
 	var/turf/my_turf = get_turf(src)
 	var/obj/item/iaa_reward/drop = new(my_turf)


### PR DESCRIPTION
# Document the changes in your pull request

Lacked active check (also can't use `.` because it returns FALSE or something)

# Changelog

:cl:  
bugfix: fixed IAA dropping multiple buttons
/:cl:
