### PR TITLE
disabled station adrift

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -415,7 +415,6 @@
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
-#define STATION_TRAIT_STATION_ADRIFT "station_trait_station_adrift"
 
 //important_recursive_contents traits
 /*

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -137,8 +137,6 @@
 
 /atom/movable/screen/plane_master/parallax/Initialize(mapload)
 	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_STATION_ADRIFT))
-		SpinAnimation(30 MINUTES)
 	// Should be moved to the world render plate when render plates get ported in
 	filters += filter(type="displace", render_source = SINGULARITY_RENDER_TARGET, size=75)
 

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -138,7 +138,7 @@
 /atom/movable/screen/plane_master/parallax/Initialize(mapload)
 	. = ..()
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_STATION_ADRIFT))
-		SpinAnimation(15 MINUTES)
+		SpinAnimation(30 MINUTES)
 	// Should be moved to the world render plate when render plates get ported in
 	filters += filter(type="displace", render_source = SINGULARITY_RENDER_TARGET, size=75)
 

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -63,7 +63,7 @@
 /datum/station_trait/station_adrift
 	name = "Adrift station"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0
+	weight = -1
 	show_in_report = TRUE
 	report_message = "Your station's gravitational anchor has malfunctioned. You are now drifting freely in space."
 	trait_to_give = STATION_TRAIT_STATION_ADRIFT

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -63,7 +63,7 @@
 /datum/station_trait/station_adrift
 	name = "Adrift station"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 100
+	weight = 0
 	show_in_report = TRUE
 	report_message = "Your station's gravitational anchor has malfunctioned. You are now drifting freely in space."
 	trait_to_give = STATION_TRAIT_STATION_ADRIFT

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -63,7 +63,7 @@
 /datum/station_trait/station_adrift
 	name = "Adrift station"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 2
+	weight = 100
 	show_in_report = TRUE
 	report_message = "Your station's gravitational anchor has malfunctioned. You are now drifting freely in space."
 	trait_to_give = STATION_TRAIT_STATION_ADRIFT

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -59,11 +59,3 @@
 /datum/station_trait/announcement_medbot/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/medbot
-
-/datum/station_trait/station_adrift
-	name = "Adrift station"
-	trait_type = STATION_TRAIT_NEUTRAL
-	weight = -1
-	show_in_report = TRUE
-	report_message = "Your station's gravitational anchor has malfunctioned. You are now drifting freely in space."
-	trait_to_give = STATION_TRAIT_STATION_ADRIFT


### PR DESCRIPTION
### Confirmed issue removal is needed
closes #19773
resolves #19121
People with low-end computer if this causes blackscreen for you react with the like

* https://github.com/yogstation13/Yogstation/issues/19121
this caused a lot of black screen issues to some low-end users
I have tested this using my old grandma potato pc and this is what happened with this trait on

![image](https://github.com/yogstation13/Yogstation/assets/89688125/498b0ca9-cbbe-4544-817a-8ccc0ec54ebf)

![image](https://github.com/yogstation13/Yogstation/assets/89688125/655309f5-8d67-422b-ba5e-17ceb992cea5)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

rscdel: Removed station adrift trait caused a lot of issues to users
fix: Blackscreen, fps issues on low end users
/:cl:




