### PR TITLE
Refactors HFR production/consumption to be more intuitive and useful

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -209,14 +209,12 @@
 		return
 
 	// Phew. Lets calculate what this means in practice.
-	var/fuel_consumption_rate = clamp(fuel_injection_rate * 0.01 * 5 * power_level, 0.05, 30)
-	var/consumption_amount = fuel_consumption_rate * delta_time
-	var/production_amount
+	var/reaction_rate = clamp((power_level * 0.5) * (500 / magnetic_constrictor) * delta_time, 0.05, 30) // constrictor controls reaction rate instead of fuel injection
 	switch(power_level)
 		if(3,4)
-			production_amount = clamp(heat_output * 5e-4, 0, fuel_consumption_rate) * delta_time
+			reaction_rate = clamp(reaction_rate * heat_output * 5e-4, 0, reaction_rate)
 		else
-			production_amount = clamp(heat_output / 10 ** (power_level+1), 0, fuel_consumption_rate) * delta_time
+			reaction_rate = clamp(reaction_rate * heat_output / (10 ** (power_level+1)), 0, reaction_rate)
 
 	// antinob production is special, and uses its own calculations from how stale the fusion mix is (via byproduct ratio and fresh fuel rate)
 	var/dirty_production_rate = scaled_fuel_list[scaled_fuel_list[3]] / fuel_injection_rate
@@ -224,52 +222,38 @@
 	// Run the effects of our selected fuel recipe
 
 	var/datum/gas_mixture/internal_output = new
-	moderator_fuel_process(delta_time, production_amount, consumption_amount, internal_output, moderator_list, selected_fuel, fuel_list)
+	moderator_fuel_process(delta_time, reaction_rate, internal_output, moderator_list, selected_fuel, fuel_list)
 
 	// Run the common effects, committing changes where applicable
 
 	// This is repetition, but is here as a placeholder for what will need to be done to allow concurrently running multiple recipes
-	var/common_production_amount = production_amount * selected_fuel.gas_production_multiplier
+	var/common_production_amount = reaction_rate * selected_fuel.gas_production_multiplier
 	moderator_common_process(delta_time, common_production_amount, internal_output, moderator_list, dirty_production_rate, heat_output, radiation_modifier)
 
 /**
  * Perform recipe specific actions. Fuel consumption and recipe based gas production happens here.
  */
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/moderator_fuel_process(delta_time, production_amount, consumption_amount, datum/gas_mixture/internal_output, moderator_list, datum/hfr_fuel/fuel, fuel_list)
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/moderator_fuel_process(delta_time, reaction_rate, datum/gas_mixture/internal_output, moderator_list, datum/hfr_fuel/fuel, fuel_list)
 	// Adjust fusion consumption/production based on this recipe's characteristics
-	var/fuel_consumption = consumption_amount * 0.85 * selected_fuel.fuel_consumption_multiplier * max(power_level, 1)
-	var/scaled_production = production_amount * selected_fuel.gas_production_multiplier * max(power_level, 1)
+	var/fuel_consumption = reaction_rate * 0.85 * selected_fuel.fuel_consumption_multiplier
+	var/scaled_production = reaction_rate * selected_fuel.gas_production_multiplier
 
 	for(var/gas_id in fuel.requirements)
 		internal_fusion.adjust_moles(gas_id, -min(fuel_list[gas_id], fuel_consumption))
 	for(var/gas_id in fuel.primary_products)
 		internal_fusion.adjust_moles(gas_id, fuel_consumption * 0.5)
 
+	if(power_level < 1)
+		return // can't produce any gases, don't need to continue
+
 	// Each recipe provides a tier list of six output gases.
 	// Which gases are produced depend on what the fusion level is.
 	var/list/tier = fuel.secondary_products
-	switch(power_level)
-		if(1)
-			moderator_internal.adjust_moles(tier[1], scaled_production * 0.95)
-			moderator_internal.adjust_moles(tier[2], scaled_production * 0.75)
-		if(2)
-			moderator_internal.adjust_moles(tier[1], scaled_production * 1.65)
-			moderator_internal.adjust_moles(tier[2], scaled_production)
-			if(moderator_list[/datum/gas/plasma] > 50)
-				moderator_internal.adjust_moles(tier[3], scaled_production * 1.15)
-		if(3)
-			moderator_internal.adjust_moles(tier[2], scaled_production * 0.5)
-			moderator_internal.adjust_moles(tier[3], scaled_production * 0.45)
-		if(4)
-			moderator_internal.adjust_moles(tier[3], scaled_production * 1.65)
-			moderator_internal.adjust_moles(tier[4], scaled_production * 1.25)
-		if(5)
-			moderator_internal.adjust_moles(tier[4], scaled_production * 0.65)
-			moderator_internal.adjust_moles(tier[5], scaled_production)
-			moderator_internal.adjust_moles(tier[6], scaled_production * 0.75)
-		if(6)
-			moderator_internal.adjust_moles(tier[5], scaled_production * 0.35)
-			moderator_internal.adjust_moles(tier[6], scaled_production)
+	moderator_internal.adjust_moles(tier[power_level], scaled_production) // gases on the same tier are produced at normal rate
+	if(power_level < 6)
+		moderator_internal.adjust_moles(tier[power_level + 1], scaled_production * 0.5) // gases on the above tier are produced at reduced rate
+	if(power_level > 1)
+		moderator_internal.adjust_moles(tier[power_level - 1], scaled_production * 1.5) // gases on the below tier are produced at increased rate
 
 /**
  * Perform common fusion actions:

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -130,7 +130,7 @@ export const HypertorusSecondaryControls = (props, context) => {
             parameter="magnetic_constrictor"
             icon="magnet"
             flipIcon
-            help="Adjusts the density of the fusion reaction. Denser reactions expose more energy, but may destabilize the reaction if too much mass is involved."
+            help="Adjusts the density of the fusion reaction. Denser reactions are much faster, but may become unstable if too much mass is involved."
           />
         </LabeledControls.Item>
         <LabeledControls.Item label="Current Damper">


### PR DESCRIPTION
# Document the changes in your pull request

HFR production and consumption are now tied together in the same variable (as it should be) which is determined by the energy of the reaction as well as the constrictor setting (lower volume = faster reaction)

This fixes some issues like not being able to add more fuel to keep up with a faster reaction, now that the reaction rate is controlled by the constrictor instead of fuel injection rate.

I've also changed how it decides which secondary byproducts it should be making as well, instead of using hardcoded numbers and a switch statement it simply produces gas on the tier of the current fusion level at a normal rate, the tier below at 1.5x the normal rate, and the tier above at 0.5x the normal rate.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: reworks HFR fuel consumption and production to make more sense and actually work properly
/:cl:
