### PR TITLE
Kills Odysseus medbeam stacking

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -535,6 +535,10 @@
 	. = ..()
 	medigun = new(src)
 
+/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/can_attach(obj/mecha/M)
+	. = ..()
+	if(locate(/obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam) in M.equipment)
+		return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/medical/mechmedbeam/Destroy()
 	qdel(medigun)


### PR DESCRIPTION
# Document the changes in your pull request

3 medbeams even for a mech is a bit strong

# Changelog

:cl:  
tweak: Odysseus mechs can no longer hold and use multiple medbeams
/:cl:
