### PR TITLE
make atmos cape fireproof

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcapes.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcapes.dm
@@ -196,6 +196,7 @@
 	icon_state = "atmos-trimmed"
 	item_state = "atmos-trimmed"
 	resistance_flags = FIRE_PROOF
+
 /obj/item/clothing/neck/skillcape/engineer
 	name = "cape of the station engineer"
 	icon_state = "engi-skillcape"

--- a/code/modules/clothing/neck/skillcapes/skillcapes.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcapes.dm
@@ -189,12 +189,13 @@
 	name = "cape of the atmospheric technician"
 	icon_state = "atmos-skillcape"
 	item_state = "atmos-skillcape"
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/neck/skillcape/trimmed/atmos
 	name = "cape of the grand atmospheric technician"
 	icon_state = "atmos-trimmed"
 	item_state = "atmos-trimmed"
-
+	resistance_flags = FIRE_PROOF
 /obj/item/clothing/neck/skillcape/engineer
 	name = "cape of the station engineer"
 	icon_state = "engi-skillcape"


### PR DESCRIPTION
the sprite isnt pretty so i think it deserves something also its really inconvenient everytime it gets burned when you doing atmos stuffs 

# Document the changes in your pull request
atmos cape is now fireproofed


# Wiki Documentation
atmos cape is now fireproofed

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: atmos cape is now fireproofed
/:cl:
