### PR TITLE
[PORT] Item hover outlines

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -232,3 +232,5 @@
 #define SCRN_OBJ_IN_PALETTE "palette"
 ///Inserted first in the list
 #define SCRN_OBJ_INSERT_FIRST "first"
+/// The filter name for the hover outline
+#define HOVER_OUTLINE_FILTER "hover_outline"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -142,6 +142,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 	var/printed = FALSE
 
+	/// item hover FX
+	var/outline_filter
+
 /obj/item/Initialize(mapload)
 
 	materials =	typelist("materials", materials)
@@ -855,15 +858,53 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		openToolTip(user,src,params,title = name,content = "[desc]<br><b>Force:</b> [force_string]",theme = "")
 
 /obj/item/MouseEntered(location, control, params)
-	if((item_flags & IN_INVENTORY || item_flags & IN_STORAGE) && usr.client.prefs.read_preference(/datum/preference/toggle/enable_tooltips) && !QDELETED(src))
-		var/timedelay = usr.client.prefs.read_preference(/datum/preference/numeric/tooltip_delay) / 100
-		var/user = usr
-		tip_timer = addtimer(CALLBACK(src, PROC_REF(openTip), location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
+	. = ..()
+	if((item_flags & IN_INVENTORY || item_flags & IN_STORAGE) && !QDELETED(src))
+		var/mob/living/L = usr
+		if(usr.client.prefs.read_preference(/datum/preference/toggle/enable_tooltips))
+			var/timedelay = usr.client.prefs.read_preference(/datum/preference/numeric/tooltip_delay) / 100
+			tip_timer = addtimer(CALLBACK(src, PROC_REF(openTip), location, control, params, usr), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
+		if(usr.client.prefs.read_preference(/datum/preference/toggle/item_outlines))
+			if(istype(L) && L.incapacitated())
+				apply_outline(COLOR_RED_GRAY) //if they're dead or handcuffed, let's show the outline as red to indicate that they can't interact with that right now
+			else
+				apply_outline() //if the player's alive and well we send the command with no color set, so it uses the theme's color
+
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	remove_filter(HOVER_OUTLINE_FILTER) //get rid of the hover effect in case the mouse exit isn't called if someone drags and drops an item and somthing goes wrong
 
 /obj/item/MouseExited()
-	deltimer(tip_timer)//delete any in-progress timer if the mouse is moved off the item before it finishes
+	deltimer(tip_timer) //delete any in-progress timer if the mouse is moved off the item before it finishes
 	closeToolTip(usr)
+	remove_filter(HOVER_OUTLINE_FILTER)
 
+/obj/item/proc/apply_outline(outline_color = null)
+	if(!(item_flags & IN_INVENTORY || item_flags & IN_STORAGE) || QDELETED(src) || isobserver(usr)) //cancel if the item isn't in an inventory, is being deleted, or if the person hovering is a ghost (so that people spectating you don't randomly make your items glow)
+		return
+	var/theme = lowertext(usr.client?.prefs?.read_preference(/datum/preference/choiced/ui_style))
+	if(!outline_color) //if we weren't provided with a color, take the theme's color
+		switch(theme) //yeah it kinda has to be this way
+			if("midnight")
+				outline_color = COLOR_THEME_MIDNIGHT
+			if("plasmafire")
+				outline_color = COLOR_THEME_PLASMAFIRE
+			if("retro")
+				outline_color = COLOR_THEME_RETRO //just as garish as the rest of this theme
+			if("slimecore")
+				outline_color = COLOR_THEME_SLIMECORE
+			if("operative")
+				outline_color = COLOR_THEME_OPERATIVE
+			if("clockwork")
+				outline_color = COLOR_THEME_CLOCKWORK //if you want free gbp go fix the fact that clockwork's tooltip css is glass'
+			if("glass")
+				outline_color = COLOR_THEME_GLASS
+			else //this should never happen, hopefully
+				outline_color = COLOR_WHITE
+	if(color)
+		outline_color = COLOR_WHITE //if the item is recolored then the outline will be too, let's make the outline white so it becomes the same color instead of some ugly mix of the theme and the tint
+
+	add_filter(HOVER_OUTLINE_FILTER, 1, list("type" = "outline", "size" = 1, "color" = outline_color))
 
 // Called when a mob tries to use the item as a tool.
 // Handles most checks.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -899,6 +899,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				outline_color = COLOR_THEME_CLOCKWORK //if you want free gbp go fix the fact that clockwork's tooltip css is glass'
 			if("glass")
 				outline_color = COLOR_THEME_GLASS
+			if("detective")
+				outline_color = COLOR_THEME_DETECTIVE
 			else //this should never happen, hopefully
 				outline_color = COLOR_WHITE
 	if(color)

--- a/code/modules/client/preferences/itemoutline.dm
+++ b/code/modules/client/preferences/itemoutline.dm
@@ -1,0 +1,5 @@
+/datum/preference/toggle/item_outlines
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "item_outlines"
+	savefile_identifier = PREFERENCE_PLAYER
+

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/item_outline.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/item_outline.tsx
@@ -1,0 +1,7 @@
+import { CheckboxInput, FeatureToggle } from "../base";
+
+export const item_outlines: FeatureToggle = {
+  name: "Item hover outlines",
+  category: "UI",
+  component: CheckboxInput,
+};

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2039,6 +2039,7 @@
 #include "code\modules\client\preferences\gender.dm"
 #include "code\modules\client\preferences\ghost.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
+#include "code\modules\client\preferences\itemoutline.dm"
 #include "code\modules\client\preferences\items.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\mood.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds item hover outlines from beestation, as well as a pref to toggle them on or off.
![image](https://github.com/yogstation13/Yogstation/assets/42524344/9a6d8b3d-005e-491e-b2cf-26196c3ed75e)
![image](https://github.com/yogstation13/Yogstation/assets/42524344/46eabaeb-2352-4d28-b6aa-f0c3b0016bba)
![image](https://github.com/yogstation13/Yogstation/assets/42524344/5c6d32da-4a03-4a02-92db-2647ea5a42b2)

# Changelog
:cl:  
rscadd: Added item hover outlines
/:cl:
