### PR TITLE
Bald

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -269,6 +269,8 @@
 #define TRAIT_MAGICALLY_PHASED "magically_phased"
 ///This mob can't use vehicles
 #define TRAIT_NOVEHICLE	"no_vehicle"
+/// BALD!!!
+#define TRAIT_BALD "bald"
 
 /// This person is crying
 #define TRAIT_CRYING "crying"

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -406,7 +406,10 @@
 	skin_tone = GLOB.skin_tones[deconstruct_block(getblock(structure, DNA_SKIN_TONE_BLOCK), GLOB.skin_tones.len)]
 	eye_color = sanitize_hexcolor(getblock(structure, DNA_EYE_COLOR_BLOCK))
 	facial_hair_style = GLOB.facial_hair_styles_list[deconstruct_block(getblock(structure, DNA_FACIAL_HAIR_STYLE_BLOCK), GLOB.facial_hair_styles_list.len)]
-	hair_style = GLOB.hair_styles_list[deconstruct_block(getblock(structure, DNA_HAIR_STYLE_BLOCK), GLOB.hair_styles_list.len)]
+	if(HAS_TRAIT(src, TRAIT_BALD))
+		hair_style = "Bald"
+	else
+		hair_style = GLOB.hair_styles_list[deconstruct_block(getblock(structure, DNA_HAIR_STYLE_BLOCK), GLOB.hair_styles_list.len)]
 	if(icon_update)
 		update_body()
 		update_hair()

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -221,6 +221,10 @@
 	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
 	mood_change = -8
 
+/datum/mood_event/bald
+	description = "I need something to cover my head..."
+	mood_change = -3
+
 /datum/mood_event/type_bait
 	description = "<span class='warning'>I caught that fish mid-conversation... I can't believe I did that...</span>\n"
 	mood_change = -1

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -188,6 +188,10 @@
 	mood_change = 10
 	timeout = 4 MINUTES
 
+/datum/mood_event/confident_mane
+	description = "I'm feeling confident with a head full of hair."
+	mood_change = 2
+
 /datum/mood_event/area
 	description = "" //Fill this out in the area
 	mood_change = 0

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -319,3 +319,59 @@
 /datum/quirk/family_heirloom/on_clone(data)
 	heirloom = data
 
+/datum/quirk/bald
+	name = "Smooth-Headed"
+	desc = "You have no hair and are quite insecure about it! Keep your head covered."
+	value = 0
+	icon = "fa-egg"
+	mob_trait = TRAIT_BALD
+	gain_text = span_notice("Your head is as smooth as can be, it's terrible.")
+	lose_text = span_notice("Your head itches, could it be... growing hair?!")
+	medical_record_text = "Patient starkly refused to take off headwear during examination."
+	/// Their original hairstyle before becoming bald
+	var/old_hair
+
+/datum/quirk/bald/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	old_hair = H.hair_style
+	H.hair_style = "Bald"
+	H.update_body_parts()
+	H.update_hair()
+	RegisterSignal(H, COMSIG_CARBON_EQUIP_HAT, PROC_REF(equip_hat))
+	RegisterSignal(H, COMSIG_CARBON_UNEQUIP_HAT, PROC_REF(unequip_hat))
+
+/datum/quirk/bald/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/head/wig/natural/W = new(get_turf(H))
+	if(old_hair == "Bald")
+		W.hair_style = pick(GLOB.hair_styles_list - "Bald")
+	else
+		W.hair_style = old_hair
+	W.update_icon()
+	var/list/slots = list(
+		"head" = ITEM_SLOT_HEAD,
+		"backpack" = ITEM_SLOT_BACKPACK,
+		"hands" = ITEM_SLOT_HANDS
+	)
+	H.equip_in_one_of_slots(W, slots, qdel_on_fail = TRUE)
+
+/datum/quirk/bald/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(QDELETED(H)) // uh oh
+		return
+	H.hair_style = old_hair
+	H.update_body_parts()
+	H.update_hair()
+	UnregisterSignal(H, COMSIG_CARBON_EQUIP_HAT)
+	UnregisterSignal(H, COMSIG_CARBON_UNEQUIP_HAT)
+	SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "bad_hair_day")
+
+/datum/quirk/bald/proc/equip_hat(mob/user, obj/item/hat)
+	if(istype(hat, /obj/item/clothing/head/wig))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_hair_day", /datum/mood_event/confident_mane)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "bad_hair_day")
+
+/datum/quirk/bald/proc/unequip_hat(mob/user, obj/item/hat)
+	SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_hair_day", /datum/mood_event/bald)

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -191,6 +191,9 @@
 				if(!get_location_accessible(H, location))
 					to_chat(user, span_warning("The headgear is in the way!"))
 					return
+				if(HAS_TRAIT(H, TRAIT_BALD))
+					to_chat(user, span_warning("[H] is just way too bald. Like, really really bald."))
+					return
 				user.visible_message(span_notice("[user] tries to change [H]'s hairstyle using [src]."), span_notice("You try to change [H]'s hairstyle using [src]."))
 				if(new_style && do_after(user, 6 SECONDS, H))
 					user.visible_message(span_notice("[user] successfully changes [H]'s hairstyle using [src]."), span_notice("You successfully change [H]'s hairstyle using [src]."))

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -64,6 +64,9 @@
 			H.update_hair()
 			return TRUE
 		if(HEAD_HAIR)
+			if(HAS_TRAIT(H, TRAIT_BALD) && selection != "Bald")
+				to_chat(H, span_notice("If only growing back hair were that easy for you..."))
+				return TRUE
 			H.hair_style = selection
 			H.update_hair()
 			return TRUE

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -83,6 +83,7 @@
 			wear_mask_update(I, toggle_off = 0)
 		if(ITEM_SLOT_HEAD)
 			head = I
+			SEND_SIGNAL(src, COMSIG_CARBON_EQUIP_HAT, I)
 			head_update(I)
 		if(ITEM_SLOT_NECK)
 			wear_neck = I
@@ -118,6 +119,7 @@
 	if(I == head)
 		head = null
 		if(!QDELETED(src))
+			SEND_SIGNAL(src, COMSIG_CARBON_UNEQUIP_HAT, I, force, newloc, no_move, invdrop, silent)
 			head_update(I)
 	else if(I == back)
 		back = null

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -495,7 +495,8 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/N = M
-		N.hair_style = "Spiky"
+		if(!HAS_TRAIT(M, TRAIT_BALD))
+			N.hair_style = "Spiky"
 		N.facial_hair_style = "Shaved"
 		N.facial_hair_color = "000"
 		N.hair_color = "000"
@@ -1840,7 +1841,7 @@
 
 /datum/reagent/barbers_aid/reaction_mob(mob/living/M, methods=TOUCH, reac_volume, show_message = 1, permeability = 1)
 	if(methods & (TOUCH|VAPOR))
-		if(M && ishuman(M) && permeability)
+		if(M && ishuman(M) && permeability && !HAS_TRAIT(M, TRAIT_BALD))
 			var/mob/living/carbon/human/H = M
 			var/datum/sprite_accessory/hair/picked_hair = pick(GLOB.hair_styles_list)
 			var/datum/sprite_accessory/facial_hair/picked_beard = pick(GLOB.facial_hair_styles_list)
@@ -1857,7 +1858,7 @@
 
 /datum/reagent/concentrated_barbers_aid/reaction_mob(mob/living/M, methods=TOUCH, reac_volume, show_message = 1, permeability = 1)
 	if(methods & (TOUCH|VAPOR))
-		if(M && ishuman(M) && permeability)
+		if(M && ishuman(M) && permeability && !HAS_TRAIT(M, TRAIT_BALD))
 			var/mob/living/carbon/human/H = M
 			H.hair_style = "Very Long Hair"
 			H.facial_hair_style = "Beard (Very Long)"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new neutral (+0) quirk called "smooth-headed" where you are permanently bald forever, and nothing can fix it. Fortunately you start off with a wig. Whether or not your head is covered by anything will slightly affect mood, if you have it enabled.

Ported from tgstation/tgstation#49932

# Wiki Documentation

Add new neutral quirk to the quirks page:
Name: "Smooth-Headed"
Balance: 0
Desc: "You have no hair and are quite insecure about it! Keep your wig on, or at least your head covered up."
Not mood-locked

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: adds bald people (new baldness quirk!)
/:cl:
