### PR TITLE
Clockwork Cult Conversion sigil now massively heals converts

### DIFF
--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -144,6 +144,11 @@
 			hierophant_message("<span class='large_brass bold'>With the conversion of a new servant the Ark's power grows. Application scriptures are now available.</span>")
 	if(add_servant_of_ratvar(L))
 		L.log_message("conversion was done with a [sigil_name]", LOG_ATTACK, color="BE8700")
+		var/brutedamage = L.getBruteLoss()
+		var/burndamage = L.getFireLoss()
+		if(brutedamage || burndamage)
+			L.adjustBruteLoss(-(brutedamage * 0.75))
+			L.adjustFireLoss(-(burndamage * 0.75))
 		if(iscarbon(L))
 			var/mob/living/carbon/M = L
 			M.uncuff()


### PR DESCRIPTION
# Document the changes in your pull request

Shamelessly stolen code from blood cult offer rune

Clockwork cult needs some ups and I think letting them be a little more rough with their converts will give them some more wiggle room

Heals for 75% of current brute and burn damage

# Changelog

:cl:  
tweak: Clockwork Cult Conversion sigil now massively heals converts
/:cl:
