### PR TITLE
Showers now clean radiation on mobs

### DIFF
--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -123,7 +123,7 @@
 	qdel(src)
 
 /obj/machinery/shower/proc/reduce_rads(mob/living/L)
-	L.radiation -= min(M.radiation, 5)
+	L.radiation -= min(L.radiation, 5)
 
 /obj/machinery/shower/proc/check_heat(mob/living/L)
 	var/mob/living/carbon/C = L

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -107,6 +107,7 @@
 	reagents.reaction(A, TOUCH, reaction_volume)
 
 	if(isliving(A))
+		reduce_rads(A)
 		check_heat(A)
 
 /obj/machinery/shower/process()
@@ -120,6 +121,9 @@
 /obj/machinery/shower/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/metal(drop_location(), 3)
 	qdel(src)
+
+/obj/machinery/shower/proc/reduce_rads(mob/living/L)
+	L.radiation -= min(M.radiation, 5)
 
 /obj/machinery/shower/proc/check_heat(mob/living/L)
 	var/mob/living/carbon/C = L


### PR DESCRIPTION
# Document the changes in your pull request

Your first reaction to this PR is probably "They didn't?"

People constantly sit in showers when irradiated despite it not actually helping anything besides removing their glow (the part that *spreads* radiation), which happens very quickly.

I say, if the players expect that it works this way and it doesn't, then it is poorly designed.

For balancing reference, potassium-iodide removes 8 rads per tick and pentetic-acid removes ~2% per tick, while this removes 5 rads per tick, so it's not really that strong, but at least it helps now!

# Changelog

:cl:  
tweak: Showers now reduce radiation on mobs
/:cl:
