### PR TITLE
Makes ointments easier to craft and have 7 more uses

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -683,17 +683,16 @@
 /datum/crafting_recipe/ointment
 	name = "Ointment"
 	result = /obj/item/stack/medical/ointment
-	reqs = list(/obj/item/reagent_containers/glass/beaker/waterbottle = 1,
-				/datum/reagent/ash = 10,
-				/datum/reagent/medicine/c2/lenturi = 15)
+	reqs = list(/datum/reagent/water = 10,
+				/datum/reagent/ash = 10)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/antisepticointment
 	name = "Antiseptic Ointment"
 	result = /obj/item/stack/medical/ointment/antiseptic
-	reqs = list(/obj/item/reagent_containers/glass/beaker/waterbottle = 1,
+	reqs = list(/datum/reagent/water = 10,
 				/datum/reagent/ash = 10,
-				/datum/reagent/space_cleaner/sterilizine = 15)
+				/datum/reagent/space_cleaner/sterilizine = 5)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/advancedmesh

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -693,7 +693,7 @@
 	result = /obj/item/stack/medical/ointment/antiseptic
 	reqs = list(/datum/reagent/water = 10,
 				/datum/reagent/ash = 10,
-				/datum/reagent/space_cleaner/sterilizine = 5)
+				/datum/reagent/silver = 10)
 	tools = list(/obj/item/weldingtool)
 	category = CAT_MEDICAL
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -685,6 +685,7 @@
 	result = /obj/item/stack/medical/ointment
 	reqs = list(/datum/reagent/water = 10,
 				/datum/reagent/ash = 10)
+	tools = list(/obj/item/weldingtool)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/antisepticointment
@@ -693,6 +694,7 @@
 	reqs = list(/datum/reagent/water = 10,
 				/datum/reagent/ash = 10,
 				/datum/reagent/space_cleaner/sterilizine = 5)
+	tools = list(/obj/item/weldingtool)
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/advancedmesh

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -333,7 +333,7 @@
 	desc = "A specialized ointment, designed with preventing infections in mind."
 	icon_state = "aointment"
 	sanitization = 1.0 // its main purpose is to disinfect
-	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 5)
+	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 4)
 
 /obj/item/stack/medical/mesh
 	name = "regenerative mesh"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -306,15 +306,15 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	apply_sounds = list('sound/effects/ointment.ogg')
-	amount = 8
-	max_amount = 8
-	self_delay = 40
-	other_delay = 20
+	amount = 15
+	max_amount = 15
+	self_delay = 4 SECONDS
+	other_delay = 2 SECONDS
 	repeating = TRUE
 	heal_burn = 5
 	flesh_regeneration = 2.5
 	sanitization = 0.25
-	grind_results = list(/datum/reagent/medicine/c2/lenturi = 10)
+	grind_results = null
 
 /obj/item/stack/medical/ointment/heal(mob/living/M, mob/user)
 	if(M.stat == DEAD)
@@ -332,11 +332,8 @@
 	name = "antiseptic ointment"
 	desc = "A specialized ointment, designed with preventing infections in mind."
 	icon_state = "aointment"
-	amount = 15
-	max_amount = 15
-	heal_burn = 3
 	sanitization = 1.0 // its main purpose is to disinfect
-	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 10)
+	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 5)
 
 /obj/item/stack/medical/mesh
 	name = "regenerative mesh"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -333,7 +333,7 @@
 	desc = "A specialized ointment, designed with preventing infections in mind."
 	icon_state = "aointment"
 	sanitization = 1.0 // its main purpose is to disinfect
-	grind_results = list(/datum/reagent/space_cleaner/sterilizine = 4)
+	grind_results = list(/datum/reagent/silver = 5)
 
 /obj/item/stack/medical/mesh
 	name = "regenerative mesh"


### PR DESCRIPTION
Ointments are basically the ghetto equivalent of regenerative meshes, but they require specialized chemicals to make, effectively making them useless as medical will just use proper surgery or other chems

Removes lenturi from the regular ointment crafting recipe and makes it use water than specifically a water bottle
Replaced the sterilizine needed for the antiseptic ointment with liquid silver, but since it still requires some effort to make i increased the amount of healing it can do to be equal to regular ointment
Added the requirement of needing a welding tool to make ointments

:cl:  
tweak: Regular and Antiseptic ointment are easier to make but require a welding tool
tweak: Regular ointment now has 15 uses instead of 8
tweak: Antiseptic ointment now heals the same as regular ointment in addition to sterilizing more
/:cl:
