### PR TITLE
Photos of station blueprints now reveal wires when in-hand

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -254,8 +254,13 @@
 		reveal_wires = TRUE
 
 	// Station blueprints do that too, but only if the wires are not randomized.
-	else if(user.is_holding_item_of_type(/obj/item/areaeditor/blueprints) && !randomize)
-		reveal_wires = TRUE
+	else if(!randomize)
+		if(user.is_holding_item_of_type(/obj/item/areaeditor/blueprints))
+			reveal_wires = TRUE
+		else if(user.is_holding_item_of_type(/obj/item/photo))
+			var/obj/item/photo/P = user.is_holding_item_of_type(/obj/item/photo)
+			if(P.picture.has_blueprints)	//if the blueprints are in frame
+				reveal_wires = TRUE
 
 	for(var/color in colors)
 		payload.Add(list(list(


### PR DESCRIPTION
# Document the changes in your pull request

Because a photo of the blueprints are just as valuable as the blueprints themselves, according to the Syndicate at least

# Changelog

:cl:  
tweak: Photos of station blueprints now reveal wires when in-hand
/:cl:
