### PR TITLE
[ADMIN] Disables buildmode copying carbons

### DIFF
--- a/code/modules/buildmode/submodes/copy.dm
+++ b/code/modules/buildmode/submodes/copy.dm
@@ -24,5 +24,8 @@
 			log_admin("Build Mode: [key_name(c)] copied [stored] to [AREACOORD(object)]")
 	else if(right_click)
 		if(ismovable(object)) // No copying turfs for now.
+			if(iscarbon(object))
+				to_chat(c, span_notice("Copying carbons is disabled due to how much it breaks the game."))
+				return
 			to_chat(c, span_notice("[object] set as template."))
 			stored = object


### PR DESCRIPTION
copying an object copies everything including its datum references
so when you copy a carbon you now have two carbons that share organs and everything else
its very bad and breaks everything relating to that mob and leads to hundreds of runtimes and other unexpected effects, potentially not easily fixable ones