### PR TITLE
Buff gas miner 

### DIFF
--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -14,7 +14,7 @@
 	resistance_flags = INDESTRUCTIBLE|ACID_PROOF|FIRE_PROOF
 	var/spawn_id = null
 	var/spawn_temp = T20C
-	var/spawn_mol = MOLES_CELLSTANDARD * 5
+	var/spawn_mol = MOLES_CELLSTANDARD * 20
 	var/max_ext_mol = INFINITY
 	var/max_ext_kpa = 6500
 	var/overlay_color = "#FFFFFF"


### PR DESCRIPTION
519 moles spawn are under 4500KPA and the chamber can be easily drained and after awhile the chamber is nearly empty so i buffed it

# Document the changes in your pull request
519 moles spawn to 2079 moles spawn




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: 519 moles spawn to 2079 moles spawn
/:cl:
