### PR TITLE
Lets people stand up while moving

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -461,7 +461,7 @@
 	if(!resting)
 		set_resting(TRUE, FALSE)
 	else
-		if(do_after(src, 1 SECONDS, src))
+		if(do_after(src, 1 SECONDS, src, stayStill = FALSE))
 			set_resting(FALSE, FALSE)
 		else
 			to_chat(src, span_notice("You fail to get up."))


### PR DESCRIPTION
No reason it needs to prevent movement, should make combat slightly more active, with falling over no longer being a death sentence
If someone wants to keep you down, there are other more reasonable ways than just dragging you around

:cl:  
tweak: Can stand up while moving
/:cl:
