### PR TITLE
Fixes ambience not disabling without reconnecting

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -73,10 +73,10 @@ SUBSYSTEM_DEF(ambience)
 
 ///Effect, random sounds that will play at random times, IC (requires the user to be able to hear)
 /datum/controller/subsystem/ambience/proc/play_ambience_effects(mob/M, _ambi_fx, area/A)
-	if(M.can_hear_ambience() && !M.client?.channel_in_use(CHANNEL_AMBIENT_EFFECTS))
+	if(M.can_hear_ambience() && !M.client?.channel_in_use(CHANNEL_AMBIENT_EFFECTS) && (M.client.prefs.toggles & SOUND_AMBIENCE))
 		SEND_SOUND(M, sound(_ambi_fx, repeat = 0, wait = 0, volume = 45, channel = CHANNEL_AMBIENT_EFFECTS))
 
 ///Play background music, the more OOC ambience, like eerie space music
 /datum/controller/subsystem/ambience/proc/play_ambience_music(mob/M, _ambi_music, area/A)
-	if(!M.client?.channel_in_use(CHANNEL_AMBIENT_MUSIC))
+	if(!M.client?.channel_in_use(CHANNEL_AMBIENT_MUSIC)&& (M.client.prefs.toggles & SOUND_AMBIENCE))
 		SEND_SOUND(M, sound(_ambi_music, repeat = 0, wait = 0, volume = 75, channel = CHANNEL_AMBIENT_MUSIC))

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -90,7 +90,7 @@
 	///Used to decide what the minimum time between ambience is
 	var/min_ambience_cooldown = 30 SECONDS
 	///Used to decide what the maximum time between ambience is
-	var/max_ambience_cooldown = 240 SECONDS
+	var/max_ambience_cooldown = 175 SECONDS
 	///Used to decide what kind of reverb the area makes sound have
 	var/sound_environment = SOUND_ENVIRONMENT_NONE
 


### PR DESCRIPTION
# Document the changes in your pull request
As title,
Also reduces the max time between ambience a little from 240 to 175

# Changelog
:cl:  
bugfix: Ambience settings now change in real time
tweak: Ambience is slightly more common
/:cl:
