### PR TITLE
Disables echolocation

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -226,8 +226,3 @@
 	icon_state = "blue_eye"
 	plane = FULLSCREEN_PLANE
 	layer = CURSE_LAYER
-
-/atom/movable/screen/fullscreen/echolocation
-	icon_state = "echo"
-	layer = CAMERA_STATIC_LAYER
-	plane = CAMERA_STATIC_PLANE

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -206,3 +206,5 @@
 /atom/movable/screen/fullscreen/echo/Destroy()
 	QDEL_NULL(particles)
 	return ..()
+
+#undef DEFAULT_ECHO_RANGE

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -49,7 +49,7 @@
 	if(!istype(echolocator))
 		return COMPONENT_INCOMPATIBLE
 	if(!danger_turfs)
-		danger_turfs = typecacheof(list(/turf/open/chasm, /turf/open/lava, /turf/open/floor/fakepit, /turf/open/space, /turf/open/openspace, /turf/open/floor/fakespace))
+		danger_turfs = typecacheof(list(/turf/open/chasm, /turf/open/lava, /turf/open/floor/fakepit))
 	if(!allowed_paths)
 		allowed_paths = typecacheof(list(/turf/closed, /obj, /mob/living)) + danger_turfs - typecacheof(/obj/effect/decal)
 	if(!isnull(echo_range))

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -1,5 +1,3 @@
-#define DEFAULT_ECHO_RANGE 4
-
 /datum/component/echolocation
 	/// Current radius, will set itself to default
 	var/echo_range
@@ -35,7 +33,7 @@
 	COOLDOWN_DECLARE(cooldown_last)
 
 /datum/component/echolocation/Initialize(
-	echo_range = DEFAULT_ECHO_RANGE,
+	echo_range = 4,
 	cooldown_time = 2 SECONDS,
 	image_expiry_time = 1.5 SECONDS,
 	fade_in_time = 0.5 SECONDS,
@@ -92,9 +90,9 @@
 		return
 	COOLDOWN_START(src, cooldown_last, cooldown_time)
 	var/mob/living/echolocator = parent
-	echo_range = echo_sound_environment(echolocator, DEFAULT_ECHO_RANGE)
+	var/real_echo_range = echo_sound_environment(echolocator, echo_range)
 	var/list/filtered = list()
-	var/list/seen = dview(echo_range, get_turf(echolocator.client?.eye || echolocator), invis_flags = echolocator.see_invisible)
+	var/list/seen = dview(real_echo_range, get_turf(echolocator.client?.eye || echolocator), invis_flags = echolocator.see_invisible)
 	for(var/atom/seen_atom as anything in seen)
 		if(!seen_atom.alpha)
 			continue
@@ -206,5 +204,3 @@
 /atom/movable/screen/fullscreen/echo/Destroy()
 	QDEL_NULL(particles)
 	return ..()
-
-#undef DEFAULT_ECHO_RANGE

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -1,22 +1,22 @@
+#define DEFAULT_ECHO_RANGE 4
+
 /datum/component/echolocation
-	///Default echo range
-	var/default_echo_range = 4
 	/// Current radius, will set itself to default
 	var/echo_range
 	/// Time between echolocations.
-	var/cooldown_time = 2 SECONDS
+	var/cooldown_time
 	/// Time for the image to start fading out.
-	var/image_expiry_time = 1.5 SECONDS
+	var/image_expiry_time
 	/// Time for the image to fade in.
-	var/fade_in_time = 0.5 SECONDS
+	var/fade_in_time
 	/// Time for the image to fade out and delete itself.
-	var/fade_out_time = 0.5 SECONDS
+	var/fade_out_time
 	/// Are images static? If yes, spawns them on the turf and makes them not change location. Otherwise they change location and pixel shift with the original.
-	var/images_are_static = TRUE
-	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images, defaults to quirk
-	var/echo_group = null
-	/// Color applied over the client
-	var/client_color = null
+	var/images_are_static
+	/// With mobs that have this echo group in their echolocation receiver trait, we share echo images.
+	var/echo_group
+	/// Ref of the client color we give to the echolocator.
+	var/client_color
 	/// Associative list of world.time when created to a list of the images.
 	var/list/images = list()
 	/// Associative list of world.time when created to a list of receivers.
@@ -31,21 +31,29 @@
 	var/static/list/black_white_matrix = list(85, 85, 85, 0, 85, 85, 85, 0, 85, 85, 85, 0, 0, 0, 0, 1, -254, -254, -254, 0)
 	/// A matrix that turns everything into pure white.
 	var/static/list/white_matrix = list(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 0, 0, 0, 1, 0, -0, 0, 0)
-
 	/// Cooldown for the echolocation.
 	COOLDOWN_DECLARE(cooldown_last)
 
-/datum/component/echolocation/Initialize(echo_range, cooldown_time, image_expiry_time, fade_in_time, fade_out_time, images_are_static, blocking_trait, echo_group, echo_icon, color_path)
+/datum/component/echolocation/Initialize(
+	echo_range = DEFAULT_ECHO_RANGE,
+	cooldown_time = 2 SECONDS,
+	image_expiry_time = 1.5 SECONDS,
+	fade_in_time = 0.5 SECONDS,
+	fade_out_time = 0.5 SECONDS,
+	images_are_static = TRUE,
+	echo_group = "default",
+	color_path = /datum/client_colour/echolocate,
+)
 	. = ..()
 	var/mob/living/echolocator = parent
 	if(!istype(echolocator))
 		return COMPONENT_INCOMPATIBLE
 	if(!danger_turfs)
-		danger_turfs = typecacheof(list(/turf/open/chasm, /turf/open/lava, /turf/open/floor/fakepit))
+		danger_turfs = typecacheof(list(/turf/open/chasm, /turf/open/lava, /turf/open/floor/fakepit, /turf/open/space, /turf/open/openspace, /turf/open/floor/fakespace))
 	if(!allowed_paths)
 		allowed_paths = typecacheof(list(/turf/closed, /obj, /mob/living)) + danger_turfs - typecacheof(/obj/effect/decal)
 	if(!isnull(echo_range))
-		src.echo_range = default_echo_range
+		src.echo_range = echo_range
 	if(!isnull(cooldown_time))
 		src.cooldown_time = cooldown_time
 	if(!isnull(image_expiry_time))
@@ -58,21 +66,17 @@
 		src.images_are_static = images_are_static
 	if(ispath(color_path))
 		client_color = echolocator.add_client_colour(color_path)
-	else
-		client_color = echolocator.add_client_colour(/datum/client_colour/echolocate)
-
 	src.echo_group = echo_group || REF(src)
 	echolocator.add_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_NIGHT_VISION), src.echo_group) //so they see all the tiles they echolocated, even if they are in the dark
 	echolocator.become_blind(ECHOLOCATION_TRAIT)
-	echolocator.overlay_fullscreen("echo", /atom/movable/screen/fullscreen/echo)
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/echolocation/Destroy(force, silent)
 	STOP_PROCESSING(SSfastprocess, src)
 	var/mob/living/echolocator = parent
+	QDEL_NULL(client_color)
 	echolocator.remove_traits(list(TRAIT_ECHOLOCATION_RECEIVER, TRAIT_NIGHT_VISION), echo_group)
 	echolocator.cure_blind(ECHOLOCATION_TRAIT)
-	echolocator.clear_fullscreen("echo")
 	for(var/timeframe in images)
 		delete_images(timeframe)
 	return ..()
@@ -88,7 +92,7 @@
 		return
 	COOLDOWN_START(src, cooldown_last, cooldown_time)
 	var/mob/living/echolocator = parent
-	echo_range = echo_sound_environment(echolocator, default_echo_range)
+	echo_range = echo_sound_environment(echolocator, DEFAULT_ECHO_RANGE)
 	var/list/filtered = list()
 	var/list/seen = dview(echo_range, get_turf(echolocator.client?.eye || echolocator), invis_flags = echolocator.see_invisible)
 	for(var/atom/seen_atom as anything in seen)
@@ -133,7 +137,7 @@
 		else
 			return range
 
-/datum/component/echolocation/proc/show_image(image/input_appearance, atom/input, current_time)
+/datum/component/echolocation/proc/show_image(mutable_appearance/input_appearance, atom/input, current_time)
 	var/image/final_image = image(input_appearance)
 	final_image.layer += EFFECTS_LAYER
 	final_image.plane = FULLSCREEN_PLANE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -55,7 +55,8 @@
 	medical_record_text = "Patient has permanent blindness."
 
 /datum/quirk/blindness/add()
-	quirk_holder.AddComponent(/datum/component/echolocation)
+	quirk_holder.become_blind(ROUNDSTART_TRAIT)
+//	quirk_holder.AddComponent(/datum/component/echolocation) //add when echolocation is fixed
 
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -44,9 +44,6 @@
 		if(!eye_blind)
 			clear_alert("blind")
 			clear_fullscreen("blind")
-			var/datum/component/echo_component = GetComponent(/datum/component/echolocation)
-			if (echo_component)
-				echo_component.Destroy()
 /**
   * Force set the blindness of a mob to some level
   */
@@ -73,9 +70,6 @@
 		if(!eye_blind)
 			clear_alert("blind")
 			clear_fullscreen("blind")
-			var/datum/component/echo_component = GetComponent(/datum/component/echolocation)
-			if (echo_component)
-				echo_component.Destroy()
 
 /**
   * Make the mobs vision blurry


### PR DESCRIPTION
# Document the changes in your pull request

Echolocation currently blocks you from being able to interact with anything.
Your client is filled with a ton of null images while echolocation is active (which is fine when the echolocation images are gone), which causes problems.
Until this is fixed, this reverts blindness to simply make you blind, without echolocation.

I also had made a ton of changes to echolocation to fix some other issues, but the null in images is what is causing the issue. It is hard to go in-depth more on this without being able to use breakpoints to see it step-by-step.
