### PR TITLE
[ASTEROID] Fixes some weird fucking mapping errors and some weird mapping choices

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -1390,9 +1390,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"ami" = (
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "amm" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/fancy/donut_box,
@@ -4110,12 +4107,6 @@
 /obj/structure/closet/crate/hydroponics,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"aIh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
 "aIj" = (
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
@@ -4885,13 +4876,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
 /area/vacant_room)
-"aQl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/storage/tech)
 "aQo" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -6180,6 +6164,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"bdF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bdS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6797,22 +6796,6 @@
 "bnn" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"bnP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "boj" = (
 /obj/structure/table,
 /obj/item/taperecorder,
@@ -8781,6 +8764,24 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bYU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "bZf" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/dark,
@@ -9083,25 +9084,6 @@
 /obj/machinery/armaments_dispenser,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"cdG" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES";
-	req_one_access_txt = "11;32"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "cdH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9829,12 +9811,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqN" = (
-/obj/structure/table/wood,
-/obj/item/folder/documents,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "cqX" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -9896,10 +9872,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"crE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "crW" = (
 /obj/machinery/vending/gifts,
 /turf/open/floor/plating,
@@ -10174,6 +10146,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"cwW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "cxd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12305,20 +12288,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"dgv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dgz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13047,6 +13016,31 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
+"duU" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES";
+	req_one_access_txt = "11;32"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "dvb" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -13142,6 +13136,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"dwB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "dwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -16788,6 +16800,26 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"eGG" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_l";
+	name = "Left side containment blast door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "eHc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17164,16 +17196,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/clerk)
-"eMi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eMm" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -17418,15 +17440,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"eRp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "eRA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -19349,25 +19362,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"fzb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/sign/warning/fire{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "fzj" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/snacks/snowcones/rainbow,
@@ -19539,6 +19533,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
+"fCK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "fCN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20573,6 +20587,25 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"fUN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/sign/warning/fire{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "fVy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -22777,6 +22810,31 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gGK" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES";
+	req_one_access_txt = "11;32"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "gGV" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel,
@@ -22824,6 +22882,12 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room)
+"gIv" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "gID" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -24730,6 +24794,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
+"hoh" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/camera{
+	c_tag = "SMES Access";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "hol" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25459,6 +25540,18 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
+"hzJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "hzL" = (
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -25759,43 +25852,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hDf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2
 	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
-"hDh" = (
-/obj/structure/closet/radiation,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "SMES Access";
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/engine/engine_smes)
+/area/hallway/primary/starboard)
 "hDn" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -27180,6 +27243,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"icE" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/hallway/secondary/exit)
 "ida" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27557,21 +27624,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"ijH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ijM" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -27932,6 +27984,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"iql" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "iqr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27972,6 +28041,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"irc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "irp" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -29350,12 +29437,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iSg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "iSn" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -29647,18 +29728,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
-"iVZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "iWn" = (
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
@@ -29681,14 +29750,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"iWR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "iWY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30369,6 +30430,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"jfb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "jfX" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing/chamber";
@@ -32504,6 +32576,21 @@
 /obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jOl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "jOn" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -32563,14 +32650,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"jPv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "jPJ" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -32644,12 +32723,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
-"jQy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "jQH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -34392,6 +34465,14 @@
 	},
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
+"kuo" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "kuG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -35217,6 +35298,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"kIQ" = (
+/obj/structure/table/wood,
+/obj/item/pen/fountain,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "kJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -35807,6 +35893,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"kUO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "kUQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36129,6 +36221,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"laJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES";
+	req_one_access_txt = "11;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "laV" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/analyzer,
@@ -36149,11 +36260,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"lby" = (
-/obj/structure/table/wood,
-/obj/item/folder/documents,
-/turf/open/floor/carpet/blue,
-/area/bridge/meeting_room)
 "lbz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -36320,17 +36426,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ldR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "lec" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -38091,18 +38186,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"lMr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "lMC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -38594,6 +38677,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lTG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/departments/minsky/security/security{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "lTK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -43511,20 +43606,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"nvE" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nvK" = (
 /obj/structure/table/wood,
 /obj/item/pen/fountain,
@@ -43927,6 +44008,30 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"nCN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nCV" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/tcoms";
@@ -43965,6 +44070,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nDy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "nDN" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -45074,6 +45193,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/bridge)
+"nWK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "nWT" = (
 /obj/vehicle/ridden/wheelchair,
 /obj/machinery/camera{
@@ -45132,6 +45264,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"nXt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nXC" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld{
@@ -45251,6 +45397,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
+"nZO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "nZZ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/light{
@@ -45727,16 +45888,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"ojt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Research Division";
-	location = "EVA"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ojx" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -46295,20 +46446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"osU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "osV" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -47109,6 +47246,15 @@
 "oGi" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
+"oGo" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "oGt" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -48205,27 +48351,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"oZi" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "oZk" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -50804,6 +50929,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"pLM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "pLY" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plating/rust,
@@ -53514,25 +53654,6 @@
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
-"qEr" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES";
-	req_one_access_txt = "11;32"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "qEt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -53610,18 +53731,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"qFj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53736,26 +53845,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qHk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "qHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -54596,26 +54685,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"qZe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_l";
-	name = "Left side containment blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "qZg" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -56109,6 +56178,17 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"rvZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rwa" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -56792,12 +56872,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rGP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rGR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -57585,12 +57659,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"rUg" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "rUk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -57836,18 +57904,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"rXq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/departments/minsky/security/security{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "rXC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59710,24 +59766,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"sFn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "sFw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -61863,21 +61901,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tlX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "tmd" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/dough,
@@ -61935,12 +61958,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"tnu" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "tnN" = (
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/plasteel/dark,
@@ -62635,6 +62652,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"tCe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES";
+	req_one_access_txt = "11;32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "tCy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -63950,6 +63986,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ucx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "ucA" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -66100,6 +66145,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"uMK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "uNd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -67176,6 +67230,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"viy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "viD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -68089,15 +68161,6 @@
 	},
 /turf/open/floor/plating,
 /area/clerk)
-"vzf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/crew_quarters/heads/hor)
 "vzg" = (
 /obj/item/flashlight/lantern/jade{
 	on = 1
@@ -68424,22 +68487,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow,
 /area/space/nearstation)
-"vGn" = (
-/obj/machinery/recharge_station,
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "vGq" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
@@ -68994,27 +69041,6 @@
 /obj/effect/spawner/lootdrop/randomfood,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vQe" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "vQg" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -71172,19 +71198,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wCu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "wCv" = (
 /obj/machinery/light{
 	dir = 4
@@ -71768,6 +71781,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wLs" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "wLC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red,
@@ -73658,15 +73679,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"xpw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "xqa" = (
 /obj/machinery/modular_computer/console/preset/command/cmo{
 	dir = 1
@@ -74100,6 +74112,24 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"xxL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "xyh" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -75659,20 +75689,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"xXC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "xXG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -75737,11 +75753,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xYv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/storage/tech)
 "xYK" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -76129,6 +76140,13 @@
 /obj/structure/grille,
 /turf/open/space,
 /area/space)
+"yfE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Research Division";
+	location = "EVA"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "yfF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -97169,7 +97187,7 @@ mQX
 bxL
 aGM
 igI
-lby
+fAC
 fAC
 jWJ
 dcX
@@ -97679,7 +97697,7 @@ nFq
 pGo
 oZo
 uEH
-cqN
+kIQ
 bxL
 aGM
 hvN
@@ -103598,9 +103616,9 @@ akp
 aAA
 aNg
 kfu
-xYv
 ycH
-aQl
+ycH
+ycH
 ycH
 gfx
 aOP
@@ -106422,9 +106440,9 @@ wxS
 pzl
 fZg
 aTK
-qZe
-jQy
-xpw
+eGG
+adX
+oGo
 oSW
 cvI
 pJs
@@ -106679,9 +106697,9 @@ gtq
 aZU
 uJJ
 aZU
-iWR
-osU
-aZU
+jfb
+iql
+wLs
 aZU
 wwD
 aZU
@@ -108461,8 +108479,8 @@ aBy
 aKT
 aKT
 aBy
-qFj
-rGP
+jOl
+xRz
 oTC
 arA
 ycV
@@ -108718,8 +108736,8 @@ aBy
 sia
 aKT
 aBy
-qFj
-iSg
+bdF
+aiZ
 hiU
 arA
 ukF
@@ -108975,8 +108993,8 @@ aBy
 aBy
 qhM
 aBy
-tlX
-iSg
+irc
+aiZ
 hiU
 arA
 wNG
@@ -109232,8 +109250,8 @@ geG
 opp
 oAQ
 mLr
-dgv
-crE
+nXt
+aiZ
 ngM
 ium
 jKr
@@ -109489,8 +109507,8 @@ gpn
 njj
 aCf
 kpy
-iVZ
-ojt
+pLM
+yfE
 pyi
 arA
 fXa
@@ -109746,8 +109764,8 @@ aCf
 njj
 aCf
 kpy
-iVZ
-iSg
+pLM
+aiZ
 tPZ
 arA
 arA
@@ -110003,8 +110021,8 @@ aBy
 mso
 aBy
 aBy
-vQe
-iSg
+nCN
+aiZ
 gBI
 raA
 qiF
@@ -110260,8 +110278,8 @@ cIa
 dIv
 aBy
 qDz
-ijH
-eMi
+xxL
+hDf
 pQJ
 hFB
 jpp
@@ -112068,8 +112086,8 @@ xzU
 rYE
 iVx
 etS
-rUg
-hDf
+kUO
+hzJ
 amR
 amR
 amR
@@ -112325,8 +112343,8 @@ gJN
 hAe
 vUC
 hyX
-vzf
-hDf
+ucx
+hzJ
 amR
 aAn
 mYt
@@ -112582,8 +112600,8 @@ mML
 vpt
 tvU
 hyX
-eRp
-hDf
+uMK
+hzJ
 amR
 aZV
 eQt
@@ -112839,8 +112857,8 @@ sPG
 sPG
 sPG
 sPG
-rXq
-lMr
+lTG
+hzJ
 amR
 aAn
 jMP
@@ -113096,8 +113114,8 @@ auI
 pIz
 pHa
 dbx
-ldR
-jPv
+cwW
+kuo
 amR
 mYG
 vGH
@@ -113353,8 +113371,8 @@ umc
 nlh
 kPp
 sPG
-tnu
-lMr
+gIv
+hzJ
 aDY
 aDY
 aDY
@@ -113610,8 +113628,8 @@ rdW
 aQb
 cME
 mnR
-ami
-xXC
+akl
+nDy
 poL
 gzP
 oqX
@@ -113867,8 +113885,8 @@ dbP
 vHN
 nHd
 mnR
-ami
-wCu
+akl
+nWK
 xVK
 jOQ
 jOQ
@@ -114124,8 +114142,8 @@ dTv
 rVy
 mMT
 mnR
-ami
-fzb
+akl
+fUN
 poL
 pht
 eBL
@@ -118514,7 +118532,7 @@ uXx
 fFj
 pXS
 gLw
-qHk
+fCK
 mfI
 aPn
 aPn
@@ -119027,7 +119045,7 @@ drR
 eMP
 fFj
 mhV
-sFn
+bYU
 eFa
 vId
 aYF
@@ -120061,7 +120079,7 @@ csp
 vsN
 ule
 urH
-bnP
+dwB
 hUL
 uUo
 rDw
@@ -121344,7 +121362,7 @@ ssp
 pIm
 gCe
 jCM
-nvE
+rvZ
 vKg
 lGS
 qew
@@ -121601,8 +121619,8 @@ aYa
 aYa
 aJj
 aAy
-aIh
-cdG
+laJ
+duU
 aAy
 aAy
 jOs
@@ -121814,7 +121832,7 @@ uam
 uam
 uam
 uam
-wgX
+aNY
 iwc
 jjp
 wsp
@@ -121858,9 +121876,9 @@ upE
 aYa
 aAy
 aAy
-hDh
-oZi
-vGn
+nZO
+viy
+hoh
 aAy
 aAy
 aVM
@@ -122071,7 +122089,7 @@ mgZ
 mgZ
 mgZ
 uLd
-dKd
+icE
 iSn
 iSn
 xkg
@@ -122115,8 +122133,8 @@ tMO
 qaZ
 aAy
 aAy
-aIh
-qEr
+tCe
+gGK
 aAy
 aAy
 aAy


### PR DESCRIPTION
# Document the changes in your pull request

Fixes/Changes include:

- Removes the two extra secret documents just sitting on the tables in the bridge meeting room, leaving the only instance of them as the set in the vault (as it SHOULD be)

- Fixes some weird pipes that were on different tiles for no reason in Central Hallway

- Fixes the RD's /area/ leaking into the hallway outside his office

- Fixes the podbay /area/ leaking into evac prisoner containment in weird way

- Fixes a scrubber and airvent that were unconnected and hiding under windows in secure tech storage (what the actual f u c k)

- Fixes two instances of wires running under walls (one in SMES and one in Xenobio)

- Fixes some absolutely autistic wiring in the CE's office that while functional was exceedingly cursed and inconsistent with the rest of the wiring on asteroid.

# Changelog

:cl:  cark
mapping: fixes mapping errors on asteroid
/:cl:
