### PR TITLE
Revert "You can now print sutures and regen mesh"

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -24,28 +24,6 @@
 	category = list("Control Interfaces", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/suture
-	name = "Suture"
-	desc = "Basic sterile sutures used to seal up cuts and lacerations and stop bleeding."
-	id = "suture"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
-	maxstack = 15
-	build_path = /obj/item/stack/medical/suture
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
-/datum/design/regenmesh
-	name = "Regenerative Mesh"
-	desc = "A bacteriostatic mesh used to dress burns."
-	id = "regenmesh"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
-	maxstack = 15
-	build_path = /obj/item/stack/medical/mesh
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
 /datum/design/bluespacebeaker
 	name = "Bluespace Beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology and Element Cuban combined with the Compound Pete. Can hold up to 300 units."
@@ -302,7 +280,7 @@
 	materials = list(/datum/material/glass = 2000, /datum/material/diamond = 1000)
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
+	
 /datum/design/hyposprayspeedupg
 	name = "Hypospray Speed Upgrade"
 	desc = "An upgrade for hyposprays that installs a springloaded mechanism, allowing it to inject with reduced delay."
@@ -547,7 +525,7 @@
 	build_path = /obj/item/organ/cyberimp/leg/magboot
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
+		
 /////////////////////////////////////////
 ////////////Regular Implants/////////////
 /////////////////////////////////////////

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -54,7 +54,7 @@
 	starting_node = TRUE
 	display_name = "Basic Tools"
 	description = "Basic mechanical, electronic, surgical and botanical tools."
-	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "decal_painter", "tile_painter", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat", "syringe", "cultivator", "plant_analyzer", "shovel", "spade", "hatchet",  "mop", "cable_coil", "suture", "regenmesh", "rpd", "analyzer", "tscanner", "large_welding_tool", "geigercounter")
+	design_ids = list("screwdriver", "wrench", "wirecutters", "crowbar", "multitool", "welding_tool", "tscanner", "analyzer", "cable_coil", "pipe_painter", "airlock_painter", "decal_painter", "tile_painter", "scalpel", "circular_saw", "bonesetter", "surgicaldrill", "retractor", "cautery", "hemostat", "syringe", "cultivator", "plant_analyzer", "shovel", "spade", "hatchet",  "mop", "cable_coil", "rpd", "analyzer", "tscanner", "large_welding_tool", "geigercounter")
 
 /////////////////////////Biotech/////////////////////////
 /datum/techweb_node/biotech


### PR DESCRIPTION
Reverts yogstation13/Yogstation#19691
This was a bad idea that harms medical and devalues the use of mechanical limbs. Self-healing methods are meant to be limited in one way or another, with mechanical self-healing being anywhere as a benefit to counter the fact that mechanical limbs suck. Especially with the recent buff to self-healing via mesh and suture where you no longer need to switch body parts to heal separate body parts, it just does it itself. The only people that this really benefits are tiders who break into medical to steal supplies for themselves as there is now a potentially infinite amount of suture and mesh that can be printed, as I rarely see medical players use sutures and mesh for anything outside of certain wounds.

# Changelog

🆑 

tweak: sutures and mesh are no longer printable at medical prolathes

/🆑
