### PR TITLE
Give advanced firefighting cargo crate 4 atmos gloves and advanced fire extinguishers

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -895,8 +895,8 @@
 	crate_name = "conveyor assembly crate"
 
 /datum/supply_pack/engineering/atmos/fire
-	name = "Advanced Atmos Firesuit Crate"
-	desc = "Contains 4 atmos firesuits"
+	name = "Advanced Firefighting Crate"
+	desc = "Station is burning? Don't worry we got you. Introducing 4 atmos firesuits, gloves and advanced extinguishers!"
 	cost = 2000
 	contains = list(/obj/item/clothing/suit/fire/atmos,
 					/obj/item/clothing/suit/fire/atmos,
@@ -905,7 +905,15 @@
 					/obj/item/clothing/head/hardhat/atmos,
 					/obj/item/clothing/head/hardhat/atmos,
 					/obj/item/clothing/head/hardhat/atmos,
-					/obj/item/clothing/head/hardhat/atmos)
+					/obj/item/clothing/head/hardhat/atmos,
+					/obj/item/clothing/gloves/atmos,
+					/obj/item/clothing/gloves/atmos,
+					/obj/item/clothing/gloves/atmos,
+					/obj/item/clothing/gloves/atmos,
+					/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced,
+					/obj/item/extinguisher/advanced)
 	crate_name = "advanced atmos firesuit crate"
 
 /datum/supply_pack/engineering/engiequipment

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -897,7 +897,7 @@
 /datum/supply_pack/engineering/atmos/fire
 	name = "Advanced Firefighting Crate"
 	desc = "Station is burning? Don't worry we got you. Introducing 4 atmos firesuits, gloves and advanced extinguishers!"
-	cost = 2000
+	cost = 3000
 	contains = list(/obj/item/clothing/suit/fire/atmos,
 					/obj/item/clothing/suit/fire/atmos,
 					/obj/item/clothing/suit/fire/atmos,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -914,7 +914,7 @@
 					/obj/item/extinguisher/advanced,
 					/obj/item/extinguisher/advanced,
 					/obj/item/extinguisher/advanced)
-	crate_name = "advanced atmos firesuit crate"
+	crate_name = "advanced firefighting crate"
 
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"


### PR DESCRIPTION
theses arent available in cargo is sad
# Document the changes in your pull request
Give advanced firefighting cargo crate 4 atmos gloves and advanced fire extinguishers


# Wiki Documentation
Give advanced firefighting cargo crate 4 atmos gloves and advanced fire extinguishers


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Give advanced firefighting cargo crate 4 atmos gloves and advanced fire extinguishers
/:cl:
