### PR TITLE
You can now craft advanced insulated glove

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -605,3 +605,12 @@
 				/obj/item/stack/sheet/animalhide/weaver_chitin = 3) //Also just one spider!
 	category = CAT_APPAREL
 	subcategory = CAT_EQUIPMENT
+
+/datum/crafting_recipe/advancedgloves
+	name = "Advanced Insulated Gloves"
+	result = /obj/item/clothing/gloves/atmos/ce
+	time = 2 SECONDS
+	reqs = list(/obj/item/clothing/gloves/atmos = 1,
+				/obj/item/clothing/gloves/color/yellow = 1)
+	category = CAT_APPAREL
+	subcategory = CAT_EQUIPMENT


### PR DESCRIPTION
Its just more convenient than just switching between the atmos glove and an insulated one also barely anyone using the atmos glove for some reason but yeah it is what it is

# Document the changes in your pull request
You can now craft advanced insulated glove which will require an insulated glove and an atmos glove



# Wiki Documentation

You can now craft advanced insulated glove which will require an insulated glove and an atmos glove

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
 
tweak: You can now craft advanced insulated glove which will require an insulated glove and an atmos glove
/:cl:
