### PR TITLE
Lowers buster arm base price from 15 TC to 13 TC

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	warned that the arm renders them unable to wear gloves and sticks out of most outerwear."
 	item = /obj/item/storage/box/syndie_kit/buster
 	player_minimum = 25
-	cost = 15
+	cost = 12
 	manufacturer = /datum/corporation/traitor/cybersun
 	surplus = 0
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	warned that the arm renders them unable to wear gloves and sticks out of most outerwear."
 	item = /obj/item/storage/box/syndie_kit/buster
 	player_minimum = 25
-	cost = 12
+	cost = 13
 	manufacturer = /datum/corporation/traitor/cybersun
 	surplus = 0
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

This item is not worth 15 TC when I can get CQC, sleeping carp or holoparasite for cheaper and be able to buy other things + this is the only martial art item that can be taken away from you.
I think 13 TC makes it more inline with the other martial art prices
This does mean however that you can potentially get it for 11 TC if you get lucky enough to get cybersun as your sponsor

# Wiki Documentation

change buster arm base price to 13 TC

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Buster arm base price is now 13 TC down from 15 TC
/:cl:
