### PR TITLE
Adds TRAIT_STRONG_GRIP, adds it to tactical gloves, gives tac gloves to contractor

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -228,6 +228,7 @@
 #define TRAIT_QUICK_CARRY		"quick-carry"
 #define TRAIT_QUICKER_CARRY		"quicker-carry"
 #define TRAIT_QUICKEST_CARRY	"quickest-carry"
+#define TRAIT_STRONG_GRIP		"strong-grip"
 #define TRAIT_UNINTELLIGIBLE_SPEECH "unintelligible-speech"
 #define TRAIT_UNSTABLE			"unstable"
 #define TRAIT_OIL_FRIED			"oil_fried"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -391,8 +391,8 @@
 	new /obj/item/clothing/under/chameleon/syndicate(src)
 	new /obj/item/clothing/mask/chameleon/syndicate(src)
 	new /obj/item/card/id/syndicate(src)
+	new /obj/item/clothing/gloves/fingerless/bigboss(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
-	new /obj/item/lighter(src)
 
 /obj/item/storage/box/syndicate/contract_kit/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -32,7 +32,7 @@
 
 /obj/item/clothing/gloves/fingerless/bigboss
 	tacticalspeed = 0.66 //Does channels 34% faster
-	clothing_traits = list(TRAIT_QUICKER_CARRY)
+	clothing_traits = list(TRAIT_QUICKER_CARRY, TRAIT_STRONG_GRIP)
 
 /obj/item/clothing/gloves/fingerless/bigboss/Touch(mob/living/target, proximity = TRUE)
 	var/mob/living/M = loc
@@ -158,7 +158,7 @@
 	button_icon_state = "cuff"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/supplypod_target.dmi'
 	click_to_activate = TRUE
-	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS 
+	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
 
 	cooldown_time = 10 SECONDS
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1632,7 +1632,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return FALSE
 	if(user.loc == target.loc)
 		return FALSE
-	if(!QDELETED(pulledby) && HAS_TRAIT(pulledby, TRAIT_STRONG_GRIP) && pulledby != user)
+	if(!QDELETED(target.pulledby) && HAS_TRAIT(target.pulledby, TRAIT_STRONG_GRIP) && target.pulledby != user)
 		return FALSE
 	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
 		return FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -211,7 +211,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/New()
 	if(!limbs_id)	//if we havent set a limbs id to use, just use our own id
 		limbs_id = id
-	
+
 	if(!plural_form)
 		plural_form = "[name]\s"
 
@@ -1632,6 +1632,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return FALSE
 	if(user.loc == target.loc)
 		return FALSE
+	if(!QDELETED(pulledby) && HAS_TRAIT(pulledby, TRAIT_STRONG_GRIP) && pulledby != user)
+		return FALSE
 	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
 		return FALSE
 	else
@@ -1907,7 +1909,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)
 		if(BRAIN)
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * hit_percent * H.physiology.brain_mod)
-	
+
 	if(H.stat == DEAD && (H.mobility_flags & MOBILITY_STAND))
 		if(H.buckled && istype(H.buckled, /obj/structure))//prevent buckling corpses to chairs to make indestructible projectile walls
 			var/obj/structure/sitter = H.buckled
@@ -2150,7 +2152,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			flyslip(H)
 		stop_wagging_tail(H)
 	return stunmod * H.physiology.stun_mod * amount
-	
+
 
 //////////////
 //Space Move//
@@ -2165,7 +2167,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(H.movement_type & FLYING)
 		return TRUE
 	return FALSE
-	
+
 /datum/species/proc/has_heavy_gravity(mob/living/carbon/human/H)
 	return FALSE
 
@@ -2745,7 +2747,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			SPECIES_PERK_DESC = "[plural_form] have limbs comprised entirely of metal and circuitry, this will make standard surgery ineffective. \
 				However, this gives [plural_form] the ability to do self-maintenance with just simple tools.",
 		))
-		
+
 	return to_add
 
 /**

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1223,8 +1223,8 @@
 						"[C] leaps out of [src]'s way!")]</span>")
 	C.Paralyze(40)
 
-/mob/living/can_be_pulled()
-	return ..() && !(buckled && buckled.buckle_prevents_pull)
+/mob/living/can_be_pulled(user, grab_state, force)
+	return ..() && !(buckled && buckled.buckle_prevents_pull) && (QDELETED(pulledby) || !HAS_TRAIT(pulledby, TRAIT_STRONG_GRIP) || pulledby == user)
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 //Robots, animals and brains have their own version so don't worry about them

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1766,7 +1766,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/tactical_gloves
 	name = "Tactical Fingerless Gloves"
 	desc = "A pair of simple fabric gloves without fingertips that allow one to perform tasks faster and act quicker in unarmed manuevers. \
-			Also greatly assists with the carrying of bodies."
+			Also greatly assists with the carrying of bodies, while not letting anyone else take them from you!"
 	item = /obj/item/clothing/gloves/fingerless/bigboss
 	cost = 2
 


### PR DESCRIPTION
# Document the changes in your pull request

Gives TRAIT_STRONG_GRIP to tactical fingerless gloves, and adds tactical fingerless gloves to the contractor loadout (rip lighter)

Essentially, TRAIT_STRONG_GRIP is meant to prevent people from easily breaking your grip on a pulled living mob.

It does this by blocking grabs and disarms on mobs that you are pulling.

At request

![image](https://github.com/yogstation13/Yogstation/assets/28408322/14a5efbb-2cc0-4cec-a9fd-02275e3c8df0)
![image](https://github.com/yogstation13/Yogstation/assets/28408322/35b83a28-28dd-474b-b4e5-123f720da2ae)

# Changelog

:cl:  
rscadd: Added TRAIT_STRONG_GRIP which prevents mobs you are pulling from being grabbed or disarmed out of your grip
tweak: Tactical fingerless gloves now give you TRAIT_STRONG_GRIP
tweak: Contractor loadout now contains tactical fingerless gloves instead of a lighter
/:cl:
