### PR TITLE
Clockwork Weapons Tweak

### DIFF
--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
@@ -2,9 +2,8 @@
 	name = "brass battle-hammer"
 	desc = "A brass hammer glowing with energy."
 	icon_state = "ratvarian_hammer"
-	force = 23
+	force = 15
 	throwforce = 15
-	armour_penetration = -20
 	sharpness = SHARP_NONE
 	attack_verb = list("bashed", "smitted", "hammered", "attacked")
 	clockwork_desc = "A powerful hammer of Ratvarian making. Enemies hit with it would be flung back."

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
@@ -2,9 +2,9 @@
 	name = "brass battle-hammer"
 	desc = "A brass hammer glowing with energy."
 	icon_state = "ratvarian_hammer"
-	force = 18
+	force = 23
 	throwforce = 15
-	wound_bonus = 10
+	armour_penetration = -20
 	sharpness = SHARP_NONE
 	attack_verb = list("bashed", "smitted", "hammered", "attacked")
 	clockwork_desc = "A powerful hammer of Ratvarian making. Enemies hit with it would be flung back."

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/battlehammer.dm
@@ -2,8 +2,9 @@
 	name = "brass battle-hammer"
 	desc = "A brass hammer glowing with energy."
 	icon_state = "ratvarian_hammer"
-	force = 15
+	force = 18
 	throwforce = 15
+	wound_bonus = 10
 	sharpness = SHARP_NONE
 	attack_verb = list("bashed", "smitted", "hammered", "attacked")
 	clockwork_desc = "A powerful hammer of Ratvarian making. Enemies hit with it would be flung back."

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/longsword.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/longsword.dm
@@ -2,14 +2,14 @@
 	name = "brass longsword"
 	desc = "A large sword made of brass."
 	icon_state = "ratvarian_sword"
-	force = 15
+	force = 18
 	throwforce = 20
 	armour_penetration = 10
 	block_chance = 35
 	attack_verb = list("attacked", "slashed", "cut", "torn", "gored")
 	clockwork_desc = "A powerful sword of Ratvarian making. Enemies hit with it will be struck with a powerful electromagnetic pulse."
 	var/emp_cooldown = 0
-	var/cooldown_duration = 20 SECONDS
+	var/cooldown_duration = 10 SECONDS
 
 /obj/item/clockwork/weapon/brass_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	. = ..()

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -8,6 +8,7 @@
 	force = 15 //Extra damage is dealt to targets in attack()
 	throwforce = 25
 	armour_penetration = 10
+	wound_bonus = 10
 	sharpness = SHARP_POINTY
 	attack_verb = list("stabbed", "poked", "slashed")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -298,6 +298,6 @@
 
 /obj/item/projectile/energy/arrow/clockbolt
 	name = "redlight bolt"
-	damage = 18
+	damage = 30
 	wound_bonus = 5
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/clockbolt

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -298,6 +298,6 @@
 
 /obj/item/projectile/energy/arrow/clockbolt
 	name = "redlight bolt"
-	damage = 30
+	damage = 20
 	wound_bonus = 5
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/clockbolt


### PR DESCRIPTION
Clockies are in need of some love, this love is something I've been antagonizing over for weeks to do.
All clockie weapons received some form of a buff, these buffs are relatively minor but they should put them on parity with other weapons that the crew can obtain as many clockie weapons simply did not deal the same amount of damage nor wound fairly.
**Spear**
- Wound Bonus of 10 
Sharp pointy stick but it doesn't wound people?  Already has decent damage and is defacto Clockie mainweapon

**Longsword:**
- 18 from 15 damage
- EMP cooldown reduced from 20 to 10 seconds
Extra damage for some added punch, EMP reduced down to 10 seconds so the weapon can be used in fights in a more reliable manner. It's one of it not their own defense against mechs.

**Clockwork Bow**
- 20 from 18
I wasn't gonna really touch this but it was asked to be beefed up. It now on parity with other bow weapons including the 40 damage infinite ammo hardlight bows

:cl:  
tweak: Clockwork longsword has 3 more force and emp cooldown is cut in half
tweak: Clockwork bow Arrows now do 20 damage instead of 18
tweak: Clockwork spear has 10 more wound bonus
/:cl:
