### PR TITLE
Saphics gaskmasks are in suitstorages in atmos now and ce locker

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -64,7 +64,7 @@
 
 /obj/machinery/suit_storage_unit/atmos
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/atmos
-	mask_type = /obj/item/clothing/mask/gas
+	mask_type = /obj/item/clothing/mask/gas/atmos
 	storage_type = /obj/item/watertank/atmos
 
 /obj/machinery/suit_storage_unit/mining

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -11,6 +11,7 @@
 	new /obj/item/storage/toolbox/mechanical(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/clothing/neck/cloak/ce(src)
+	new /obj/item/clothing/mask/gas/atmos(src)
 	new /obj/item/areaeditor/blueprints(src)
 	new /obj/item/airlock_painter(src)
 	new /obj/item/holosign_creator/atmos(src)


### PR DESCRIPTION
# Document the changes in your pull request

put the new atmos gas mask from saphic in the atmos suitstorages instead of those nasty cringe icky yucky plebian normie gasmasks also in ce lockers

# Spriting



# Wiki Documentation

something something gasmasks are atmos version now :)

# Changelog

:cl:  
rscadd: adds atmos gasmasks to the suitstorages and ce lockers
/:cl:
