### PR TITLE
Readding shotgun darts to Autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -890,6 +890,14 @@
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list("hacked", "Security")
 
+/datum/design/shotgun_dart
+	name = "Shotgun Dart"
+	id = "shotgun_dart"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/dart
+	category = list("hacked", "Security")
+
 /datum/design/incendiary_slug
 	name = "Incendiary Slug"
 	id = "incendiary_slug"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -657,16 +657,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 50
 
-/datum/uplink_item/stealthy_weapons/dart_syringe
-	name = "Box of Chemical Shotgun Darts"
-	desc = "A box of 7 empty shotgun darts capable of holding 30 units of any reagent, cleverly \
-			disguised as non-lethal beanbag slugs. People will still notice the big dart sticking \
-			out of their arm. Be careful not to mix them up with actual beanbag slugs!"
-	item = /obj/item/storage/box/beanbag/syndie_darts
-	manufacturer = /datum/corporation/traitor/vahlen
-	cost = 2
-	surplus = 0 // useless for most people
-
 /datum/uplink_item/stealthy_weapons/dehy_carp
 	name = "Dehydrated Space Carp"
 	desc = "Looks like a plush toy carp, but just add water and it becomes a real-life space carp! Activate in \


### PR DESCRIPTION
# Document the changes in your pull request

With the re-addition of syringe guns and that they're staying. It only makes sense to re-add the shotgun darts back to hacked autolathe machines. No one really uses them apart from barkeeps and buying them wastes a good chunk of TC for some darts that now have been nerfed transfer embedded wise it is just a big slap to any shotgun users that want to have some fun

# Changelog

:cl:  
rscadd: Added shotgun darts back to hacked autolathes 
rscdel: Removed shotgun dart TC uplink

/:cl:
