### PR TITLE
Makes emergency sutures less terrible

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -242,8 +242,6 @@
 	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."
 	icon_state = "suture_green"
 	heal_brute = 5
-	amount = 5
-	max_amount = 5
 	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 1)
 
 /obj/item/stack/medical/suture/emergency/makeshift
@@ -251,8 +249,6 @@
 	desc = "A makeshift suture, gnarly looking, but it...should work."
 	heal_brute = 4
 	stop_bleeding = 0.44
-	amount = 5
-	max_amount = 5
 	grind_results = null
 
 /obj/item/stack/medical/suture/emergency/makeshift/tribal
@@ -261,8 +257,6 @@
 	icon_state = "suture_tribal"
 	heal_brute = 6
 	stop_bleeding = 0.55
-	amount = 10
-	max_amount = 10
 	grind_results = list(/datum/reagent/liquidgibs = 2)
 
 /obj/item/stack/medical/suture/medicated


### PR DESCRIPTION
They already heal for less than half of what regular sutures heal
They can at least be a stack of 15 instead of only a stack of 5

:cl:  
tweak: All emergency sutures now start at 15 in a stack instead of 5
/:cl:
