### PR TITLE
Makes the stealth martial art inject sodium thiopental first instead of cyanide

### DIFF
--- a/yogstation/code/datums/martial/stealth.dm
+++ b/yogstation/code/datums/martial/stealth.dm
@@ -74,13 +74,13 @@
 
 /datum/martial_art/stealth/proc/injection(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(findtext(streak, INJECTION_COMBO))
-		D.reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 8)
-		to_chat(A, span_warning("You inject sodium thiopental into [D]!"))
+		D.reagents.add_reagent(/datum/reagent/toxin/cyanide, 5)
+		to_chat(A, span_warning("You inject cyanide into [D]!"))
 		to_chat(D, span_notice("You feel a tiny prick."))
 		streak = ""
 	else 
-		D.reagents.add_reagent(/datum/reagent/toxin/cyanide, 5)
-		to_chat(A, span_warning("You inject cyanide into [D]!"))
+		D.reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 8)
+		to_chat(A, span_warning("You inject sodium thiopental into [D]!"))
 		to_chat(D, span_notice("You feel a tiny prick."))		
 
 /datum/martial_art/stealth/proc/fingergun(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -138,7 +138,7 @@
 	to_chat(usr, "<b><i>You try to remember some basic actions from your upgraded combat modules.</i></b>")
 
 	to_chat(usr, "[span_notice("Hidden Blade")]: Harm Harm Grab. The second strike will deal 20 stamina and 5 brute damage, and finishing the combo will make you stab the victim with a hidden blade, dealing 30 brute damage.")
-	to_chat(usr, "[span_notice("Injection")]: Disarm Harm Disarm. The second and third attack will stealthy inject respectively 5 units of cyanide and 8 unites of sodium thiopental.")
+	to_chat(usr, "[span_notice("Injection")]: Disarm Harm Disarm. The second and third input will silently inject 8 units of sodium thiopental and 5 units of cyanide respectively.")
 	to_chat(usr, "[span_notice("Finger gun")]: Harm Disarm Disarm. Finishing the combo will paralyse your target and place a stealthy version of a stechkin in your hand.")
 
 #undef PRE_DAGGER_COMBO

--- a/yogstation/code/datums/martial/stealth.dm
+++ b/yogstation/code/datums/martial/stealth.dm
@@ -2,8 +2,8 @@
 #define PRE_DAGGER_COMBO "HH"
 #define DAGGER_COMBO "HHG"
 ///injection
-#define PRE_INJECTION_COMBO "DH"
-#define INJECTION_COMBO "DHD"
+#define PRE_INJECTION_COMBO "DG"
+#define INJECTION_COMBO "DGD"
 ///fingergun
 #define FINGERGUN_COMBO "HDD"
 
@@ -138,7 +138,7 @@
 	to_chat(usr, "<b><i>You try to remember some basic actions from your upgraded combat modules.</i></b>")
 
 	to_chat(usr, "[span_notice("Hidden Blade")]: Harm Harm Grab. The second strike will deal 20 stamina and 5 brute damage, and finishing the combo will make you stab the victim with a hidden blade, dealing 30 brute damage.")
-	to_chat(usr, "[span_notice("Injection")]: Disarm Harm Disarm. The second and third input will silently inject 8 units of sodium thiopental and 5 units of cyanide respectively.")
+	to_chat(usr, "[span_notice("Injection")]: Disarm Grab Disarm. The second and third input will silently inject 8 units of sodium thiopental and 5 units of cyanide respectively.")
 	to_chat(usr, "[span_notice("Finger gun")]: Harm Disarm Disarm. Finishing the combo will paralyse your target and place a stealthy version of a stechkin in your hand.")
 
 #undef PRE_DAGGER_COMBO


### PR DESCRIPTION
What's the point of the martial art being so stealthy if you immediately start killing your target when doing the stealthiest combo

Swaps the two chems so it's possible to sleep someone without killing them

also changes the combo to prevent mixing with the finger gun combo

:cl:  
tweak: Remnant Liquidator injects sodium thiopental before the cyanide now
tweak: Injection is now Disarm Grab Disarm instead of Disarm Harm Disarm
/:cl:
