### PR TITLE
Secure closets now properly inherit one-access when crafted

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -17,5 +17,8 @@
 	. = ..()
 	electronics = locate(/obj/item/electronics/airlock) in parts_list
 	if(electronics)
-		req_access = electronics.accesses
+		if(electronics.one_access)
+			req_one_access = electronics.accesses
+		else
+			req_access = electronics.accesses
 		qdel(electronics)


### PR DESCRIPTION
# Document the changes in your pull request

Flag was ignored when spawning from electronics

# Changelog

:cl:  
bugfix: Secure closets now properly inherit requiring "one access" from electronics when crafted
/:cl:
