### PR TITLE
Fixes the CE's holosign creator

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -12,10 +12,12 @@
 	throw_speed = 3
 	throw_range = 7
 	item_flags = NOBLUDGEON
-	var/list/signs = list()
+	///List of all holosigns currently made.
+	var/list/obj/item/holosign_creator/signs = list()
+	///The type of holosign to make from this projector.
+	var/obj/structure/holosign/holosign_type = /obj/structure/holosign/wetsign
 	var/max_signs = 10
 	var/creation_time = 0 SECONDS //time to create a holosign in deciseconds.
-	var/obj/structure/holosign/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
 
 /obj/item/holosign_creator/afterattack(atom/target, mob/user, flag)
@@ -54,10 +56,15 @@
 	return
 
 /obj/item/holosign_creator/attack_self(mob/user)
-	if(signs.len)
-		for(var/H in signs)
-			qdel(H)
-		to_chat(user, span_notice("You clear all active hard light barriers."))
+	. = ..()
+	if(.)
+		return TRUE
+	if(!signs.len)
+		return FALSE
+	for(var/obj/item/holosign_creator as anything in signs)
+		qdel(holosign_creator)
+	to_chat(user, span_notice("You clear all active hard light barriers."))
+	return TRUE
 
 /obj/item/holosign_creator/janibarrier
 	name = "custodial holobarrier projector"
@@ -165,16 +172,15 @@
 	var/list/holodesigns = list()
 
 /obj/item/holosign_creator/multi/attack_self(mob/user)
-	if(signs.len)
-		for(var/H in signs)
-			qdel(H)
-		to_chat(user, span_notice("You clear all active hard light barriers."))
-	else
-		holosign_type = next_list_item(holosign_type, holodesigns)
-		to_chat(user, span_notice("You switch to [initial(holosign_type.name)]"))
+	. = ..()
+	if(.)
+		return TRUE
+	holosign_type = next_list_item(holosign_type, holodesigns)
+	to_chat(user, span_notice("You switch to [initial(holosign_type.name)]"))
+	return TRUE
 
 /obj/item/holosign_creator/multi/chief_engineer
-	name = "CE holofan projector"
+	name = "advanced holofan projector"
 	desc = "A holographic projector that creates hard light barriers that prevent changes in atmosphere conditions or engineering barriers."
 	icon_state = "signmaker_atmos"
 	holosign_type = /obj/structure/holosign/barrier/atmos

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -13,7 +13,7 @@
 	throw_range = 7
 	item_flags = NOBLUDGEON
 	///List of all holosigns currently made.
-	var/list/obj/item/holosign_creator/signs = list()
+	var/list/obj/structure/holosign/signs = list()
 	///The type of holosign to make from this projector.
 	var/obj/structure/holosign/holosign_type = /obj/structure/holosign/wetsign
 	var/max_signs = 10

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -15,7 +15,7 @@
 	var/list/signs = list()
 	var/max_signs = 10
 	var/creation_time = 0 SECONDS //time to create a holosign in deciseconds.
-	var/holosign_type = /obj/structure/holosign/wetsign
+	var/obj/structure/holosign/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
 
 /obj/item/holosign_creator/afterattack(atom/target, mob/user, flag)
@@ -157,8 +157,11 @@
 			qdel(H)
 		to_chat(user, span_notice("You clear all active hard light barriers."))
 
+///Multi-barrier type that allows you to swap between several types of barriers.
+///You can only use one type at a time, you have to clear them to swap to the other.
 /obj/item/holosign_creator/multi
-	name = "multiple holosign projector"  //Fork from this to make multiple barriers
+	name = "multiple holosign projector"
+	///List of all designs that this can choose.
 	var/list/holodesigns = list()
 
 /obj/item/holosign_creator/multi/attack_self(mob/user)
@@ -168,9 +171,9 @@
 		to_chat(user, span_notice("You clear all active hard light barriers."))
 	else
 		holosign_type = next_list_item(holosign_type, holodesigns)
-		to_chat(user, span_notice("You switch to [holosign_type]"))
+		to_chat(user, span_notice("You switch to [initial(holosign_type.name)]"))
 
-/obj/item/holosign_creator/multi/CE
+/obj/item/holosign_creator/multi/chief_engineer
 	name = "CE holofan projector"
 	desc = "A holographic projector that creates hard light barriers that prevent changes in atmosphere conditions or engineering barriers."
 	icon_state = "signmaker_atmos"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -69,7 +69,7 @@
 		/obj/item/construction/rcd,
 		/obj/item/pipe_dispenser,
 		/obj/item/inducer,
-		/obj/item/holosign_creator/multi/CE,
+		/obj/item/holosign_creator/multi/chief_engineer,
 		/obj/item/airlock_painter,
 		/obj/item/grenade/chem_grenade/smart_metal_foam,
 		/obj/item/grenade/chem_grenade/metalfoam,
@@ -79,8 +79,8 @@
 		/obj/item/shuttle_creator, //Yogs: Added this here cause I felt it fits
 		/obj/item/barrier_taperoll/engineering,
 		/obj/item/storage/bag/sheetsnatcher,
-		/obj/item/holotool
-		))
+		/obj/item/holotool,
+	))
 
 /obj/item/storage/belt/utility/makeshift
 	name = "makeshift toolbelt"
@@ -110,7 +110,7 @@
 	SSwardrobe.provide_type(/obj/item/multitool/tricorder, src)	//yogs: changes the multitool to the tricorder and removes the analyzer
 	SSwardrobe.provide_type(/obj/item/stack/cable_coil, src)
 	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
-	SSwardrobe.provide_type(/obj/item/holosign_creator/multi/CE, src)
+	SSwardrobe.provide_type(/obj/item/holosign_creator/multi/chief_engineer, src)
 	//much roomier now that we've managed to remove two tools
 
 /obj/item/storage/belt/utility/chief/full/ert
@@ -125,7 +125,7 @@
 	to_preload += /obj/item/multitool/tricorder
 	to_preload += /obj/item/stack/cable_coil
 	to_preload += /obj/item/extinguisher/mini
-	to_preload += /obj/item/holosign_creator/multi/CE
+	to_preload += /obj/item/holosign_creator/multi/chief_engineer
 	return to_preload
 
 /obj/item/storage/belt/utility/chief/admin/full
@@ -141,7 +141,7 @@
 	SSwardrobe.provide_type(/obj/item/multitool/tricorder, src)	//yogs: changes the multitool to the tricorder and removes the analyzer
 	SSwardrobe.provide_type(/obj/item/storage/bag/construction/admin/full, src)
 	SSwardrobe.provide_type(/obj/item/extinguisher/mini, src)
-	SSwardrobe.provide_type(/obj/item/holosign_creator/multi/CE, src)
+	SSwardrobe.provide_type(/obj/item/holosign_creator/multi/chief_engineer, src)
 
 /obj/item/storage/belt/utility/full/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/screwdriver, src)
@@ -620,7 +620,7 @@
 	new /obj/item/multitool/tricorder(src)
 	new /obj/item/storage/bag/construction/admin/full(src)
 	new /obj/item/extinguisher/mini(src)
-	new /obj/item/holosign_creator/multi/CE(src)
+	new /obj/item/holosign_creator/multi/chief_engineer(src)
 	new /obj/item/restraints/handcuffs/alien(src)
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/assembly/flash/handheld(src)


### PR DESCRIPTION
# Document the changes in your pull request

This has been broken since it was added and no one seemed to have noticed, well **I** did when I was looking into a bug report on update_appearance.
Also adds autodoc and repaths the item so vscode doesn't treat it like a define.

before
![image](https://github.com/yogstation13/Yogstation/assets/53777086/6e47df12-74ca-4db4-91c3-d3d8170251fd)

after
![image](https://github.com/yogstation13/Yogstation/assets/53777086/6caa2e40-1dee-4559-acb7-f88da6b7b3c3)

# Changelog

:cl:  
bugfix: The CE's holosign creator now doesn't give you the raw path of the sign it is creating.
/:cl:
