### PR TITLE
Mechanical limb replacement is back!

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -63,7 +63,7 @@
 	requires_real_bodypart = TRUE
 
 /datum/surgery/augmentation/can_start(mob/user, mob/living/carbon/target)
-	if(isgolem(target) || target.dna?.species.armor > 50) // no armor stacking
+	if(isgolem(target)) // no armor stacking
 		to_chat(user, span_warning("[target]'s exterior is too strong already!"))
 		return FALSE
 	else

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -20,6 +20,7 @@
 	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100)
 	time = 32
 	var/obj/item/bodypart/L = null // L because "limb"
+	var/blacklisted_self_zones = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST) // list of body zones you can't self-augment
 
 
 /datum/surgery_step/replace_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)//change this so digitigrade species can only use digitigrade limbs
@@ -31,6 +32,9 @@
 		return -1
 	if(aug.body_zone != target_zone)
 		to_chat(user, span_warning("[tool] isn't the right type for [parse_zone(target_zone)]."))
+		return -1
+	if(target == user && (aug.body_zone in blacklisted_self_zones)) // can't exactly replace your entire chest or head all by yourself
+		to_chat(user, span_warning("You can't augment your own [parse_zone(aug.body_zone)]!"))
 		return -1
 	L = surgery.operated_bodypart
 	if(L)
@@ -59,13 +63,12 @@
 	requires_real_bodypart = TRUE
 
 /datum/surgery/augmentation/can_start(mob/user, mob/living/carbon/target)
-	if(isgolem(target) || isipc(target) || ispreternis(target))
-		to_chat(user, span_warning("You can only augment organics!"))
+	if(isgolem(target) || target.dna?.species.armor > 50) // no armor stacking
+		to_chat(user, span_warning("[target]'s exterior is too strong already!"))
 		return FALSE
 	else
 		return TRUE
 
-/*
 /datum/surgery/augmentation/mechanic
 	steps = list(/datum/surgery_step/mechanic_open,
 				/datum/surgery_step/open_hatch,
@@ -73,7 +76,8 @@
 				/datum/surgery_step/prepare_electronics,
 				/datum/surgery_step/replace_limb)
 	requires_bodypart_type = BODYPART_ROBOTIC
-*/ //no you cannot augment already mechanical beings.
+	self_operable = TRUE // you can swap out your own arms and legs yourself, but chest and head have to be done by someone else
+// "no you cannot augment already mechanical beings" it's called replacement, silly
 
 //SURGERY STEP SUCCESSES
 


### PR DESCRIPTION
# Document the changes in your pull request

Partially reverts an old anti-QoL PR made a while ago, #15871, with some changes.

You can once again augment prosthetics with better robotic limbs directly instead of having to amputate them first. This also means it can be done on IPCs and preternis but they could already just cut off and reattach parts anyway.

You still can't augment golems though.

# Wiki Documentation

Change "You cannot augment a preternis, IPC, or golem" to "You cannot augment a golem" in the description for augmentation on the guide to surgery.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: augmentation can replace prosthetic limbs again
/:cl:
