### PR TITLE
[MDB IGNORE] Asteroid Trims Overhaul

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -62,7 +62,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -203,7 +203,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "abU" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -257,7 +257,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -270,7 +270,7 @@
 /area/science/nanite)
 "aco" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -597,7 +597,7 @@
 /area/tcommsat/server)
 "afM" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -661,7 +661,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -682,7 +682,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "agq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/chair{
@@ -709,7 +709,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "agE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -787,7 +787,7 @@
 /area/maintenance/department/electrical)
 "agW" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -892,7 +892,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -909,7 +909,7 @@
 /turf/open/space/basic,
 /area/space)
 "aiM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -1038,7 +1038,7 @@
 "ajC" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1118,7 +1118,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -1140,7 +1140,7 @@
 /area/crew_quarters/heads/captain)
 "aku" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -1153,7 +1153,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -1298,7 +1298,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1377,7 +1377,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/item/stack/packageWrap{
@@ -1472,7 +1472,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "amZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1482,7 +1482,7 @@
 /obj/structure/bedsheetbin{
 	pixel_x = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anj" = (
@@ -1890,7 +1890,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2047,7 +2047,7 @@
 /obj/structure/sign/departments/evac{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "asx" = (
@@ -2205,7 +2205,7 @@
 /obj/structure/sign/map/right{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "atv" = (
@@ -2276,7 +2276,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -2342,7 +2342,7 @@
 /area/maintenance/port/fore)
 "aup" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -2392,7 +2392,7 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2550,7 +2550,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -2695,7 +2695,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -2738,7 +2738,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2786,10 +2786,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2821,7 +2821,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2837,7 +2837,7 @@
 /turf/template_noop,
 /area/crew_quarters/dorms)
 "ayJ" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2924,8 +2924,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3074,7 +3074,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -3158,7 +3158,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aBc" = (
@@ -3169,7 +3169,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3766,7 +3766,7 @@
 /area/science/xenobiology)
 "aFv" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3829,7 +3829,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "aFT" = (
@@ -4264,7 +4264,7 @@
 /area/library)
 "aJC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -4318,7 +4318,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "aKb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4461,7 +4461,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -4576,7 +4576,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4691,7 +4691,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "aOy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -4953,7 +4953,7 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "aRd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRh" = (
@@ -5216,7 +5216,7 @@
 /area/security/checkpoint/supply)
 "aTs" = (
 /obj/machinery/gulag_processor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5247,7 +5247,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aTJ" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5378,7 +5378,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aVl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5445,7 +5445,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -5479,7 +5479,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5491,7 +5491,7 @@
 	},
 /area/holodeck/rec_center)
 "aWL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -5522,7 +5522,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -5555,7 +5555,7 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -5582,7 +5582,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5779,7 +5779,7 @@
 /area/hallway/secondary/exit)
 "aYC" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -5792,10 +5792,10 @@
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "aYJ" = (
@@ -5900,7 +5900,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6061,7 +6061,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "baQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6079,7 +6079,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "bbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -6160,7 +6160,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bdu" = (
@@ -6184,7 +6184,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bep" = (
@@ -6351,7 +6351,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhy" = (
@@ -6367,7 +6367,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6382,7 +6382,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6395,7 +6395,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6410,7 +6410,7 @@
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6485,10 +6485,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bjb" = (
@@ -6518,7 +6518,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "bjt" = (
@@ -6547,7 +6547,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6587,7 +6587,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6652,7 +6652,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6747,7 +6747,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bmw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/report_crimes{
@@ -6760,7 +6760,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6788,7 +6788,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
 "bnm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -6822,7 +6822,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boz" = (
@@ -6895,7 +6895,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bpC" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6911,7 +6911,7 @@
 /area/ai_monitored/storage/satellite)
 "bqd" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -6966,10 +6966,10 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "bqV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -7043,7 +7043,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7061,7 +7061,7 @@
 	dir = 8;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -7189,7 +7189,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7205,7 +7205,7 @@
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "btS" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btU" = (
@@ -7321,7 +7321,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bwi" = (
@@ -7464,7 +7464,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7473,7 +7473,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -7522,10 +7522,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bAo" = (
@@ -7546,7 +7546,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bAF" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bAO" = (
@@ -7554,7 +7554,7 @@
 	name = "glass table"
 	},
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7564,10 +7564,10 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "bBj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/vending/snack/random,
@@ -7608,7 +7608,7 @@
 	c_tag = "Central Hallway North-East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7818,7 +7818,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Hallway"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7850,7 +7850,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -7882,7 +7882,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7950,7 +7950,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIq" = (
@@ -8009,7 +8009,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bIX" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8049,7 +8049,7 @@
 /obj/structure/sign/departments/minsky/research/robotics{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJJ" = (
@@ -8062,7 +8062,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8077,14 +8077,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bKc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8108,7 +8108,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bKW" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bLc" = (
@@ -8172,7 +8172,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8196,7 +8196,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8210,13 +8210,13 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8247,7 +8247,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "bNW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -8275,7 +8275,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8426,7 +8426,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -8501,7 +8501,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bSy" = (
@@ -8512,11 +8512,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bSO" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -8554,7 +8554,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bVa" = (
@@ -8571,7 +8571,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8584,7 +8584,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bVE" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bVK" = (
@@ -8592,7 +8592,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -8622,7 +8622,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -8847,7 +8847,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9003,7 +9003,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9024,7 +9024,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9034,7 +9034,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9077,7 +9077,7 @@
 /area/medical/medbay/lobby)
 "cdC" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/armaments_dispenser,
@@ -9202,7 +9202,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9226,7 +9226,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/meter,
@@ -9237,7 +9237,7 @@
 	c_tag = "Engineering South";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9250,7 +9250,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9531,7 +9531,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/camera{
 	c_tag = "Medbay West";
 	dir = 1;
@@ -9554,7 +9554,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cks" = (
@@ -9569,7 +9569,7 @@
 	pixel_y = -24
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "ckB" = (
@@ -9615,7 +9615,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "clb" = (
@@ -9770,7 +9770,7 @@
 "cnU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "coo" = (
@@ -9804,7 +9804,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cqa" = (
@@ -9840,7 +9840,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "cqZ" = (
@@ -9852,7 +9852,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "crb" = (
@@ -9870,13 +9870,13 @@
 /obj/structure/mirror{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cri" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -9976,7 +9976,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "cts" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -10003,7 +10003,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cua" = (
@@ -10033,7 +10033,7 @@
 /area/science/xenobiology)
 "cuH" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "cuU" = (
@@ -10161,7 +10161,7 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cwO" = (
@@ -10253,7 +10253,7 @@
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -10286,7 +10286,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -10299,7 +10299,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "czo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10324,7 +10324,7 @@
 	dir = 4;
 	name = "hallway camera"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10336,7 +10336,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10443,7 +10443,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10604,7 +10604,7 @@
 	id = "crematoriumChapel";
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10671,7 +10671,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cEO" = (
@@ -10696,7 +10696,7 @@
 /area/science/xenobiology)
 "cEY" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -10769,7 +10769,7 @@
 /obj/structure/sign/poster/ripped{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve{
@@ -10823,7 +10823,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cHo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10852,7 +10852,7 @@
 "cHX" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/stock_parts/cell/high/plus,
@@ -11074,7 +11074,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cMf" = (
@@ -11090,7 +11090,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11114,7 +11114,7 @@
 /area/crew_quarters/heads/captain)
 "cME" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "cMI" = (
@@ -11122,13 +11122,13 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "cMJ" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cMS" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -11217,7 +11217,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11259,7 +11259,7 @@
 	c_tag = "Construction Area North";
 	dir = 0
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11312,7 +11312,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cOM" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11404,7 +11404,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -11443,7 +11443,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -11468,7 +11468,7 @@
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -11486,7 +11486,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11505,10 +11505,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11618,8 +11618,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11644,7 +11644,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11660,7 +11660,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cVr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11687,10 +11687,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12066,15 +12066,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dci" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12092,7 +12092,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12200,7 +12200,7 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "dez" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -12238,7 +12238,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12253,7 +12253,7 @@
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -12265,7 +12265,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12313,7 +12313,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -12358,7 +12358,7 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -12386,7 +12386,7 @@
 	name = "Surgery APC";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12494,7 +12494,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "diM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12511,12 +12511,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "djY" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12642,7 +12642,7 @@
 /area/clerk)
 "dlA" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -12665,7 +12665,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "dmh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12712,7 +12712,7 @@
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12777,7 +12777,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -12811,7 +12811,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dqq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12975,7 +12975,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12985,7 +12985,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -13015,7 +13015,7 @@
 /area/science/xenobiology)
 "duv" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -13092,7 +13092,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -13109,14 +13109,14 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dwt" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -13134,10 +13134,10 @@
 	pixel_x = -4;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13183,7 +13183,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13241,7 +13241,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13261,7 +13261,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "dyV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13283,7 +13283,7 @@
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
 /obj/item/toy/figure/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -13298,7 +13298,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -13352,7 +13352,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/fancy/donut_box,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13404,7 +13404,7 @@
 /area/engine/engineering)
 "dAU" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13473,7 +13473,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13482,7 +13482,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13503,7 +13503,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dEf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13534,7 +13534,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "dEV" = (
@@ -13553,7 +13553,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13566,7 +13566,7 @@
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13627,7 +13627,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13757,7 +13757,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13767,7 +13767,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13810,7 +13810,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13847,7 +13847,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dKN" = (
@@ -13885,7 +13885,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -14230,7 +14230,7 @@
 	c_tag = "Security Office";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = -32
 	},
@@ -14274,7 +14274,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14350,7 +14350,7 @@
 	pixel_y = 10
 	},
 /obj/item/analyzer,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14462,7 +14462,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14506,7 +14506,7 @@
 	dir = 1;
 	sortType = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dWc" = (
@@ -14516,7 +14516,7 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14671,10 +14671,10 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "dZY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eab" = (
@@ -14686,7 +14686,7 @@
 /area/space/nearstation)
 "eae" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14725,7 +14725,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14785,7 +14785,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14817,7 +14817,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14847,7 +14847,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14870,7 +14870,7 @@
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14901,7 +14901,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "edl" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -14955,7 +14955,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15077,7 +15077,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "efO" = (
@@ -15119,7 +15119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "egF" = (
@@ -15153,10 +15153,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15213,7 +15213,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15238,7 +15238,7 @@
 "eiC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "eiN" = (
@@ -15282,7 +15282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15357,7 +15357,7 @@
 /area/hallway/secondary/exit)
 "ejV" = (
 /obj/structure/table/optable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15457,7 +15457,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15507,7 +15507,7 @@
 	name = "Genetics Requests Console";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -15557,7 +15557,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -15613,7 +15613,7 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15681,10 +15681,10 @@
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eoO" = (
@@ -15751,7 +15751,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "epy" = (
@@ -15767,7 +15767,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eqh" = (
@@ -15796,7 +15796,7 @@
 /area/maintenance/disposal)
 "eqq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16024,7 +16024,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -16041,7 +16041,7 @@
 	dir = 1;
 	name = "Station Alert Console"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "etM" = (
@@ -16060,7 +16060,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "etS" = (
@@ -16153,7 +16153,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "evy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "evA" = (
@@ -16265,7 +16265,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "eye" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -16297,7 +16297,7 @@
 	dir = 8
 	},
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16312,7 +16312,7 @@
 /obj/structure/sign/map/left{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eyX" = (
@@ -16323,7 +16323,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ezv" = (
@@ -16414,7 +16414,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "eAT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -16452,7 +16452,7 @@
 /obj/machinery/bounty_board{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eBv" = (
@@ -16472,7 +16472,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "eBD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16513,7 +16513,7 @@
 /area/medical/paramedic)
 "eCu" = (
 /obj/item/stack/ore/iron,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16538,7 +16538,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eCV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -16556,7 +16556,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16582,10 +16582,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "eDH" = (
@@ -16593,7 +16593,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16606,7 +16606,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -16640,7 +16640,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -16661,7 +16661,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "eFa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -16742,7 +16742,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16830,7 +16830,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eHs" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16852,7 +16852,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16875,7 +16875,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "eIf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16940,7 +16940,7 @@
 /obj/machinery/computer/security/telescreen/cmo{
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16953,7 +16953,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eJh" = (
@@ -16979,7 +16979,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17073,7 +17073,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "eLh" = (
@@ -17112,7 +17112,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -17138,7 +17138,7 @@
 /area/engine/atmos/distro)
 "eLU" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17219,7 +17219,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "eMP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -17233,7 +17233,7 @@
 	name = "Unfiltered to Mix";
 	on = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17266,7 +17266,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17275,7 +17275,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17287,7 +17287,7 @@
 	},
 /area/crew_quarters/kitchen)
 "eOd" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eOp" = (
@@ -17368,7 +17368,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17388,7 +17388,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17413,7 +17413,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eRm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17607,7 +17607,7 @@
 /obj/structure/sign/departments/minsky/research/genetics{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eUv" = (
@@ -17623,7 +17623,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17720,7 +17720,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eXy" = (
@@ -17787,7 +17787,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17838,7 +17838,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17881,7 +17881,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "fbs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -17934,7 +17934,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "fcF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -17981,7 +17981,7 @@
 	pixel_x = -25;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -17998,13 +17998,13 @@
 	dir = 1
 	},
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "fdi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18038,7 +18038,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fdm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18080,7 +18080,7 @@
 /area/hallway/secondary/entry)
 "feA" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/newscaster{
@@ -18100,7 +18100,7 @@
 /obj/item/storage/box/zipties{
 	pixel_x = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "feE" = (
@@ -18167,7 +18167,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18190,7 +18190,7 @@
 	dir = 1;
 	pixel_y = 38
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -18269,7 +18269,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
@@ -18326,13 +18326,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fib" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -18537,7 +18537,7 @@
 	name = "Air to Distro";
 	target_pressure = 4500
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18582,7 +18582,7 @@
 /area/teleporter)
 "flQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18617,7 +18617,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fmB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -18630,7 +18630,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fmL" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -18667,7 +18667,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/ten,
 /obj/item/toy/figure/atmos,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18697,7 +18697,7 @@
 /obj/structure/sign/plaques/atmos{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/pipedispenser,
@@ -18705,7 +18705,7 @@
 /area/engine/atmos)
 "fod" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18806,13 +18806,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fpZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -18975,7 +18975,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fta" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -18993,7 +18993,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19036,7 +19036,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "fuM" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19069,7 +19069,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "fvj" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19078,7 +19078,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "fvw" = (
@@ -19122,7 +19122,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "fvV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fwl" = (
@@ -19143,7 +19143,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19152,10 +19152,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "fwF" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19182,7 +19182,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -19244,7 +19244,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fxy" = (
@@ -19280,14 +19280,14 @@
 /area/maintenance/port)
 "fxN" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fxW" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -19363,7 +19363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19384,7 +19384,7 @@
 	},
 /area/crew_quarters/kitchen)
 "fzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -19412,7 +19412,7 @@
 /turf/open/floor/carpet,
 /area/lawoffice)
 "fAi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -19444,7 +19444,7 @@
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "fAO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -19498,7 +19498,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "fBW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19517,7 +19517,7 @@
 	pixel_y = 10
 	},
 /obj/item/stack/packageWrap,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "fCn" = (
@@ -19534,7 +19534,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fCJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19561,7 +19561,7 @@
 /area/hydroponics/garden)
 "fDb" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -19592,14 +19592,14 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fDQ" = (
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19625,7 +19625,7 @@
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/core,
 /obj/item/paper/guides/jobs/atmos/hypertorus,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -19643,7 +19643,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "fEV" = (
@@ -19673,10 +19673,10 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "fFp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19705,7 +19705,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19781,7 +19781,7 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19826,14 +19826,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "fIl" = (
 /obj/machinery/papershredder,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/status_display/supply{
@@ -19886,13 +19886,13 @@
 /area/crew_quarters/bar)
 "fJL" = (
 /obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fJM" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19921,7 +19921,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19945,7 +19945,7 @@
 	dir = 4;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19954,7 +19954,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "fKN" = (
@@ -19969,7 +19969,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20086,7 +20086,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20126,7 +20126,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20211,7 +20211,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "fPN" = (
@@ -20224,7 +20224,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/table,
@@ -20313,7 +20313,7 @@
 	c_tag = "Engineering Access";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20397,7 +20397,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20471,7 +20471,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20498,7 +20498,7 @@
 	},
 /area/crew_quarters/kitchen)
 "fTM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/coffee,
@@ -20534,13 +20534,13 @@
 /area/vacant_room)
 "fUd" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fUj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20656,7 +20656,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20691,7 +20691,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20757,7 +20757,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fYa" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -20790,17 +20790,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fZb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20849,7 +20849,7 @@
 /obj/structure/table,
 /obj/item/electropack,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20907,7 +20907,7 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -20919,7 +20919,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20928,7 +20928,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20995,7 +20995,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gbH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -21034,7 +21034,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -21153,7 +21153,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "geG" = (
@@ -21184,7 +21184,7 @@
 	},
 /obj/item/pen/red,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21321,7 +21321,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -21376,7 +21376,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21456,7 +21456,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -21514,7 +21514,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -21526,7 +21526,7 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21610,7 +21610,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21628,7 +21628,7 @@
 /area/crew_quarters/bar)
 "gnq" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gnw" = (
@@ -21656,7 +21656,7 @@
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "gnM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "gnT" = (
@@ -21700,7 +21700,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "goW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21710,7 +21710,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21736,7 +21736,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gqx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/papershredder,
@@ -21755,7 +21755,7 @@
 /area/maintenance/starboard/aft)
 "gqJ" = (
 /obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -21775,7 +21775,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21920,7 +21920,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "gtu" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gtC" = (
@@ -21949,7 +21949,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22136,7 +22136,7 @@
 /obj/item/sequence_scanner,
 /obj/item/sequence_scanner,
 /obj/item/stack/cable_coil/white,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -22202,7 +22202,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gyz" = (
@@ -22218,7 +22218,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gyU" = (
@@ -22331,10 +22331,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gzS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -22352,7 +22352,7 @@
 /area/hallway/primary/fore)
 "gAc" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -22367,7 +22367,7 @@
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gAM" = (
@@ -22439,7 +22439,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22457,7 +22457,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gBO" = (
@@ -22488,7 +22488,7 @@
 	c_tag = "Brig Central";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
@@ -22516,7 +22516,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gDb" = (
@@ -22535,7 +22535,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gDq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -22543,7 +22543,7 @@
 /area/engine/atmos/storage)
 "gDx" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22601,14 +22601,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gEx" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "gER" = (
@@ -22688,11 +22688,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gFZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22741,7 +22741,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22757,7 +22757,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22955,7 +22955,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gKM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23043,7 +23043,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23066,7 +23066,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23113,8 +23113,8 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "gNo" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23208,7 +23208,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "gOI" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23263,7 +23263,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating/corner{
@@ -23277,7 +23277,7 @@
 /obj/item/radio/headset/headset_med,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23298,7 +23298,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -23317,13 +23317,13 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "gQG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -23379,7 +23379,7 @@
 "gRg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23483,7 +23483,7 @@
 /area/crew_quarters/bar)
 "gSN" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23518,7 +23518,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "gTD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "gTH" = (
@@ -23535,7 +23535,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "gTI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23548,7 +23548,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "gUj" = (
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gUo" = (
@@ -23649,10 +23649,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23692,7 +23692,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23866,7 +23866,7 @@
 /area/crew_quarters/fitness)
 "hbF" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -23915,7 +23915,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23927,7 +23927,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hdk" = (
@@ -23962,7 +23962,7 @@
 "hdB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hdK" = (
@@ -23987,7 +23987,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -24099,7 +24099,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24122,7 +24122,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24233,7 +24233,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -24328,7 +24328,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24357,7 +24357,7 @@
 /area/crew_quarters/bar)
 "hii" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
 	name = "Central Hall APC";
@@ -24399,7 +24399,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hiB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -24444,7 +24444,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hiU" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hiX" = (
@@ -24487,7 +24487,7 @@
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -24592,7 +24592,7 @@
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24647,7 +24647,7 @@
 	dir = 4;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24665,7 +24665,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hmV" = (
@@ -24712,7 +24712,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24766,7 +24766,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24830,7 +24830,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "hpE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24892,7 +24892,7 @@
 	icon_state = "1-4";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -24918,7 +24918,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24960,7 +24960,7 @@
 	dir = 1
 	},
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25021,7 +25021,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hsu" = (
@@ -25034,7 +25034,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25047,11 +25047,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hsM" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25166,7 +25166,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "hvl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -25258,7 +25258,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "hwc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -25295,7 +25295,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -25308,7 +25308,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -25321,7 +25321,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hxK" = (
@@ -25349,7 +25349,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hxO" = (
@@ -25363,10 +25363,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25384,7 +25384,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hxZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25527,7 +25527,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "hAq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25649,7 +25649,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25805,7 +25805,7 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25814,7 +25814,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/warning/electricshock{
@@ -25870,13 +25870,13 @@
 /area/bridge)
 "hEK" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "hFg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "hFp" = (
@@ -25917,7 +25917,7 @@
 /area/science/xenobiology)
 "hFT" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -25938,7 +25938,7 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25978,7 +25978,7 @@
 /area/ai_monitored/storage/eva)
 "hGu" = (
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -26125,7 +26125,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hIo" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -26181,13 +26181,13 @@
 	pixel_x = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hJu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -26217,7 +26217,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26240,10 +26240,10 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hKz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hKS" = (
@@ -26266,10 +26266,10 @@
 "hLS" = (
 /obj/structure/table,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26360,7 +26360,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hMZ" = (
@@ -26374,7 +26374,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "hNc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26401,7 +26401,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/obj/effect/turf_decal/trimline/neutral/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "hNt" = (
@@ -26531,7 +26531,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26567,7 +26567,7 @@
 /turf/open/space/basic,
 /area/space)
 "hQp" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26576,14 +26576,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hQP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 2;
@@ -26607,7 +26607,7 @@
 /area/science/mixing)
 "hRX" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -26627,7 +26627,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "hSm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -26643,7 +26643,7 @@
 /area/engine/gravity_generator)
 "hSz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26671,14 +26671,14 @@
 /area/storage/primary)
 "hSV" = (
 /obj/structure/closet/l3closet,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "hTi" = (
 /obj/machinery/computer/bounty{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "hTw" = (
@@ -26707,7 +26707,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "hTG" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26735,7 +26735,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26834,7 +26834,7 @@
 /obj/item/razor{
 	pixel_x = -6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hXl" = (
@@ -26844,7 +26844,7 @@
 "hXF" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -26987,7 +26987,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hZz" = (
@@ -27022,7 +27022,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27069,7 +27069,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "iaS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/research/xenobiology{
@@ -27086,10 +27086,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -27169,7 +27169,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "icC" = (
@@ -27191,7 +27191,7 @@
 /area/science/explab)
 "idB" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "idE" = (
@@ -27266,7 +27266,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ifa" = (
@@ -27291,7 +27291,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27396,7 +27396,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27450,7 +27450,7 @@
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27534,7 +27534,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ijv" = (
@@ -27579,7 +27579,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ijO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/filingcabinet{
@@ -27607,7 +27607,7 @@
 /area/library)
 "ikq" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27621,7 +27621,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27735,7 +27735,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "imy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27763,14 +27763,14 @@
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "imT" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27778,7 +27778,7 @@
 "imY" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -27827,7 +27827,7 @@
 /area/crew_quarters/theatre)
 "iog" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27871,7 +27871,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ioR" = (
@@ -27907,7 +27907,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27927,7 +27927,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27955,10 +27955,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iqs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -27974,7 +27974,7 @@
 /area/maintenance/starboard/aft)
 "irp" = (
 /obj/structure/closet/secure_closet/paramedic,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "irz" = (
@@ -28057,7 +28057,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "itc" = (
@@ -28112,7 +28112,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -28137,7 +28137,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iul" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28179,10 +28179,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28192,7 +28192,7 @@
 	c_tag = "Atmospherics North West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -28282,7 +28282,7 @@
 	dir = 4
 	},
 /obj/structure/closet/crate,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -28299,7 +28299,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
@@ -28310,7 +28310,7 @@
 "iwl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28412,7 +28412,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "iyK" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "iyZ" = (
@@ -28420,7 +28420,7 @@
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/listeningstation)
 "izg" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
@@ -28440,7 +28440,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "izw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -28482,7 +28482,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iAT" = (
@@ -28557,7 +28557,7 @@
 /obj/item/clothing/head/welding,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "iBN" = (
@@ -28606,7 +28606,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28672,10 +28672,10 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28729,7 +28729,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28766,7 +28766,7 @@
 /area/ai_monitored/turret_protected/ai)
 "iGQ" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iGT" = (
@@ -28789,7 +28789,7 @@
 	c_tag = "Central Hallway West 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28988,7 +28988,7 @@
 /area/medical/surgery)
 "iLq" = (
 /obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -29011,7 +29011,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -29076,7 +29076,7 @@
 	pixel_y = 7
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -29113,10 +29113,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iNd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29126,7 +29126,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -31
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -29157,7 +29157,7 @@
 /area/science/mixing)
 "iNC" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29205,11 +29205,11 @@
 /turf/open/floor/grass,
 /area/medical/medbay/aft)
 "iOu" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "iOJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -29361,7 +29361,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iSr" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iSv" = (
@@ -29385,7 +29385,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29426,7 +29426,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -29636,7 +29636,7 @@
 	pixel_y = 6
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29651,7 +29651,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29673,7 +29673,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -29756,7 +29756,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29912,7 +29912,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iZV" = (
@@ -29920,7 +29920,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29999,7 +29999,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jaz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/crate,
@@ -30038,7 +30038,7 @@
 /obj/structure/sign/barsign{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30086,13 +30086,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jbh" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -30146,10 +30146,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30225,7 +30225,7 @@
 	name = "Robotics Desk";
 	req_one_access_txt = "29;75"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jdm" = (
@@ -30352,7 +30352,7 @@
 "jeQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30402,7 +30402,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "jgg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -30419,7 +30419,7 @@
 /area/maintenance/starboard/fore)
 "jgs" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30492,7 +30492,7 @@
 /area/medical/genetics)
 "jgU" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30530,7 +30530,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30547,7 +30547,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30588,7 +30588,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30600,7 +30600,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "jit" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/bed/dogbed{
 	desc = "Autumn's Bed! Looks comfy.";
 	name = "Autumn's Bed"
@@ -30644,7 +30644,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "jiH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -30696,7 +30696,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30734,7 +30734,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30976,7 +30976,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "joq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
@@ -31068,7 +31068,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jqy" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31101,7 +31101,7 @@
 /area/maintenance/solars/starboard/aft)
 "jqP" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31139,14 +31139,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jrt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -31200,7 +31200,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered)
 "jsq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
@@ -31218,7 +31218,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -31244,7 +31244,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31253,7 +31253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jtG" = (
@@ -31284,7 +31284,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31401,7 +31401,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31462,7 +31462,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31476,7 +31476,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jxh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -31524,7 +31524,7 @@
 /turf/open/floor/engine,
 /area/escapepodbay)
 "jxV" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -31549,7 +31549,7 @@
 /area/ai_monitored/security/armory)
 "jyK" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -31589,7 +31589,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31617,7 +31617,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable/yellow,
@@ -31643,7 +31643,7 @@
 /area/crew_quarters/kitchen)
 "jAf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31671,21 +31671,21 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "jAz" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "jAB" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31744,7 +31744,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
 "jBN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31822,7 +31822,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31844,7 +31844,7 @@
 	c_tag = "Virology Monkey Pen";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -31865,8 +31865,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31953,7 +31953,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32045,7 +32045,7 @@
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -32093,7 +32093,7 @@
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32104,7 +32104,7 @@
 "jGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "jGN" = (
@@ -32120,7 +32120,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jHb" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -32171,7 +32171,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32186,8 +32186,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32362,7 +32362,7 @@
 /obj/machinery/computer/turbine_computer{
 	id = "incineratorturbine"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 6
 	},
@@ -32397,7 +32397,7 @@
 	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -32425,7 +32425,7 @@
 /area/crew_quarters/theatre)
 "jMp" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/twohanded/rcl/pre_loaded,
@@ -32498,7 +32498,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/pipedispenser/disposal,
@@ -32528,7 +32528,7 @@
 /area/hallway/primary/port)
 "jOE" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jOQ" = (
@@ -32606,7 +32606,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -32761,7 +32761,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32794,7 +32794,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/folder/white,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32810,7 +32810,7 @@
 /area/crew_quarters/heads/hop)
 "jSO" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32850,7 +32850,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -32891,7 +32891,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jUC" = (
@@ -32903,7 +32903,7 @@
 /area/medical/virology)
 "jUF" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -32913,7 +32913,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "jVp" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -32951,7 +32951,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33000,7 +33000,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33049,7 +33049,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -33167,7 +33167,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jZh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -33211,7 +33211,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -33226,7 +33226,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "kbb" = (
@@ -33280,7 +33280,7 @@
 /turf/open/floor/plating,
 /area/science/nanite)
 "kbK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -33305,7 +33305,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33347,10 +33347,10 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "keh" = (
@@ -33364,7 +33364,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "keF" = (
@@ -33429,7 +33429,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "kfG" = (
@@ -33445,7 +33445,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33496,7 +33496,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "kgj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -33620,7 +33620,7 @@
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -33639,14 +33639,14 @@
 "kiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kiL" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -33658,7 +33658,7 @@
 /obj/structure/sign/departments/minsky/medical/medical2{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kjm" = (
@@ -33754,7 +33754,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -33821,7 +33821,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33893,7 +33893,7 @@
 	dir = 8
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -34037,7 +34037,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kpQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -34054,7 +34054,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kpV" = (
@@ -34097,7 +34097,7 @@
 	pixel_y = -28
 	},
 /obj/item/pickaxe/mini,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kqK" = (
@@ -34153,7 +34153,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "krp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1
 	},
@@ -34313,7 +34313,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -34354,7 +34354,7 @@
 	dir = 1;
 	name = "Tank Monitor"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -34415,7 +34415,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -34432,7 +34432,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kvk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34487,7 +34487,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34500,13 +34500,13 @@
 /area/engine/atmos/hfr)
 "kww" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kwL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34534,7 +34534,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34616,13 +34616,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kyz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34634,7 +34634,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34724,7 +34724,7 @@
 	req_access_txt = "1"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -34736,11 +34736,11 @@
 "kAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "kBc" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34856,7 +34856,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kDv" = (
@@ -34887,7 +34887,7 @@
 	pixel_y = -9;
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35009,7 +35009,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35019,7 +35019,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kFv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -35084,7 +35084,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kGW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35148,7 +35148,7 @@
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -35186,7 +35186,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -35247,7 +35247,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35267,7 +35267,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "kJM" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35296,7 +35296,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "kLe" = (
@@ -35312,7 +35312,7 @@
 /obj/item/clothing/glasses/hud/health{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -35336,7 +35336,7 @@
 	pixel_y = 4
 	},
 /obj/item/pickaxe/mini,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kLl" = (
@@ -35370,10 +35370,10 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35458,7 +35458,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35489,7 +35489,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "kPr" = (
@@ -35514,7 +35514,7 @@
 	name = "Medbay RC";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -35523,13 +35523,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kQx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -35614,14 +35614,14 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "kRi" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35673,7 +35673,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "kSs" = (
@@ -35751,7 +35751,7 @@
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -35764,7 +35764,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35773,7 +35773,7 @@
 /obj/structure/sign/departments/minsky/command/charge{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kUc" = (
@@ -35851,11 +35851,11 @@
 "kVE" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "kVH" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kVJ" = (
@@ -35879,7 +35879,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/starboard/aft)
 "kWb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -35901,7 +35901,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35959,7 +35959,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kXR" = (
@@ -36057,7 +36057,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -36066,14 +36066,14 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kZw" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kZD" = (
@@ -36095,7 +36095,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "lad" = (
@@ -36118,7 +36118,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36193,7 +36193,7 @@
 /area/maintenance/port/fore)
 "lca" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36263,7 +36263,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36290,7 +36290,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36305,7 +36305,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ldu" = (
@@ -36326,7 +36326,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36398,7 +36398,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36440,7 +36440,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -36477,7 +36477,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lip" = (
@@ -36542,7 +36542,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ljH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -36567,7 +36567,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lkc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36587,7 +36587,7 @@
 /area/quartermaster/miningdock)
 "lkG" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -36601,7 +36601,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36632,7 +36632,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "llu" = (
@@ -36648,7 +36648,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36669,7 +36669,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lml" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -36729,7 +36729,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36796,7 +36796,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36835,7 +36835,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lrc" = (
@@ -36881,7 +36881,7 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -37077,7 +37077,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37087,7 +37087,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37197,7 +37197,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37217,7 +37217,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lxi" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37329,10 +37329,10 @@
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37355,7 +37355,7 @@
 /area/maintenance/central/secondary)
 "lyK" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -37363,7 +37363,7 @@
 	},
 /area/crew_quarters/heads/chief)
 "lyY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37393,7 +37393,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lzO" = (
@@ -37406,7 +37406,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -37435,7 +37435,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37447,7 +37447,7 @@
 /obj/machinery/modular_computer/console/preset/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37478,7 +37478,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
 "lAy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -37533,13 +37533,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "lBM" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37661,7 +37661,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37694,7 +37694,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37763,7 +37763,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37807,7 +37807,7 @@
 	layer = 4;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lIp" = (
@@ -37838,7 +37838,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "lIF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -37856,7 +37856,7 @@
 /area/maintenance/starboard/fore)
 "lIU" = (
 /obj/machinery/clonepod,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -37864,7 +37864,7 @@
 "lJd" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37889,7 +37889,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "lJD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -37920,7 +37920,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lJY" = (
@@ -37939,7 +37939,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lKG" = (
@@ -37998,7 +37998,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lLs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -38030,7 +38030,7 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -38116,7 +38116,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/obj/effect/turf_decal/trimline/neutral/warning/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -38175,7 +38175,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38184,7 +38184,7 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "lNc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -38214,7 +38214,7 @@
 /area/hallway/primary/central)
 "lNW" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lNX" = (
@@ -38251,7 +38251,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38294,7 +38294,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lPh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -38311,7 +38311,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lPj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38355,14 +38355,14 @@
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "lQw" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lQx" = (
@@ -38517,7 +38517,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38537,7 +38537,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38580,7 +38580,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lTz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38631,7 +38631,7 @@
 /area/engine/engineering)
 "lTX" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lUe" = (
@@ -38667,13 +38667,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lUG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lVv" = (
@@ -38756,7 +38756,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38845,7 +38845,7 @@
 /area/ai_monitored/storage/satellite)
 "lYD" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38896,7 +38896,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -38908,7 +38908,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38942,7 +38942,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mal" = (
@@ -39000,14 +39000,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "maH" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -39025,7 +39025,7 @@
 /area/engine/engineering)
 "mbf" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "mbj" = (
@@ -39049,7 +39049,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/wardrobe/pjs,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mbH" = (
@@ -39066,7 +39066,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -39083,7 +39083,7 @@
 	tag = ""
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mcg" = (
@@ -39112,7 +39112,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "mcD" = (
@@ -39146,7 +39146,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mcQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39319,7 +39319,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39369,7 +39369,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "mgd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
@@ -39411,13 +39411,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mgM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
@@ -39467,7 +39467,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mhM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -39498,7 +39498,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "mhV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "mhY" = (
@@ -39518,7 +39518,7 @@
 /area/science/mixing)
 "min" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39619,7 +39619,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mka" = (
@@ -39632,7 +39632,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39716,7 +39716,7 @@
 	c_tag = "Virology Module";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39729,7 +39729,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39814,7 +39814,7 @@
 	pixel_x = 11;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -39854,7 +39854,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39971,7 +39971,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "mpo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39981,7 +39981,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mqb" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -40024,7 +40024,7 @@
 	},
 /area/science/xenobiology)
 "mqv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -40092,13 +40092,13 @@
 /area/engine/engineering)
 "mrK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mrX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -40208,7 +40208,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "mtA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "mtG" = (
@@ -40257,7 +40257,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40281,7 +40281,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "muZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/conveyor{
@@ -40294,7 +40294,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -40326,7 +40326,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "mvU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40388,8 +40388,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40413,7 +40413,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40465,7 +40465,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40490,8 +40490,8 @@
 /area/engine/atmos)
 "mzO" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40515,7 +40515,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mAG" = (
@@ -40533,7 +40533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mAX" = (
@@ -40598,7 +40598,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40620,7 +40620,7 @@
 	pixel_x = -1;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40691,7 +40691,7 @@
 /area/maintenance/starboard/aft)
 "mDQ" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -40710,7 +40710,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mEn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/enlist{
@@ -40745,7 +40745,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40807,7 +40807,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40817,7 +40817,7 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "mGC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40926,7 +40926,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40947,7 +40947,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "mIo" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "mIz" = (
@@ -41070,7 +41070,7 @@
 /area/maintenance/starboard/fore)
 "mLm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -41204,7 +41204,7 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41216,7 +41216,7 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -41293,7 +41293,7 @@
 	network = list("ss13","medical")
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41316,7 +41316,7 @@
 /area/hallway/secondary/entry)
 "mNZ" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -41430,10 +41430,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41443,7 +41443,7 @@
 	c_tag = "Starboard Primary Hallway 4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41459,7 +41459,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41492,7 +41492,7 @@
 /area/ai_monitored/security/armory)
 "mRe" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "mRy" = (
@@ -41519,7 +41519,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -41532,7 +41532,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mTb" = (
@@ -41553,12 +41553,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mTt" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41591,7 +41591,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "mTH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/port";
 	name = "Port Hall APC";
@@ -41645,7 +41645,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41660,7 +41660,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41769,7 +41769,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -41789,7 +41789,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41819,7 +41819,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mXg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -41859,7 +41859,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41933,7 +41933,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41975,7 +41975,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
@@ -41985,7 +41985,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42110,7 +42110,7 @@
 /area/lawoffice)
 "mZx" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42119,13 +42119,13 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mZI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42156,7 +42156,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nai" = (
@@ -42185,7 +42185,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "naq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -42262,7 +42262,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/anesthetic_machine/roundstart,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42281,7 +42281,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ncT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42335,7 +42335,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -42455,7 +42455,7 @@
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -42478,7 +42478,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42598,7 +42598,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42625,7 +42625,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "ngM" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ngP" = (
@@ -42671,7 +42671,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nik" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "niA" = (
@@ -42690,7 +42690,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "niC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -42889,7 +42889,7 @@
 /area/security/courtroom)
 "nlu" = (
 /mob/living/carbon/monkey,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42990,7 +42990,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "nmW" = (
@@ -43002,7 +43002,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nng" = (
@@ -43010,7 +43010,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43028,7 +43028,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43038,7 +43038,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43053,7 +43053,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43066,7 +43066,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "noq" = (
@@ -43104,7 +43104,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -43156,7 +43156,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43238,7 +43238,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43369,7 +43369,7 @@
 /area/hallway/secondary/entry)
 "ntR" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ntS" = (
@@ -43377,11 +43377,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nuc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43391,7 +43391,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43416,7 +43416,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "nuv" = (
@@ -43427,7 +43427,7 @@
 /area/quartermaster/office)
 "nuw" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43467,7 +43467,7 @@
 /area/hallway/secondary/entry)
 "nuU" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43480,7 +43480,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nvv" = (
@@ -43520,7 +43520,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43591,19 +43591,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nxs" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "nxt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -43646,7 +43646,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nxX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -43687,7 +43687,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nys" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -43711,7 +43711,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "nze" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -43748,7 +43748,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43773,7 +43773,7 @@
 /area/engine/atmos/pumproom)
 "nzW" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43858,7 +43858,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nBf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nBt" = (
@@ -43884,7 +43884,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nBN" = (
@@ -43894,7 +43894,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43966,7 +43966,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nDN" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44016,7 +44016,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44120,7 +44120,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "nHl" = (
@@ -44190,7 +44190,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44199,7 +44199,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -44215,7 +44215,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
 "nIY" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "nJl" = (
@@ -44267,7 +44267,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -44333,7 +44333,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "nLZ" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -44384,7 +44384,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -44414,7 +44414,7 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nNW" = (
@@ -44432,7 +44432,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -44514,7 +44514,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44523,7 +44523,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "nPy" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44579,7 +44579,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nQn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44596,7 +44596,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44614,7 +44614,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nQY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44631,7 +44631,7 @@
 	pixel_x = 26;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44640,7 +44640,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/obj/effect/turf_decal/trimline/neutral/warning/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -44677,7 +44677,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nRM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -44748,10 +44748,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nSy" = (
@@ -44777,7 +44777,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/item/hand_labeler{
@@ -44826,7 +44826,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44853,7 +44853,7 @@
 	pixel_y = -7;
 	req_one_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -44868,7 +44868,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44944,10 +44944,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "nUZ" = (
@@ -44965,7 +44965,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "nVi" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45082,7 +45082,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -45111,7 +45111,7 @@
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45182,7 +45182,7 @@
 	pixel_y = 25;
 	req_access_txt = "36"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45240,7 +45240,7 @@
 	name = "Labor Camp Monitoring";
 	network = list("labor")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45274,7 +45274,7 @@
 	c_tag = "Atmospherics Tanks South";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
@@ -45284,7 +45284,7 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45325,7 +45325,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45345,7 +45345,7 @@
 	dir = 4;
 	pixel_y = 37
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45401,7 +45401,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/firstsingularity{
@@ -45454,7 +45454,7 @@
 	c_tag = "Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45489,7 +45489,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ocY" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45507,7 +45507,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "odp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/research/research{
@@ -45582,7 +45582,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -45654,8 +45654,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45718,7 +45718,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oin" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45741,7 +45741,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45803,7 +45803,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45823,7 +45823,7 @@
 "oki" = (
 /obj/structure/table,
 /obj/item/multitool,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -45860,7 +45860,7 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "oll" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -45885,7 +45885,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -45905,7 +45905,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "omj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -45936,7 +45936,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45951,7 +45951,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45990,8 +45990,8 @@
 	dir = 8;
 	name = "hallway camera"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46030,10 +46030,10 @@
 /obj/machinery/computer/warrant{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46043,14 +46043,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ooB" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46290,7 +46290,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46311,7 +46311,7 @@
 /area/science/xenobiology)
 "osV" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -46463,7 +46463,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ovy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -46524,7 +46524,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "owL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46575,7 +46575,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -46596,7 +46596,7 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46619,7 +46619,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46689,7 +46689,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ozT" = (
@@ -46711,7 +46711,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46749,7 +46749,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "oAn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46844,7 +46844,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46853,7 +46853,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oCq" = (
@@ -46869,7 +46869,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47037,10 +47037,10 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tanks North"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "oFo" = (
@@ -47133,7 +47133,7 @@
 /area/hallway/primary/central)
 "oHj" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47176,10 +47176,10 @@
 	c_tag = "Garden West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47304,7 +47304,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
@@ -47347,7 +47347,7 @@
 /obj/structure/sign/departments/minsky/command/bridge{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oKW" = (
@@ -47368,7 +47368,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -47386,7 +47386,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47436,7 +47436,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oMh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -47472,7 +47472,7 @@
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oMS" = (
@@ -47639,7 +47639,7 @@
 /area/maintenance/port/fore)
 "oQc" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /obj/item/clothing/glasses/meson{
@@ -47665,7 +47665,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "oQp" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47674,7 +47674,7 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "oQu" = (
@@ -47689,7 +47689,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "oQv" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47698,7 +47698,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -47732,7 +47732,7 @@
 /area/maintenance/department/tcoms)
 "oQW" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47747,7 +47747,7 @@
 /area/ruin/powered)
 "oRq" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47771,7 +47771,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oRG" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -47853,7 +47853,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47871,7 +47871,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "oSS" = (
@@ -47916,7 +47916,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oTw" = (
@@ -47948,7 +47948,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47958,7 +47958,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oTN" = (
@@ -48111,7 +48111,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -48129,7 +48129,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48157,14 +48157,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oXw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "oXP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -48230,7 +48230,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -48276,7 +48276,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48373,7 +48373,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48462,7 +48462,7 @@
 /area/science/mixing/chamber)
 "pbU" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pbV" = (
@@ -48472,7 +48472,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pbY" = (
@@ -48480,7 +48480,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48611,7 +48611,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48640,7 +48640,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area{
@@ -48679,7 +48679,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pfh" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48689,7 +48689,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west{
@@ -48698,7 +48698,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pfK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48752,7 +48752,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48780,7 +48780,7 @@
 /area/crew_quarters/bar)
 "phb" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "phj" = (
@@ -48813,7 +48813,7 @@
 	dir = 4;
 	name = "Input Gas Connector Port"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -48833,7 +48833,7 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pib" = (
@@ -48847,19 +48847,19 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pir" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pit" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -48929,7 +48929,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pjX" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49067,7 +49067,7 @@
 /obj/machinery/light{
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49075,7 +49075,7 @@
 "pmi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pmj" = (
@@ -49095,7 +49095,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -49116,7 +49116,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "pmv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -49193,7 +49193,7 @@
 	pixel_x = 0;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "pnm" = (
@@ -49427,7 +49427,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ppT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -49475,10 +49475,10 @@
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49494,7 +49494,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49519,7 +49519,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "prh" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49546,7 +49546,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49603,7 +49603,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "psi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/level_interface{
@@ -49681,7 +49681,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ptS" = (
@@ -49703,7 +49703,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49774,7 +49774,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pvk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pvB" = (
@@ -49887,7 +49887,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "pwu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49951,7 +49951,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49996,7 +49996,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pyp" = (
@@ -50105,7 +50105,7 @@
 	dir = 4
 	},
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50135,7 +50135,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50305,7 +50305,7 @@
 	pixel_y = -23
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "pDM" = (
@@ -50324,7 +50324,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pEe" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -50342,7 +50342,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "pEm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50394,8 +50394,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pFo" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50426,7 +50426,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -50470,7 +50470,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "pGq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50506,8 +50506,8 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50521,7 +50521,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/janitor)
 "pHT" = (
@@ -50545,7 +50545,7 @@
 /area/maintenance/central)
 "pHZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -50565,14 +50565,14 @@
 "pIm" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pIs" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
@@ -50600,7 +50600,7 @@
 	dir = 4;
 	network = list("ss13","rd","chpt")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50639,7 +50639,7 @@
 /area/science/xenobiology)
 "pJw" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -50723,7 +50723,7 @@
 "pKp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50749,7 +50749,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50761,7 +50761,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50783,7 +50783,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50799,7 +50799,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50820,7 +50820,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pMi" = (
@@ -50828,7 +50828,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51033,11 +51033,11 @@
 	dir = 8;
 	pixel_y = -40
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pOV" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51074,7 +51074,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "pPz" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51112,7 +51112,7 @@
 /area/hallway/primary/starboard)
 "pQr" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51128,7 +51128,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51139,7 +51139,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/item/destTagger{
@@ -51167,7 +51167,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -51227,7 +51227,7 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "pRU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51236,7 +51236,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -51254,7 +51254,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "pSx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargo{
@@ -51299,7 +51299,7 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51331,7 +51331,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51481,7 +51481,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51535,7 +51535,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -51582,7 +51582,7 @@
 "pWP" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51708,7 +51708,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "pXN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51723,7 +51723,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51734,7 +51734,7 @@
 	c_tag = "Engineering Foyer";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "pYp" = (
@@ -51899,7 +51899,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qbl" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qbt" = (
@@ -51922,10 +51922,10 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51963,7 +51963,7 @@
 	pixel_x = 32;
 	pixel_y = 40
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51982,7 +51982,7 @@
 /area/crew_quarters/locker)
 "qdp" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -51994,7 +51994,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qdH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -52042,7 +52042,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52057,7 +52057,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/command/charge{
@@ -52066,7 +52066,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qey" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -52120,7 +52120,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52133,7 +52133,7 @@
 	c_tag = "Atmospherics Auxiliary Storage";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -52223,7 +52223,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -52232,7 +52232,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "qhl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/machinery/light,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
@@ -52271,7 +52271,7 @@
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52323,7 +52323,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qiX" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -52360,7 +52360,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qkh" = (
@@ -52407,7 +52407,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52439,7 +52439,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52461,7 +52461,7 @@
 	},
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -52595,7 +52595,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -52719,7 +52719,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -52735,7 +52735,7 @@
 	dir = 4;
 	name = "Input Port Pump"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -52794,10 +52794,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "qri" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -52864,7 +52864,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -52913,7 +52913,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53002,7 +53002,7 @@
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -53038,7 +53038,7 @@
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
 "qvn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53141,7 +53141,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53152,7 +53152,7 @@
 "qya" = (
 /obj/machinery/light,
 /obj/machinery/vending/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -53185,7 +53185,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qyW" = (
@@ -53206,7 +53206,7 @@
 /area/science/storage)
 "qza" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -53222,7 +53222,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qzA" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 10
 	},
 /obj/machinery/button/flasher{
@@ -53236,7 +53236,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -53251,7 +53251,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "qAG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53362,7 +53362,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53455,7 +53455,7 @@
 /area/clerk)
 "qDT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53505,7 +53505,7 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -53534,7 +53534,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "qEt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53625,13 +53625,13 @@
 "qFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "qFQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -53657,7 +53657,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -53677,7 +53677,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -53715,7 +53715,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -53730,7 +53730,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qHe" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/vending/cola/random,
@@ -53859,14 +53859,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "qHT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qHV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -53952,7 +53952,7 @@
 	c_tag = "Garden South";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qKr" = (
@@ -53970,7 +53970,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54048,7 +54048,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -54255,8 +54255,8 @@
 /obj/machinery/light{
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54405,14 +54405,14 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qVk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qVm" = (
@@ -54472,7 +54472,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qWz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -54505,7 +54505,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qXp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -54532,7 +54532,7 @@
 "qXQ" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -54546,7 +54546,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54625,7 +54625,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/item/paper_bin{
@@ -54818,7 +54818,7 @@
 /area/crew_quarters/locker)
 "rct" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rcz" = (
@@ -54834,7 +54834,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54898,7 +54898,7 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54986,7 +54986,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -54998,7 +54998,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -55072,7 +55072,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55174,7 +55174,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rgQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -55227,7 +55227,7 @@
 /area/science/mixing)
 "rhk" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55288,7 +55288,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "riq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/radiation,
@@ -55365,7 +55365,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rjT" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "rjX" = (
@@ -55439,7 +55439,7 @@
 /area/science/xenobiology)
 "rkY" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55458,7 +55458,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55505,7 +55505,7 @@
 /obj/structure/sign/map/left{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rlJ" = (
@@ -55515,7 +55515,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55583,7 +55583,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "rnf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -55634,13 +55634,13 @@
 	},
 /obj/item/radio/off,
 /obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "rnZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55765,7 +55765,7 @@
 /area/crew_quarters/heads/chief)
 "rqd" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rqp" = (
@@ -55798,7 +55798,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rqK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55816,10 +55816,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55837,7 +55837,7 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "rrQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -55884,7 +55884,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -55909,7 +55909,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "rtb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/conveyor{
@@ -55948,7 +55948,7 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "ruc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55963,7 +55963,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56198,7 +56198,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -56222,7 +56222,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rxC" = (
@@ -56260,7 +56260,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -56288,7 +56288,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "ryM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56346,7 +56346,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rAN" = (
@@ -56381,7 +56381,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "rBz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "rBG" = (
@@ -56435,7 +56435,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rCy" = (
@@ -56508,7 +56508,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56530,7 +56530,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56581,7 +56581,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56592,7 +56592,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rEj" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -56615,7 +56615,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/rdconsole/production,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56627,7 +56627,7 @@
 	},
 /area/crew_quarters/bar)
 "rEz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rEG" = (
@@ -56670,7 +56670,7 @@
 	dir = 8;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56680,7 +56680,7 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56755,7 +56755,7 @@
 /area/hallway/primary/starboard)
 "rGh" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -56787,7 +56787,7 @@
 /area/maintenance/starboard/aft)
 "rGK" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -56808,7 +56808,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -56827,7 +56827,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "rHg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "rHj" = (
@@ -56891,7 +56891,7 @@
 	pixel_x = 29;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "rIB" = (
@@ -56943,7 +56943,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57002,7 +57002,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57045,7 +57045,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57117,7 +57117,7 @@
 	pixel_x = 5;
 	pixel_y = 13
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57139,7 +57139,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57187,7 +57187,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -57228,7 +57228,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "rOQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -57257,7 +57257,7 @@
 	name = "Atmos RC";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rPd" = (
@@ -57270,7 +57270,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rPf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rPh" = (
@@ -57368,7 +57368,7 @@
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57386,7 +57386,7 @@
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57421,7 +57421,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rQV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57431,7 +57431,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "rRe" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57492,7 +57492,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -57534,7 +57534,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57596,8 +57596,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
 "rUt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57656,7 +57656,7 @@
 /area/escapepodbay)
 "rVc" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -57703,7 +57703,7 @@
 "rVy" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57760,7 +57760,7 @@
 	name = "Output Gas Connector Port"
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "rWB" = (
@@ -57818,7 +57818,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "rWT" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rXg" = (
@@ -57843,7 +57843,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57923,7 +57923,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57990,7 +57990,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58057,7 +58057,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -58069,13 +58069,13 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sbf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sbl" = (
@@ -58287,10 +58287,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "sdd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -58387,7 +58387,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "seA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -58416,7 +58416,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58472,7 +58472,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "sht" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -58513,14 +58513,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "sir" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "siw" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58532,7 +58532,7 @@
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58562,7 +58562,7 @@
 /obj/structure/table/glass,
 /obj/item/crowbar,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -58615,7 +58615,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "skV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58634,7 +58634,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "slm" = (
@@ -58709,7 +58709,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "sni" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58737,7 +58737,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58757,7 +58757,7 @@
 /obj/machinery/camera{
 	c_tag = "Port Hallway"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58867,7 +58867,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sqa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -58881,7 +58881,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sqC" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58929,7 +58929,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58988,7 +58988,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -58999,7 +58999,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59044,7 +59044,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "stv" = (
@@ -59356,10 +59356,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "szr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -59438,7 +59438,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59480,7 +59480,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sBP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "sBX" = (
@@ -59498,7 +59498,7 @@
 	dir = 8;
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59511,7 +59511,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sCd" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /obj/structure/chair/office/dark{
@@ -59533,7 +59533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59588,7 +59588,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "sCG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
@@ -59617,7 +59617,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59628,7 +59628,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59734,7 +59734,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59766,7 +59766,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sFS" = (
@@ -59797,7 +59797,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59846,7 +59846,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "sGV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59887,14 +59887,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sHK" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60032,7 +60032,7 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "sIQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
@@ -60091,7 +60091,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sKr" = (
@@ -60141,7 +60141,7 @@
 "sKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60191,7 +60191,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "sLf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60316,7 +60316,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60390,7 +60390,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60491,7 +60491,7 @@
 /area/science/xenobiology)
 "sNK" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -60515,7 +60515,7 @@
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60608,7 +60608,7 @@
 /area/hallway/primary/starboard)
 "sQf" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60620,7 +60620,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/aiModule/reset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60644,7 +60644,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sQO" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60660,7 +60660,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -60686,7 +60686,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60753,7 +60753,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60784,7 +60784,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -60846,7 +60846,7 @@
 	pixel_x = 7;
 	pixel_y = 39
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -60857,7 +60857,7 @@
 "sTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60899,7 +60899,7 @@
 /area/crew_quarters/toilet/locker)
 "sUr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61011,7 +61011,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "sWY" = (
@@ -61073,7 +61073,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -61099,7 +61099,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "sYq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61120,7 +61120,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sYO" = (
@@ -61158,7 +61158,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61288,7 +61288,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "tbv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -61332,7 +61332,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tcN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61342,7 +61342,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "tcX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/chair{
@@ -61392,13 +61392,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tdo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61444,7 +61444,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61466,7 +61466,7 @@
 "tdW" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "teA" = (
@@ -61486,7 +61486,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61565,7 +61565,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tgz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -61579,7 +61579,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61600,7 +61600,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "thu" = (
@@ -61731,7 +61731,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -61743,7 +61743,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -61798,7 +61798,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "tkI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61860,7 +61860,7 @@
 	pixel_x = 1;
 	pixel_y = -37
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tlX" = (
@@ -61873,7 +61873,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61919,7 +61919,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tnp" = (
@@ -61930,13 +61930,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tnu" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -61954,7 +61954,7 @@
 /area/space/nearstation)
 "tob" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -61991,7 +61991,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "toY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Pure to Mix"
@@ -62020,7 +62020,7 @@
 	pixel_y = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62033,7 +62033,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "tpZ" = (
@@ -62148,7 +62148,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62221,14 +62221,14 @@
 "ttp" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ttt" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -62241,7 +62241,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "ttL" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ttV" = (
@@ -62293,7 +62293,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -62371,7 +62371,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "twR" = (
@@ -62412,7 +62412,7 @@
 /area/engine/atmos/distro)
 "txw" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62466,7 +62466,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -62493,7 +62493,7 @@
 /obj/machinery/recharger{
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -62587,13 +62587,13 @@
 	},
 /area/crew_quarters/kitchen)
 "tBi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tBR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -62652,7 +62652,7 @@
 	dir = 4;
 	id = "crematoriumChapel"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62760,7 +62760,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62772,7 +62772,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tFs" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62804,7 +62804,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62821,7 +62821,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62883,7 +62883,7 @@
 	pixel_x = -1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tGG" = (
@@ -62924,7 +62924,7 @@
 	c_tag = "Aft Primary Hallway 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62961,7 +62961,7 @@
 /area/engine/atmos/distro)
 "tHQ" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/firecloset,
@@ -62990,7 +62990,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63102,7 +63102,7 @@
 /area/crew_quarters/kitchen)
 "tJY" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -63200,7 +63200,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63209,7 +63209,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -63233,7 +63233,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "tPe" = (
 /obj/machinery/autolathe,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tPg" = (
@@ -63255,7 +63255,7 @@
 /area/maintenance/port/fore)
 "tPH" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -63286,7 +63286,7 @@
 /obj/structure/sign/departments/science{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tQh" = (
@@ -63331,7 +63331,7 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63388,7 +63388,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tSh" = (
@@ -63500,7 +63500,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tUq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63594,7 +63594,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "tVL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/starboard";
 	name = "Starboard Primary Hallway APC";
@@ -63664,7 +63664,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tXi" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63697,7 +63697,7 @@
 /area/maintenance/solars/starboard/aft)
 "tXv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63753,7 +63753,7 @@
 	c_tag = "Mining Dock External";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/advanced_airlock_controller{
@@ -63772,7 +63772,7 @@
 /obj/machinery/bounty_board{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tZb" = (
@@ -63833,7 +63833,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63886,7 +63886,7 @@
 /obj/item/hfr_box/body/interface,
 /obj/item/hfr_box/body/moderator_input,
 /obj/item/hfr_box/body/waste_output,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63911,7 +63911,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63939,13 +63939,13 @@
 	dir = 1
 	},
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uct" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64075,7 +64075,7 @@
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ufs" = (
@@ -64191,7 +64191,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64209,7 +64209,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uhv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhE" = (
@@ -64218,7 +64218,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64242,10 +64242,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uhV" = (
@@ -64276,7 +64276,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64288,7 +64288,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64304,7 +64304,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64313,13 +64313,13 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uiG" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64346,7 +64346,7 @@
 /area/hallway/primary/starboard)
 "uiJ" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -64417,7 +64417,7 @@
 	c_tag = "Robotics Lab";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64445,12 +64445,12 @@
 	pixel_x = 33;
 	pixel_y = -31
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ukO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64588,7 +64588,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "umX" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64619,7 +64619,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -64651,7 +64651,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64772,7 +64772,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64822,7 +64822,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64841,7 +64841,7 @@
 /area/hydroponics)
 "urH" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
@@ -64902,7 +64902,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64914,7 +64914,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -64979,11 +64979,11 @@
 /obj/structure/sign/map/right{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "utK" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65032,7 +65032,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65059,7 +65059,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65107,7 +65107,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/item/book/manual/wiki/security_space_law,
@@ -65145,7 +65145,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65166,7 +65166,7 @@
 /obj/structure/sign/departments/minsky/research/xenobiology{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -65175,7 +65175,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uyJ" = (
@@ -65194,14 +65194,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65229,7 +65229,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65238,13 +65238,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uzB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65379,13 +65379,13 @@
 /area/hallway/primary/aft)
 "uBg" = (
 /obj/machinery/computer/aifixer,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "uBp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65430,7 +65430,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65472,7 +65472,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65529,7 +65529,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65569,7 +65569,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uDT" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65590,14 +65590,14 @@
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical1{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uEu" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uEH" = (
@@ -65653,7 +65653,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65702,7 +65702,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable/orange{
@@ -65784,7 +65784,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65801,7 +65801,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65861,15 +65861,15 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "uIq" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uIu" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/status_display/evac{
@@ -65899,7 +65899,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -65960,7 +65960,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65989,7 +65989,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -66019,7 +66019,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/computer/atmos_sim{
 	dir = 1;
 	mode = 1
@@ -66031,7 +66031,7 @@
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
 "uLU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66043,7 +66043,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66145,7 +66145,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uOD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -66317,7 +66317,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uRn" = (
@@ -66359,7 +66359,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uSU" = (
@@ -66427,7 +66427,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66467,7 +66467,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66477,7 +66477,7 @@
 	c_tag = "Atmospherics South East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -66556,7 +66556,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66586,20 +66586,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uXx" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uXD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66630,7 +66630,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66654,7 +66654,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66779,7 +66779,7 @@
 "uZS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66814,14 +66814,14 @@
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "vaY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -66861,7 +66861,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "vbM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66894,7 +66894,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vct" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66976,7 +66976,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "veN" = (
@@ -66998,7 +66998,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67039,7 +67039,7 @@
 	c_tag = "Central Hallway South-East";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67064,7 +67064,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "vgd" = (
@@ -67076,7 +67076,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67102,7 +67102,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "vgW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -67124,10 +67124,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67171,7 +67171,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "viq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67193,7 +67193,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vjn" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -67261,14 +67261,14 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vjZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67292,7 +67292,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "vkP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -67342,7 +67342,7 @@
 /area/maintenance/port/fore)
 "vlb" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67357,7 +67357,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67407,7 +67407,7 @@
 /area/janitor)
 "vmG" = (
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "vmX" = (
@@ -67432,7 +67432,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vnJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -67458,14 +67458,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "voL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "voX" = (
@@ -67506,7 +67506,7 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "vpN" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -67560,7 +67560,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67649,7 +67649,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vsN" = (
@@ -67711,7 +67711,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67762,7 +67762,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -67771,7 +67771,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "vuD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -67803,7 +67803,7 @@
 /obj/machinery/camera{
 	c_tag = "Brig East"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67827,7 +67827,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67971,7 +67971,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68038,7 +68038,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68066,7 +68066,7 @@
 	c_tag = "Fore Primary Hallway East";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68144,7 +68144,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -68157,7 +68157,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "vAs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68205,7 +68205,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vCu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -68229,7 +68229,7 @@
 /area/science/robotics/lab)
 "vDu" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68238,7 +68238,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68295,7 +68295,7 @@
 "vEw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "vED" = (
@@ -68307,7 +68307,7 @@
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
 "vEM" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -68379,7 +68379,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68388,7 +68388,7 @@
 /obj/machinery/computer/cloning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68408,7 +68408,7 @@
 	dir = 8
 	},
 /obj/item/a_gift,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -68458,7 +68458,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vGF" = (
@@ -68469,7 +68469,7 @@
 	},
 /area/crew_quarters/bar)
 "vGG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -68495,7 +68495,7 @@
 /area/ai_monitored/secondarydatacore)
 "vGN" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68541,7 +68541,7 @@
 /area/hallway/primary/fore)
 "vJj" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68622,7 +68622,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68710,7 +68710,7 @@
 	dir = 8;
 	name = "cargo camera"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68747,7 +68747,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68827,10 +68827,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "vMU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -68896,7 +68896,7 @@
 /turf/open/floor/wood,
 /area/library)
 "vNJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68931,7 +68931,7 @@
 	pixel_x = 32;
 	pixel_y = -9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/item/radio/off,
@@ -68980,13 +68980,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vPP" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vQb" = (
@@ -69007,7 +69007,7 @@
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69041,7 +69041,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "vQB" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69096,7 +69096,7 @@
 "vRu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vRT" = (
@@ -69116,7 +69116,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69174,7 +69174,7 @@
 /turf/open/floor/plating,
 /area/janitor)
 "vSA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69199,7 +69199,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69207,7 +69207,7 @@
 "vTw" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -69261,7 +69261,7 @@
 /area/tcommsat/server)
 "vUd" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -69327,7 +69327,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "vVC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "vVP" = (
@@ -69335,7 +69335,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69377,7 +69377,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69416,7 +69416,7 @@
 	pixel_y = -24;
 	req_access_txt = "17"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vXp" = (
@@ -69465,7 +69465,7 @@
 /area/quartermaster/miningdock)
 "vYn" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "vYC" = (
@@ -69531,7 +69531,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69676,7 +69676,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69704,7 +69704,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -69783,11 +69783,11 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "wek" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69862,7 +69862,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
@@ -69925,10 +69925,10 @@
 /area/hallway/primary/central)
 "wfE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69946,7 +69946,7 @@
 /obj/structure/closet/wardrobe/white,
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -69964,7 +69964,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70012,7 +70012,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70055,7 +70055,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "wiK" = (
@@ -70115,7 +70115,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "wjK" = (
@@ -70153,7 +70153,7 @@
 /area/hydroponics/garden)
 "wjS" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -70190,7 +70190,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -70334,7 +70334,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "wmn" = (
@@ -70353,7 +70353,7 @@
 /area/hallway/primary/central)
 "wms" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70389,7 +70389,7 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70425,7 +70425,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70472,7 +70472,7 @@
 /area/quartermaster/miningdock)
 "wow" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -70485,7 +70485,7 @@
 /area/quartermaster/storage)
 "woS" = (
 /obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "wpj" = (
@@ -70509,7 +70509,7 @@
 /obj/machinery/bounty_board{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -70535,7 +70535,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -70619,7 +70619,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70720,7 +70720,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70729,7 +70729,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70760,7 +70760,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70782,7 +70782,7 @@
 	layer = 2.4;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70852,7 +70852,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wwm" = (
@@ -70957,7 +70957,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71015,7 +71015,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71121,7 +71121,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "wBs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -71182,7 +71182,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCv" = (
@@ -71199,7 +71199,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCL" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71264,14 +71264,14 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "wDM" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -71287,7 +71287,7 @@
 /area/engine/engine_smes)
 "wDS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71373,7 +71373,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "wFh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71405,7 +71405,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71489,7 +71489,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wGS" = (
@@ -71502,7 +71502,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71524,7 +71524,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wHT" = (
@@ -71556,8 +71556,8 @@
 /area/chapel/main)
 "wIc" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71568,7 +71568,7 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -71578,7 +71578,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -71612,7 +71612,7 @@
 	name = "Medical Backrooms APC";
 	pixel_y = -23
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "wIC" = (
@@ -71691,7 +71691,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71700,7 +71700,7 @@
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71730,7 +71730,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wKJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -71753,7 +71753,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71791,7 +71791,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wMr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -71802,7 +71802,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "wMt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71851,7 +71851,7 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "wNm" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71883,7 +71883,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -71994,7 +71994,7 @@
 /turf/closed/wall,
 /area/medical/storage)
 "wPe" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72080,7 +72080,7 @@
 /area/ai_monitored/storage/eva)
 "wQU" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -72107,7 +72107,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72174,7 +72174,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wSk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72228,7 +72228,7 @@
 /area/science/misc_lab)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72250,7 +72250,7 @@
 	pixel_x = -27;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72271,7 +72271,7 @@
 /area/teleporter)
 "wTL" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72373,7 +72373,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72388,7 +72388,7 @@
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
 /obj/item/gun/energy/laser/practice,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "wVj" = (
@@ -72426,7 +72426,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wVv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
@@ -72481,7 +72481,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -72547,7 +72547,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "wWl" = (
@@ -72581,7 +72581,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "wWA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -72651,7 +72651,7 @@
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "wWV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -72764,7 +72764,7 @@
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72786,7 +72786,7 @@
 	dir = 4;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72882,8 +72882,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72892,7 +72892,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -72923,7 +72923,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -72997,8 +72997,8 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -73010,7 +73010,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xdY" = (
@@ -73033,7 +73033,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xet" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xeu" = (
@@ -73049,7 +73049,7 @@
 /area/ai_monitored/turret_protected/ai)
 "xez" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -73069,7 +73069,7 @@
 "xeJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xfh" = (
@@ -73133,7 +73133,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xfD" = (
@@ -73171,7 +73171,7 @@
 /obj/item/storage/belt/medical{
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73226,7 +73226,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73270,7 +73270,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73291,7 +73291,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73400,7 +73400,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73417,7 +73417,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "xkG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
@@ -73503,7 +73503,7 @@
 /obj/structure/sign/departments/minsky/research/robotics{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xmy" = (
@@ -73555,7 +73555,7 @@
 /area/science/explab)
 "xnl" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -73567,7 +73567,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xnD" = (
@@ -73623,7 +73623,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73644,7 +73644,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
@@ -73692,7 +73692,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xqR" = (
@@ -73753,7 +73753,7 @@
 /area/chapel/office)
 "xrQ" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -73856,7 +73856,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xuf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73983,7 +73983,7 @@
 	pixel_y = 31
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74054,7 +74054,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74063,7 +74063,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/button/flasher{
@@ -74096,7 +74096,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -74126,7 +74126,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74262,7 +74262,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74338,7 +74338,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xBe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -74410,7 +74410,7 @@
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74466,7 +74466,7 @@
 	dir = 8;
 	pixel_y = 41
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74530,7 +74530,7 @@
 	pixel_y = -32
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xFE" = (
@@ -74594,7 +74594,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xGW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74630,7 +74630,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xHK" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xHY" = (
@@ -74649,7 +74649,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74697,7 +74697,7 @@
 "xIu" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/depsec/service,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "xIy" = (
@@ -74705,7 +74705,7 @@
 	c_tag = "Construction Area South";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xIB" = (
@@ -74745,7 +74745,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xIY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -74814,7 +74814,7 @@
 /area/quartermaster/office)
 "xKl" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/item/radio/off,
@@ -74837,7 +74837,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74991,7 +74991,7 @@
 /area/medical/sleeper)
 "xMa" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -75007,7 +75007,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75024,7 +75024,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
 "xMN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -75067,7 +75067,7 @@
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75129,7 +75129,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xNH" = (
@@ -75145,14 +75145,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xNW" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75160,7 +75160,7 @@
 "xOk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xOD" = (
@@ -75231,7 +75231,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -75288,7 +75288,7 @@
 	dir = 8
 	},
 /obj/item/storage/box/disks,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -75298,7 +75298,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75308,10 +75308,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75388,7 +75388,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRY" = (
@@ -75427,7 +75427,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xTh" = (
@@ -75625,7 +75625,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75650,7 +75650,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xXv" = (
@@ -75670,7 +75670,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xXG" = (
@@ -75687,13 +75687,13 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "xXN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -75811,7 +75811,7 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "yaX" = (
@@ -75890,7 +75890,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "ycw" = (
@@ -75910,7 +75910,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75928,7 +75928,7 @@
 /area/maintenance/starboard/aft)
 "ycV" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -76026,7 +76026,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76091,7 +76091,7 @@
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -76122,7 +76122,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "yfr" = (
@@ -76154,14 +76154,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ygn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76230,7 +76230,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76254,7 +76254,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -76263,7 +76263,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "yim" = (
@@ -76321,7 +76321,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "yjL" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -76401,7 +76401,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ykU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76418,7 +76418,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -76436,7 +76436,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -76445,7 +76445,7 @@
 /obj/structure/sign/departments/minsky/medical/clone/cloning2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -76466,7 +76466,7 @@
 	c_tag = "Garden East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -62,7 +62,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -203,7 +203,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "abU" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -257,7 +257,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -270,7 +270,7 @@
 /area/science/nanite)
 "aco" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -491,7 +491,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "aeR" = (
-/turf/open/floor/plasteel/dark/corner{
+/turf/open/floor/plasteel/dark/corner/lower{
 	dir = 4
 	},
 /area/chapel/main)
@@ -597,7 +597,7 @@
 /area/tcommsat/server)
 "afM" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -658,10 +658,10 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -682,7 +682,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "agq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/chair{
@@ -709,7 +709,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "agE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -787,7 +787,7 @@
 /area/maintenance/department/electrical)
 "agW" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -892,7 +892,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -909,7 +909,7 @@
 /turf/open/space/basic,
 /area/space)
 "aiM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -1038,7 +1038,7 @@
 "ajC" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1118,7 +1118,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -1140,7 +1140,7 @@
 /area/crew_quarters/heads/captain)
 "aku" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -1153,7 +1153,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -1298,7 +1298,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1377,7 +1377,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/item/stack/packageWrap{
@@ -1472,7 +1472,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "amZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1483,7 +1483,7 @@
 	pixel_x = 2
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anj" = (
 /turf/closed/wall,
@@ -1684,7 +1684,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aoZ" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1890,7 +1890,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2048,7 +2048,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "asx" = (
 /turf/closed/wall/r_wall,
@@ -2205,8 +2205,8 @@
 /obj/structure/sign/map/right{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "atv" = (
 /obj/structure/closet/radiation,
@@ -2276,7 +2276,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -2287,7 +2287,7 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "aua" = (
-/turf/open/floor/plasteel/dark/corner{
+/turf/open/floor/plasteel/dark/corner/lower{
 	dir = 1
 	},
 /area/chapel/main)
@@ -2342,7 +2342,7 @@
 /area/maintenance/port/fore)
 "aup" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -2392,7 +2392,7 @@
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2490,7 +2490,7 @@
 "avP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -2550,7 +2550,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -2627,7 +2627,7 @@
 /area/medical/morgue)
 "awU" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "awZ" = (
 /obj/machinery/mass_driver{
@@ -2695,7 +2695,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -2738,7 +2738,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2786,10 +2786,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2821,7 +2821,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2837,7 +2837,7 @@
 /turf/template_noop,
 /area/crew_quarters/dorms)
 "ayJ" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2924,8 +2924,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3074,7 +3074,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -3159,7 +3159,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aBc" = (
 /obj/machinery/door/airlock/public/glass{
@@ -3169,7 +3169,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3191,7 +3191,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3341,7 +3341,7 @@
 /area/space)
 "aCk" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/dark/corner{
+/turf/open/floor/plasteel/dark/corner/lower{
 	dir = 8
 	},
 /area/chapel/main)
@@ -3539,7 +3539,7 @@
 /turf/open/floor/wood,
 /area/library)
 "aDx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3766,7 +3766,7 @@
 /area/science/xenobiology)
 "aFv" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3830,7 +3830,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4264,7 +4264,7 @@
 /area/library)
 "aJC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -4318,7 +4318,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "aKb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4461,7 +4461,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -4526,10 +4526,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4576,7 +4576,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4691,7 +4691,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "aOy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -4756,7 +4756,7 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -4954,7 +4954,7 @@
 /area/solar/starboard/aft)
 "aRd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRh" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -5216,7 +5216,7 @@
 /area/security/checkpoint/supply)
 "aTs" = (
 /obj/machinery/gulag_processor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5247,7 +5247,7 @@
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aTJ" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5378,7 +5378,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aVl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5445,7 +5445,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -5479,7 +5479,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5491,7 +5491,7 @@
 	},
 /area/holodeck/rec_center)
 "aWL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -5522,8 +5522,8 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -5555,7 +5555,7 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -5582,7 +5582,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5779,7 +5779,7 @@
 /area/hallway/secondary/exit)
 "aYC" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -5792,7 +5792,7 @@
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -5851,7 +5851,7 @@
 /turf/open/space/basic,
 /area/solar/port/fore)
 "aZc" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5900,7 +5900,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5995,7 +5995,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bam" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6017,7 +6017,7 @@
 /obj/item/crowbar,
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+lower//turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "baF" = (
 /obj/effect/turf_decal/pool,
@@ -6061,7 +6061,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "baQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6079,10 +6079,10 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "bbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6145,7 +6145,7 @@
 /area/security/prison)
 "bda" = (
 /obj/machinery/announcement_system,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -6160,8 +6160,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/brig)
 "bdu" = (
 /obj/structure/chair/sofa/corner,
@@ -6352,7 +6352,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6364,10 +6364,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bhC" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6382,7 +6382,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6395,7 +6395,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6410,7 +6410,7 @@
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6485,10 +6485,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bjb" = (
@@ -6518,8 +6518,8 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/main)
 "bjt" = (
 /obj/structure/table/wood,
@@ -6547,7 +6547,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6587,7 +6587,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6652,7 +6652,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6747,7 +6747,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bmw" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/report_crimes{
@@ -6760,7 +6760,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6789,7 +6789,7 @@
 /area/medical/patients_rooms/room_b)
 "bnm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/cable/orange{
+lower//obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -6822,7 +6822,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boz" = (
@@ -6895,7 +6895,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bpC" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6911,7 +6911,7 @@
 /area/ai_monitored/storage/satellite)
 "bqd" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -6966,10 +6966,10 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "bqV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -7043,7 +7043,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7061,7 +7061,7 @@
 	dir = 8;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -7189,7 +7189,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7205,12 +7205,12 @@
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "btS" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btU" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7322,7 +7322,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bwi" = (
 /obj/structure/disposalpipe/segment,
@@ -7464,7 +7464,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7522,17 +7522,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bAo" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/l3closet,
@@ -7554,7 +7554,7 @@
 	name = "glass table"
 	},
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7564,10 +7564,10 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "bBj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/vending/snack/random,
@@ -7608,7 +7608,7 @@
 	c_tag = "Central Hallway North-East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7818,7 +7818,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Hallway"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7850,7 +7850,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -7882,7 +7882,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7951,7 +7951,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIq" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
@@ -8009,7 +8009,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bIX" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8050,7 +8050,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -8062,13 +8062,13 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJK" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8077,14 +8077,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bKc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8114,7 +8114,7 @@
 "bLc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8172,7 +8172,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8196,7 +8196,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8210,13 +8210,13 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8247,7 +8247,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "bNW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -8275,7 +8275,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8427,7 +8427,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable{
+lower//obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -8469,7 +8469,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bRG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -8501,7 +8501,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bSy" = (
@@ -8513,10 +8513,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bSO" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -8555,7 +8555,7 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bVa" = (
 /obj/structure/window/reinforced{
@@ -8571,7 +8571,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8585,14 +8585,14 @@
 "bVE" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bVK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -8622,7 +8622,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -8847,7 +8847,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8940,7 +8940,7 @@
 "cbr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8983,7 +8983,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cch" = (
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/white{
@@ -9003,7 +9003,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9024,7 +9024,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9034,7 +9034,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9077,7 +9077,7 @@
 /area/medical/medbay/lobby)
 "cdC" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/armaments_dispenser,
@@ -9202,7 +9202,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9226,7 +9226,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/meter,
@@ -9237,7 +9237,7 @@
 	c_tag = "Engineering South";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9250,7 +9250,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9261,7 +9261,7 @@
 	},
 /area/maintenance/starboard/aft)
 "cgw" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes{
@@ -9348,7 +9348,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
@@ -9501,7 +9501,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cjO" = (
 /obj/machinery/light,
@@ -9532,7 +9532,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/camera{
+lower//obj/machinery/camera{
 	c_tag = "Medbay West";
 	dir = 1;
 	network = list("ss13","medbay");
@@ -9555,7 +9555,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cks" = (
 /obj/structure/disposalpipe/segment{
@@ -9615,7 +9615,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "clb" = (
@@ -9689,7 +9689,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "clx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/structure/closet/l3closet,
@@ -9770,7 +9770,7 @@
 "cnU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "coo" = (
@@ -9804,8 +9804,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cqa" = (
 /obj/structure/cable{
@@ -9853,7 +9853,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "crb" = (
 /obj/structure/rack,
@@ -9870,13 +9870,13 @@
 /obj/structure/mirror{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cri" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -9976,13 +9976,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "cts" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating/corner{
+/obj/effect/turf_decal/siding/wideplating/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10003,7 +10003,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cua" = (
@@ -10034,7 +10034,7 @@
 "cuH" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "cuU" = (
 /obj/machinery/button/door{
@@ -10158,10 +10158,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cwI" = (
-/obj/effect/turf_decal/trimline/white/corner{
+/obj/effect/turf_decal/trimline/white/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cwO" = (
@@ -10237,7 +10237,7 @@
 /area/storage/primary)
 "cyj" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /obj/structure/cable/yellow{
@@ -10253,7 +10253,7 @@
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -10271,7 +10271,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10286,8 +10286,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/extinguisher_cabinet{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -10299,7 +10299,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "czo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10324,7 +10324,7 @@
 	dir = 4;
 	name = "hallway camera"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10336,7 +10336,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10418,7 +10418,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "cAw" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10443,7 +10443,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10470,7 +10470,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cAW" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10604,7 +10604,7 @@
 	id = "crematoriumChapel";
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10672,12 +10672,12 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cEO" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/item/circuitboard/computer/ai_upload_download,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -10696,7 +10696,7 @@
 /area/science/xenobiology)
 "cEY" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -10769,7 +10769,7 @@
 /obj/structure/sign/poster/ripped{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve{
@@ -10823,7 +10823,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cHo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10852,7 +10852,7 @@
 "cHX" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/stock_parts/cell/high/plus,
@@ -10975,7 +10975,7 @@
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11090,7 +11090,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11114,21 +11114,21 @@
 /area/crew_quarters/heads/captain)
 "cME" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "cMI" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "cMJ" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cMS" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -11217,7 +11217,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11259,7 +11259,7 @@
 	c_tag = "Construction Area North";
 	dir = 0
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11312,7 +11312,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cOM" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11404,7 +11404,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -11443,7 +11443,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -11468,7 +11468,7 @@
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -11486,7 +11486,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11505,10 +11505,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11618,8 +11618,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11644,7 +11644,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11660,7 +11660,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cVr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11687,10 +11687,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11742,10 +11742,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11837,7 +11837,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -11972,7 +11972,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "daT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -12066,15 +12066,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dci" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12092,7 +12092,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12200,7 +12200,7 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "dez" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -12238,7 +12238,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12253,7 +12253,7 @@
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -12265,14 +12265,14 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "dft" = (
 /obj/structure/displaycase/labcage,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -12358,7 +12358,7 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -12386,7 +12386,7 @@
 	name = "Surgery APC";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12512,11 +12512,11 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "djY" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12642,7 +12642,7 @@
 /area/clerk)
 "dlA" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -12665,7 +12665,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "dmh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12712,7 +12712,7 @@
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12777,7 +12777,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -12811,7 +12811,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dqq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12887,7 +12887,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "dsM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -12929,7 +12929,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dtt" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -12975,7 +12975,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12985,7 +12985,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -13015,7 +13015,7 @@
 /area/science/xenobiology)
 "duv" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -13092,7 +13092,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -13109,7 +13109,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -13117,7 +13117,7 @@
 "dwt" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/vending/modularpc,
+lower//obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "dwv" = (
@@ -13134,10 +13134,10 @@
 	pixel_x = -4;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13183,7 +13183,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13241,7 +13241,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13261,7 +13261,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "dyV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13283,10 +13283,10 @@
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
 /obj/item/toy/figure/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/white/corner/lower{
 	dir = 8
 	},
 /area/crew_quarters/heads/chief)
@@ -13298,7 +13298,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -13352,7 +13352,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/fancy/donut_box,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13404,7 +13404,7 @@
 /area/engine/engineering)
 "dAU" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13473,7 +13473,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13482,7 +13482,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13503,7 +13503,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dEf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13534,8 +13534,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/processing)
 "dEV" = (
 /obj/structure/cable{
@@ -13553,7 +13553,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13566,7 +13566,7 @@
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13627,7 +13627,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13757,7 +13757,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13767,7 +13767,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13810,7 +13810,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13848,7 +13848,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dKN" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -13885,7 +13885,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -14230,8 +14230,8 @@
 	c_tag = "Security Office";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/sign/poster/official/space_cops{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/structure/sign/poster/official/space_cops{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -14247,7 +14247,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14274,7 +14274,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14350,7 +14350,7 @@
 	pixel_y = 10
 	},
 /obj/item/analyzer,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14462,7 +14462,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14506,7 +14506,7 @@
 	dir = 1;
 	sortType = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dWc" = (
@@ -14516,7 +14516,7 @@
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14671,7 +14671,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "dZY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -14686,7 +14686,7 @@
 /area/space/nearstation)
 "eae" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14725,7 +14725,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14785,7 +14785,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14817,7 +14817,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14847,7 +14847,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14870,7 +14870,7 @@
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14901,7 +14901,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "edl" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -14955,7 +14955,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15077,8 +15077,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "efO" = (
 /obj/machinery/door/airlock/command/glass{
@@ -15119,7 +15119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "egF" = (
@@ -15153,10 +15153,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15213,7 +15213,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15238,7 +15238,7 @@
 "eiC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "eiN" = (
@@ -15282,7 +15282,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15357,7 +15357,7 @@
 /area/hallway/secondary/exit)
 "ejV" = (
 /obj/structure/table/optable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15457,7 +15457,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15507,7 +15507,7 @@
 	name = "Genetics Requests Console";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -15557,7 +15557,7 @@
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -15613,7 +15613,7 @@
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15681,7 +15681,7 @@
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15752,7 +15752,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "epy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -15768,7 +15768,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eqh" = (
 /obj/structure/cable{
@@ -15778,7 +15778,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "eql" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/oil,
@@ -15796,7 +15796,7 @@
 /area/maintenance/disposal)
 "eqq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15905,7 +15905,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "esc" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+lower//obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -16024,7 +16024,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -16042,7 +16042,7 @@
 	name = "Station Alert Console"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "etM" = (
 /obj/structure/cable{
@@ -16061,7 +16061,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "etS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16109,10 +16109,10 @@
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
@@ -16265,7 +16265,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "eye" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -16297,7 +16297,7 @@
 	dir = 8
 	},
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16313,7 +16313,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eyX" = (
 /obj/structure/sign/poster/contraband/communist_state,
@@ -16324,7 +16324,7 @@
 	icon_state = "L14"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ezv" = (
 /obj/machinery/door/airlock/maintenance/external{
@@ -16415,7 +16415,7 @@
 /area/maintenance/solars/port/aft)
 "eAT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/bed/roller,
+lower//obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "eBe" = (
@@ -16453,7 +16453,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eBv" = (
 /obj/machinery/power/apc{
@@ -16469,10 +16469,10 @@
 /area/hallway/primary/aft)
 "eBw" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "eBD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16513,7 +16513,7 @@
 /area/medical/paramedic)
 "eCu" = (
 /obj/item/stack/ore/iron,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16538,7 +16538,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eCV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -16556,7 +16556,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16582,7 +16582,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
@@ -16593,7 +16593,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16606,7 +16606,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -16640,7 +16640,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -16661,7 +16661,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "eFa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -16706,7 +16706,7 @@
 /area/bridge/meeting_room)
 "eFu" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+lower//turf/open/floor/plating,
 /area/security/execution/transfer)
 "eFx" = (
 /obj/structure/window/reinforced,
@@ -16721,7 +16721,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "eFF" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16742,7 +16742,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16830,7 +16830,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eHs" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16852,7 +16852,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16875,10 +16875,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "eIf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16940,7 +16940,7 @@
 /obj/machinery/computer/security/telescreen/cmo{
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16953,8 +16953,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "eJh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16979,7 +16979,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17074,7 +17074,7 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "eLh" = (
 /obj/item/reagent_containers/syringe,
@@ -17112,7 +17112,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -17138,7 +17138,7 @@
 /area/engine/atmos/distro)
 "eLU" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17219,7 +17219,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "eMP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -17233,7 +17233,7 @@
 	name = "Unfiltered to Mix";
 	on = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17266,7 +17266,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17275,7 +17275,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17368,7 +17368,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17388,7 +17388,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17407,13 +17407,13 @@
 /area/crew_quarters/heads/hop)
 "eRb" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eRm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17554,7 +17554,7 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -17608,7 +17608,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eUv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -17623,7 +17623,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17646,7 +17646,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "eVX" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -17721,7 +17721,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eXy" = (
 /obj/structure/sign/departments/minsky/command/space{
@@ -17771,7 +17771,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "eYe" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -17787,7 +17787,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17838,7 +17838,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17881,7 +17881,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "fbs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -17934,7 +17934,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "fcF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -17981,7 +17981,7 @@
 	pixel_x = -25;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -17998,13 +17998,13 @@
 	dir = 1
 	},
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "fdi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18038,7 +18038,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fdm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18080,7 +18080,7 @@
 /area/hallway/secondary/entry)
 "feA" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/newscaster{
@@ -18100,8 +18100,8 @@
 /obj/item/storage/box/zipties{
 	pixel_x = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "feE" = (
 /obj/structure/table/wood,
@@ -18145,10 +18145,10 @@
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18167,7 +18167,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18190,7 +18190,7 @@
 	dir = 1;
 	pixel_y = 38
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -18269,8 +18269,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_y = -32
@@ -18326,13 +18326,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fib" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -18537,7 +18537,7 @@
 	name = "Air to Distro";
 	target_pressure = 4500
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18582,7 +18582,7 @@
 /area/teleporter)
 "flQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18611,13 +18611,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fmB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -18630,7 +18630,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fmL" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -18667,7 +18667,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/ten,
 /obj/item/toy/figure/atmos,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18697,7 +18697,7 @@
 /obj/structure/sign/plaques/atmos{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/pipedispenser,
@@ -18705,7 +18705,7 @@
 /area/engine/atmos)
 "fod" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18806,13 +18806,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fpZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -18975,7 +18975,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fta" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -18993,7 +18993,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19036,7 +19036,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "fuM" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19069,7 +19069,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "fvj" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19079,7 +19079,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "fvw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -19127,7 +19127,7 @@
 /area/engine/atmos)
 "fwl" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+lower//turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "fww" = (
 /obj/structure/falsewall,
@@ -19143,19 +19143,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "fwF" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19182,7 +19182,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -19244,7 +19244,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fxy" = (
@@ -19280,14 +19280,14 @@
 /area/maintenance/port)
 "fxN" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fxW" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -19363,7 +19363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19384,10 +19384,10 @@
 	},
 /area/crew_quarters/kitchen)
 "fzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19412,7 +19412,7 @@
 /turf/open/floor/carpet,
 /area/lawoffice)
 "fAi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -19498,7 +19498,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "fBW" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19517,8 +19517,8 @@
 	pixel_y = 10
 	},
 /obj/item/stack/packageWrap,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/main)
 "fCn" = (
 /obj/machinery/paystand,
@@ -19534,7 +19534,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fCJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19561,7 +19561,7 @@
 /area/hydroponics/garden)
 "fDb" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -19592,14 +19592,14 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fDQ" = (
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19625,7 +19625,7 @@
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/core,
 /obj/item/paper/guides/jobs/atmos/hypertorus,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -19643,7 +19643,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "fEV" = (
@@ -19673,10 +19673,10 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "fFp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19705,7 +19705,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19739,7 +19739,7 @@
 /area/science/misc_lab)
 "fGA" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -19781,7 +19781,7 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19826,14 +19826,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "fIl" = (
 /obj/machinery/papershredder,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/status_display/supply{
@@ -19887,12 +19887,12 @@
 "fJL" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fJM" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19901,7 +19901,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -19921,7 +19921,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19945,7 +19945,7 @@
 	dir = 4;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19969,7 +19969,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20086,7 +20086,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20126,7 +20126,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20211,7 +20211,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "fPN" = (
@@ -20224,7 +20224,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/table,
@@ -20279,7 +20279,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
+/obj/effect/turf_decal/siding/wideplating/dark/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -20313,7 +20313,7 @@
 	c_tag = "Engineering Access";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20397,7 +20397,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20449,7 +20449,7 @@
 /area/crew_quarters/fitness)
 "fTh" = (
 /obj/machinery/power/smes,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /obj/structure/cable,
@@ -20471,7 +20471,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20498,7 +20498,7 @@
 	},
 /area/crew_quarters/kitchen)
 "fTM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/vending/coffee,
@@ -20534,13 +20534,13 @@
 /area/vacant_room)
 "fUd" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fUj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20564,10 +20564,10 @@
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/structure/plasticflaps,
@@ -20656,7 +20656,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20691,7 +20691,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20757,7 +20757,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fYa" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -20790,17 +20790,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fZb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20849,7 +20849,7 @@
 /obj/structure/table,
 /obj/item/electropack,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20907,7 +20907,7 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -20919,7 +20919,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20928,7 +20928,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20995,7 +20995,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gbH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -21034,7 +21034,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -21070,7 +21070,7 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "gdx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -21154,7 +21154,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "geG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -21184,7 +21184,7 @@
 	},
 /obj/item/pen/red,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21321,7 +21321,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -21376,7 +21376,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21456,7 +21456,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -21514,7 +21514,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -21526,7 +21526,7 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21610,7 +21610,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21628,8 +21628,8 @@
 /area/crew_quarters/bar)
 "gnq" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gnw" = (
 /obj/structure/window/reinforced{
@@ -21657,7 +21657,7 @@
 /area/escapepodbay)
 "gnM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "gnT" = (
 /obj/machinery/holopad,
@@ -21700,7 +21700,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "goW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21710,7 +21710,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21736,7 +21736,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gqx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/papershredder,
@@ -21755,7 +21755,7 @@
 /area/maintenance/starboard/aft)
 "gqJ" = (
 /obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -21775,7 +21775,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21920,7 +21920,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "gtu" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gtC" = (
@@ -21949,7 +21949,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21991,7 +21991,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "gvk" = (
 /obj/machinery/vending/cola/random,
@@ -22136,7 +22136,7 @@
 /obj/item/sequence_scanner,
 /obj/item/sequence_scanner,
 /obj/item/stack/cable_coil/white,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -22202,11 +22202,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/brig)
 "gyz" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -22219,7 +22219,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gyU" = (
 /obj/machinery/camera{
@@ -22331,10 +22331,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gzS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -22352,7 +22352,7 @@
 /area/hallway/primary/fore)
 "gAc" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -22368,14 +22368,14 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gAM" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
 	piping_layer = 2
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -22439,7 +22439,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22458,7 +22458,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gBO" = (
 /obj/structure/rack,
@@ -22488,8 +22488,8 @@
 	c_tag = "Brig Central";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
@@ -22516,7 +22516,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gDb" = (
@@ -22535,7 +22535,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gDq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -22543,7 +22543,7 @@
 /area/engine/atmos/storage)
 "gDx" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22601,8 +22601,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gEx" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -22689,10 +22689,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gFZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22741,7 +22741,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22757,7 +22757,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22955,7 +22955,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gKM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23043,7 +23043,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23066,7 +23066,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23114,7 +23114,7 @@
 /area/maintenance/starboard/fore)
 "gNo" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23208,7 +23208,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "gOI" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23263,10 +23263,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/corner{
+/obj/effect/turf_decal/siding/wideplating/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23277,7 +23277,7 @@
 /obj/item/radio/headset/headset_med,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23298,7 +23298,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -23317,13 +23317,13 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "gQG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -23379,7 +23379,7 @@
 "gRg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23483,13 +23483,13 @@
 /area/crew_quarters/bar)
 "gSN" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "gSQ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -23519,7 +23519,7 @@
 /area/engine/engineering)
 "gTD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "gTH" = (
 /obj/machinery/light,
@@ -23535,7 +23535,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "gTI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23548,7 +23548,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "gUj" = (
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gUo" = (
@@ -23649,10 +23649,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23692,7 +23692,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23866,7 +23866,7 @@
 /area/crew_quarters/fitness)
 "hbF" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -23915,7 +23915,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23927,7 +23927,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hdk" = (
@@ -23962,7 +23962,7 @@
 "hdB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hdK" = (
@@ -23987,7 +23987,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -24099,7 +24099,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24122,7 +24122,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24233,7 +24233,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -24328,7 +24328,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24358,7 +24358,7 @@
 "hii" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/power/apc{
+lower//obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
 	name = "Central Hall APC";
 	pixel_y = -23
@@ -24399,7 +24399,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hiB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -24445,7 +24445,7 @@
 /area/medical/chemistry)
 "hiU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hiX" = (
 /turf/closed/wall,
@@ -24487,7 +24487,7 @@
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -24592,7 +24592,7 @@
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24647,7 +24647,7 @@
 	dir = 4;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24665,7 +24665,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hmV" = (
@@ -24680,7 +24680,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24712,7 +24712,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24766,7 +24766,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24830,7 +24830,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "hpE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24892,7 +24892,7 @@
 	icon_state = "1-4";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -24918,7 +24918,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24960,7 +24960,7 @@
 	dir = 1
 	},
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25021,8 +25021,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hsu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -25034,7 +25034,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25047,11 +25047,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hsM" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25166,7 +25166,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "hvl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -25258,7 +25258,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "hwc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -25285,7 +25285,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hwW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -25295,7 +25295,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -25308,7 +25308,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -25322,7 +25322,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hxK" = (
 /obj/machinery/meter{
@@ -25349,8 +25349,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hxO" = (
 /obj/structure/cable{
@@ -25363,10 +25363,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25384,7 +25384,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hxZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25527,7 +25527,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "hAq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25649,13 +25649,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "hCs" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25788,10 +25788,10 @@
 	c_tag = "SMES Access";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25805,7 +25805,7 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25814,7 +25814,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/warning/electricshock{
@@ -25823,7 +25823,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hDC" = (
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/white{
@@ -25870,14 +25870,14 @@
 /area/bridge)
 "hEK" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "hFg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "hFp" = (
 /obj/structure/girder,
@@ -25917,7 +25917,7 @@
 /area/science/xenobiology)
 "hFT" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -25938,7 +25938,7 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25978,7 +25978,7 @@
 /area/ai_monitored/storage/eva)
 "hGu" = (
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -26125,7 +26125,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hIo" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -26181,13 +26181,13 @@
 	pixel_x = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hJu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -26217,7 +26217,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26240,7 +26240,7 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hKz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -26266,10 +26266,10 @@
 "hLS" = (
 /obj/structure/table,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26360,7 +26360,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hMZ" = (
@@ -26374,7 +26374,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "hNc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26479,7 +26479,7 @@
 "hOf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26531,7 +26531,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26567,7 +26567,7 @@
 /turf/open/space/basic,
 /area/space)
 "hQp" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26577,10 +26577,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hQP" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -26607,7 +26607,7 @@
 /area/science/mixing)
 "hRX" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -26627,7 +26627,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "hSm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -26643,7 +26643,7 @@
 /area/engine/gravity_generator)
 "hSz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26672,14 +26672,14 @@
 "hSV" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "hTi" = (
 /obj/machinery/computer/bounty{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "hTw" = (
 /turf/open/space/basic,
@@ -26707,7 +26707,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "hTG" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26724,7 +26724,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+lower//obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26735,7 +26735,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26767,7 +26767,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26834,8 +26834,8 @@
 /obj/item/razor{
 	pixel_x = -6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "hXl" = (
 /obj/structure/chair/office/dark,
@@ -26844,7 +26844,7 @@
 "hXF" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -26867,7 +26867,7 @@
 "hXL" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26987,7 +26987,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hZz" = (
@@ -27022,7 +27022,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27069,7 +27069,7 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "iaS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/research/xenobiology{
@@ -27086,10 +27086,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -27125,7 +27125,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "ibs" = (
-/obj/structure/chair/sofa/corner{
+/obj/structure/chair/sofa/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27170,7 +27170,7 @@
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "icC" = (
 /obj/structure/closet/bombcloset,
@@ -27192,7 +27192,7 @@
 "idB" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "idE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27267,7 +27267,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ifa" = (
 /turf/open/floor/plasteel,
@@ -27291,7 +27291,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27333,7 +27333,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "igg" = (
 /obj/machinery/door/airlock/maintenance{
@@ -27396,7 +27396,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27450,7 +27450,7 @@
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27535,7 +27535,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ijv" = (
 /obj/structure/cable/yellow{
@@ -27579,7 +27579,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ijO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/filingcabinet{
@@ -27607,7 +27607,7 @@
 /area/library)
 "ikq" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27621,7 +27621,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27693,7 +27693,7 @@
 /turf/closed/wall,
 /area/hydroponics)
 "imc" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -27735,7 +27735,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "imy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27763,14 +27763,14 @@
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "imT" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27779,7 +27779,7 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/item/radio/intercom{
+lower//obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
@@ -27827,7 +27827,7 @@
 /area/crew_quarters/theatre)
 "iog" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27907,7 +27907,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27927,7 +27927,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27955,10 +27955,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iqs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -27975,7 +27975,7 @@
 "irp" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "irz" = (
 /obj/structure/cable{
@@ -28057,8 +28057,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/brig)
 "itc" = (
 /turf/open/floor/plating/airless{
@@ -28112,7 +28112,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -28137,7 +28137,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iul" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28179,10 +28179,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28192,7 +28192,7 @@
 	c_tag = "Atmospherics North West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -28228,7 +28228,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ivd" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28282,14 +28282,14 @@
 	dir = 4
 	},
 /obj/structure/closet/crate,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iwc" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28299,8 +28299,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
@@ -28310,7 +28310,7 @@
 "iwl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28412,7 +28412,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "iyK" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "iyZ" = (
@@ -28420,7 +28420,7 @@
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/listeningstation)
 "izg" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
@@ -28440,7 +28440,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "izw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -28482,7 +28482,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iAT" = (
@@ -28558,7 +28558,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "iBN" = (
 /obj/effect/overlay/palmtree_l{
@@ -28606,7 +28606,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28672,10 +28672,10 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28695,7 +28695,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28729,7 +28729,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28767,7 +28767,7 @@
 "iGQ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iGT" = (
 /obj/structure/disposalpipe/segment{
@@ -28789,7 +28789,7 @@
 	c_tag = "Central Hallway West 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28888,7 +28888,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -28988,7 +28988,7 @@
 /area/medical/surgery)
 "iLq" = (
 /obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -29011,7 +29011,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -29050,7 +29050,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29076,7 +29076,7 @@
 	pixel_y = 7
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -29113,10 +29113,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iNd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29126,7 +29126,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -31
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -29157,7 +29157,7 @@
 /area/science/mixing)
 "iNC" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29205,11 +29205,11 @@
 /turf/open/floor/grass,
 /area/medical/medbay/aft)
 "iOu" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "iOJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -29362,7 +29362,7 @@
 /area/hallway/secondary/exit)
 "iSr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iSv" = (
 /obj/structure/window{
@@ -29385,7 +29385,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29426,7 +29426,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -29636,7 +29636,7 @@
 	pixel_y = 6
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29673,7 +29673,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -29705,7 +29705,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "iXf" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -29756,13 +29756,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iYo" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
@@ -29913,14 +29913,14 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iZV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29934,7 +29934,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -29944,7 +29944,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29999,7 +29999,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jaz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/crate,
@@ -30038,7 +30038,7 @@
 /obj/structure/sign/barsign{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30086,13 +30086,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jbh" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -30146,10 +30146,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30225,7 +30225,7 @@
 	name = "Robotics Desk";
 	req_one_access_txt = "29;75"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jdm" = (
@@ -30352,7 +30352,7 @@
 "jeQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30402,7 +30402,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "jgg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -30419,7 +30419,7 @@
 /area/maintenance/starboard/fore)
 "jgs" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30464,7 +30464,7 @@
 /area/bridge)
 "jgP" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+lower//obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/computer/rdservercontrol{
@@ -30492,7 +30492,7 @@
 /area/medical/genetics)
 "jgU" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30530,7 +30530,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30547,7 +30547,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30588,7 +30588,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30601,7 +30601,7 @@
 /area/quartermaster/qm)
 "jit" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/bed/dogbed{
+lower//obj/structure/bed/dogbed{
 	desc = "Autumn's Bed! Looks comfy.";
 	name = "Autumn's Bed"
 	},
@@ -30644,7 +30644,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "jiH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -30696,13 +30696,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jjp" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30734,7 +30734,7 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30775,14 +30775,14 @@
 	pixel_x = -30;
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jkI" = (
 /mob/living/simple_animal/cockroach,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -30922,7 +30922,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30976,7 +30976,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "joq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
@@ -31068,7 +31068,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jqy" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31101,7 +31101,7 @@
 /area/maintenance/solars/starboard/aft)
 "jqP" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31140,13 +31140,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+lower//obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jrt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -31201,7 +31201,7 @@
 /area/ruin/powered)
 "jsq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -31218,7 +31218,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -31226,7 +31226,7 @@
 "jsv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -31244,7 +31244,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31254,10 +31254,10 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jtG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -31284,7 +31284,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31347,7 +31347,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jvI" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -31401,7 +31401,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31462,7 +31462,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31476,7 +31476,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jxh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -31524,7 +31524,7 @@
 /turf/open/floor/engine,
 /area/escapepodbay)
 "jxV" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -31549,7 +31549,7 @@
 /area/ai_monitored/security/armory)
 "jyK" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -31589,7 +31589,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31617,7 +31617,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable/yellow,
@@ -31643,7 +31643,7 @@
 /area/crew_quarters/kitchen)
 "jAf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31671,21 +31671,21 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "jAz" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "jAB" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31744,7 +31744,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
 "jBN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31778,7 +31778,7 @@
 /area/maintenance/port/fore)
 "jCg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -31822,7 +31822,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31844,7 +31844,7 @@
 	c_tag = "Virology Monkey Pen";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -31865,8 +31865,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31953,7 +31953,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32045,7 +32045,7 @@
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -32093,7 +32093,7 @@
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32120,7 +32120,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jHb" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -32156,7 +32156,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -32171,7 +32171,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32186,8 +32186,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32397,7 +32397,7 @@
 	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -32418,14 +32418,14 @@
 /area/ai_monitored/turret_protected/ai)
 "jMl" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/theatre)
 "jMp" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/item/twohanded/rcl/pre_loaded,
@@ -32498,7 +32498,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/pipedispenser/disposal,
@@ -32510,7 +32510,7 @@
 /area/crew_quarters/bar)
 "jOs" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32529,7 +32529,7 @@
 "jOE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jOQ" = (
 /turf/open/floor/plating,
@@ -32606,7 +32606,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -32695,7 +32695,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "jRd" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -32761,7 +32761,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32794,7 +32794,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/folder/white,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32810,7 +32810,7 @@
 /area/crew_quarters/heads/hop)
 "jSO" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32850,7 +32850,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -32891,8 +32891,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "jUC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -32903,7 +32903,7 @@
 /area/medical/virology)
 "jUF" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -32914,7 +32914,7 @@
 /area/crew_quarters/kitchen)
 "jVp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
+lower//obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "jVs" = (
@@ -32951,7 +32951,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33000,7 +33000,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33049,7 +33049,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -33168,7 +33168,7 @@
 /area/security/prison)
 "jZh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
+lower//obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/sign/warning/electricshock{
@@ -33211,7 +33211,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -33226,7 +33226,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "kbb" = (
@@ -33280,7 +33280,7 @@
 /turf/open/floor/plating,
 /area/science/nanite)
 "kbK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -33305,7 +33305,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33347,7 +33347,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -33365,7 +33365,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "keF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -33445,7 +33445,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33496,7 +33496,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "kgj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -33620,7 +33620,7 @@
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -33639,14 +33639,14 @@
 "kiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kiL" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -33659,7 +33659,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kjm" = (
 /obj/machinery/disposal/bin,
@@ -33751,10 +33751,10 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -33764,11 +33764,11 @@
 	dir = 8;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
+lower//obj/machinery/light,
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
@@ -33821,7 +33821,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33893,7 +33893,7 @@
 	dir = 8
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -34038,7 +34038,7 @@
 /area/maintenance/port)
 "kpQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/extinguisher_cabinet{
+lower//obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -34054,8 +34054,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kpV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -34098,7 +34098,7 @@
 	},
 /obj/item/pickaxe/mini,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kqK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34119,7 +34119,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "kqQ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -34154,7 +34154,7 @@
 /area/ruin/space/has_grav/listeningstation)
 "krp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/modular_computer/console/preset/command/ce{
+lower//obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side{
@@ -34313,7 +34313,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -34354,7 +34354,7 @@
 	dir = 1;
 	name = "Tank Monitor"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -34415,7 +34415,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -34432,7 +34432,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kvk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34469,7 +34469,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "kvW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /obj/structure/railing{
@@ -34487,7 +34487,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34500,13 +34500,13 @@
 /area/engine/atmos/hfr)
 "kww" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kwL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34534,7 +34534,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34616,13 +34616,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kyz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34635,7 +34635,7 @@
 	icon_state = "L4"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
+lower//obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34724,7 +34724,7 @@
 	req_access_txt = "1"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -34736,11 +34736,11 @@
 "kAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "kBc" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34754,7 +34754,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -34856,7 +34856,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kDv" = (
@@ -34887,7 +34887,7 @@
 	pixel_y = -9;
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35009,7 +35009,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35084,7 +35084,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kGW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35148,7 +35148,7 @@
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -35186,7 +35186,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -35247,7 +35247,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35267,7 +35267,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "kJM" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35296,7 +35296,7 @@
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "kLe" = (
@@ -35312,7 +35312,7 @@
 /obj/item/clothing/glasses/hud/health{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -35337,7 +35337,7 @@
 	},
 /obj/item/pickaxe/mini,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kLl" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
@@ -35370,10 +35370,10 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35458,7 +35458,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35489,8 +35489,8 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "kPr" = (
 /obj/structure/table/glass,
@@ -35514,7 +35514,7 @@
 	name = "Medbay RC";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -35523,13 +35523,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kQx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -35614,7 +35614,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -35673,8 +35673,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "kSs" = (
 /obj/effect/turf_decal/tile/red,
@@ -35751,7 +35751,7 @@
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -35764,7 +35764,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35774,7 +35774,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kUc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -35851,12 +35851,12 @@
 "kVE" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "kVH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos)
 "kVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35901,7 +35901,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35960,7 +35960,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kXR" = (
 /obj/machinery/light{
@@ -36044,7 +36044,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36057,7 +36057,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -36067,14 +36067,14 @@
 	icon_state = "L8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kZw" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos)
 "kZD" = (
 /obj/structure/cable{
@@ -36096,7 +36096,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "lad" = (
 /obj/structure/disposalpipe/segment{
@@ -36118,7 +36118,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36193,7 +36193,7 @@
 /area/maintenance/port/fore)
 "lca" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36263,7 +36263,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36290,7 +36290,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36305,8 +36305,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/processing)
 "ldu" = (
 /obj/structure/cable{
@@ -36326,7 +36326,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36398,7 +36398,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36440,7 +36440,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -36478,7 +36478,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lip" = (
 /obj/structure/cable{
@@ -36542,7 +36542,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ljH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -36567,7 +36567,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lkc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36587,7 +36587,7 @@
 /area/quartermaster/miningdock)
 "lkG" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -36601,7 +36601,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36633,7 +36633,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "llu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36648,7 +36648,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36669,7 +36669,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lml" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -36683,7 +36683,7 @@
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -36695,7 +36695,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -36729,31 +36729,31 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "lnK" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "lnV" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "lnY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36796,7 +36796,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36835,8 +36835,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/brig)
 "lrc" = (
 /turf/open/floor/plating/asteroid,
@@ -36858,7 +36858,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36881,7 +36881,7 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -37012,7 +37012,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ltr" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /obj/machinery/door/airlock/command{
@@ -37077,7 +37077,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37087,7 +37087,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37105,7 +37105,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -37197,7 +37197,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37217,7 +37217,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lxi" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37329,10 +37329,10 @@
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37355,15 +37355,15 @@
 /area/maintenance/central/secondary)
 "lyK" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/white/corner/lower{
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
 "lyY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37394,7 +37394,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lzO" = (
 /obj/structure/disposalpipe/segment{
@@ -37406,13 +37406,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "lzP" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -37447,7 +37447,7 @@
 /obj/machinery/modular_computer/console/preset/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37478,7 +37478,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
 "lAy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -37524,7 +37524,7 @@
 	},
 /area/maintenance/port/aft)
 "lBg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 2
 	},
 /turf/open/floor/plasteel,
@@ -37533,13 +37533,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "lBM" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37552,10 +37552,10 @@
 	c_tag = "Cargo Bay East";
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37661,7 +37661,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37694,7 +37694,7 @@
 /obj/item/restraints/handcuffs,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37763,7 +37763,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37808,7 +37808,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lIp" = (
 /obj/machinery/door/firedoor/border_only{
@@ -37838,7 +37838,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "lIF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -37856,7 +37856,7 @@
 /area/maintenance/starboard/fore)
 "lIU" = (
 /obj/machinery/clonepod,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -37864,7 +37864,7 @@
 "lJd" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37889,7 +37889,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "lJD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -37921,7 +37921,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lJY" = (
 /obj/structure/cable{
@@ -37939,7 +37939,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lKG" = (
@@ -37998,7 +37998,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lLs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -38030,7 +38030,7 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -38053,7 +38053,7 @@
 	id = "QMLoad2"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+lower//obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38175,7 +38175,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38185,7 +38185,7 @@
 /area/science/research)
 "lNc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/radiation,
+lower//obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "lNd" = (
@@ -38214,7 +38214,7 @@
 /area/hallway/primary/central)
 "lNW" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lNX" = (
@@ -38251,7 +38251,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38311,7 +38311,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lPj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38355,7 +38355,7 @@
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -38363,7 +38363,7 @@
 "lQw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lQx" = (
 /obj/structure/rack,
@@ -38517,7 +38517,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38537,7 +38537,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38580,7 +38580,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lTz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38620,7 +38620,7 @@
 /area/quartermaster/office)
 "lTU" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/structure/cable/yellow{
@@ -38632,7 +38632,7 @@
 "lTX" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lUe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38667,14 +38667,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lUG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos)
 "lVv" = (
 /obj/structure/chair/office/dark{
@@ -38756,7 +38756,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38845,7 +38845,7 @@
 /area/ai_monitored/storage/satellite)
 "lYD" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38896,7 +38896,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -38908,7 +38908,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38943,7 +38943,7 @@
 	icon_state = "L10"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mal" = (
 /obj/machinery/holopad,
@@ -39000,14 +39000,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "maH" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -39026,7 +39026,7 @@
 "mbf" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -39050,7 +39050,7 @@
 	},
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mbH" = (
 /obj/structure/filingcabinet,
@@ -39066,7 +39066,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -39084,7 +39084,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mcg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -39112,7 +39112,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "mcD" = (
@@ -39146,7 +39146,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mcQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39172,7 +39172,7 @@
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -39319,7 +39319,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39369,7 +39369,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "mgd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
@@ -39411,13 +39411,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mgM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
@@ -39467,7 +39467,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mhM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -39499,7 +39499,7 @@
 /area/science/xenobiology)
 "mhV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/foyer)
 "mhY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -39518,7 +39518,7 @@
 /area/science/mixing)
 "min" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39527,7 +39527,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
 "miz" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -39619,7 +39619,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mka" = (
@@ -39632,7 +39632,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39716,7 +39716,7 @@
 	c_tag = "Virology Module";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39729,7 +39729,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39814,7 +39814,7 @@
 	pixel_x = 11;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -39854,7 +39854,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39971,7 +39971,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "mpo" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39981,7 +39981,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mqb" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -40024,7 +40024,7 @@
 	},
 /area/science/xenobiology)
 "mqv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -40092,13 +40092,13 @@
 /area/engine/engineering)
 "mrK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mrX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -40209,7 +40209,7 @@
 /area/crew_quarters/dorms)
 "mtA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "mtG" = (
 /obj/structure/chair/stool{
@@ -40257,7 +40257,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40281,7 +40281,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "muZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/conveyor{
@@ -40294,7 +40294,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -40326,7 +40326,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "mvU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40389,7 +40389,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40413,7 +40413,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40465,7 +40465,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40491,7 +40491,7 @@
 "mzO" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40516,11 +40516,11 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mAG" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mAH" = (
@@ -40533,7 +40533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mAX" = (
@@ -40559,7 +40559,7 @@
 /turf/open/floor/black,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mBb" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /obj/machinery/doorButtons/access_button{
@@ -40598,7 +40598,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40620,7 +40620,7 @@
 	pixel_x = -1;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40691,7 +40691,7 @@
 /area/maintenance/starboard/aft)
 "mDQ" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -40710,7 +40710,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mEn" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/enlist{
@@ -40745,7 +40745,7 @@
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40782,7 +40782,7 @@
 /obj/item/paicard{
 	pixel_x = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -40807,7 +40807,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40817,7 +40817,7 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "mGC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40926,7 +40926,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40947,8 +40947,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "mIo" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "mIz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -41070,7 +41070,7 @@
 /area/maintenance/starboard/fore)
 "mLm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -41201,10 +41201,10 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/white/corner{
+/obj/effect/turf_decal/trimline/white/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41216,7 +41216,7 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -41293,7 +41293,7 @@
 	network = list("ss13","medical")
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41312,11 +41312,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mNZ" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -41330,10 +41330,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41430,10 +41430,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41443,7 +41443,7 @@
 	c_tag = "Starboard Primary Hallway 4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41459,7 +41459,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41519,7 +41519,7 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -41533,7 +41533,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mTb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41554,11 +41554,11 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mTt" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41592,7 +41592,7 @@
 /area/science/mixing)
 "mTH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/power/apc{
+lower//obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/port";
 	name = "Port Hall APC";
 	pixel_y = -23
@@ -41645,7 +41645,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41660,7 +41660,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41675,7 +41675,7 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "mVk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -41769,7 +41769,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -41789,7 +41789,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41819,7 +41819,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mXg" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -41859,7 +41859,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41933,7 +41933,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41976,7 +41976,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/siding/thinplating{
+lower//obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41985,7 +41985,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42110,7 +42110,7 @@
 /area/lawoffice)
 "mZx" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42119,13 +42119,13 @@
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mZI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42157,7 +42157,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nai" = (
 /obj/machinery/door/airlock/engineering{
@@ -42185,7 +42185,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "naq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -42262,7 +42262,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/anesthetic_machine/roundstart,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42281,7 +42281,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ncT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42335,7 +42335,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -42455,7 +42455,7 @@
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -42469,7 +42469,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+lower//turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "neS" = (
 /obj/machinery/light{
@@ -42478,7 +42478,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42598,7 +42598,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42625,7 +42625,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "ngM" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ngP" = (
@@ -42671,7 +42671,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nik" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "niA" = (
@@ -42690,7 +42690,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "niC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -42889,7 +42889,7 @@
 /area/security/courtroom)
 "nlu" = (
 /mob/living/carbon/monkey,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42990,7 +42990,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "nmW" = (
@@ -43002,7 +43002,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nng" = (
@@ -43010,7 +43010,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43028,7 +43028,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43038,7 +43038,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43053,7 +43053,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43104,7 +43104,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -43156,7 +43156,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43238,7 +43238,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43362,26 +43362,26 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "ntf" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ntR" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ntS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nuc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43391,7 +43391,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43427,7 +43427,7 @@
 /area/quartermaster/office)
 "nuw" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43467,7 +43467,7 @@
 /area/hallway/secondary/entry)
 "nuU" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43481,7 +43481,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nvv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -43520,7 +43520,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43591,19 +43591,19 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nxs" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "nxt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -43646,7 +43646,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nxX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -43687,7 +43687,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nys" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -43711,7 +43711,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "nze" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -43748,7 +43748,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43773,7 +43773,7 @@
 /area/engine/atmos/pumproom)
 "nzW" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43858,7 +43858,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nBf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nBt" = (
@@ -43884,7 +43884,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nBN" = (
@@ -43894,7 +43894,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43966,7 +43966,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nDN" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44016,7 +44016,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44053,7 +44053,7 @@
 	id = "executionflash";
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/light/small{
@@ -44120,8 +44120,8 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "nHl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -44190,7 +44190,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44199,7 +44199,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -44215,7 +44215,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
 "nIY" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "nJl" = (
@@ -44267,7 +44267,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -44312,10 +44312,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44333,7 +44333,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "nLZ" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -44385,7 +44385,7 @@
 	icon_state = "L2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
+lower//obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -44432,7 +44432,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -44514,7 +44514,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44523,7 +44523,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "nPy" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44579,7 +44579,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nQn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44596,7 +44596,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44614,7 +44614,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nQY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44631,7 +44631,7 @@
 	pixel_x = 26;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44677,7 +44677,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nRM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -44728,7 +44728,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "nSp" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44748,10 +44748,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nSy" = (
@@ -44777,7 +44777,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/item/hand_labeler{
@@ -44826,7 +44826,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44853,7 +44853,7 @@
 	pixel_y = -7;
 	req_one_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -44868,7 +44868,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44944,7 +44944,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -44965,7 +44965,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "nVi" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45082,7 +45082,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -45111,7 +45111,7 @@
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45154,7 +45154,7 @@
 /turf/open/floor/wood,
 /area/vacant_room)
 "nXU" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45182,7 +45182,7 @@
 	pixel_y = 25;
 	req_access_txt = "36"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45240,7 +45240,7 @@
 	name = "Labor Camp Monitoring";
 	network = list("labor")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45264,7 +45264,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -45275,7 +45275,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45284,7 +45284,7 @@
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45325,7 +45325,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45345,7 +45345,7 @@
 	dir = 4;
 	pixel_y = 37
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45401,7 +45401,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/firstsingularity{
@@ -45454,7 +45454,7 @@
 	c_tag = "Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45489,7 +45489,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ocY" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45507,7 +45507,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "odp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/research/research{
@@ -45582,7 +45582,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -45655,7 +45655,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45718,7 +45718,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oin" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45741,7 +45741,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45751,7 +45751,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45803,7 +45803,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45823,7 +45823,7 @@
 "oki" = (
 /obj/structure/table,
 /obj/item/multitool,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -45860,7 +45860,7 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "oll" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -45885,7 +45885,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -45905,7 +45905,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "omj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -45936,7 +45936,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45951,7 +45951,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45991,7 +45991,7 @@
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46030,10 +46030,10 @@
 /obj/machinery/computer/warrant{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46043,14 +46043,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ooB" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46290,7 +46290,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46311,13 +46311,13 @@
 /area/science/xenobiology)
 "osV" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "otc" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
+lower//obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -46359,7 +46359,7 @@
 	amount = 10
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+lower//turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ott" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -46463,7 +46463,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ovy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -46524,7 +46524,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "owL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46575,7 +46575,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -46596,7 +46596,7 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46619,7 +46619,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46677,7 +46677,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/listeningstation)
 "ozN" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -46689,7 +46689,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ozT" = (
@@ -46711,7 +46711,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46743,13 +46743,13 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "oAk" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "oAn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46844,7 +46844,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46854,7 +46854,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oCq" = (
 /obj/structure/disposalpipe/segment{
@@ -46869,7 +46869,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47017,7 +47017,7 @@
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47037,7 +47037,7 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tanks North"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -47133,7 +47133,7 @@
 /area/hallway/primary/central)
 "oHj" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47176,10 +47176,10 @@
 	c_tag = "Garden West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47305,7 +47305,7 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/sign/poster/official/random{
+lower//obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
@@ -47348,7 +47348,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oKW" = (
 /obj/structure/sign/departments/minsky/supply/mining{
@@ -47368,7 +47368,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -47386,7 +47386,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47437,7 +47437,7 @@
 /area/maintenance/port/fore)
 "oMh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/lapvend,
+lower//obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "oMk" = (
@@ -47473,7 +47473,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oMS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -47625,10 +47625,10 @@
 	dir = 10;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -47639,7 +47639,7 @@
 /area/maintenance/port/fore)
 "oQc" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /obj/item/clothing/glasses/meson{
@@ -47650,7 +47650,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/white/corner/lower{
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
@@ -47665,7 +47665,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "oQp" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47689,7 +47689,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "oQv" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47699,7 +47699,7 @@
 	icon_state = "L6"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
+lower//obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -47732,7 +47732,7 @@
 /area/maintenance/department/tcoms)
 "oQW" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47747,7 +47747,7 @@
 /area/ruin/powered)
 "oRq" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47771,7 +47771,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oRG" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -47853,7 +47853,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47871,7 +47871,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "oSS" = (
@@ -47917,7 +47917,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oTw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -47926,10 +47926,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47948,7 +47948,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47959,7 +47959,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oTN" = (
 /obj/machinery/light,
@@ -47996,7 +47996,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "oUH" = (
 /obj/structure/grille,
@@ -48111,7 +48111,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -48129,7 +48129,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48158,16 +48158,16 @@
 /area/maintenance/port/aft)
 "oXw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "oXP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48218,10 +48218,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48230,7 +48230,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -48276,7 +48276,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48373,7 +48373,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48463,7 +48463,7 @@
 "pbU" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pbV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -48473,14 +48473,14 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos)
 "pbY" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48611,7 +48611,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48640,7 +48640,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area{
@@ -48679,7 +48679,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pfh" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48689,7 +48689,7 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west{
@@ -48698,7 +48698,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pfK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48752,7 +48752,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48781,7 +48781,7 @@
 "phb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "phj" = (
 /obj/machinery/door/window/northleft{
@@ -48813,7 +48813,7 @@
 	dir = 4;
 	name = "Input Gas Connector Port"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -48830,7 +48830,7 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
 "phV" = (
-/obj/effect/turf_decal/trimline/white/corner{
+/obj/effect/turf_decal/trimline/white/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -48847,19 +48847,19 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pir" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pit" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -48929,7 +48929,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pjX" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49067,7 +49067,7 @@
 /obj/machinery/light{
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49075,7 +49075,7 @@
 "pmi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pmj" = (
@@ -49095,7 +49095,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -49116,7 +49116,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "pmv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -49167,7 +49167,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49194,10 +49194,10 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage)
 "pnm" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -49367,7 +49367,7 @@
 	id = "QMLoad2"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
+lower//obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -49427,7 +49427,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ppT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -49475,10 +49475,10 @@
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49494,7 +49494,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49519,7 +49519,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "prh" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49546,7 +49546,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49589,10 +49589,10 @@
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/plasticflaps,
@@ -49603,7 +49603,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "psi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/level_interface{
@@ -49682,7 +49682,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ptS" = (
 /obj/structure/disposalpipe/segment{
@@ -49703,7 +49703,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49775,7 +49775,7 @@
 /area/maintenance/port/aft)
 "pvk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pvB" = (
 /obj/structure/cable{
@@ -49887,7 +49887,7 @@
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "pwu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49951,7 +49951,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49997,7 +49997,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pyp" = (
 /obj/machinery/door/airlock/security/glass{
@@ -50105,7 +50105,7 @@
 	dir = 4
 	},
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50135,7 +50135,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50306,7 +50306,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "pDM" = (
 /obj/machinery/light/small{
@@ -50324,7 +50324,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pEe" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -50342,7 +50342,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "pEm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50395,7 +50395,7 @@
 /area/hallway/primary/port)
 "pFo" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50426,7 +50426,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -50470,7 +50470,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "pGq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50506,8 +50506,8 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50545,7 +50545,7 @@
 /area/maintenance/central)
 "pHZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -50565,7 +50565,7 @@
 "pIm" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50573,7 +50573,7 @@
 "pIs" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/mineral/plasma{
+lower//obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
 /obj/item/stack/rods/fifty,
@@ -50600,7 +50600,7 @@
 	dir = 4;
 	network = list("ss13","rd","chpt")
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50639,7 +50639,7 @@
 /area/science/xenobiology)
 "pJw" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -50723,7 +50723,7 @@
 "pKp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50749,7 +50749,7 @@
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50761,7 +50761,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50783,7 +50783,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50799,7 +50799,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50820,15 +50820,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/brig)
 "pMi" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51034,10 +51034,10 @@
 	pixel_y = -40
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pOV" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51074,7 +51074,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "pPz" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51112,7 +51112,7 @@
 /area/hallway/primary/starboard)
 "pQr" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51128,7 +51128,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51139,7 +51139,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/item/destTagger{
@@ -51167,7 +51167,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/turf_decal/trimline/purple/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -51227,16 +51227,16 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "pRU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "pSo" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -51254,7 +51254,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "pSx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargo{
@@ -51299,7 +51299,7 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51331,7 +51331,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51481,7 +51481,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51535,7 +51535,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -51582,7 +51582,7 @@
 "pWP" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51708,7 +51708,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "pXN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51723,7 +51723,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51735,7 +51735,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/foyer)
 "pYp" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
@@ -51858,10 +51858,10 @@
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
@@ -51900,7 +51900,7 @@
 /area/hallway/primary/starboard)
 "qbl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qbt" = (
 /obj/structure/cable{
@@ -51911,7 +51911,7 @@
 /area/solar/port/aft)
 "qbz" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/item/storage/box/lights/mixed,
@@ -51922,10 +51922,10 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51963,7 +51963,7 @@
 	pixel_x = 32;
 	pixel_y = 40
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51982,7 +51982,7 @@
 /area/crew_quarters/locker)
 "qdp" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -51995,7 +51995,7 @@
 /area/hallway/primary/port)
 "qdH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/chair{
+lower//obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52042,7 +52042,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52057,7 +52057,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/command/charge{
@@ -52066,7 +52066,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qey" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -52120,7 +52120,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52133,7 +52133,7 @@
 	c_tag = "Atmospherics Auxiliary Storage";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -52233,7 +52233,7 @@
 /area/hallway/secondary/exit)
 "qhl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light,
+lower//obj/machinery/light,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -52271,7 +52271,7 @@
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52291,7 +52291,7 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -52323,7 +52323,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qiX" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -52361,7 +52361,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qkh" = (
 /obj/structure/sign/departments/minsky/supply/cargo{
@@ -52407,7 +52407,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52439,7 +52439,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52461,7 +52461,7 @@
 	},
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -52595,7 +52595,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -52630,7 +52630,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qoj" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -52719,7 +52719,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -52735,7 +52735,7 @@
 	dir = 4;
 	name = "Input Port Pump"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -52744,7 +52744,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "qqa" = (
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/white{
@@ -52794,10 +52794,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "qri" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -52861,10 +52861,10 @@
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -52897,7 +52897,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qtt" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -52913,7 +52913,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53002,10 +53002,10 @@
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/white/corner/lower{
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
@@ -53038,7 +53038,7 @@
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
 "qvn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53141,7 +53141,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53152,7 +53152,7 @@
 "qya" = (
 /obj/machinery/light,
 /obj/machinery/vending/security,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -53186,7 +53186,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qyW" = (
 /obj/structure/cable{
@@ -53206,7 +53206,7 @@
 /area/science/storage)
 "qza" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -53222,7 +53222,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qzA" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 10
 	},
 /obj/machinery/button/flasher{
@@ -53236,7 +53236,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -53251,7 +53251,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "qAG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53362,7 +53362,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53455,7 +53455,7 @@
 /area/clerk)
 "qDT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53505,7 +53505,7 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -53534,7 +53534,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "qEt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53625,13 +53625,13 @@
 "qFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "qFQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -53657,7 +53657,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -53677,8 +53677,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qGv" = (
@@ -53715,7 +53715,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -53730,7 +53730,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qHe" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 5
 	},
 /obj/machinery/vending/cola/random,
@@ -53860,13 +53860,13 @@
 /area/medical/storage/backroom)
 "qHT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qHV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -53953,7 +53953,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qKr" = (
 /turf/open/floor/plasteel{
@@ -53970,7 +53970,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54005,7 +54005,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "qLY" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54048,7 +54048,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -54169,7 +54169,7 @@
 /area/science/misc_lab)
 "qOJ" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/structure/chair/office/light{
@@ -54256,7 +54256,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54300,7 +54300,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qSg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -54406,13 +54406,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qVk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qVm" = (
@@ -54472,7 +54472,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qWz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -54505,7 +54505,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qXp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -54532,7 +54532,7 @@
 "qXQ" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -54546,7 +54546,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54625,7 +54625,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /obj/item/paper_bin{
@@ -54742,10 +54742,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54819,7 +54819,7 @@
 "rct" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rcz" = (
 /obj/structure/cable{
@@ -54834,7 +54834,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54898,7 +54898,7 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54986,7 +54986,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -54998,7 +54998,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -55072,7 +55072,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55174,7 +55174,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rgQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -55227,7 +55227,7 @@
 /area/science/mixing)
 "rhk" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55254,7 +55254,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "rib" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55288,7 +55288,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "riq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /obj/structure/closet/radiation,
@@ -55305,7 +55305,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "riV" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -55365,8 +55365,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rjT" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/processing)
 "rjX" = (
 /obj/effect/turf_decal/loading_area{
@@ -55439,7 +55439,7 @@
 /area/science/xenobiology)
 "rkY" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55458,7 +55458,7 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55505,8 +55505,8 @@
 /obj/structure/sign/map/left{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rlJ" = (
 /turf/open/floor/mineral/silver,
@@ -55515,7 +55515,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55583,7 +55583,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "rnf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -55634,16 +55634,16 @@
 	},
 /obj/item/radio/off,
 /obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "rnZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55766,7 +55766,7 @@
 "rqd" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rqp" = (
 /obj/structure/closet/firecloset,
@@ -55798,7 +55798,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rqK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55816,10 +55816,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55837,7 +55837,7 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "rrQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -55884,16 +55884,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "rsS" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -55909,7 +55909,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "rtb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/conveyor{
@@ -55948,7 +55948,7 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "ruc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55963,7 +55963,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -55998,10 +55998,10 @@
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56198,7 +56198,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -56223,7 +56223,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rxC" = (
 /obj/structure/window/reinforced,
@@ -56260,7 +56260,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -56288,7 +56288,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "ryM" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56347,7 +56347,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rAN" = (
 /obj/structure/table/wood,
@@ -56382,7 +56382,7 @@
 /area/crew_quarters/heads/cmo)
 "rBz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "rBG" = (
 /obj/machinery/vending/sovietsoda,
@@ -56436,7 +56436,7 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rCy" = (
 /obj/structure/window/reinforced{
@@ -56493,7 +56493,7 @@
 /area/engine/engineering)
 "rDw" = (
 /obj/effect/decal/cleanable/glass/plasma,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -56508,7 +56508,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56530,7 +56530,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56581,7 +56581,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56592,7 +56592,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rEj" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -56615,7 +56615,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/rdconsole/production,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56628,7 +56628,7 @@
 /area/crew_quarters/bar)
 "rEz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rEG" = (
 /obj/machinery/light{
@@ -56670,7 +56670,7 @@
 	dir = 8;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56680,7 +56680,7 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56755,7 +56755,7 @@
 /area/hallway/primary/starboard)
 "rGh" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -56787,7 +56787,7 @@
 /area/maintenance/starboard/aft)
 "rGK" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -56808,7 +56808,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -56828,7 +56828,7 @@
 /area/space/nearstation)
 "rHg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "rHj" = (
 /obj/structure/cable{
@@ -56943,7 +56943,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57002,7 +57002,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57045,7 +57045,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57117,7 +57117,7 @@
 	pixel_x = 5;
 	pixel_y = 13
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57139,7 +57139,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57187,7 +57187,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -57196,7 +57196,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rOt" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -57228,7 +57228,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "rOQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -57258,7 +57258,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rPd" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -57271,7 +57271,7 @@
 /area/maintenance/port/fore)
 "rPf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rPh" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57368,7 +57368,7 @@
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57386,7 +57386,7 @@
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57415,13 +57415,13 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rQV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57431,7 +57431,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "rRe" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57492,7 +57492,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -57534,7 +57534,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57547,10 +57547,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57574,7 +57574,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "rTI" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/structure/railing{
@@ -57597,7 +57597,7 @@
 /area/medical/patients_rooms/room_a)
 "rUt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57629,7 +57629,7 @@
 "rUN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -57649,14 +57649,14 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "rUZ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/engine/airless,
 /area/escapepodbay)
 "rVc" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -57703,7 +57703,7 @@
 "rVy" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57761,7 +57761,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "rWB" = (
 /obj/structure/cable{
@@ -57843,7 +57843,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57923,7 +57923,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57990,7 +57990,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58057,7 +58057,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -58069,13 +58069,13 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sbf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sbl" = (
@@ -58112,7 +58112,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
+lower//obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -58287,10 +58287,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "sdd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -58387,7 +58387,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "seA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -58416,7 +58416,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58473,7 +58473,7 @@
 /area/crew_quarters/toilet/locker)
 "sht" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/closet/radiation,
+lower//obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "shu" = (
@@ -58513,14 +58513,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "sir" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "siw" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58532,7 +58532,7 @@
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58562,7 +58562,7 @@
 /obj/structure/table/glass,
 /obj/item/crowbar,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -58615,7 +58615,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "skV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58635,7 +58635,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "slm" = (
 /obj/structure/shuttle/engine/large{
@@ -58709,7 +58709,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "sni" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58737,7 +58737,7 @@
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58757,7 +58757,7 @@
 /obj/machinery/camera{
 	c_tag = "Port Hallway"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58867,7 +58867,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sqa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -58881,7 +58881,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sqC" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58929,7 +58929,7 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58988,8 +58988,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -58999,7 +58999,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59045,7 +59045,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "stv" = (
 /obj/structure/cable{
@@ -59188,7 +59188,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "swg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/glass,
@@ -59356,10 +59356,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "szr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -59368,7 +59368,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "szs" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -59405,7 +59405,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/electrolyzer,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -59438,7 +59438,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59447,7 +59447,7 @@
 /obj/structure/table,
 /obj/item/flashlight,
 /obj/item/assembly/igniter,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59481,7 +59481,7 @@
 /area/maintenance/port)
 "sBP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "sBX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -59498,7 +59498,7 @@
 	dir = 8;
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59511,7 +59511,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sCd" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 4
 	},
 /obj/structure/chair/office/dark{
@@ -59533,7 +59533,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59589,7 +59589,7 @@
 /area/maintenance/port/aft)
 "sCG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light,
+lower//obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "sDk" = (
@@ -59617,7 +59617,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59628,7 +59628,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59729,12 +59729,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "sFw" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59767,7 +59767,7 @@
 	icon_state = "L12"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sFS" = (
 /obj/machinery/light{
@@ -59797,7 +59797,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59846,7 +59846,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "sGV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59887,14 +59887,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sHK" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60033,7 +60033,7 @@
 /area/science/mixing/chamber)
 "sIQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60091,7 +60091,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sKr" = (
@@ -60141,7 +60141,7 @@
 "sKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60191,7 +60191,7 @@
 /turf/open/floor/plasteel,
 /area/clerk)
 "sLf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60316,7 +60316,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60390,7 +60390,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60491,7 +60491,7 @@
 /area/science/xenobiology)
 "sNK" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -60515,7 +60515,7 @@
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60608,7 +60608,7 @@
 /area/hallway/primary/starboard)
 "sQf" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60620,7 +60620,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/aiModule/reset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60644,7 +60644,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sQO" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60660,7 +60660,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -60686,7 +60686,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60753,7 +60753,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60784,7 +60784,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -60846,7 +60846,7 @@
 	pixel_x = 7;
 	pixel_y = 39
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -60857,7 +60857,7 @@
 "sTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60899,7 +60899,7 @@
 /area/crew_quarters/toilet/locker)
 "sUr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61012,7 +61012,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "sWY" = (
 /obj/effect/turf_decal/tile/blue{
@@ -61073,7 +61073,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -61099,7 +61099,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "sYq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61121,7 +61121,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sYO" = (
 /obj/structure/window/reinforced{
@@ -61158,7 +61158,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61288,7 +61288,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "tbv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -61332,7 +61332,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tcN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61342,7 +61342,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "tcX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/chair{
@@ -61392,13 +61392,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tdo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61444,7 +61444,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61467,7 +61467,7 @@
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "teA" = (
 /obj/machinery/door/firedoor/border_only{
@@ -61486,7 +61486,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61565,7 +61565,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tgz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -61579,7 +61579,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61601,7 +61601,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "thu" = (
 /obj/machinery/door/airlock/public{
@@ -61691,7 +61691,7 @@
 /obj/item/electronics/firelock,
 /obj/item/multitool,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -61731,7 +61731,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -61743,7 +61743,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -61798,7 +61798,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "tkI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61861,7 +61861,7 @@
 	pixel_y = -37
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tlX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -61873,7 +61873,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61920,7 +61920,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -61930,13 +61930,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tnu" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -61954,7 +61954,7 @@
 /area/space/nearstation)
 "tob" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -62020,7 +62020,7 @@
 	pixel_y = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62034,7 +62034,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "tpZ" = (
 /obj/machinery/door/window{
@@ -62148,7 +62148,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62221,14 +62221,14 @@
 "ttp" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ttt" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -62293,7 +62293,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -62372,7 +62372,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "twR" = (
 /obj/structure/window/reinforced{
@@ -62412,7 +62412,7 @@
 /area/engine/atmos/distro)
 "txw" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62466,7 +62466,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -62493,7 +62493,7 @@
 /obj/machinery/recharger{
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -62587,13 +62587,13 @@
 	},
 /area/crew_quarters/kitchen)
 "tBi" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tBR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/table,
@@ -62652,7 +62652,7 @@
 	dir = 4;
 	id = "crematoriumChapel"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62760,7 +62760,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62772,7 +62772,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tFs" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62804,7 +62804,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62821,7 +62821,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62848,7 +62848,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62884,7 +62884,7 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tGG" = (
 /obj/structure/disposalpipe/segment,
@@ -62924,7 +62924,7 @@
 	c_tag = "Aft Primary Hallway 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62961,7 +62961,7 @@
 /area/engine/atmos/distro)
 "tHQ" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/structure/closet/firecloset,
@@ -62990,7 +62990,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63085,7 +63085,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "tJJ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -63102,7 +63102,7 @@
 /area/crew_quarters/kitchen)
 "tJY" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -63135,7 +63135,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "tLi" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -63200,7 +63200,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63209,7 +63209,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -63234,7 +63234,7 @@
 "tPe" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tPg" = (
 /obj/structure/cable/yellow{
@@ -63255,13 +63255,13 @@
 /area/maintenance/port/fore)
 "tPH" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "tPL" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -63287,7 +63287,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tQh" = (
 /obj/machinery/computer/bounty{
@@ -63331,7 +63331,7 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63389,7 +63389,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tSh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63414,7 +63414,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/listeningstation)
 "tSu" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63500,13 +63500,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tUq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tUD" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -63595,7 +63595,7 @@
 /area/science/lab)
 "tVL" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/power/apc{
+lower//obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/starboard";
 	name = "Starboard Primary Hallway APC";
 	pixel_y = -23
@@ -63664,7 +63664,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tXi" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63697,7 +63697,7 @@
 /area/maintenance/solars/starboard/aft)
 "tXv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63753,7 +63753,7 @@
 	c_tag = "Mining Dock External";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/advanced_airlock_controller{
@@ -63773,7 +63773,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tZb" = (
 /obj/structure/cable{
@@ -63833,7 +63833,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63886,7 +63886,7 @@
 /obj/item/hfr_box/body/interface,
 /obj/item/hfr_box/body/moderator_input,
 /obj/item/hfr_box/body/waste_output,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63911,13 +63911,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ucm" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -63939,13 +63939,13 @@
 	dir = 1
 	},
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uct" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64075,8 +64075,8 @@
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/prison)
 "ufs" = (
 /obj/structure/plasticflaps{
@@ -64191,13 +64191,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uhk" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 10
 	},
 /obj/structure/railing{
@@ -64218,7 +64218,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64242,7 +64242,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -64258,7 +64258,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "uhW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64276,7 +64276,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64288,7 +64288,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64304,7 +64304,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64313,13 +64313,13 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uiG" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64346,7 +64346,7 @@
 /area/hallway/primary/starboard)
 "uiJ" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -64417,7 +64417,7 @@
 	c_tag = "Robotics Lab";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64446,11 +64446,11 @@
 	pixel_y = -31
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ukO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64561,7 +64561,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "umM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -64588,7 +64588,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "umX" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64619,7 +64619,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -64651,7 +64651,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64769,10 +64769,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/corner{
+/obj/effect/turf_decal/siding/thinplating/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64813,7 +64813,7 @@
 	pixel_y = -7
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+lower//obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -64822,7 +64822,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64842,7 +64842,7 @@
 "urH" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/stack/sheet/metal/fifty,
+lower//obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
 	pixel_x = 1;
@@ -64902,7 +64902,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64914,7 +64914,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -64980,10 +64980,10 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "utK" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65032,7 +65032,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65059,7 +65059,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65107,7 +65107,7 @@
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/item/book/manual/wiki/security_space_law,
@@ -65136,7 +65136,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -65145,7 +65145,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65166,7 +65166,7 @@
 /obj/structure/sign/departments/minsky/research/xenobiology{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -65176,7 +65176,7 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uyJ" = (
 /obj/machinery/door/firedoor/border_only{
@@ -65194,14 +65194,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65229,7 +65229,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65238,13 +65238,13 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uzB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65268,7 +65268,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+lower//turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "uAm" = (
 /obj/structure/girder/reinforced,
@@ -65302,7 +65302,7 @@
 	network = list("ss13","rd")
 	},
 /obj/item/crowbar,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -65379,13 +65379,13 @@
 /area/hallway/primary/aft)
 "uBg" = (
 /obj/machinery/computer/aifixer,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "uBp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65430,7 +65430,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65439,7 +65439,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65472,7 +65472,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65529,7 +65529,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65562,14 +65562,14 @@
 	dir = 5;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uDT" = (
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65591,14 +65591,14 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uEu" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uEH" = (
 /obj/structure/sign/poster/official/love_ian,
@@ -65653,7 +65653,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65702,7 +65702,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable/orange{
@@ -65784,7 +65784,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65801,7 +65801,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65861,7 +65861,7 @@
 /turf/open/space/basic,
 /area/solar/port/aft)
 "uIq" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -65869,7 +65869,7 @@
 /area/hallway/primary/central)
 "uIu" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/status_display/evac{
@@ -65899,7 +65899,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -65960,7 +65960,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65989,7 +65989,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -66020,7 +66020,7 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/computer/atmos_sim{
+lower//obj/machinery/computer/atmos_sim{
 	dir = 1;
 	mode = 1
 	},
@@ -66031,7 +66031,7 @@
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
 "uLU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66043,13 +66043,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uMl" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66145,7 +66145,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uOD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -66279,10 +66279,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66318,7 +66318,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uRn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -66360,7 +66360,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uSU" = (
 /obj/structure/cable{
@@ -66427,7 +66427,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66467,7 +66467,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66477,7 +66477,7 @@
 	c_tag = "Atmospherics South East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -66556,7 +66556,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66586,20 +66586,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uXx" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uXD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66630,7 +66630,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66654,7 +66654,7 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66771,7 +66771,7 @@
 /area/maintenance/port/fore)
 "uZH" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -66779,7 +66779,7 @@
 "uZS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66804,7 +66804,7 @@
 /area/maintenance/starboard/fore)
 "vax" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66815,13 +66815,13 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "vaY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -66861,7 +66861,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "vbM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66894,7 +66894,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vct" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66976,8 +66976,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "veN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -66998,7 +66998,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67039,7 +67039,7 @@
 	c_tag = "Central Hallway South-East";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67064,7 +67064,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "vgd" = (
@@ -67076,7 +67076,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67102,7 +67102,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "vgW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -67124,10 +67124,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67171,7 +67171,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "viq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67193,7 +67193,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vjn" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 8
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -67209,10 +67209,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vjD" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67261,14 +67261,14 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vjZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67292,7 +67292,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "vkP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -67342,7 +67342,7 @@
 /area/maintenance/port/fore)
 "vlb" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67357,7 +67357,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67432,7 +67432,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vnJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -67466,7 +67466,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "voX" = (
 /obj/effect/turf_decal/bot,
@@ -67506,7 +67506,7 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "vpN" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -67560,7 +67560,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67585,7 +67585,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "vrT" = (
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/fish/salmon,
@@ -67650,7 +67650,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vsN" = (
 /obj/structure/cable{
@@ -67671,7 +67671,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "vsP" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -67711,7 +67711,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67762,7 +67762,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -67771,13 +67771,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "vuD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vuM" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -67803,7 +67803,7 @@
 /obj/machinery/camera{
 	c_tag = "Brig East"
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67824,10 +67824,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vwg" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67971,7 +67971,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68038,7 +68038,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68066,7 +68066,7 @@
 	c_tag = "Fore Primary Hallway East";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68144,7 +68144,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -68157,7 +68157,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "vAs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68205,7 +68205,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vCu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -68229,7 +68229,7 @@
 /area/science/robotics/lab)
 "vDu" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68238,7 +68238,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68295,7 +68295,7 @@
 "vEw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "vED" = (
@@ -68307,7 +68307,7 @@
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
 "vEM" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -68379,7 +68379,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68388,7 +68388,7 @@
 /obj/machinery/computer/cloning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68408,7 +68408,7 @@
 	dir = 8
 	},
 /obj/item/a_gift,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -68432,10 +68432,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -68459,7 +68459,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vGF" = (
 /turf/open/water/safe{
@@ -68469,7 +68469,7 @@
 	},
 /area/crew_quarters/bar)
 "vGG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -68495,7 +68495,7 @@
 /area/ai_monitored/secondarydatacore)
 "vGN" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68509,7 +68509,7 @@
 /area/crew_quarters/bar)
 "vHx" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68541,7 +68541,7 @@
 /area/hallway/primary/fore)
 "vJj" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68622,7 +68622,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68710,7 +68710,7 @@
 	dir = 8;
 	name = "cargo camera"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68747,7 +68747,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68759,7 +68759,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68778,7 +68778,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "vMv" = (
 /obj/machinery/computer/security/telescreen/vault{
@@ -68827,10 +68827,10 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "vMU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -68896,7 +68896,7 @@
 /turf/open/floor/wood,
 /area/library)
 "vNJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68931,7 +68931,7 @@
 	pixel_x = 32;
 	pixel_y = -9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/item/radio/off,
@@ -68980,14 +68980,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vPP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vQb" = (
 /obj/structure/table,
@@ -69004,10 +69004,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/siding/wideplating/corner{
+/obj/effect/turf_decal/siding/wideplating/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69041,7 +69041,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "vQB" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69096,7 +69096,7 @@
 "vRu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vRT" = (
@@ -69116,7 +69116,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69174,7 +69174,7 @@
 /turf/open/floor/plating,
 /area/janitor)
 "vSA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69199,7 +69199,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69207,7 +69207,7 @@
 "vTw" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -69261,7 +69261,7 @@
 /area/tcommsat/server)
 "vUd" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -69270,7 +69270,7 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -69327,7 +69327,7 @@
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "vVC" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "vVP" = (
@@ -69335,7 +69335,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69377,7 +69377,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69417,11 +69417,11 @@
 	req_access_txt = "17"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vXp" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/cell_charger{
@@ -69466,7 +69466,7 @@
 "vYn" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "vYC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -69531,7 +69531,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69650,7 +69650,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "wbO" = (
 /obj/machinery/light{
@@ -69676,7 +69676,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69704,7 +69704,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -69784,10 +69784,10 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "wek" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69846,7 +69846,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/corner{
+/obj/effect/turf_decal/trimline/white/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69862,8 +69862,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/airalarm{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -69925,10 +69925,10 @@
 /area/hallway/primary/central)
 "wfE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69946,7 +69946,7 @@
 /obj/structure/closet/wardrobe/white,
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -69964,7 +69964,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70012,7 +70012,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70115,8 +70115,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/main)
 "wjK" = (
 /obj/machinery/power/apc{
@@ -70153,7 +70153,7 @@
 /area/hydroponics/garden)
 "wjS" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -70190,7 +70190,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -70335,7 +70335,7 @@
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "wmn" = (
 /obj/effect/decal/cleanable/vomit/old,
@@ -70353,7 +70353,7 @@
 /area/hallway/primary/central)
 "wms" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70389,14 +70389,14 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "wnn" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+lower//obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -70425,7 +70425,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70472,7 +70472,7 @@
 /area/quartermaster/miningdock)
 "wow" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -70486,7 +70486,7 @@
 "woS" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "wpj" = (
 /obj/structure/table,
@@ -70509,7 +70509,7 @@
 /obj/machinery/bounty_board{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -70535,7 +70535,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -70619,7 +70619,7 @@
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70666,7 +70666,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70720,7 +70720,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/warning{
+/obj/effect/turf_decal/trimline/brown/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70729,7 +70729,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70760,7 +70760,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70782,7 +70782,7 @@
 	layer = 2.4;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70852,7 +70852,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wwm" = (
@@ -70860,7 +70860,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -70893,7 +70893,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wxK" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 6
 	},
 /obj/item/wrench,
@@ -70957,7 +70957,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71015,7 +71015,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71121,7 +71121,7 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "wBs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -71182,7 +71182,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCv" = (
@@ -71199,7 +71199,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCL" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71264,14 +71264,14 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "wDM" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -71287,7 +71287,7 @@
 /area/engine/engine_smes)
 "wDS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71373,7 +71373,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "wFh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71405,7 +71405,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71458,7 +71458,7 @@
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+lower//obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -71490,7 +71490,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wGS" = (
 /obj/machinery/light{
@@ -71502,7 +71502,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71557,7 +71557,7 @@
 "wIc" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71568,7 +71568,7 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -71579,7 +71579,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel/white/side{
+lower//turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
@@ -71588,7 +71588,7 @@
 	c_tag = "Arrivals Bay 1 East";
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71613,13 +71613,13 @@
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "wIC" = (
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/disk/holodisk/tutorial/AICore,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -71691,7 +71691,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71700,7 +71700,7 @@
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71730,7 +71730,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wKJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -71753,7 +71753,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71791,7 +71791,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wMr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -71802,7 +71802,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "wMt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71820,7 +71820,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71851,7 +71851,7 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "wNm" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71883,7 +71883,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -71994,7 +71994,7 @@
 /turf/closed/wall,
 /area/medical/storage)
 "wPe" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72004,10 +72004,10 @@
 	dir = 6;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72080,7 +72080,7 @@
 /area/ai_monitored/storage/eva)
 "wQU" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -72107,7 +72107,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72138,7 +72138,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "wRE" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -72165,7 +72165,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wSh" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -72174,7 +72174,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wSk" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72228,7 +72228,7 @@
 /area/science/misc_lab)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72250,7 +72250,7 @@
 	pixel_x = -27;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72271,7 +72271,7 @@
 /area/teleporter)
 "wTL" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72373,7 +72373,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72388,8 +72388,8 @@
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
 /obj/item/gun/energy/laser/practice,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/main)
 "wVj" = (
 /obj/structure/table/wood,
@@ -72426,7 +72426,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wVv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
@@ -72481,7 +72481,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -72548,7 +72548,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "wWl" = (
 /obj/structure/sign/poster/contraband/random{
@@ -72581,7 +72581,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "wWA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -72651,7 +72651,7 @@
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "wWV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -72764,7 +72764,7 @@
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72786,7 +72786,7 @@
 	dir = 4;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72882,8 +72882,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72892,7 +72892,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -72923,7 +72923,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -72998,7 +72998,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -73010,7 +73010,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xdY" = (
@@ -73049,7 +73049,7 @@
 /area/ai_monitored/turret_protected/ai)
 "xez" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -73069,7 +73069,7 @@
 "xeJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xfh" = (
@@ -73133,7 +73133,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xfD" = (
@@ -73171,7 +73171,7 @@
 /obj/item/storage/belt/medical{
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73192,7 +73192,7 @@
 	},
 /obj/item/flashlight,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+lower//turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xfT" = (
 /mob/living/simple_animal/hostile/bear/russian,
@@ -73226,7 +73226,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73270,7 +73270,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73291,7 +73291,7 @@
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73400,7 +73400,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73417,7 +73417,7 @@
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "xkG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
@@ -73504,7 +73504,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xmy" = (
 /obj/structure/closet/emcloset,
@@ -73555,7 +73555,7 @@
 /area/science/explab)
 "xnl" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -73567,7 +73567,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/secred/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xnD" = (
@@ -73623,7 +73623,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73644,7 +73644,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
@@ -73693,18 +73693,18 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xqR" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "xra" = (
 /obj/machinery/photocopier,
@@ -73753,7 +73753,7 @@
 /area/chapel/office)
 "xrQ" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -73856,7 +73856,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xuf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73983,7 +73983,7 @@
 	pixel_y = 31
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74054,7 +74054,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74063,7 +74063,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
 	},
 /obj/machinery/button/flasher{
@@ -74126,7 +74126,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74147,7 +74147,7 @@
 	c_tag = "Escape Arm Airlocks";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74262,7 +74262,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74338,7 +74338,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xBe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 8
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -74410,7 +74410,7 @@
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74445,7 +74445,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xDt" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74466,7 +74466,7 @@
 	dir = 8;
 	pixel_y = 41
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74530,8 +74530,8 @@
 	pixel_y = -32
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xFE" = (
 /obj/machinery/light/small{
@@ -74594,7 +74594,7 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xGW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74631,7 +74631,7 @@
 /area/medical/medbay/aft)
 "xHK" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xHY" = (
 /obj/structure/cable{
@@ -74649,7 +74649,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74677,7 +74677,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "xIn" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -74697,7 +74697,7 @@
 "xIu" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/depsec/service,
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "xIy" = (
@@ -74706,7 +74706,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xIB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -74745,7 +74745,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xIY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -74814,7 +74814,7 @@
 /area/quartermaster/office)
 "xKl" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 9
 	},
 /obj/item/radio/off,
@@ -74837,7 +74837,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74991,7 +74991,7 @@
 /area/medical/sleeper)
 "xMa" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -75007,7 +75007,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75025,7 +75025,7 @@
 /area/medical/patients_rooms/room_b)
 "xMN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/chair/office/light,
+lower//obj/structure/chair/office/light,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "xNb" = (
@@ -75067,7 +75067,7 @@
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75130,7 +75130,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xNH" = (
 /obj/machinery/newscaster{
@@ -75145,14 +75145,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xNW" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75160,7 +75160,7 @@
 "xOk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xOD" = (
@@ -75231,7 +75231,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -75288,7 +75288,7 @@
 	dir = 8
 	},
 /obj/item/storage/box/disks,
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -75298,7 +75298,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/blue/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75308,10 +75308,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75345,7 +75345,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRC" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75389,7 +75389,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRY" = (
 /obj/structure/cable{
@@ -75493,7 +75493,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xVg" = (
 /obj/structure/chair{
@@ -75625,7 +75625,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75651,7 +75651,7 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel,
+lower//turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xXv" = (
 /obj/machinery/light_switch{
@@ -75687,13 +75687,13 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "xXN" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -75812,7 +75812,7 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "yaX" = (
 /obj/machinery/camera{
@@ -75890,7 +75890,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/turf_decal/trimline/blue/warning/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "ycw" = (
@@ -75910,7 +75910,7 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75928,7 +75928,7 @@
 /area/maintenance/starboard/aft)
 "ycV" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -76026,7 +76026,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76091,7 +76091,7 @@
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -76123,7 +76123,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/plasteel/white,
+lower//turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "yfr" = (
 /obj/structure/grille,
@@ -76154,14 +76154,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ygn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76230,7 +76230,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76254,7 +76254,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/warning{
+/obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -76263,11 +76263,11 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/secred/filled/line,
+lower//turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "yim" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/line/lower{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -76298,7 +76298,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "yjg" = (
-/obj/effect/turf_decal/pool/corner{
+/obj/effect/turf_decal/pool/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76321,7 +76321,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "yjL" = (
-/obj/effect/turf_decal/trimline/green/filled/warning{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -76364,13 +76364,13 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
+lower//obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "ykz" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76401,7 +76401,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ykU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76418,7 +76418,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
+/obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -76436,7 +76436,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -76445,7 +76445,7 @@
 /obj/structure/sign/departments/minsky/medical/clone/cloning2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -76466,7 +76466,7 @@
 	c_tag = "Garden East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -62,7 +62,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -203,7 +203,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "abU" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -257,7 +257,7 @@
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -270,7 +270,7 @@
 /area/science/nanite)
 "aco" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -491,7 +491,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "aeR" = (
-/turf/open/floor/plasteel/dark/corner/lower{
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
 /area/chapel/main)
@@ -597,7 +597,7 @@
 /area/tcommsat/server)
 "afM" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -658,10 +658,10 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -682,7 +682,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
 "agq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/structure/chair{
@@ -709,7 +709,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
 "agE" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -787,7 +787,7 @@
 /area/maintenance/department/electrical)
 "agW" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -892,7 +892,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -909,7 +909,7 @@
 /turf/open/space/basic,
 /area/space)
 "aiM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -1038,7 +1038,7 @@
 "ajC" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1118,7 +1118,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -1140,7 +1140,7 @@
 /area/crew_quarters/heads/captain)
 "aku" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -1153,7 +1153,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -1298,7 +1298,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1377,7 +1377,7 @@
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/item/stack/packageWrap{
@@ -1472,7 +1472,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "amZ" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1483,7 +1483,7 @@
 	pixel_x = 2
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "anj" = (
 /turf/closed/wall,
@@ -1684,7 +1684,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aoZ" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1890,7 +1890,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2048,7 +2048,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "asx" = (
 /turf/closed/wall/r_wall,
@@ -2205,8 +2205,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/map/right{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "atv" = (
 /obj/structure/closet/radiation,
@@ -2276,7 +2276,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -2287,7 +2287,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "aua" = (
-/turf/open/floor/plasteel/dark/corner/lower{
+/turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
 /area/chapel/main)
@@ -2342,7 +2342,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aup" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -2392,7 +2392,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = -24;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2490,7 +2490,7 @@ lower//turf/open/floor/plasteel,
 "avP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -2550,7 +2550,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -2627,7 +2627,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/morgue)
 "awU" = (
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "awZ" = (
 /obj/machinery/mass_driver{
@@ -2695,7 +2695,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -2738,7 +2738,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2786,10 +2786,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2821,7 +2821,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2837,7 +2837,7 @@ lower//turf/open/floor/plasteel,
 /turf/template_noop,
 /area/crew_quarters/dorms)
 "ayJ" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2924,8 +2924,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3074,7 +3074,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -3159,7 +3159,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aBc" = (
 /obj/machinery/door/airlock/public/glass{
@@ -3169,7 +3169,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3191,7 +3191,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3341,7 +3341,7 @@ lower//turf/open/floor/plasteel,
 /area/space)
 "aCk" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/dark/corner/lower{
+/turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
 /area/chapel/main)
@@ -3539,7 +3539,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/library)
 "aDx" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -3766,7 +3766,7 @@ lower//turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aFv" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3830,7 +3830,7 @@ lower//turf/open/floor/plasteel,
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "aFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4264,7 +4264,7 @@ lower//turf/open/floor/plasteel/white,
 /area/library)
 "aJC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -4318,7 +4318,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "aKb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -4461,7 +4461,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -4526,10 +4526,10 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4576,7 +4576,7 @@ lower//turf/open/floor/plasteel/white,
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4691,7 +4691,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "aOy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -4756,7 +4756,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -4954,7 +4954,7 @@ lower//turf/open/floor/plasteel/white,
 /area/solar/starboard/aft)
 "aRd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRh" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -5216,7 +5216,7 @@ lower//turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aTs" = (
 /obj/machinery/gulag_processor,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5247,7 +5247,7 @@ lower//turf/open/floor/plasteel,
 /turf/closed/wall/r_wall,
 /area/security/prison)
 "aTJ" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5378,7 +5378,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aVl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5445,7 +5445,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -5479,7 +5479,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5491,7 +5491,7 @@ lower//turf/open/floor/plasteel,
 	},
 /area/holodeck/rec_center)
 "aWL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -5522,8 +5522,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/structure/cable{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -5555,7 +5555,7 @@ lower//obj/structure/cable{
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -5582,7 +5582,7 @@ lower//obj/structure/cable{
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5779,7 +5779,7 @@ lower//obj/structure/cable{
 /area/hallway/secondary/exit)
 "aYC" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -5792,7 +5792,7 @@ lower//obj/structure/cable{
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -5851,7 +5851,7 @@ lower//obj/structure/cable{
 /turf/open/space/basic,
 /area/solar/port/fore)
 "aZc" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -5900,7 +5900,7 @@ lower//obj/structure/cable{
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5995,7 +5995,7 @@ lower//obj/structure/cable{
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bam" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6017,7 +6017,7 @@ lower//obj/structure/cable{
 /obj/item/crowbar,
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "baF" = (
 /obj/effect/turf_decal/pool,
@@ -6061,7 +6061,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "baQ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6079,10 +6079,10 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "bbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6145,7 +6145,7 @@ lower//turf/open/floor/plasteel/dark,
 /area/security/prison)
 "bda" = (
 /obj/machinery/announcement_system,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -6160,8 +6160,8 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "bdu" = (
 /obj/structure/chair/sofa/corner,
@@ -6352,7 +6352,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6364,10 +6364,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bhC" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6382,7 +6382,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6395,7 +6395,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6410,7 +6410,7 @@ lower//turf/open/floor/plasteel,
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6485,10 +6485,10 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bjb" = (
@@ -6518,8 +6518,8 @@ lower//turf/open/floor/plasteel,
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "bjt" = (
 /obj/structure/table/wood,
@@ -6547,7 +6547,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6587,7 +6587,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6652,7 +6652,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6747,7 +6747,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "bmw" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/report_crimes{
@@ -6760,7 +6760,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6789,7 +6789,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/patients_rooms/room_b)
 "bnm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/structure/cable/orange{
+/obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
@@ -6822,7 +6822,7 @@ lower//obj/structure/cable/orange{
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boz" = (
@@ -6895,7 +6895,7 @@ lower//obj/structure/cable/orange{
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bpC" = (
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6911,7 +6911,7 @@ lower//obj/structure/cable/orange{
 /area/ai_monitored/storage/satellite)
 "bqd" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -6966,10 +6966,10 @@ lower//obj/structure/cable/orange{
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "bqV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -7043,7 +7043,7 @@ lower//obj/structure/cable/orange{
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7061,7 +7061,7 @@ lower//obj/structure/cable/orange{
 	dir = 8;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -7189,7 +7189,7 @@ lower//obj/structure/cable/orange{
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7205,12 +7205,12 @@ lower//obj/structure/cable/orange{
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
 "btS" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btU" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7322,7 +7322,7 @@ lower//obj/structure/cable/orange{
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bwi" = (
 /obj/structure/disposalpipe/segment,
@@ -7464,7 +7464,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7522,17 +7522,17 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "bAo" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/closet/l3closet,
@@ -7554,7 +7554,7 @@ lower//turf/open/floor/plasteel,
 	name = "glass table"
 	},
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7564,10 +7564,10 @@ lower//turf/open/floor/plasteel,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "bBj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/machinery/vending/snack/random,
@@ -7608,7 +7608,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Central Hallway North-East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7818,7 +7818,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Hallway"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7850,7 +7850,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -7882,7 +7882,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7951,7 +7951,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIq" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
@@ -8009,7 +8009,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bIX" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8050,7 +8050,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -8062,13 +8062,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bJK" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8077,14 +8077,14 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bKc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8114,7 +8114,7 @@ lower//turf/open/floor/plasteel,
 "bLc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8172,7 +8172,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8196,7 +8196,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8210,13 +8210,13 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8247,7 +8247,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "bNW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/machinery/requests_console{
@@ -8275,7 +8275,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8427,7 +8427,7 @@ lower//turf/open/floor/plasteel,
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//obj/structure/cable{
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
@@ -8469,7 +8469,7 @@ lower//obj/structure/cable{
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bRG" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -8501,7 +8501,7 @@ lower//obj/structure/cable{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bSy" = (
@@ -8513,10 +8513,10 @@ lower//obj/structure/cable{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bSO" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -8555,7 +8555,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bVa" = (
 /obj/structure/window/reinforced{
@@ -8571,7 +8571,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8585,14 +8585,14 @@ lower//turf/open/floor/plasteel/white,
 "bVE" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bVK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -8622,7 +8622,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -8847,7 +8847,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8940,7 +8940,7 @@ lower//turf/open/floor/plasteel/white,
 "cbr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8983,7 +8983,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cch" = (
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 8
 	},
 /turf/open/floor/white{
@@ -9003,7 +9003,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9024,7 +9024,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9034,7 +9034,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9077,7 +9077,7 @@ lower//turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "cdC" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/armaments_dispenser,
@@ -9202,7 +9202,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9226,7 +9226,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/meter,
@@ -9237,7 +9237,7 @@ lower//turf/open/floor/plasteel/white,
 	c_tag = "Engineering South";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9250,7 +9250,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -9261,7 +9261,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /area/maintenance/starboard/aft)
 "cgw" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes{
@@ -9348,7 +9348,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/clothing/mask/gas,
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
@@ -9501,7 +9501,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cjO" = (
 /obj/machinery/light,
@@ -9532,7 +9532,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/machinery/camera{
+/obj/machinery/camera{
 	c_tag = "Medbay West";
 	dir = 1;
 	network = list("ss13","medbay");
@@ -9555,7 +9555,7 @@ lower//obj/machinery/camera{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cks" = (
 /obj/structure/disposalpipe/segment{
@@ -9615,7 +9615,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "clb" = (
@@ -9689,7 +9689,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "clx" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/closet/l3closet,
@@ -9770,7 +9770,7 @@ lower//turf/open/floor/plasteel,
 "cnU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "coo" = (
@@ -9804,8 +9804,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cqa" = (
 /obj/structure/cable{
@@ -9853,7 +9853,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "crb" = (
 /obj/structure/rack,
@@ -9870,13 +9870,13 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/mirror{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cri" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -9976,13 +9976,13 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "cts" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating/corner/lower{
+/obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10003,7 +10003,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cua" = (
@@ -10034,7 +10034,7 @@ lower//turf/open/floor/plasteel/white,
 "cuH" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "cuU" = (
 /obj/machinery/button/door{
@@ -10158,10 +10158,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cwI" = (
-/obj/effect/turf_decal/trimline/white/corner/lower{
+/obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cwO" = (
@@ -10237,7 +10237,7 @@ lower//turf/open/floor/plasteel,
 /area/storage/primary)
 "cyj" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/cable/yellow{
@@ -10253,7 +10253,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -10271,7 +10271,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10286,8 +10286,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/structure/extinguisher_cabinet{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -10299,7 +10299,7 @@ lower//obj/structure/extinguisher_cabinet{
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "czo" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10324,7 +10324,7 @@ lower//obj/structure/extinguisher_cabinet{
 	dir = 4;
 	name = "hallway camera"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10336,7 +10336,7 @@ lower//obj/structure/extinguisher_cabinet{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10418,7 +10418,7 @@ lower//obj/structure/extinguisher_cabinet{
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "cAw" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10443,7 +10443,7 @@ lower//obj/structure/extinguisher_cabinet{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10470,7 +10470,7 @@ lower//obj/structure/extinguisher_cabinet{
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cAW" = (
-/obj/effect/turf_decal/siding/wood/corner/lower{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10604,7 +10604,7 @@ lower//obj/structure/extinguisher_cabinet{
 	id = "crematoriumChapel";
 	pixel_y = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10672,12 +10672,12 @@ lower//obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cEO" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/item/circuitboard/computer/ai_upload_download,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -10696,7 +10696,7 @@ lower//turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cEY" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -10769,7 +10769,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/ripped{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve{
@@ -10823,7 +10823,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cHo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10852,7 +10852,7 @@ lower//turf/open/floor/plasteel,
 "cHX" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/item/stock_parts/cell/high/plus,
@@ -10975,7 +10975,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/micro_laser/high,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11090,7 +11090,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11114,21 +11114,21 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/heads/captain)
 "cME" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "cMI" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "cMJ" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cMS" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -11217,7 +11217,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11259,7 +11259,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Construction Area North";
 	dir = 0
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11312,7 +11312,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cOM" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11404,7 +11404,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -11443,7 +11443,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -11468,7 +11468,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -11486,7 +11486,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11505,10 +11505,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11618,8 +11618,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11644,7 +11644,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11660,7 +11660,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "cVr" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11687,10 +11687,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11742,10 +11742,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11837,7 +11837,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -11972,7 +11972,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "daT" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -12066,15 +12066,15 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dci" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12092,7 +12092,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12200,7 +12200,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "dez" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -12238,7 +12238,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12253,7 +12253,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -12265,14 +12265,14 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "dft" = (
 /obj/structure/displaycase/labcage,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -12358,7 +12358,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar/red,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -12386,7 +12386,7 @@ lower//turf/open/floor/plasteel,
 	name = "Surgery APC";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -12512,11 +12512,11 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "djY" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12642,7 +12642,7 @@ lower//turf/open/floor/plasteel/white,
 /area/clerk)
 "dlA" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -12665,7 +12665,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "dmh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12712,7 +12712,7 @@ lower//turf/open/floor/plasteel/white,
 	network = list("prison");
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12777,7 +12777,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -12811,7 +12811,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dqq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -12887,7 +12887,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "dsM" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -12929,7 +12929,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dtt" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -12975,7 +12975,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12985,7 +12985,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -13015,7 +13015,7 @@ lower//turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "duv" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -13092,7 +13092,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -4
 	},
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -13109,7 +13109,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -13117,7 +13117,7 @@ lower//turf/open/floor/plasteel/white,
 "dwt" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//obj/machinery/vending/modularpc,
+/obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "dwv" = (
@@ -13134,10 +13134,10 @@ lower//obj/machinery/vending/modularpc,
 	pixel_x = -4;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13183,7 +13183,7 @@ lower//obj/machinery/vending/modularpc,
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13241,7 +13241,7 @@ lower//obj/machinery/vending/modularpc,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13261,7 +13261,7 @@ lower//obj/machinery/vending/modularpc,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "dyV" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13283,10 +13283,10 @@ lower//obj/machinery/vending/modularpc,
 /obj/structure/filingcabinet/chestdrawer,
 /mob/living/simple_animal/parrot/Poly,
 /obj/item/toy/figure/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white/corner/lower{
+/turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
 /area/crew_quarters/heads/chief)
@@ -13298,7 +13298,7 @@ lower//obj/machinery/vending/modularpc,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -13352,7 +13352,7 @@ lower//obj/machinery/vending/modularpc,
 	},
 /obj/structure/table,
 /obj/item/storage/box/fancy/donut_box,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13404,7 +13404,7 @@ lower//obj/machinery/vending/modularpc,
 /area/engine/engineering)
 "dAU" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13473,7 +13473,7 @@ lower//obj/machinery/vending/modularpc,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13482,7 +13482,7 @@ lower//obj/machinery/vending/modularpc,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13503,7 +13503,7 @@ lower//obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dEf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13534,8 +13534,8 @@ lower//obj/machinery/vending/modularpc,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "dEV" = (
 /obj/structure/cable{
@@ -13553,7 +13553,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13566,7 +13566,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Starboard Primary Hallway 3";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13627,7 +13627,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13757,7 +13757,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13767,7 +13767,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13810,7 +13810,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13848,7 +13848,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dKN" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -13885,7 +13885,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -14230,8 +14230,8 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Security Office";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/structure/sign/poster/official/space_cops{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/sign/poster/official/space_cops{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -14247,7 +14247,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14274,7 +14274,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14350,7 +14350,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 	pixel_y = 10
 	},
 /obj/item/analyzer,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14462,7 +14462,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14506,7 +14506,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 	dir = 1;
 	sortType = 10
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dWc" = (
@@ -14516,7 +14516,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 	name = "medical camera";
 	network = list("ss13","medical")
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14671,7 +14671,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /turf/open/floor/plasteel,
 /area/clerk)
 "dZY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -14686,7 +14686,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /area/space/nearstation)
 "eae" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14725,7 +14725,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14785,7 +14785,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14817,7 +14817,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/vomit/old,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14847,7 +14847,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14870,7 +14870,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/machinery/modular_computer/console/preset/medical{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14901,7 +14901,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "edl" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -14955,7 +14955,7 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15077,8 +15077,8 @@ lower//obj/structure/sign/poster/official/space_cops{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "efO" = (
 /obj/machinery/door/airlock/command/glass{
@@ -15119,7 +15119,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "egF" = (
@@ -15153,10 +15153,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15213,7 +15213,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15238,7 +15238,7 @@ lower//turf/open/floor/plasteel,
 "eiC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "eiN" = (
@@ -15282,7 +15282,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15357,7 +15357,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ejV" = (
 /obj/structure/table/optable,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15457,7 +15457,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15507,7 +15507,7 @@ lower//turf/open/floor/plasteel,
 	name = "Genetics Requests Console";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -15557,7 +15557,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -15613,7 +15613,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15681,7 +15681,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15752,7 +15752,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "epy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -15768,7 +15768,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eqh" = (
 /obj/structure/cable{
@@ -15778,7 +15778,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "eql" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/oil,
@@ -15796,7 +15796,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "eqq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15905,7 +15905,7 @@ lower//turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "esc" = (
 /obj/effect/turf_decal/stripes/line,
-lower//obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -16024,7 +16024,7 @@ lower//obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -16042,7 +16042,7 @@ lower//obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	name = "Station Alert Console"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "etM" = (
 /obj/structure/cable{
@@ -16061,7 +16061,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "etS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16109,10 +16109,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
@@ -16265,7 +16265,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "eye" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -16297,7 +16297,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16313,7 +16313,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eyX" = (
 /obj/structure/sign/poster/contraband/communist_state,
@@ -16324,7 +16324,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "L14"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ezv" = (
 /obj/machinery/door/airlock/maintenance/external{
@@ -16415,7 +16415,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
 "eAT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/bed/roller,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "eBe" = (
@@ -16453,7 +16453,7 @@ lower//obj/structure/bed/roller,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eBv" = (
 /obj/machinery/power/apc{
@@ -16469,10 +16469,10 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eBw" = (
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "eBD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16513,7 +16513,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/paramedic)
 "eCu" = (
 /obj/item/stack/ore/iron,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16538,7 +16538,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "eCV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -16556,7 +16556,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16582,7 +16582,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
@@ -16593,7 +16593,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16606,7 +16606,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -16640,7 +16640,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -16661,7 +16661,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "eFa" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -16706,7 +16706,7 @@ lower//turf/open/floor/plasteel,
 /area/bridge/meeting_room)
 "eFu" = (
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plating,
+/turf/open/floor/plating,
 /area/security/execution/transfer)
 "eFx" = (
 /obj/structure/window/reinforced,
@@ -16721,7 +16721,7 @@ lower//turf/open/floor/plating,
 /turf/open/space/basic,
 /area/solar/port/aft)
 "eFF" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16742,7 +16742,7 @@ lower//turf/open/floor/plating,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16830,7 +16830,7 @@ lower//turf/open/floor/plating,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eHs" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16852,7 +16852,7 @@ lower//turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16875,10 +16875,10 @@ lower//turf/open/floor/plating,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "eIf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16940,7 +16940,7 @@ lower//turf/open/floor/plating,
 /obj/machinery/computer/security/telescreen/cmo{
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16953,8 +16953,8 @@ lower//turf/open/floor/plating,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "eJh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16979,7 +16979,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17074,7 +17074,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "eLh" = (
 /obj/item/reagent_containers/syringe,
@@ -17112,7 +17112,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -17138,7 +17138,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "eLU" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17219,7 +17219,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "eMP" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/table,
@@ -17233,7 +17233,7 @@ lower//turf/open/floor/plasteel,
 	name = "Unfiltered to Mix";
 	on = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17266,7 +17266,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17275,7 +17275,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17368,7 +17368,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17388,7 +17388,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17407,13 +17407,13 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "eRb" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "eRm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17554,7 +17554,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -17608,7 +17608,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "eUv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -17623,7 +17623,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17646,7 +17646,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "eVX" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -17721,7 +17721,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eXy" = (
 /obj/structure/sign/departments/minsky/command/space{
@@ -17771,7 +17771,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "eYe" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -17787,7 +17787,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17838,7 +17838,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17881,7 +17881,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "fbs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -17934,7 +17934,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "fcF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -17981,7 +17981,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = -25;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -17998,13 +17998,13 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "fdi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18038,7 +18038,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fdm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18080,7 +18080,7 @@ lower//turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "feA" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /obj/machinery/newscaster{
@@ -18100,8 +18100,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/storage/box/zipties{
 	pixel_x = 5
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "feE" = (
 /obj/structure/table/wood,
@@ -18145,10 +18145,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18167,7 +18167,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18190,7 +18190,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1;
 	pixel_y = 38
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -18269,8 +18269,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_y = -32
@@ -18326,13 +18326,13 @@ lower//obj/machinery/door_timer{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fib" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -18537,7 +18537,7 @@ lower//obj/machinery/door_timer{
 	name = "Air to Distro";
 	target_pressure = 4500
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18582,7 +18582,7 @@ lower//obj/machinery/door_timer{
 /area/teleporter)
 "flQ" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18611,13 +18611,13 @@ lower//obj/machinery/door_timer{
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fmB" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/machinery/door/airlock/public/glass{
@@ -18630,7 +18630,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fmL" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -18667,7 +18667,7 @@ lower//obj/machinery/door_timer{
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/ten,
 /obj/item/toy/figure/atmos,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -18697,7 +18697,7 @@ lower//obj/machinery/door_timer{
 /obj/structure/sign/plaques/atmos{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/pipedispenser,
@@ -18705,7 +18705,7 @@ lower//obj/machinery/door_timer{
 /area/engine/atmos)
 "fod" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18806,13 +18806,13 @@ lower//obj/machinery/door_timer{
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fpZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable/orange{
@@ -18975,7 +18975,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fta" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -18993,7 +18993,7 @@ lower//obj/machinery/door_timer{
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19036,7 +19036,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "fuM" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19069,7 +19069,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "fvj" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19079,7 +19079,7 @@ lower//obj/machinery/door_timer{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "fvw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -19127,7 +19127,7 @@ lower//turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "fwl" = (
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "fww" = (
 /obj/structure/falsewall,
@@ -19143,19 +19143,19 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "fwF" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19182,7 +19182,7 @@ lower//turf/open/floor/plasteel/dark,
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -19244,7 +19244,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fxy" = (
@@ -19280,14 +19280,14 @@ lower//turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "fxN" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fxW" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -19363,7 +19363,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19384,10 +19384,10 @@ lower//turf/open/floor/plasteel/dark,
 	},
 /area/crew_quarters/kitchen)
 "fzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19412,7 +19412,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/carpet,
 /area/lawoffice)
 "fAi" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -19498,7 +19498,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "fBW" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19517,8 +19517,8 @@ lower//turf/open/floor/plasteel/dark,
 	pixel_y = 10
 	},
 /obj/item/stack/packageWrap,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "fCn" = (
 /obj/machinery/paystand,
@@ -19534,7 +19534,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fCJ" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19561,7 +19561,7 @@ lower//turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "fDb" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -19592,14 +19592,14 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fDQ" = (
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19625,7 +19625,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/core,
 /obj/item/paper/guides/jobs/atmos/hypertorus,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -19643,7 +19643,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "fEV" = (
@@ -19673,10 +19673,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "fFp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -19705,7 +19705,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19739,7 +19739,7 @@ lower//turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fGA" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -19781,7 +19781,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19826,14 +19826,14 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "fIl" = (
 /obj/machinery/papershredder,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/machinery/status_display/supply{
@@ -19887,12 +19887,12 @@ lower//turf/open/floor/plasteel,
 "fJL" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fJM" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19901,7 +19901,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -19921,7 +19921,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19945,7 +19945,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19969,7 +19969,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20086,7 +20086,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20126,7 +20126,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20211,7 +20211,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "fPN" = (
@@ -20224,7 +20224,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /obj/structure/table,
@@ -20279,7 +20279,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner/lower{
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -20313,7 +20313,7 @@ lower//turf/open/floor/plasteel/white,
 	c_tag = "Engineering Access";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20397,7 +20397,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20449,7 +20449,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness)
 "fTh" = (
 /obj/machinery/power/smes,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/cable,
@@ -20471,7 +20471,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20498,7 +20498,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /area/crew_quarters/kitchen)
 "fTM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /obj/machinery/vending/coffee,
@@ -20534,13 +20534,13 @@ lower//turf/open/floor/plasteel/white,
 /area/vacant_room)
 "fUd" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fUj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20564,10 +20564,10 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/plasticflaps,
@@ -20656,7 +20656,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20691,7 +20691,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20757,7 +20757,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fYa" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -20790,17 +20790,17 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "fZb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20849,7 +20849,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/table,
 /obj/item/electropack,
 /obj/item/restraints/handcuffs,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20907,7 +20907,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -20919,7 +20919,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20928,7 +20928,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20995,7 +20995,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gbH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -21034,7 +21034,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -21070,7 +21070,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "gdx" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -21154,7 +21154,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "geG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -21184,7 +21184,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/pen/red,
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21321,7 +21321,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wideplating{
@@ -21376,7 +21376,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21456,7 +21456,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -21514,7 +21514,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
@@ -21526,7 +21526,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21610,7 +21610,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21628,8 +21628,8 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "gnq" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gnw" = (
 /obj/structure/window/reinforced{
@@ -21657,7 +21657,7 @@ lower//turf/open/floor/plasteel,
 /area/escapepodbay)
 "gnM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "gnT" = (
 /obj/machinery/holopad,
@@ -21700,7 +21700,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "goW" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21710,7 +21710,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21736,7 +21736,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gqx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/machinery/papershredder,
@@ -21755,7 +21755,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "gqJ" = (
 /obj/machinery/rnd/production/techfab/department/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -21775,7 +21775,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21920,7 +21920,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "gtu" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gtC" = (
@@ -21949,7 +21949,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21991,7 +21991,7 @@ lower//turf/open/floor/plasteel,
 	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "gvk" = (
 /obj/machinery/vending/cola/random,
@@ -22136,7 +22136,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/sequence_scanner,
 /obj/item/sequence_scanner,
 /obj/item/stack/cable_coil/white,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -22202,11 +22202,11 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "gyz" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -22219,7 +22219,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "gyU" = (
 /obj/machinery/camera{
@@ -22331,10 +22331,10 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gzS" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -22352,7 +22352,7 @@ lower//turf/open/floor/plasteel/white,
 /area/hallway/primary/fore)
 "gAc" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -22368,14 +22368,14 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gAM" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 8;
 	piping_layer = 2
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -22439,7 +22439,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22458,7 +22458,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gBO" = (
 /obj/structure/rack,
@@ -22488,8 +22488,8 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Brig Central";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
@@ -22516,7 +22516,7 @@ lower//obj/machinery/door_timer{
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "gDb" = (
@@ -22535,7 +22535,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gDq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /obj/structure/reagent_dispensers/foamtank,
@@ -22543,7 +22543,7 @@ lower//obj/machinery/door_timer{
 /area/engine/atmos/storage)
 "gDx" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22601,8 +22601,8 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gEx" = (
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gEK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -22689,10 +22689,10 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gFZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22741,7 +22741,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22757,7 +22757,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22955,7 +22955,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gKM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23043,7 +23043,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23066,7 +23066,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23114,7 +23114,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/starboard/fore)
 "gNo" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23208,7 +23208,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "gOI" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23263,10 +23263,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/corner/lower{
+/obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23277,7 +23277,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/radio/headset/headset_med,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23298,7 +23298,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -23317,13 +23317,13 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "gQG" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -23379,7 +23379,7 @@ lower//turf/open/floor/plasteel/white,
 "gRg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -23483,13 +23483,13 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/bar)
 "gSN" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "gSQ" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -23519,7 +23519,7 @@ lower//turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "gTD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "gTH" = (
 /obj/machinery/light,
@@ -23535,7 +23535,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "gTI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23548,7 +23548,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "gUj" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gUo" = (
@@ -23649,10 +23649,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23692,7 +23692,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23866,7 +23866,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness)
 "hbF" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -23915,7 +23915,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23927,7 +23927,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hdk" = (
@@ -23962,7 +23962,7 @@ lower//turf/open/floor/plasteel/white,
 "hdB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hdK" = (
@@ -23987,7 +23987,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -24099,7 +24099,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24122,7 +24122,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24233,7 +24233,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -24328,7 +24328,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24358,7 +24358,7 @@ lower//turf/open/floor/plasteel/white,
 "hii" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/machinery/power/apc{
+/obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/central";
 	name = "Central Hall APC";
 	pixel_y = -23
@@ -24399,7 +24399,7 @@ lower//obj/machinery/power/apc{
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hiB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -24445,7 +24445,7 @@ lower//obj/machinery/power/apc{
 /area/medical/chemistry)
 "hiU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hiX" = (
 /turf/closed/wall,
@@ -24487,7 +24487,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -24592,7 +24592,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24647,7 +24647,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24665,7 +24665,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hmV" = (
@@ -24680,7 +24680,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24712,7 +24712,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24766,7 +24766,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24830,7 +24830,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/clerk)
 "hpE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24892,7 +24892,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "1-4";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -24918,7 +24918,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24960,7 +24960,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25021,8 +25021,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hsu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -25034,7 +25034,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -25047,11 +25047,11 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hsM" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25166,7 +25166,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/solar/port/aft)
 "hvl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/structure/cable{
@@ -25258,7 +25258,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "hwc" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -25285,7 +25285,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hwW" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -25295,7 +25295,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -25308,7 +25308,7 @@ lower//turf/open/floor/plasteel,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -25322,7 +25322,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "hxK" = (
 /obj/machinery/meter{
@@ -25349,8 +25349,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "hxO" = (
 /obj/structure/cable{
@@ -25363,10 +25363,10 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25384,7 +25384,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hxZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25527,7 +25527,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "hAq" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25649,13 +25649,13 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "hCs" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25788,10 +25788,10 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	c_tag = "SMES Access";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25805,7 +25805,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25814,7 +25814,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/warning/electricshock{
@@ -25823,7 +25823,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hDC" = (
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 1
 	},
 /turf/open/floor/white{
@@ -25870,14 +25870,14 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
 "hEK" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "hFg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "hFp" = (
 /obj/structure/girder,
@@ -25917,7 +25917,7 @@ lower//turf/open/floor/plasteel,
 /area/science/xenobiology)
 "hFT" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -25938,7 +25938,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25978,7 +25978,7 @@ lower//turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "hGu" = (
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -26125,7 +26125,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "hIo" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -26181,13 +26181,13 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hJu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -26217,7 +26217,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26240,7 +26240,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "hKz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -26266,10 +26266,10 @@ lower//turf/open/floor/plasteel,
 "hLS" = (
 /obj/structure/table,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26360,7 +26360,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hMZ" = (
@@ -26374,7 +26374,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "hNc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26479,7 +26479,7 @@ lower//turf/open/floor/plasteel,
 "hOf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26531,7 +26531,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26567,7 +26567,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/space)
 "hQp" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26577,10 +26577,10 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hQP" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -26607,7 +26607,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "hRX" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -26627,7 +26627,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "hSm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -26643,7 +26643,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "hSz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26672,14 +26672,14 @@ lower//turf/open/floor/plasteel,
 "hSV" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "hTi" = (
 /obj/machinery/computer/bounty{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "hTw" = (
 /turf/open/space/basic,
@@ -26707,7 +26707,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "hTG" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26724,7 +26724,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/structure/cable/yellow{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -26735,7 +26735,7 @@ lower//obj/structure/cable/yellow{
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -26767,7 +26767,7 @@ lower//obj/structure/cable/yellow{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26834,8 +26834,8 @@ lower//obj/structure/cable/yellow{
 /obj/item/razor{
 	pixel_x = -6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "hXl" = (
 /obj/structure/chair/office/dark,
@@ -26844,7 +26844,7 @@ lower//turf/open/floor/plasteel,
 "hXF" = (
 /obj/machinery/light,
 /obj/structure/closet/l3closet/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -26867,7 +26867,7 @@ lower//turf/open/floor/plasteel,
 "hXL" = (
 /obj/machinery/light,
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26987,7 +26987,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hZz" = (
@@ -27022,7 +27022,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27069,7 +27069,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "iaS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/research/xenobiology{
@@ -27086,10 +27086,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -27125,7 +27125,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "ibs" = (
-/obj/structure/chair/sofa/corner/lower{
+/obj/structure/chair/sofa/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -27170,7 +27170,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "icC" = (
 /obj/structure/closet/bombcloset,
@@ -27192,7 +27192,7 @@ lower//turf/open/floor/plasteel,
 "idB" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "idE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27267,7 +27267,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "ifa" = (
 /turf/open/floor/plasteel,
@@ -27291,7 +27291,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -27333,7 +27333,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "igg" = (
 /obj/machinery/door/airlock/maintenance{
@@ -27396,7 +27396,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27450,7 +27450,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27535,7 +27535,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ijv" = (
 /obj/structure/cable/yellow{
@@ -27579,7 +27579,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ijO" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/structure/filingcabinet{
@@ -27607,7 +27607,7 @@ lower//turf/open/floor/plasteel,
 /area/library)
 "ikq" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27621,7 +27621,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27693,7 +27693,7 @@ lower//turf/open/floor/plasteel,
 /turf/closed/wall,
 /area/hydroponics)
 "imc" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -27735,7 +27735,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "imy" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27763,14 +27763,14 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "imT" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -27779,7 +27779,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//obj/item/radio/intercom{
+/obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
@@ -27827,7 +27827,7 @@ lower//obj/item/radio/intercom{
 /area/crew_quarters/theatre)
 "iog" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27907,7 +27907,7 @@ lower//obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27927,7 +27927,7 @@ lower//obj/item/radio/intercom{
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27955,10 +27955,10 @@ lower//obj/item/radio/intercom{
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "iqs" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -27975,7 +27975,7 @@ lower//obj/item/radio/intercom{
 "irp" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "irz" = (
 /obj/structure/cable{
@@ -28057,8 +28057,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "itc" = (
 /turf/open/floor/plating/airless{
@@ -28112,7 +28112,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -28137,7 +28137,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iul" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28179,10 +28179,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28192,7 +28192,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Atmospherics North West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -28228,7 +28228,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ivd" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28282,14 +28282,14 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/structure/closet/crate,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "iwc" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28299,8 +28299,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/door_timer{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
@@ -28310,7 +28310,7 @@ lower//obj/machinery/door_timer{
 "iwl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28412,7 +28412,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "iyK" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "iyZ" = (
@@ -28420,7 +28420,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/listeningstation)
 "izg" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
@@ -28440,7 +28440,7 @@ lower//obj/machinery/door_timer{
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "izw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -28482,7 +28482,7 @@ lower//obj/machinery/door_timer{
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iAT" = (
@@ -28558,7 +28558,7 @@ lower//obj/machinery/door_timer{
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "iBN" = (
 /obj/effect/overlay/palmtree_l{
@@ -28606,7 +28606,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -28672,10 +28672,10 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28695,7 +28695,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28729,7 +28729,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28767,7 +28767,7 @@ lower//turf/open/floor/plasteel,
 "iGQ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "iGT" = (
 /obj/structure/disposalpipe/segment{
@@ -28789,7 +28789,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Central Hallway West 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28888,7 +28888,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -28988,7 +28988,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/surgery)
 "iLq" = (
 /obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -29011,7 +29011,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -29050,7 +29050,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29076,7 +29076,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 7
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -29113,10 +29113,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "iNd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29126,7 +29126,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/fireaxecabinet{
 	pixel_x = -31
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -29157,7 +29157,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "iNC" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29205,11 +29205,11 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/grass,
 /area/medical/medbay/aft)
 "iOu" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "iOJ" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -29362,7 +29362,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "iSr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iSv" = (
 /obj/structure/window{
@@ -29385,7 +29385,7 @@ lower//turf/open/floor/plasteel,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29426,7 +29426,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -29636,7 +29636,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 6
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29673,7 +29673,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -29705,7 +29705,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "iXf" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -29756,13 +29756,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "iYo" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
@@ -29913,14 +29913,14 @@ lower//turf/open/floor/plasteel,
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "iZV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29934,7 +29934,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -29944,7 +29944,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29999,7 +29999,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jaz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/structure/closet/crate,
@@ -30038,7 +30038,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/barsign{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30086,13 +30086,13 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jbh" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jbC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -30146,10 +30146,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30225,7 +30225,7 @@ lower//turf/open/floor/plasteel/white,
 	name = "Robotics Desk";
 	req_one_access_txt = "29;75"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jdm" = (
@@ -30352,7 +30352,7 @@ lower//turf/open/floor/plasteel/white,
 "jeQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30402,7 +30402,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "jgg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -30419,7 +30419,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/starboard/fore)
 "jgs" = (
 /obj/structure/closet/secure_closet/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30464,7 +30464,7 @@ lower//turf/open/floor/plasteel/white,
 /area/bridge)
 "jgP" = (
 /obj/effect/turf_decal/stripes/line,
-lower//obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/computer/rdservercontrol{
@@ -30492,7 +30492,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /area/medical/genetics)
 "jgU" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -30530,7 +30530,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30547,7 +30547,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30588,7 +30588,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -30601,7 +30601,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /area/quartermaster/qm)
 "jit" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//obj/structure/bed/dogbed{
+/obj/structure/bed/dogbed{
 	desc = "Autumn's Bed! Looks comfy.";
 	name = "Autumn's Bed"
 	},
@@ -30644,7 +30644,7 @@ lower//obj/structure/bed/dogbed{
 /turf/open/floor/plasteel,
 /area/clerk)
 "jiH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -30696,13 +30696,13 @@ lower//obj/structure/bed/dogbed{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jjp" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30734,7 +30734,7 @@ lower//obj/structure/bed/dogbed{
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30775,14 +30775,14 @@ lower//obj/structure/bed/dogbed{
 	pixel_x = -30;
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "jkI" = (
 /mob/living/simple_animal/cockroach,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -30922,7 +30922,7 @@ lower//obj/structure/bed/dogbed{
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30976,7 +30976,7 @@ lower//obj/structure/bed/dogbed{
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "joq" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
@@ -31068,7 +31068,7 @@ lower//obj/structure/bed/dogbed{
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jqy" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31101,7 +31101,7 @@ lower//obj/structure/bed/dogbed{
 /area/maintenance/solars/starboard/aft)
 "jqP" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31140,13 +31140,13 @@ lower//obj/structure/bed/dogbed{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "jrt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -31201,7 +31201,7 @@ lower//obj/machinery/atmospherics/pipe/simple/green/visible{
 /area/ruin/powered)
 "jsq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -31218,7 +31218,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -31226,7 +31226,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 "jsv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -31244,7 +31244,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31254,10 +31254,10 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 2
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jtG" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -31284,7 +31284,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31347,7 +31347,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "jvI" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -31401,7 +31401,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31462,7 +31462,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31476,7 +31476,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jxh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -31524,7 +31524,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/engine,
 /area/escapepodbay)
 "jxV" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -31549,7 +31549,7 @@ lower//turf/open/floor/plasteel/white,
 /area/ai_monitored/security/armory)
 "jyK" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -31589,7 +31589,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31617,7 +31617,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /obj/structure/cable/yellow,
@@ -31643,7 +31643,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/kitchen)
 "jAf" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -31671,21 +31671,21 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "jAz" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "jAB" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31744,7 +31744,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
 "jBN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31778,7 +31778,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/port/fore)
 "jCg" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -31822,7 +31822,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31844,7 +31844,7 @@ lower//turf/open/floor/plasteel/white,
 	c_tag = "Virology Monkey Pen";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -31865,8 +31865,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31953,7 +31953,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32045,7 +32045,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = 1;
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -32093,7 +32093,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32120,7 +32120,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "jHb" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -32156,7 +32156,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -32171,7 +32171,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32186,8 +32186,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32397,7 +32397,7 @@ lower//turf/open/floor/plasteel/white,
 	c_tag = "Atmospherics Storage";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -32418,14 +32418,14 @@ lower//turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "jMl" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/theatre)
 "jMp" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/item/twohanded/rcl/pre_loaded,
@@ -32498,7 +32498,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/pipedispenser/disposal,
@@ -32510,7 +32510,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/bar)
 "jOs" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32529,7 +32529,7 @@ lower//turf/open/floor/plasteel/white,
 "jOE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jOQ" = (
 /turf/open/floor/plating,
@@ -32606,7 +32606,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -32695,7 +32695,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "jRd" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -32761,7 +32761,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32794,7 +32794,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/folder/white,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32810,7 +32810,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hop)
 "jSO" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32850,7 +32850,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -32891,8 +32891,8 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "jUC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -32903,7 +32903,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/virology)
 "jUF" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -32914,7 +32914,7 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "jVp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//obj/machinery/light,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "jVs" = (
@@ -32951,7 +32951,7 @@ lower//obj/machinery/light,
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33000,7 +33000,7 @@ lower//obj/machinery/light,
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33049,7 +33049,7 @@ lower//obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -33168,7 +33168,7 @@ lower//obj/machinery/light,
 /area/security/prison)
 "jZh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/structure/table,
+/obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/sign/warning/electricshock{
@@ -33211,7 +33211,7 @@ lower//obj/structure/table,
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -33226,7 +33226,7 @@ lower//obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "kbb" = (
@@ -33280,7 +33280,7 @@ lower//obj/structure/table,
 /turf/open/floor/plating,
 /area/science/nanite)
 "kbK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -33305,7 +33305,7 @@ lower//obj/structure/table,
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -33347,7 +33347,7 @@ lower//obj/structure/table,
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -33365,7 +33365,7 @@ lower//obj/structure/table,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "keF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -33445,7 +33445,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33496,7 +33496,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
 "kgj" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -33620,7 +33620,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 1;
 	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -33639,14 +33639,14 @@ lower//turf/open/floor/plasteel,
 "kiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kiL" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -33659,7 +33659,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kjm" = (
 /obj/machinery/disposal/bin,
@@ -33751,10 +33751,10 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -33764,11 +33764,11 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/machinery/light,
+/obj/machinery/light,
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
@@ -33821,7 +33821,7 @@ lower//obj/machinery/light,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33893,7 +33893,7 @@ lower//obj/machinery/light,
 	dir = 8
 	},
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -34038,7 +34038,7 @@ lower//obj/machinery/light,
 /area/maintenance/port)
 "kpQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/structure/extinguisher_cabinet{
+/obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -34054,8 +34054,8 @@ lower//obj/structure/extinguisher_cabinet{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kpV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -34098,7 +34098,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/pickaxe/mini,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kqK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34119,7 +34119,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "kqQ" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -34154,7 +34154,7 @@ lower//turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/listeningstation)
 "krp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/machinery/modular_computer/console/preset/command/ce{
+/obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side{
@@ -34313,7 +34313,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -34354,7 +34354,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 	dir = 1;
 	name = "Tank Monitor"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -34415,7 +34415,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -34432,7 +34432,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kvk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34469,7 +34469,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "kvW" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/railing{
@@ -34487,7 +34487,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34500,13 +34500,13 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /area/engine/atmos/hfr)
 "kww" = (
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kwL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34534,7 +34534,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34616,13 +34616,13 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "kyz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -34635,7 +34635,7 @@ lower//obj/machinery/modular_computer/console/preset/command/ce{
 	icon_state = "L4"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34724,7 +34724,7 @@ lower//obj/structure/disposalpipe/segment{
 	req_access_txt = "1"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -34736,11 +34736,11 @@ lower//obj/structure/disposalpipe/segment{
 "kAT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "kBc" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34754,7 +34754,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -34856,7 +34856,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "kDv" = (
@@ -34887,7 +34887,7 @@ lower//obj/structure/disposalpipe/segment{
 	pixel_y = -9;
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35009,7 +35009,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35084,7 +35084,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kGW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -35148,7 +35148,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/sign/departments/minsky/supply/hydroponics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -35186,7 +35186,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "kIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -35247,7 +35247,7 @@ lower//obj/structure/disposalpipe/segment{
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35267,7 +35267,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "kJM" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35296,7 +35296,7 @@ lower//obj/structure/disposalpipe/segment{
 	icon_state = "1-2";
 	tag = ""
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "kLe" = (
@@ -35312,7 +35312,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/item/clothing/glasses/hud/health{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -35337,7 +35337,7 @@ lower//obj/structure/disposalpipe/segment{
 	},
 /obj/item/pickaxe/mini,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "kLl" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
@@ -35370,10 +35370,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35458,7 +35458,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35489,8 +35489,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "kPr" = (
 /obj/structure/table/glass,
@@ -35514,7 +35514,7 @@ lower//turf/open/floor/plasteel,
 	name = "Medbay RC";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -35523,13 +35523,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "kQx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -35614,7 +35614,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -35673,8 +35673,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "kSs" = (
 /obj/effect/turf_decal/tile/red,
@@ -35751,7 +35751,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 24
 	},
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -35764,7 +35764,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35774,7 +35774,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "kUc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -35851,12 +35851,12 @@ lower//turf/open/floor/plasteel,
 "kVE" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "kVH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "kVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35901,7 +35901,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35960,7 +35960,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kXR" = (
 /obj/machinery/light{
@@ -36044,7 +36044,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36057,7 +36057,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -36067,14 +36067,14 @@ lower//turf/open/floor/plasteel,
 	icon_state = "L8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kZw" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "kZD" = (
 /obj/structure/cable{
@@ -36096,7 +36096,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "lad" = (
 /obj/structure/disposalpipe/segment{
@@ -36118,7 +36118,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36193,7 +36193,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "lca" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36263,7 +36263,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36290,7 +36290,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36305,8 +36305,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "ldu" = (
 /obj/structure/cable{
@@ -36326,7 +36326,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36398,7 +36398,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -36440,7 +36440,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -36478,7 +36478,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lip" = (
 /obj/structure/cable{
@@ -36542,7 +36542,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ljH" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -36567,7 +36567,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lkc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36587,7 +36587,7 @@ lower//turf/open/floor/plasteel/white,
 /area/quartermaster/miningdock)
 "lkG" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -36601,7 +36601,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36633,7 +36633,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "llu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36648,7 +36648,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -36669,7 +36669,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lml" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -36683,7 +36683,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -36695,7 +36695,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -36729,31 +36729,31 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "lnK" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "lnV" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "lnY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36796,7 +36796,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36835,8 +36835,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "lrc" = (
 /turf/open/floor/plating/asteroid,
@@ -36858,7 +36858,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -36881,7 +36881,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -37012,7 +37012,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ltr" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/door/airlock/command{
@@ -37077,7 +37077,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37087,7 +37087,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37105,7 +37105,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -37197,7 +37197,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37217,7 +37217,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lxi" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37329,10 +37329,10 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37355,15 +37355,15 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/central/secondary)
 "lyK" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white/corner/lower{
+/turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
 "lyY" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37394,7 +37394,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lzO" = (
 /obj/structure/disposalpipe/segment{
@@ -37406,13 +37406,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "lzP" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -37447,7 +37447,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/modular_computer/console/preset/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37478,7 +37478,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/powered)
 "lAy" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -37524,7 +37524,7 @@ lower//turf/open/floor/plasteel,
 	},
 /area/maintenance/port/aft)
 "lBg" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
 /turf/open/floor/plasteel,
@@ -37533,13 +37533,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "lBM" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37552,10 +37552,10 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Cargo Bay East";
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37661,7 +37661,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37694,7 +37694,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/restraints/handcuffs,
 /obj/item/crowbar,
 /obj/item/wrench,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37763,7 +37763,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37808,7 +37808,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lIp" = (
 /obj/machinery/door/firedoor/border_only{
@@ -37838,7 +37838,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/clerk)
 "lIF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -37856,7 +37856,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "lIU" = (
 /obj/machinery/clonepod,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -37864,7 +37864,7 @@ lower//turf/open/floor/plasteel,
 "lJd" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37889,7 +37889,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "lJD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -37921,7 +37921,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lJY" = (
 /obj/structure/cable{
@@ -37939,7 +37939,7 @@ lower//turf/open/floor/plasteel,
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lKG" = (
@@ -37998,7 +37998,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lLs" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -38030,7 +38030,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -38053,7 +38053,7 @@ lower//turf/open/floor/plasteel,
 	id = "QMLoad2"
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38175,7 +38175,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38185,7 +38185,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /area/science/research)
 "lNc" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/closet/radiation,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "lNd" = (
@@ -38214,7 +38214,7 @@ lower//obj/structure/closet/radiation,
 /area/hallway/primary/central)
 "lNW" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lNX" = (
@@ -38251,7 +38251,7 @@ lower//obj/structure/closet/radiation,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38311,7 +38311,7 @@ lower//obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lPj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38355,7 +38355,7 @@ lower//obj/structure/closet/radiation,
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -38363,7 +38363,7 @@ lower//obj/structure/closet/radiation,
 "lQw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lQx" = (
 /obj/structure/rack,
@@ -38517,7 +38517,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38537,7 +38537,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38580,7 +38580,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "lTz" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38620,7 +38620,7 @@ lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lTU" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/structure/cable/yellow{
@@ -38632,7 +38632,7 @@ lower//turf/open/floor/plasteel,
 "lTX" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lUe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38667,14 +38667,14 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lUG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "lVv" = (
 /obj/structure/chair/office/dark{
@@ -38756,7 +38756,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38845,7 +38845,7 @@ lower//turf/open/floor/plasteel,
 /area/ai_monitored/storage/satellite)
 "lYD" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38896,7 +38896,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -38908,7 +38908,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -38943,7 +38943,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "L10"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mal" = (
 /obj/machinery/holopad,
@@ -39000,14 +39000,14 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "maH" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -39026,7 +39026,7 @@ lower//turf/open/floor/plasteel,
 "mbf" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -39050,7 +39050,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mbH" = (
 /obj/structure/filingcabinet,
@@ -39066,7 +39066,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -39084,7 +39084,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mcg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -39112,7 +39112,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "mcD" = (
@@ -39146,7 +39146,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "mcQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39172,7 +39172,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/computer/telecomms/server{
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -39319,7 +39319,7 @@ lower//turf/open/floor/plasteel/white,
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39369,7 +39369,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "mgd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
@@ -39411,13 +39411,13 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mgM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
@@ -39467,7 +39467,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mhM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -39499,7 +39499,7 @@ lower//turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "mhV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/foyer)
 "mhY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -39518,7 +39518,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "min" = (
 /obj/effect/landmark/start/security_officer,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39527,7 +39527,7 @@ lower//turf/open/floor/plasteel,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
 "miz" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -39619,7 +39619,7 @@ lower//turf/open/floor/plasteel,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mka" = (
@@ -39632,7 +39632,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39716,7 +39716,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Virology Module";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39729,7 +39729,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39814,7 +39814,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 11;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -39854,7 +39854,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39971,7 +39971,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "mpo" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39981,7 +39981,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mqb" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -40024,7 +40024,7 @@ lower//turf/open/floor/plasteel,
 	},
 /area/science/xenobiology)
 "mqv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -40092,13 +40092,13 @@ lower//turf/open/floor/plasteel,
 /area/engine/engineering)
 "mrK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mrX" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -40209,7 +40209,7 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "mtA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "mtG" = (
 /obj/structure/chair/stool{
@@ -40257,7 +40257,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40281,7 +40281,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "muZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/machinery/conveyor{
@@ -40294,7 +40294,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -40326,7 +40326,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/carpet,
 /area/library)
 "mvU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40389,7 +40389,7 @@ lower//turf/open/floor/plasteel/white,
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40413,7 +40413,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40465,7 +40465,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mzz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40491,7 +40491,7 @@ lower//turf/open/floor/plasteel/white,
 "mzO" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40516,11 +40516,11 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mAG" = (
 /obj/effect/turf_decal/stripes/line,
-lower//obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mAH" = (
@@ -40533,7 +40533,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mAX" = (
@@ -40559,7 +40559,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/black,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mBb" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/machinery/doorButtons/access_button{
@@ -40598,7 +40598,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40620,7 +40620,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 	pixel_x = -1;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40691,7 +40691,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /area/maintenance/starboard/aft)
 "mDQ" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -40710,7 +40710,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "mEn" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/enlist{
@@ -40745,7 +40745,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40782,7 +40782,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/paicard{
 	pixel_x = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -40807,7 +40807,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40817,7 +40817,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "mGC" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40926,7 +40926,7 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40947,8 +40947,8 @@ lower//obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "mIo" = (
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel/showroomfloor,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "mIz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -41070,7 +41070,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/starboard/fore)
 "mLm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -41201,10 +41201,10 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/white/corner/lower{
+/obj/effect/turf_decal/trimline/white/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41216,7 +41216,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -41293,7 +41293,7 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	network = list("ss13","medical")
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41312,11 +41312,11 @@ lower//turf/open/floor/plasteel/showroomfloor,
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mNZ" = (
 /obj/effect/decal/cleanable/glass,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -41330,10 +41330,10 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41430,10 +41430,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41443,7 +41443,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Starboard Primary Hallway 4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41459,7 +41459,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41519,7 +41519,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -41533,7 +41533,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "mTb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41554,11 +41554,11 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "mTt" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41592,7 +41592,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "mTH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//obj/machinery/power/apc{
+/obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/port";
 	name = "Port Hall APC";
 	pixel_y = -23
@@ -41645,7 +41645,7 @@ lower//obj/machinery/power/apc{
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41660,7 +41660,7 @@ lower//obj/machinery/power/apc{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41675,7 +41675,7 @@ lower//obj/machinery/power/apc{
 	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "mVk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -41769,7 +41769,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -41789,7 +41789,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41819,7 +41819,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mXg" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
@@ -41859,7 +41859,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41933,7 +41933,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41976,7 +41976,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/effect/turf_decal/siding/thinplating{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41985,7 +41985,7 @@ lower//obj/effect/turf_decal/siding/thinplating{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42110,7 +42110,7 @@ lower//obj/effect/turf_decal/siding/thinplating{
 /area/lawoffice)
 "mZx" = (
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42119,13 +42119,13 @@ lower//obj/effect/turf_decal/siding/thinplating{
 /obj/structure/table,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mZI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42157,7 +42157,7 @@ lower//obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nai" = (
 /obj/machinery/door/airlock/engineering{
@@ -42185,7 +42185,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "naq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -42262,7 +42262,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 28
 	},
 /obj/machinery/anesthetic_machine/roundstart,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42281,7 +42281,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ncT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42335,7 +42335,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -42455,7 +42455,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 6;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -42469,7 +42469,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "neS" = (
 /obj/machinery/light{
@@ -42478,7 +42478,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42598,7 +42598,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42625,7 +42625,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "ngM" = (
-/obj/effect/turf_decal/trimline/purple/warning/lower,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ngP" = (
@@ -42671,7 +42671,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nik" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "niA" = (
@@ -42690,7 +42690,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "niC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -42889,7 +42889,7 @@ lower//turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "nlu" = (
 /mob/living/carbon/monkey,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42990,7 +42990,7 @@ lower//turf/open/floor/plasteel/dark,
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "nmW" = (
@@ -43002,7 +43002,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nng" = (
@@ -43010,7 +43010,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43028,7 +43028,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43038,7 +43038,7 @@ lower//turf/open/floor/plasteel/dark,
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43053,7 +43053,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43104,7 +43104,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -43156,7 +43156,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43238,7 +43238,7 @@ lower//turf/open/floor/plasteel/dark,
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43362,26 +43362,26 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "ntf" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ntR" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ntS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nuc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43391,7 +43391,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43427,7 +43427,7 @@ lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nuw" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43467,7 +43467,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "nuU" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43481,7 +43481,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nvv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -43520,7 +43520,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43591,19 +43591,19 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nxs" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "nxt" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -43646,7 +43646,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nxX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -43687,7 +43687,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/hfr)
 "nys" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -43711,7 +43711,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "nze" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -43748,7 +43748,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43773,7 +43773,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "nzW" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -43858,7 +43858,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nBf" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "nBt" = (
@@ -43884,7 +43884,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nBN" = (
@@ -43894,7 +43894,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43966,7 +43966,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nDN" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44016,7 +44016,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44053,7 +44053,7 @@ lower//turf/open/floor/plasteel,
 	id = "executionflash";
 	pixel_y = 25
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light/small{
@@ -44120,8 +44120,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "nHl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -44190,7 +44190,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44199,7 +44199,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nIv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -44215,7 +44215,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/hallway/primary/starboard)
 "nIY" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "nJl" = (
@@ -44267,7 +44267,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -44312,10 +44312,10 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44333,7 +44333,7 @@ lower//turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nLZ" = (
 /obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -44385,7 +44385,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "L2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -44432,7 +44432,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -44514,7 +44514,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44523,7 +44523,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "nPy" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44579,7 +44579,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "nQn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44596,7 +44596,7 @@ lower//obj/structure/disposalpipe/segment{
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44614,7 +44614,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nQY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44631,7 +44631,7 @@ lower//obj/structure/disposalpipe/segment{
 	pixel_x = 26;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44677,7 +44677,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "nRM" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -44728,7 +44728,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "nSp" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44748,10 +44748,10 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "nSy" = (
@@ -44777,7 +44777,7 @@ lower//obj/structure/disposalpipe/segment{
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/item/hand_labeler{
@@ -44826,7 +44826,7 @@ lower//obj/structure/disposalpipe/segment{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44853,7 +44853,7 @@ lower//obj/structure/disposalpipe/segment{
 	pixel_y = -7;
 	req_one_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -44868,7 +44868,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44944,7 +44944,7 @@ lower//obj/structure/disposalpipe/segment{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -44965,7 +44965,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "nVi" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45082,7 +45082,7 @@ lower//obj/structure/disposalpipe/segment{
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -45111,7 +45111,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45154,7 +45154,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/wood,
 /area/vacant_room)
 "nXU" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45182,7 +45182,7 @@ lower//obj/structure/disposalpipe/segment{
 	pixel_y = 25;
 	req_access_txt = "36"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45240,7 +45240,7 @@ lower//obj/structure/disposalpipe/segment{
 	name = "Labor Camp Monitoring";
 	network = list("labor")
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45264,7 +45264,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -45275,7 +45275,7 @@ lower//obj/structure/disposalpipe/segment{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45284,7 +45284,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/sink{
 	pixel_y = 20
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45325,7 +45325,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45345,7 +45345,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4;
 	pixel_y = 37
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45401,7 +45401,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/firstsingularity{
@@ -45454,7 +45454,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	c_tag = "Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45489,7 +45489,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ocY" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45507,7 +45507,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "odp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/research/research{
@@ -45582,7 +45582,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -45655,7 +45655,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45718,7 +45718,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oin" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45741,7 +45741,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45751,7 +45751,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45803,7 +45803,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45823,7 +45823,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 "oki" = (
 /obj/structure/table,
 /obj/item/multitool,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -45860,7 +45860,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/wood,
 /area/medical/psych)
 "oll" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -45885,7 +45885,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/structure/table,
@@ -45905,7 +45905,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "omj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -45936,7 +45936,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45951,7 +45951,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45991,7 +45991,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46030,10 +46030,10 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/computer/warrant{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46043,14 +46043,14 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ooB" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46290,7 +46290,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46311,13 +46311,13 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /area/science/xenobiology)
 "osV" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "otc" = (
 /obj/effect/turf_decal/stripes/line,
-lower//obj/machinery/light/small{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -46359,7 +46359,7 @@ lower//obj/machinery/light/small{
 	amount = 10
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ott" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -46463,7 +46463,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ovy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
@@ -46524,7 +46524,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/closed/wall,
 /area/maintenance/disposal)
 "owL" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46575,7 +46575,7 @@ lower//turf/open/floor/plasteel/dark,
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -46596,7 +46596,7 @@ lower//turf/open/floor/plasteel/dark,
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46619,7 +46619,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46677,7 +46677,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/listeningstation)
 "ozN" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -46689,7 +46689,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ozT" = (
@@ -46711,7 +46711,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46743,13 +46743,13 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "oAk" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "oAn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46844,7 +46844,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46854,7 +46854,7 @@ lower//turf/open/floor/plasteel/dark,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oCq" = (
 /obj/structure/disposalpipe/segment{
@@ -46869,7 +46869,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47017,7 +47017,7 @@ lower//turf/open/floor/plasteel,
 "oEN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47037,7 +47037,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tanks North"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -47133,7 +47133,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oHj" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47176,10 +47176,10 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Garden West";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47305,7 +47305,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/sign/poster/official/random{
+/obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
@@ -47348,7 +47348,7 @@ lower//obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oKW" = (
 /obj/structure/sign/departments/minsky/supply/mining{
@@ -47368,7 +47368,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/structure/table,
@@ -47386,7 +47386,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47437,7 +47437,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "oMh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//obj/machinery/lapvend,
+/obj/machinery/lapvend,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "oMk" = (
@@ -47473,7 +47473,7 @@ lower//obj/machinery/lapvend,
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oMS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -47625,10 +47625,10 @@ lower//turf/open/floor/plasteel/white,
 	dir = 10;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -47639,7 +47639,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/port/fore)
 "oQc" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /obj/item/clothing/glasses/meson{
@@ -47650,7 +47650,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8;
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/white/corner/lower{
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
@@ -47665,7 +47665,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "oQp" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47689,7 +47689,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "oQv" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -47699,7 +47699,7 @@ lower//turf/open/floor/plasteel/white,
 	icon_state = "L6"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -47732,7 +47732,7 @@ lower//obj/structure/disposalpipe/segment{
 /area/maintenance/department/tcoms)
 "oQW" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47747,7 +47747,7 @@ lower//obj/structure/disposalpipe/segment{
 /area/ruin/powered)
 "oRq" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47771,7 +47771,7 @@ lower//obj/structure/disposalpipe/segment{
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oRG" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -47853,7 +47853,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47871,7 +47871,7 @@ lower//obj/structure/disposalpipe/segment{
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "oSS" = (
@@ -47917,7 +47917,7 @@ lower//obj/structure/disposalpipe/segment{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "oTw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -47926,10 +47926,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47948,7 +47948,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47959,7 +47959,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "oTN" = (
 /obj/machinery/light,
@@ -47996,7 +47996,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "oUH" = (
 /obj/structure/grille,
@@ -48111,7 +48111,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -48129,7 +48129,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48158,16 +48158,16 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "oXw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "oXP" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48218,10 +48218,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48230,7 +48230,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /obj/machinery/recharger/wallrecharger{
@@ -48276,7 +48276,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48373,7 +48373,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48463,7 +48463,7 @@ lower//turf/open/floor/plasteel,
 "pbU" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pbV" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -48473,14 +48473,14 @@ lower//turf/open/floor/plasteel,
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "pbY" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48611,7 +48611,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48640,7 +48640,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area{
@@ -48679,7 +48679,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pfh" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48689,7 +48689,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west{
@@ -48698,7 +48698,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "pfK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48752,7 +48752,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48781,7 +48781,7 @@ lower//turf/open/floor/plasteel,
 "phb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "phj" = (
 /obj/machinery/door/window/northleft{
@@ -48813,7 +48813,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	name = "Input Gas Connector Port"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /obj/structure/cable{
@@ -48830,7 +48830,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
 "phV" = (
-/obj/effect/turf_decal/trimline/white/corner/lower{
+/obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -48847,19 +48847,19 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pir" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pit" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -48929,7 +48929,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pjX" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49067,7 +49067,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49075,7 +49075,7 @@ lower//turf/open/floor/plasteel,
 "pmi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pmj" = (
@@ -49095,7 +49095,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -49116,7 +49116,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "pmv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -49167,7 +49167,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49194,10 +49194,10 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "pnm" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -49367,7 +49367,7 @@ lower//turf/open/floor/plasteel/white,
 	id = "QMLoad2"
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light,
@@ -49427,7 +49427,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ppT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /obj/structure/table/reinforced,
@@ -49475,10 +49475,10 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49494,7 +49494,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49519,7 +49519,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "prh" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49546,7 +49546,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49589,10 +49589,10 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/plasticflaps,
@@ -49603,7 +49603,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "psi" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/machinery/level_interface{
@@ -49682,7 +49682,7 @@ lower//obj/effect/turf_decal/stripes/line/lower{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ptS" = (
 /obj/structure/disposalpipe/segment{
@@ -49703,7 +49703,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49775,7 +49775,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "pvk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "pvB" = (
 /obj/structure/cable{
@@ -49887,7 +49887,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "pwu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49951,7 +49951,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 28
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49997,7 +49997,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pyp" = (
 /obj/machinery/door/airlock/security/glass{
@@ -50105,7 +50105,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50135,7 +50135,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50306,7 +50306,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "pDM" = (
 /obj/machinery/light/small{
@@ -50324,7 +50324,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pEe" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -50342,7 +50342,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "pEm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50395,7 +50395,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pFo" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50426,7 +50426,7 @@ lower//turf/open/floor/plasteel,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -50470,7 +50470,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "pGq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50506,8 +50506,8 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50545,7 +50545,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/central)
 "pHZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -50565,7 +50565,7 @@ lower//turf/open/floor/plasteel,
 "pIm" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50573,7 +50573,7 @@ lower//turf/open/floor/plasteel,
 "pIs" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/item/stack/sheet/mineral/plasma{
+/obj/item/stack/sheet/mineral/plasma{
 	amount = 30
 	},
 /obj/item/stack/rods/fifty,
@@ -50600,7 +50600,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 	dir = 4;
 	network = list("ss13","rd","chpt")
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50639,7 +50639,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /area/science/xenobiology)
 "pJw" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -50723,7 +50723,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 "pKp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50749,7 +50749,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50761,7 +50761,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -50783,7 +50783,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -50799,7 +50799,7 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50820,15 +50820,15 @@ lower//obj/item/stack/sheet/mineral/plasma{
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "pMi" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51034,10 +51034,10 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -40
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pOV" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51074,7 +51074,7 @@ lower//turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pPz" = (
 /obj/structure/closet/bombcloset/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51112,7 +51112,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pQr" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51128,7 +51128,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51139,7 +51139,7 @@ lower//turf/open/floor/plasteel,
 	layer = 2.9
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /obj/item/destTagger{
@@ -51167,7 +51167,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower,
+/obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -51227,16 +51227,16 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/main)
 "pRU" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "pSo" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -51254,7 +51254,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "pSx" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargo{
@@ -51299,7 +51299,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51331,7 +51331,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51481,7 +51481,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -51535,7 +51535,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -51582,7 +51582,7 @@ lower//turf/open/floor/plasteel,
 "pWP" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51708,7 +51708,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "pXN" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51723,7 +51723,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51735,7 +51735,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/foyer)
 "pYp" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
@@ -51858,10 +51858,10 @@ lower//turf/open/floor/plasteel,
 	dir = 1;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
@@ -51900,7 +51900,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qbl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qbt" = (
 /obj/structure/cable{
@@ -51911,7 +51911,7 @@ lower//turf/open/floor/plasteel,
 /area/solar/port/aft)
 "qbz" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/item/storage/box/lights/mixed,
@@ -51922,10 +51922,10 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51963,7 +51963,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 32;
 	pixel_y = 40
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51982,7 +51982,7 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "qdp" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -51995,7 +51995,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qdH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/structure/chair{
+/obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52042,7 +52042,7 @@ lower//obj/structure/chair{
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52057,7 +52057,7 @@ lower//obj/structure/chair{
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/structure/sign/departments/minsky/command/charge{
@@ -52066,7 +52066,7 @@ lower//obj/structure/chair{
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qey" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
@@ -52120,7 +52120,7 @@ lower//obj/structure/chair{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52133,7 +52133,7 @@ lower//obj/structure/chair{
 	c_tag = "Atmospherics Auxiliary Storage";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -52233,7 +52233,7 @@ lower//obj/structure/chair{
 /area/hallway/secondary/exit)
 "qhl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/machinery/light,
+/obj/machinery/light,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -52271,7 +52271,7 @@ lower//obj/machinery/light,
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52291,7 +52291,7 @@ lower//obj/machinery/light,
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -52323,7 +52323,7 @@ lower//obj/machinery/light,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qiX" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -52361,7 +52361,7 @@ lower//obj/machinery/light,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qkh" = (
 /obj/structure/sign/departments/minsky/supply/cargo{
@@ -52407,7 +52407,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52439,7 +52439,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52461,7 +52461,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -52595,7 +52595,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -52630,7 +52630,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qoj" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -52719,7 +52719,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -52735,7 +52735,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	name = "Input Port Pump"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -52744,7 +52744,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "qqa" = (
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 4
 	},
 /turf/open/floor/white{
@@ -52794,10 +52794,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "qri" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -52861,10 +52861,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/gulag_item_reclaimer{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -52897,7 +52897,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qtt" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -52913,7 +52913,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53002,10 +53002,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white/corner/lower{
+/turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
 /area/crew_quarters/heads/chief)
@@ -53038,7 +53038,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/eighties,
 /area/maintenance/starboard/fore)
 "qvn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -53141,7 +53141,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53152,7 +53152,7 @@ lower//turf/open/floor/plasteel,
 "qya" = (
 /obj/machinery/light,
 /obj/machinery/vending/security,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -53186,7 +53186,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qyW" = (
 /obj/structure/cable{
@@ -53206,7 +53206,7 @@ lower//turf/open/floor/plasteel,
 /area/science/storage)
 "qza" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -53222,7 +53222,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qzA" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 10
 	},
 /obj/machinery/button/flasher{
@@ -53236,7 +53236,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -53251,7 +53251,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "qAG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53362,7 +53362,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "qBV" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53455,7 +53455,7 @@ lower//turf/open/floor/plasteel,
 /area/clerk)
 "qDT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53505,7 +53505,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -53534,7 +53534,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "qEt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53625,13 +53625,13 @@ lower//turf/open/floor/plasteel,
 "qFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "qFQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -53657,7 +53657,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -53677,8 +53677,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/light,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qGv" = (
@@ -53715,7 +53715,7 @@ lower//obj/machinery/light,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -53730,7 +53730,7 @@ lower//obj/machinery/light,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qHe" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 5
 	},
 /obj/machinery/vending/cola/random,
@@ -53860,13 +53860,13 @@ lower//obj/machinery/light,
 /area/medical/storage/backroom)
 "qHT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qHV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -53953,7 +53953,7 @@ lower//obj/machinery/light,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qKr" = (
 /turf/open/floor/plasteel{
@@ -53970,7 +53970,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54005,7 +54005,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "qLY" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54048,7 +54048,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -54169,7 +54169,7 @@ lower//turf/open/floor/plasteel,
 /area/science/misc_lab)
 "qOJ" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/chair/office/light{
@@ -54256,7 +54256,7 @@ lower//turf/open/floor/plasteel,
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54300,7 +54300,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qSg" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -54406,13 +54406,13 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "qVk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qVm" = (
@@ -54472,7 +54472,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qWz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -54505,7 +54505,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qXp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -54532,7 +54532,7 @@ lower//turf/open/floor/plasteel,
 "qXQ" = (
 /obj/structure/window/reinforced,
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -54546,7 +54546,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -54625,7 +54625,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /obj/item/paper_bin{
@@ -54742,10 +54742,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54819,7 +54819,7 @@ lower//turf/open/floor/plasteel,
 "rct" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rcz" = (
 /obj/structure/cable{
@@ -54834,7 +54834,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54898,7 +54898,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54986,7 +54986,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -54998,7 +54998,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -55072,7 +55072,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55174,7 +55174,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/space/nearstation)
 "rgQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -55227,7 +55227,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing)
 "rhk" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55254,7 +55254,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "rib" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55288,7 +55288,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "riq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/structure/closet/radiation,
@@ -55305,7 +55305,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/space/nearstation)
 "riV" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -55365,8 +55365,8 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "rjT" = (
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "rjX" = (
 /obj/effect/turf_decal/loading_area{
@@ -55439,7 +55439,7 @@ lower//turf/open/floor/plasteel,
 /area/science/xenobiology)
 "rkY" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55458,7 +55458,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -55505,8 +55505,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/map/left{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rlJ" = (
 /turf/open/floor/mineral/silver,
@@ -55515,7 +55515,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55583,7 +55583,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "rnf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -55634,16 +55634,16 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/radio/off,
 /obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "rnZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55766,7 +55766,7 @@ lower//turf/open/floor/plasteel,
 "rqd" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rqp" = (
 /obj/structure/closet/firecloset,
@@ -55798,7 +55798,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "rqK" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55816,10 +55816,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55837,7 +55837,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "rrQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/firealarm{
@@ -55884,16 +55884,16 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "rsS" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -55909,7 +55909,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "rtb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /obj/machinery/conveyor{
@@ -55948,7 +55948,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "ruc" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55963,7 +55963,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -55998,10 +55998,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56198,7 +56198,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -56223,7 +56223,7 @@ lower//turf/open/floor/plasteel/white,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rxC" = (
 /obj/structure/window/reinforced,
@@ -56260,7 +56260,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -56288,7 +56288,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "ryM" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56347,7 +56347,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rAN" = (
 /obj/structure/table/wood,
@@ -56382,7 +56382,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "rBz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "rBG" = (
 /obj/machinery/vending/sovietsoda,
@@ -56436,7 +56436,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rCy" = (
 /obj/structure/window/reinforced{
@@ -56493,7 +56493,7 @@ lower//turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "rDw" = (
 /obj/effect/decal/cleanable/glass/plasma,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -56508,7 +56508,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56530,7 +56530,7 @@ lower//turf/open/floor/plasteel/white,
 	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56581,7 +56581,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56592,7 +56592,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rEj" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -56615,7 +56615,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/computer/rdconsole/production,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56628,7 +56628,7 @@ lower//turf/open/floor/plasteel/white,
 /area/crew_quarters/bar)
 "rEz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "rEG" = (
 /obj/machinery/light{
@@ -56670,7 +56670,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56680,7 +56680,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56755,7 +56755,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rGh" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -56787,7 +56787,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "rGK" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -56808,7 +56808,7 @@ lower//turf/open/floor/plasteel,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -56828,7 +56828,7 @@ lower//turf/open/floor/plasteel,
 /area/space/nearstation)
 "rHg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "rHj" = (
 /obj/structure/cable{
@@ -56943,7 +56943,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57002,7 +57002,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57045,7 +57045,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57117,7 +57117,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = 5;
 	pixel_y = 13
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57139,7 +57139,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57187,7 +57187,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -57196,7 +57196,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rOt" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -57228,7 +57228,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "rOQ" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/machinery/power/apc{
@@ -57258,7 +57258,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "rPd" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -57271,7 +57271,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "rPf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rPh" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57368,7 +57368,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57386,7 +57386,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57415,13 +57415,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rQV" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57431,7 +57431,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "rRe" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57492,7 +57492,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -57534,7 +57534,7 @@ lower//turf/open/floor/plasteel,
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57547,10 +57547,10 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57574,7 +57574,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
 "rTI" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/railing{
@@ -57597,7 +57597,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/patients_rooms/room_a)
 "rUt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57629,7 +57629,7 @@ lower//turf/open/floor/plasteel,
 "rUN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -57649,14 +57649,14 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "rUZ" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/engine/airless,
 /area/escapepodbay)
 "rVc" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -57703,7 +57703,7 @@ lower//turf/open/floor/plasteel,
 "rVy" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57761,7 +57761,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "rWB" = (
 /obj/structure/cable{
@@ -57843,7 +57843,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -57923,7 +57923,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57990,7 +57990,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58057,7 +58057,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -58069,13 +58069,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sbf" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sbl" = (
@@ -58112,7 +58112,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line,
-lower//obj/structure/window/reinforced{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -58287,10 +58287,10 @@ lower//obj/structure/window/reinforced{
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "sdd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -58387,7 +58387,7 @@ lower//obj/structure/window/reinforced{
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "seA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -58416,7 +58416,7 @@ lower//obj/structure/window/reinforced{
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58473,7 +58473,7 @@ lower//obj/structure/window/reinforced{
 /area/crew_quarters/toilet/locker)
 "sht" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/structure/closet/radiation,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "shu" = (
@@ -58513,14 +58513,14 @@ lower//obj/structure/closet/radiation,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "sir" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "siw" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58532,7 +58532,7 @@ lower//obj/structure/closet/radiation,
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58562,7 +58562,7 @@ lower//obj/structure/closet/radiation,
 /obj/structure/table/glass,
 /obj/item/crowbar,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -58615,7 +58615,7 @@ lower//obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "skV" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58635,7 +58635,7 @@ lower//obj/structure/closet/radiation,
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "slm" = (
 /obj/structure/shuttle/engine/large{
@@ -58709,7 +58709,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "sni" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58737,7 +58737,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58757,7 +58757,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Port Hallway"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58867,7 +58867,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sqa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -58881,7 +58881,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sqC" = (
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58929,7 +58929,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58988,8 +58988,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/structure/cable{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
@@ -58999,7 +58999,7 @@ lower//obj/structure/cable{
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59045,7 +59045,7 @@ lower//obj/structure/cable{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "stv" = (
 /obj/structure/cable{
@@ -59188,7 +59188,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "swg" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/glass,
@@ -59356,10 +59356,10 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "szr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -59368,7 +59368,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "szs" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -59405,7 +59405,7 @@ lower//turf/open/floor/plasteel/white,
 	},
 /obj/machinery/meter,
 /obj/machinery/electrolyzer,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -59438,7 +59438,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59447,7 +59447,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/table,
 /obj/item/flashlight,
 /obj/item/assembly/igniter,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59481,7 +59481,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/port)
 "sBP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "sBX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -59498,7 +59498,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59511,7 +59511,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "sCd" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
 /obj/structure/chair/office/dark{
@@ -59533,7 +59533,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59589,7 +59589,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "sCG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/machinery/light,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "sDk" = (
@@ -59617,7 +59617,7 @@ lower//obj/machinery/light,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59628,7 +59628,7 @@ lower//obj/machinery/light,
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59729,12 +59729,12 @@ lower//obj/machinery/light,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
 "sFw" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59767,7 +59767,7 @@ lower//obj/machinery/light,
 	icon_state = "L12"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sFS" = (
 /obj/machinery/light{
@@ -59797,7 +59797,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59846,7 +59846,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "sGV" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -59887,14 +59887,14 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "sHK" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60033,7 +60033,7 @@ lower//turf/open/floor/plasteel,
 /area/science/mixing/chamber)
 "sIQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60091,7 +60091,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sKr" = (
@@ -60141,7 +60141,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 "sKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60191,7 +60191,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plasteel,
 /area/clerk)
 "sLf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60316,7 +60316,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60390,7 +60390,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60491,7 +60491,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /area/science/xenobiology)
 "sNK" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -60515,7 +60515,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	pixel_x = 32;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60608,7 +60608,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /area/hallway/primary/starboard)
 "sQf" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60620,7 +60620,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	},
 /obj/structure/window/reinforced,
 /obj/item/aiModule/reset,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60644,7 +60644,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "sQO" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -60660,7 +60660,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -60686,7 +60686,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60753,7 +60753,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60784,7 +60784,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -60846,7 +60846,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	pixel_x = 7;
 	pixel_y = 39
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -60857,7 +60857,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 "sTw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60899,7 +60899,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 /area/crew_quarters/toilet/locker)
 "sUr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61012,7 +61012,7 @@ lower//obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "sWY" = (
 /obj/effect/turf_decal/tile/blue{
@@ -61073,7 +61073,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -61099,7 +61099,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "sYq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61121,7 +61121,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sYO" = (
 /obj/structure/window/reinforced{
@@ -61158,7 +61158,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61288,7 +61288,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "tbv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -61332,7 +61332,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tcN" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61342,7 +61342,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "tcX" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /obj/structure/chair{
@@ -61392,13 +61392,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tdo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -61444,7 +61444,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61467,7 +61467,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "teA" = (
 /obj/machinery/door/firedoor/border_only{
@@ -61486,7 +61486,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61565,7 +61565,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tgz" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/sec,
@@ -61579,7 +61579,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61601,7 +61601,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "thu" = (
 /obj/machinery/door/airlock/public{
@@ -61691,7 +61691,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/electronics/firelock,
 /obj/item/multitool,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -61731,7 +61731,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -61743,7 +61743,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -61798,7 +61798,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "tkI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61861,7 +61861,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -37
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tlX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -61873,7 +61873,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61920,7 +61920,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -61930,13 +61930,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tnu" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -61954,7 +61954,7 @@ lower//turf/open/floor/plasteel,
 /area/space/nearstation)
 "tob" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -62020,7 +62020,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 26
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62034,7 +62034,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "tpZ" = (
 /obj/machinery/door/window{
@@ -62148,7 +62148,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62221,14 +62221,14 @@ lower//turf/open/floor/plasteel/white,
 "ttp" = (
 /obj/structure/filingcabinet,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "ttt" = (
 /obj/machinery/chem_dispenser,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -62293,7 +62293,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -25
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -62372,7 +62372,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "twR" = (
 /obj/structure/window/reinforced{
@@ -62412,7 +62412,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "txw" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62466,7 +62466,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -62493,7 +62493,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/recharger{
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -62587,13 +62587,13 @@ lower//turf/open/floor/plasteel,
 	},
 /area/crew_quarters/kitchen)
 "tBi" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tBR" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /obj/structure/table,
@@ -62652,7 +62652,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4;
 	id = "crematoriumChapel"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62760,7 +62760,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62772,7 +62772,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tFs" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62804,7 +62804,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62821,7 +62821,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -62848,7 +62848,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62884,7 +62884,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "tGG" = (
 /obj/structure/disposalpipe/segment,
@@ -62924,7 +62924,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Aft Primary Hallway 2";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62961,7 +62961,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "tHQ" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/structure/closet/firecloset,
@@ -62990,7 +62990,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63085,7 +63085,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "tJJ" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -63102,7 +63102,7 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "tJY" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -63135,7 +63135,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/solar/port/aft)
 "tLi" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -63200,7 +63200,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63209,7 +63209,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -63234,7 +63234,7 @@ lower//turf/open/floor/plasteel,
 "tPe" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tPg" = (
 /obj/structure/cable/yellow{
@@ -63255,13 +63255,13 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "tPH" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "tPL" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -63287,7 +63287,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tQh" = (
 /obj/machinery/computer/bounty{
@@ -63331,7 +63331,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63389,7 +63389,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tSh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63414,7 +63414,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/listeningstation)
 "tSu" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63500,13 +63500,13 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tUq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tUD" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -63595,7 +63595,7 @@ lower//turf/open/floor/plasteel,
 /area/science/lab)
 "tVL" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//obj/machinery/power/apc{
+/obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/starboard";
 	name = "Starboard Primary Hallway APC";
 	pixel_y = -23
@@ -63664,7 +63664,7 @@ lower//obj/machinery/power/apc{
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tXi" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63697,7 +63697,7 @@ lower//obj/machinery/power/apc{
 /area/maintenance/solars/starboard/aft)
 "tXv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63753,7 +63753,7 @@ lower//obj/machinery/power/apc{
 	c_tag = "Mining Dock External";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/machinery/advanced_airlock_controller{
@@ -63773,7 +63773,7 @@ lower//obj/machinery/power/apc{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "tZb" = (
 /obj/structure/cable{
@@ -63833,7 +63833,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63886,7 +63886,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/hfr_box/body/interface,
 /obj/item/hfr_box/body/moderator_input,
 /obj/item/hfr_box/body/waste_output,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63911,13 +63911,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ucm" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -63939,13 +63939,13 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/vending/engivend,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uct" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64075,8 +64075,8 @@ lower//turf/open/floor/plasteel,
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ufs" = (
 /obj/structure/plasticflaps{
@@ -64191,13 +64191,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uhk" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/railing{
@@ -64218,7 +64218,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64242,7 +64242,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -64258,7 +64258,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "uhW" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64276,7 +64276,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64288,7 +64288,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64304,7 +64304,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64313,13 +64313,13 @@ lower//turf/open/floor/plasteel,
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "uiG" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64346,7 +64346,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uiJ" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -64417,7 +64417,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Robotics Lab";
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64446,11 +64446,11 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -31
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ukO" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64561,7 +64561,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "umM" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -64588,7 +64588,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "umX" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64619,7 +64619,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -64651,7 +64651,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -64769,10 +64769,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/thinplating/corner/lower{
+/obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64813,7 +64813,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -7
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/structure/cable/yellow{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -64822,7 +64822,7 @@ lower//obj/structure/cable/yellow{
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64842,7 +64842,7 @@ lower//obj/structure/cable/yellow{
 "urH" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
 	pixel_x = 1;
@@ -64902,7 +64902,7 @@ lower//obj/item/stack/sheet/metal/fifty,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64914,7 +64914,7 @@ lower//obj/item/stack/sheet/metal/fifty,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -64980,10 +64980,10 @@ lower//obj/item/stack/sheet/metal/fifty,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "utK" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65032,7 +65032,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65059,7 +65059,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65107,7 +65107,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/item/book/manual/wiki/security_space_law,
@@ -65136,7 +65136,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -65145,7 +65145,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65166,7 +65166,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/research/xenobiology{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -65176,7 +65176,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uyJ" = (
 /obj/machinery/door/firedoor/border_only{
@@ -65194,14 +65194,14 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uzh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65229,7 +65229,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65238,13 +65238,13 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uzB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65268,7 +65268,7 @@ lower//turf/open/floor/plasteel,
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plating,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "uAm" = (
 /obj/structure/girder/reinforced,
@@ -65302,7 +65302,7 @@ lower//turf/open/floor/plating,
 	network = list("ss13","rd")
 	},
 /obj/item/crowbar,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -65379,13 +65379,13 @@ lower//turf/open/floor/plating,
 /area/hallway/primary/aft)
 "uBg" = (
 /obj/machinery/computer/aifixer,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "uBp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65430,7 +65430,7 @@ lower//turf/open/floor/plating,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65439,7 +65439,7 @@ lower//turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65472,7 +65472,7 @@ lower//turf/open/floor/plating,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -65529,7 +65529,7 @@ lower//turf/open/floor/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65562,14 +65562,14 @@ lower//turf/open/floor/plating,
 	dir = 5;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uDT" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65591,14 +65591,14 @@ lower//turf/open/floor/plating,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uEu" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "uEH" = (
 /obj/structure/sign/poster/official/love_ian,
@@ -65653,7 +65653,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65702,7 +65702,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/cable/orange{
@@ -65784,7 +65784,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65801,7 +65801,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65861,7 +65861,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/solar/port/aft)
 "uIq" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -65869,7 +65869,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uIu" = (
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /obj/machinery/status_display/evac{
@@ -65899,7 +65899,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -65960,7 +65960,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -65989,7 +65989,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
@@ -66020,7 +66020,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//obj/machinery/computer/atmos_sim{
+/obj/machinery/computer/atmos_sim{
 	dir = 1;
 	mode = 1
 	},
@@ -66031,7 +66031,7 @@ lower//obj/machinery/computer/atmos_sim{
 /turf/open/floor/plasteel/bluespace,
 /area/crew_quarters/heads/hor)
 "uLU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66043,13 +66043,13 @@ lower//obj/machinery/computer/atmos_sim{
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uMl" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66145,7 +66145,7 @@ lower//obj/machinery/computer/atmos_sim{
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uOD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/power/apc/highcap/five_k{
@@ -66279,10 +66279,10 @@ lower//obj/machinery/computer/atmos_sim{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66318,7 +66318,7 @@ lower//obj/machinery/computer/atmos_sim{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uRn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -66360,7 +66360,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uSU" = (
 /obj/structure/cable{
@@ -66427,7 +66427,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66467,7 +66467,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66477,7 +66477,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Atmospherics South East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -66556,7 +66556,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66586,20 +66586,20 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uXx" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uXD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66630,7 +66630,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -66654,7 +66654,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66771,7 +66771,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "uZH" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -66779,7 +66779,7 @@ lower//turf/open/floor/plasteel,
 "uZS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66804,7 +66804,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "vax" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66815,13 +66815,13 @@ lower//turf/open/floor/plasteel,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "vaY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -66861,7 +66861,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "vbM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66894,7 +66894,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vct" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+/obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66976,8 +66976,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "veN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -66998,7 +66998,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67039,7 +67039,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Central Hallway South-East";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67064,7 +67064,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "vgd" = (
@@ -67076,7 +67076,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67102,7 +67102,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
 "vgW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/scrubber,
@@ -67124,10 +67124,10 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67171,7 +67171,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/space/basic,
 /area/space/nearstation)
 "viq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67193,7 +67193,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vjn" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
 /obj/machinery/conveyor_switch/oneway{
@@ -67209,10 +67209,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vjD" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67261,14 +67261,14 @@ lower//turf/open/floor/plasteel,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vjZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67292,7 +67292,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "vkP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -67342,7 +67342,7 @@ lower//turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "vlb" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -67357,7 +67357,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67432,7 +67432,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vnJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -67466,7 +67466,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "voX" = (
 /obj/effect/turf_decal/bot,
@@ -67506,7 +67506,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "vpN" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -67560,7 +67560,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67585,7 +67585,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "vrT" = (
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/fish/salmon,
@@ -67650,7 +67650,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vsN" = (
 /obj/structure/cable{
@@ -67671,7 +67671,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "vsP" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -67711,7 +67711,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67762,7 +67762,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -67771,13 +67771,13 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "vuD" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vuM" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -67803,7 +67803,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/camera{
 	c_tag = "Brig East"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67824,10 +67824,10 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vwg" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67971,7 +67971,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68038,7 +68038,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68066,7 +68066,7 @@ lower//turf/open/floor/plasteel/white,
 	c_tag = "Fore Primary Hallway East";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68144,7 +68144,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -68157,7 +68157,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "vAs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68205,7 +68205,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "vCu" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -68229,7 +68229,7 @@ lower//turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "vDu" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68238,7 +68238,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68295,7 +68295,7 @@ lower//turf/open/floor/plasteel/white,
 "vEw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "vED" = (
@@ -68307,7 +68307,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
 "vEM" = (
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -68379,7 +68379,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68388,7 +68388,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/computer/cloning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -68408,7 +68408,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/item/a_gift,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -68432,10 +68432,10 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -68459,7 +68459,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vGF" = (
 /turf/open/water/safe{
@@ -68469,7 +68469,7 @@ lower//turf/open/floor/plasteel,
 	},
 /area/crew_quarters/bar)
 "vGG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -68495,7 +68495,7 @@ lower//turf/open/floor/plasteel,
 /area/ai_monitored/secondarydatacore)
 "vGN" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68509,7 +68509,7 @@ lower//turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "vHx" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68541,7 +68541,7 @@ lower//turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "vJj" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68622,7 +68622,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68710,7 +68710,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	name = "cargo camera"
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68747,7 +68747,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68759,7 +68759,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68778,7 +68778,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "vMv" = (
 /obj/machinery/computer/security/telescreen/vault{
@@ -68827,10 +68827,10 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "vMU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
@@ -68896,7 +68896,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/wood,
 /area/library)
 "vNJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68931,7 +68931,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 32;
 	pixel_y = -9
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/item/radio/off,
@@ -68980,14 +68980,14 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vPP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vQb" = (
 /obj/structure/table,
@@ -69004,10 +69004,10 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/siding/wideplating/corner/lower{
+/obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69041,7 +69041,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "vQB" = (
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69096,7 +69096,7 @@ lower//turf/open/floor/plasteel,
 "vRu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/warning/lower,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "vRT" = (
@@ -69116,7 +69116,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -69174,7 +69174,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/janitor)
 "vSA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69199,7 +69199,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69207,7 +69207,7 @@ lower//turf/open/floor/plasteel,
 "vTw" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -69261,7 +69261,7 @@ lower//turf/open/floor/plasteel,
 /area/tcommsat/server)
 "vUd" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -69270,7 +69270,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -69327,7 +69327,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/engine,
 /area/maintenance/starboard/fore)
 "vVC" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "vVP" = (
@@ -69335,7 +69335,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69377,7 +69377,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69417,11 +69417,11 @@ lower//turf/open/floor/plasteel,
 	req_access_txt = "17"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vXp" = (
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/cell_charger{
@@ -69466,7 +69466,7 @@ lower//turf/open/floor/plasteel,
 "vYn" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "vYC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -69531,7 +69531,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -69650,7 +69650,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "wbO" = (
 /obj/machinery/light{
@@ -69676,7 +69676,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69704,7 +69704,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -69784,10 +69784,10 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "wek" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69846,7 +69846,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/corner/lower{
+/obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69862,8 +69862,8 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/machinery/airalarm{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
 	},
@@ -69925,10 +69925,10 @@ lower//obj/machinery/airalarm{
 /area/hallway/primary/central)
 "wfE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69946,7 +69946,7 @@ lower//obj/machinery/airalarm{
 /obj/structure/closet/wardrobe/white,
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -69964,7 +69964,7 @@ lower//obj/machinery/airalarm{
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70012,7 +70012,7 @@ lower//obj/machinery/airalarm{
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70115,8 +70115,8 @@ lower//obj/machinery/airalarm{
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "wjK" = (
 /obj/machinery/power/apc{
@@ -70153,7 +70153,7 @@ lower//turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "wjS" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -70190,7 +70190,7 @@ lower//turf/open/floor/plasteel,
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -70335,7 +70335,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "wmn" = (
 /obj/effect/decal/cleanable/vomit/old,
@@ -70353,7 +70353,7 @@ lower//turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "wms" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70389,14 +70389,14 @@ lower//turf/open/floor/plasteel/white,
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "wnn" = (
 /obj/effect/turf_decal/stripes/line,
-lower//obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -70425,7 +70425,7 @@ lower//obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70472,7 +70472,7 @@ lower//obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 /area/quartermaster/miningdock)
 "wow" = (
 /obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -70486,7 +70486,7 @@ lower//obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 "woS" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "wpj" = (
 /obj/structure/table,
@@ -70509,7 +70509,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/bounty_board{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -70535,7 +70535,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -70619,7 +70619,7 @@ lower//turf/open/floor/plasteel,
 	persistence_id = "public";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70666,7 +70666,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70720,7 +70720,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70729,7 +70729,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70760,7 +70760,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70782,7 +70782,7 @@ lower//turf/open/floor/plasteel,
 	layer = 2.4;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70852,7 +70852,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/warning/lower,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wwm" = (
@@ -70860,7 +70860,7 @@ lower//turf/open/floor/plasteel,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /obj/structure/rack,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -70893,7 +70893,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wxK" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/item/wrench,
@@ -70957,7 +70957,7 @@ lower//turf/open/floor/plasteel,
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71015,7 +71015,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71121,7 +71121,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "wBs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -71182,7 +71182,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/warning/lower,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCv" = (
@@ -71199,7 +71199,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wCL" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71264,14 +71264,14 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "wDM" = (
 /obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -71287,7 +71287,7 @@ lower//turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "wDS" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71373,7 +71373,7 @@ lower//turf/open/floor/plasteel,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
 "wFh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71405,7 +71405,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71458,7 +71458,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//obj/structure/cable/yellow{
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
@@ -71490,7 +71490,7 @@ lower//obj/structure/cable/yellow{
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wGS" = (
 /obj/machinery/light{
@@ -71502,7 +71502,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71557,7 +71557,7 @@ lower//turf/open/floor/plasteel/white,
 "wIc" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71568,7 +71568,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -71579,7 +71579,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel/white/side{
+/turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
@@ -71588,7 +71588,7 @@ lower//turf/open/floor/plasteel/white/side{
 	c_tag = "Arrivals Bay 1 East";
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71613,13 +71613,13 @@ lower//turf/open/floor/plasteel/white/side{
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
 "wIC" = (
 /obj/structure/rack,
 /obj/item/aicard,
 /obj/item/disk/holodisk/tutorial/AICore,
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -71691,7 +71691,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71700,7 +71700,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71730,7 +71730,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "wKJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/light{
@@ -71753,7 +71753,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71791,7 +71791,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wMr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
@@ -71802,7 +71802,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "wMt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71820,7 +71820,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71851,7 +71851,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/carpet/black,
 /area/maintenance/department/tcoms)
 "wNm" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71883,7 +71883,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -71994,7 +71994,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/closed/wall,
 /area/medical/storage)
 "wPe" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72004,10 +72004,10 @@ lower//turf/open/floor/plasteel/white,
 	dir = 6;
 	id = "QMLoad2"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72080,7 +72080,7 @@ lower//turf/open/floor/plasteel/white,
 /area/ai_monitored/storage/eva)
 "wQU" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -72107,7 +72107,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72138,7 +72138,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "wRE" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -72165,7 +72165,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wSh" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -72174,7 +72174,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wSk" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72228,7 +72228,7 @@ lower//turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72250,7 +72250,7 @@ lower//turf/open/floor/plasteel/white,
 	pixel_x = -27;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72271,7 +72271,7 @@ lower//turf/open/floor/plasteel/white,
 /area/teleporter)
 "wTL" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72373,7 +72373,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72388,8 +72388,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
 /obj/item/gun/energy/laser/practice,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/main)
 "wVj" = (
 /obj/structure/table/wood,
@@ -72426,7 +72426,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "wVv" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
@@ -72481,7 +72481,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -72548,7 +72548,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "wWl" = (
 /obj/structure/sign/poster/contraband/random{
@@ -72581,7 +72581,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "wWA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/light{
@@ -72651,7 +72651,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "wWV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -72764,7 +72764,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72786,7 +72786,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 4;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72882,8 +72882,8 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72892,7 +72892,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /obj/machinery/computer/shuttle/mining{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -72923,7 +72923,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -72998,7 +72998,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -73010,7 +73010,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xdY" = (
@@ -73049,7 +73049,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /area/ai_monitored/turret_protected/ai)
 "xez" = (
 /obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -73069,7 +73069,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 "xeJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xfh" = (
@@ -73133,7 +73133,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xfD" = (
@@ -73171,7 +73171,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 /obj/item/storage/belt/medical{
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73192,7 +73192,7 @@ lower//obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	},
 /obj/item/flashlight,
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xfT" = (
 /mob/living/simple_animal/hostile/bear/russian,
@@ -73226,7 +73226,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73270,7 +73270,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73291,7 +73291,7 @@ lower//turf/open/floor/plasteel/dark,
 	color = "#99ccff";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -73400,7 +73400,7 @@ lower//turf/open/floor/plasteel/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73417,7 +73417,7 @@ lower//turf/open/floor/plasteel/dark,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
 "xkG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
@@ -73504,7 +73504,7 @@ lower//turf/open/floor/plasteel/dark,
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xmy" = (
 /obj/structure/closet/emcloset,
@@ -73555,7 +73555,7 @@ lower//turf/open/floor/plasteel,
 /area/science/explab)
 "xnl" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -73567,7 +73567,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xnD" = (
@@ -73623,7 +73623,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73644,7 +73644,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
@@ -73693,18 +73693,18 @@ lower//turf/open/floor/plasteel,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "xqR" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad"
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "xra" = (
 /obj/machinery/photocopier,
@@ -73753,7 +73753,7 @@ lower//turf/open/floor/plasteel,
 /area/chapel/office)
 "xrQ" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -73856,7 +73856,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xuf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73983,7 +73983,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 31
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74054,7 +74054,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74063,7 +74063,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /obj/machinery/button/flasher{
@@ -74126,7 +74126,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74147,7 +74147,7 @@ lower//turf/open/floor/plasteel,
 	c_tag = "Escape Arm Airlocks";
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74262,7 +74262,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74338,7 +74338,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xBe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -74410,7 +74410,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74445,7 +74445,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xDt" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74466,7 +74466,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_y = 41
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74530,8 +74530,8 @@ lower//turf/open/floor/plasteel,
 	pixel_y = -32
 	},
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "xFE" = (
 /obj/machinery/light/small{
@@ -74594,7 +74594,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xGW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74631,7 +74631,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/medbay/aft)
 "xHK" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "xHY" = (
 /obj/structure/cable{
@@ -74649,7 +74649,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74677,7 +74677,7 @@ lower//turf/open/floor/plasteel/white,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "xIn" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -74697,7 +74697,7 @@ lower//turf/open/floor/plasteel/white,
 "xIu" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/depsec/service,
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "xIy" = (
@@ -74706,7 +74706,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xIB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -74745,7 +74745,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xIY" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -74814,7 +74814,7 @@ lower//turf/open/floor/plasteel,
 /area/quartermaster/office)
 "xKl" = (
 /obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /obj/item/radio/off,
@@ -74837,7 +74837,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -74991,7 +74991,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/sleeper)
 "xMa" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -75007,7 +75007,7 @@ lower//turf/open/floor/plasteel,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75025,7 +75025,7 @@ lower//turf/open/floor/plasteel,
 /area/medical/patients_rooms/room_b)
 "xMN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//obj/structure/chair/office/light,
+/obj/structure/chair/office/light,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "xNb" = (
@@ -75067,7 +75067,7 @@ lower//obj/structure/chair/office/light,
 /obj/structure/sign/departments/science{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75130,7 +75130,7 @@ lower//obj/structure/chair/office/light,
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xNH" = (
 /obj/machinery/newscaster{
@@ -75145,14 +75145,14 @@ lower//turf/open/floor/plasteel,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xNW" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75160,7 +75160,7 @@ lower//turf/open/floor/plasteel,
 "xOk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "xOD" = (
@@ -75231,7 +75231,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -75288,7 +75288,7 @@ lower//turf/open/floor/plasteel,
 	dir = 8
 	},
 /obj/item/storage/box/disks,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -75298,7 +75298,7 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/warning/lower{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75308,10 +75308,10 @@ lower//turf/open/floor/plasteel,
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75345,7 +75345,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRC" = (
-/obj/effect/turf_decal/stripes/corner/lower{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75389,7 +75389,7 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRY" = (
 /obj/structure/cable{
@@ -75493,7 +75493,7 @@ lower//turf/open/floor/plasteel,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xVg" = (
 /obj/structure/chair{
@@ -75625,7 +75625,7 @@ lower//turf/open/floor/plasteel,
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/white/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75651,7 +75651,7 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel,
+/turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
 "xXv" = (
 /obj/machinery/light_switch{
@@ -75687,13 +75687,13 @@ lower//turf/open/floor/plasteel,
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "xXN" = (
-/obj/effect/turf_decal/trimline/yellow/warning/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -75812,7 +75812,7 @@ lower//turf/open/floor/plasteel,
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "yaX" = (
 /obj/machinery/camera{
@@ -75890,7 +75890,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/blue/warning/lower,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "ycw" = (
@@ -75910,7 +75910,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75928,7 +75928,7 @@ lower//turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "ycV" = (
 /obj/machinery/computer/operating,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/button/door{
@@ -76026,7 +76026,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line/lower{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76091,7 +76091,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -76123,7 +76123,7 @@ lower//turf/open/floor/plasteel/white,
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-lower//turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "yfr" = (
 /obj/structure/grille,
@@ -76154,14 +76154,14 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ygn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76230,7 +76230,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76254,7 +76254,7 @@ lower//turf/open/floor/plasteel/white,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/purple/warning/lower{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -76263,11 +76263,11 @@ lower//turf/open/floor/plasteel/white,
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line,
-lower//turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "yim" = (
-/obj/effect/turf_decal/stripes/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -76298,7 +76298,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "yjg" = (
-/obj/effect/turf_decal/pool/corner/lower{
+/obj/effect/turf_decal/pool/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76321,7 +76321,7 @@ lower//turf/open/floor/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "yjL" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -76364,13 +76364,13 @@ lower//turf/open/floor/plasteel,
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /obj/effect/turf_decal/stripes/line,
-lower//obj/structure/window/reinforced{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/pumproom)
 "ykz" = (
-/obj/effect/turf_decal/siding/wood/corner/lower{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76401,7 +76401,7 @@ lower//obj/structure/window/reinforced{
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ykU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76418,7 +76418,7 @@ lower//obj/structure/window/reinforced{
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
+/obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -76436,7 +76436,7 @@ lower//obj/structure/window/reinforced{
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -76445,7 +76445,7 @@ lower//obj/structure/window/reinforced{
 /obj/structure/sign/departments/minsky/medical/clone/cloning2{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -76466,7 +76466,7 @@ lower//obj/structure/window/reinforced{
 	c_tag = "Garden East";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,


### PR DESCRIPTION
# Document the changes in your pull request

replaces the asteroid trims to be the same as box, gax and icemeta

# Spriting


# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: completely overhauls asteroid trims
/:cl:
