### PR TITLE
Re-Adds Battlemage Armor to the wizards spellbook

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -125,6 +125,18 @@
 	item_path = /obj/item/clothing/suit/space/hardsuit/wizard
 	category = "Defensive"
 
+/datum/spellbook_entry/item/battlemage
+	name = "Battlemage Armour"
+	desc = "An ensorceled suit of armour, protected by a powerful shield. The shield can completely negate sixteen attacks before being permanently depleted. It is not protected against the void of space."
+	item_path = /obj/item/clothing/suit/wizrobe/armor
+	limit = 1
+	category = "Defensive"
+
+/datum/spellbook_entry/item/battlemage/buy_spell(mob/living/carbon/human/user,obj/item/spellbook/book)
+	. =..()
+	if(.)
+		new /obj/item/clothing/head/wizard/armor(get_turf(user))//To complete the outfit
+	
 /datum/spellbook_entry/item/battlemage_charge
 	name = "Battlemage Armour Charges"
 	desc = "A powerful defensive rune, it will grant eight additional charges to a battlemage shield."


### PR DESCRIPTION

# Document the changes in your pull request

Re-adds battlemage armor to spellbook
unsure if it was taken out on purpose or just forgotten

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Added new things  
bugfix: battlemage armor can be purchased again
/:cl:
