### PR TITLE
Makes self surgery slightly less painfully slow

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -95,7 +95,7 @@
 
 	var/speed_mod = 1
 	if(user == target)
-		speed_mod *= 3 // harder to do on yourself
+		speed_mod *= 1.5 // harder to do on yourself, but not "wait 15 seconds for a single step" hard
 
 	if(preop(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = FALSE


### PR DESCRIPTION
One of the few upsides of robotic limbs, instead became far too tedious to be "fun"
Some steps take FAR too long, especially if they can mess up

:cl:  
tweak: Self surgery is only 1.5x regular length instead of 3x
/:cl:
