### PR TITLE
Makes worldbreaker hijack only

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -166,7 +166,7 @@
 	restricted_species = list("preternis")
 	player_minimum = 25 //basically a fuckin megafauna
 	cant_discount = TRUE
-	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
+	include_objectives = list(/datum/objective/hijack)
 
 /datum/uplink_item/race_restricted/explosive_fist_art
 	name = "Burned scroll"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -165,6 +165,7 @@
 	item = /obj/item/book/granter/martial/worldbreaker
 	manufacturer = /datum/corporation/traitor/vahlen
 	restricted_species = list("preternis")
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
 
 /datum/uplink_item/race_restricted/explosive_fist_art
 	name = "Burned scroll"

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -161,10 +161,11 @@
 	Said to cause rapid muscle and plate growth in any Preternis that consumes it. It's believed to have been used by Vxtrin to transform their workers into highly effective commando units.\
 	It is not uncommon for Preterni that have consumed it to be crushed under the weight of their own ever-growing skin. The weight will also prevent use of conventional vehicles."
 	cost = 20
-	player_minimum = 25 //basically a fuckin megafauna
 	item = /obj/item/book/granter/martial/worldbreaker
 	manufacturer = /datum/corporation/traitor/vahlen
 	restricted_species = list("preternis")
+	player_minimum = 25 //basically a fuckin megafauna
+	cant_discount = TRUE
 	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr)
 
 /datum/uplink_item/race_restricted/explosive_fist_art


### PR DESCRIPTION
Simply put, i'm not satisfied with the martial art, but i can think of no way to touch it without it being miserable for everyone facing it
so i've locked it behind hijack only so it's more rare

i decided against it having glorious death since the martial art itself actively fights against dying

:cl:  
tweak: Worldbreaker is restricted to hijack traitors
tweak: Worldbreaker can't get discounts
/:cl:
