### PR TITLE
Tweaks and fixes to preternis rock eating

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -102,7 +102,7 @@
 	eaten_text = "The uranium ore tingles a bit as it goes down."
 
 /obj/item/stack/ore/uranium/eaten(mob/living/carbon/human/H)
-	radiation_pulse(H, 20)
+	radiation_pulse(H, 100)
 	return TRUE
 
 /obj/item/stack/ore/iron
@@ -117,6 +117,7 @@
 
 /obj/item/stack/ore/iron/eaten(mob/living/carbon/human/H)
 	H.heal_overall_damage(2, 0, 0, BODYPART_ROBOTIC)
+	return TRUE
 
 /obj/item/stack/ore/glass
 	name = "sand pile"

--- a/yogstation/code/game/objects/items/stacks/dilithiumcrystal.dm
+++ b/yogstation/code/game/objects/items/stacks/dilithiumcrystal.dm
@@ -28,6 +28,7 @@
 	use(1)
 
 /obj/item/stack/ore/dilithium_crystal/eaten(mob/living/carbon/human/H)
+	H.adjust_fire_stacks(1)
 	H.ignite_mob()
 	return TRUE
 


### PR DESCRIPTION
Radioactivity was too low to ever be reasonably noticeable, so i've increased it a bit

:cl:  
bugfix: Iron ore gets consumed when a preternis eats it
bugfix: Dilithium eating can now actually light the eater on fire
tweak: Uranium eating is now slightly more radioactive
/:cl:
