### PR TITLE
Remove Buster Arm from IAA

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -335,6 +335,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 15
 	manufacturer = /datum/corporation/traitor/cybersun
 	surplus = 0
+	exclude_modes = list(/datum/game_mode/infiltration, /datum/game_mode/traitor/internal_affairs)
 
 /datum/uplink_item/dangerous/rawketlawnchair
 	name = "84mm Rocket Propelled Grenade Launcher"


### PR DESCRIPTION
# Document the changes in your pull request

Removes Buster Arm from the uplink for IAA. 

Buster arms, like holopara's, have become the only meta choice for IAA, and go against the core idea of IAA, being that it's agents fighting among each other, WITHOUT causing suspicion or collateral damage. Buster arm does neither of those.

# Spriting

# Wiki Documentation

# Changelog

:cl:  
rscdel: Removed Buster Arm from IAA uplink
/:cl:
