### PR TITLE
Mining Cyborg Start With 20% Upgradable Melee Armor

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1103,7 +1103,7 @@
 		update_transform()
 	logevent("Chassis configuration has been reset.")
 	icon = initial(icon) //Should fix invisi-donorborgs ~ Kmc
-	module.transform_to(/obj/item/robot_module)
+	module.transform_to(/obj/item/robot_module) // Will reset armor & armor_plates as well. 
 
 	// Remove upgrades.
 	for(var/obj/item/borg/upgrade/I in upgrades)
@@ -1112,7 +1112,6 @@
 		I.dropped()
 
 	upgrades.Cut()
-	armor = getArmor(arglist(initial(armor)))
 
 	speed = 0
 	ionpulse = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1112,6 +1112,7 @@
 		I.dropped()
 
 	upgrades.Cut()
+	armor = getArmor(arglist(initial(armor)))
 
 	speed = 0
 	ionpulse = FALSE

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -36,17 +36,14 @@
 		flash_act()
 		var/stunprob = M.powerlevel * 7 + 10
 		if(prob(stunprob) && M.powerlevel >= 8)
-			adjustBruteLoss(M.powerlevel * rand(6,10))
+			adjustBruteLoss(run_armor(M.powerlevel * rand(6,10), BRUTE, MELEE))
 
 	var/damage = rand(1, 3)
-
 	if(M.is_adult)
 		damage = rand(20, 40)
 	else
 		damage = rand(5, 35)
-	damage = round(damage / 2) // borgs receive half damage
-	adjustBruteLoss(damage)
-
+	adjustBruteLoss(run_armor(damage/2, BRUTE, MELEE)) // Cyborgs receive half damage plus armor.
 	return
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
@@ -175,7 +172,8 @@
 
 /mob/living/silicon/robot/blob_act(obj/structure/blob/B)
 	if(stat != DEAD)
-		adjustBruteLoss(30)
+		var/damage = run_armor(30, BRUTE, MELEE)
+		adjustBruteLoss(damage)
 	else
 		gib()
 	return TRUE
@@ -187,11 +185,11 @@
 			return
 		if(2)
 			if (stat != DEAD)
-				adjustBruteLoss(60)
-				adjustFireLoss(60)
+				adjustBruteLoss(run_armor(60, BRUTE, BOMB))
+				adjustFireLoss(run_armor(60, BURN, BOMB))
 		if(3)
 			if (stat != DEAD)
-				adjustBruteLoss(30)
+				adjustBruteLoss(run_armor(30, BRUTE, BOMB))
 
 /mob/living/silicon/robot/bullet_act(obj/item/projectile/Proj, def_zone)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -10,6 +10,8 @@
 
 	/// Sets the cyborg's armor values to these upon selecting their module.
 	var/list/module_armor = list()
+	/// Determines if the module will give '/datum/component/armor_plate' and how many times it can be done.
+	var/use_armorplates = 0
 
 	var/list/basic_modules = list() ///a list of paths, converted to a list of instances on New()
 	var/list/emag_modules = list() ///ditto
@@ -66,6 +68,7 @@
 	modules.Cut()
 	added_modules.Cut()
 	storages.Cut()
+
 	return ..()
 
 /obj/item/robot_module/emp_act(severity)
@@ -204,6 +207,13 @@
 	R.update_module_innate()
 	RM.rebuild_modules()
 	R.radio.recalculateChannels()
+	var/datum/component/armor_plate/C = R.GetComponent(/datum/component/armor_plate)
+	if(C) // Remove armor plating.
+		C.dropplates()
+		if(!RM.use_armorplates)
+			C.Destroy()
+	if(RM.use_armorplates > 0) // Add armor plating.
+		R.AddComponent(/datum/component/armor_plate, RM.use_armorplates)
 	R.armor = getArmor(arglist(RM.module_armor))
 
 	INVOKE_ASYNC(RM, PROC_REF(do_transform_animation))
@@ -598,8 +608,9 @@
 	moduleselect_icon = "miner"
 	hat_offset = 0
 	module_armor = list(MELEE = 20)
+	use_armorplates = 3
 	var/obj/item/t_scanner/adv_mining_scanner/cyborg/mining_scanner //built in memes.
-	
+
 /obj/item/robot_module/miner/rebuild_modules()
 	. = ..()
 	if(!mining_scanner)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -210,8 +210,7 @@
 	var/datum/component/armor_plate/C = R.GetComponent(/datum/component/armor_plate)
 	if(C) // Remove armor plating.
 		C.dropplates()
-		if(!RM.use_armorplates)
-			C.Destroy()
+		C.Destroy() // It is possible to switch over to a module that has a different 'use_armorplates' value, thus we remove in all cases.
 	if(RM.use_armorplates > 0) // Add armor plating.
 		R.AddComponent(/datum/component/armor_plate, RM.use_armorplates)
 	R.armor = getArmor(arglist(RM.module_armor))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -8,6 +8,9 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1
 
+	/// Sets the cyborg's armor values to these upon selecting their module.
+	var/list/module_armor = list()
+
 	var/list/basic_modules = list() ///a list of paths, converted to a list of instances on New()
 	var/list/emag_modules = list() ///ditto
 	var/list/ratvar_modules = list() ///ditto ditto
@@ -42,6 +45,7 @@
 
 /obj/item/robot_module/Initialize(mapload)
 	. = ..()
+	//module_armor = getArmor(arglist(module_armor))
 	for(var/i in basic_modules)
 		var/obj/item/I = new i(src)
 		basic_modules += I
@@ -54,6 +58,7 @@
 		var/obj/item/I = new i(src)
 		ratvar_modules += I
 		ratvar_modules -= i
+	
 
 /obj/item/robot_module/Destroy()
 	basic_modules.Cut()
@@ -200,6 +205,7 @@
 	R.update_module_innate()
 	RM.rebuild_modules()
 	R.radio.recalculateChannels()
+	R.armor = getArmor(arglist(RM.module_armor))//RM.module_armor
 
 	INVOKE_ASYNC(RM, PROC_REF(do_transform_animation))
 	qdel(src)
@@ -592,8 +598,9 @@
 	cyborg_base_icon = "miner"
 	moduleselect_icon = "miner"
 	hat_offset = 0
+	module_armor = list(MELEE = 20)
 	var/obj/item/t_scanner/adv_mining_scanner/cyborg/mining_scanner //built in memes.
-
+	
 /obj/item/robot_module/miner/rebuild_modules()
 	. = ..()
 	if(!mining_scanner)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -45,7 +45,6 @@
 
 /obj/item/robot_module/Initialize(mapload)
 	. = ..()
-	//module_armor = getArmor(arglist(module_armor))
 	for(var/i in basic_modules)
 		var/obj/item/I = new i(src)
 		basic_modules += I
@@ -205,7 +204,7 @@
 	R.update_module_innate()
 	RM.rebuild_modules()
 	R.radio.recalculateChannels()
-	R.armor = getArmor(arglist(RM.module_armor))//RM.module_armor
+	R.armor = getArmor(arglist(RM.module_armor))
 
 	INVOKE_ASYNC(RM, PROC_REF(do_transform_animation))
 	qdel(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -16,6 +16,9 @@
 	speech_span = SPAN_ROBOT
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 | HEAR_1 | RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 
+	// Set during initialization. If initially a list, then the resulting armor will gain the listed armor values.
+	var/datum/armor/armor
+
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/last_lawchange_announce = 0
 	var/list/alarms_to_show = list()
@@ -60,7 +63,12 @@
 	diag_hud_set_status()
 	diag_hud_set_health()
 	ADD_TRAIT(src, TRAIT_FORCED_STANDING, "cyborg") // not CYBORG_ITEM_TRAIT because not an item
-
+	if (islist(armor))
+		armor = getArmor(arglist(armor))
+	else if (!armor)
+		armor = getArmor()
+	else if (!istype(armor, /datum/armor))
+		stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize(mapload)")
 
 /mob/living/silicon/med_hud_set_health()
 	return //we use a different hud
@@ -508,3 +516,29 @@
 			else
 				jobname = "Silicon"
 			msgr.username = "[newname] ([jobname])"
+
+/// Returns damage value after processing various factors like the silicon's armor and armor penetration.
+/mob/living/silicon/proc/run_armor(damage_amount, damage_type, damage_flag = 0, armor_penetration = 0)
+	if(damage_type != BRUTE && damage_type != BURN)
+		return 0
+	var/armor_protection = 0
+	if(damage_flag)
+		armor_protection = armor.getRating(damage_flag)
+	if(armor_protection) // Armour penetration only matters if the silicon has armour.
+		armor_protection = clamp(armor_protection - armor_penetration, min(armor_protection, 0), 100) // Reduce 'armor_protection' down by 'armor_penetration' to minimum of 0.
+	return clamp(damage_amount * (1 - armor_protection/100), 1, damage_amount) // Minimum of 1 damage.
+
+/// Copy of '/mob/living/attacked_by', except it sets damage to what is returned by 'proc/run_armor'.
+/mob/living/silicon/attacked_by(obj/item/I, mob/living/user)
+	send_item_attack_message(I, user)
+	if(I.force)
+		var/damage = run_armor(I.force, I.damtype, MELEE)
+		apply_damage(damage, I.damtype)
+		if(I.damtype == BRUTE)
+			if(prob(33))
+				I.add_mob_blood(src)
+				var/turf/location = get_turf(src)
+				add_splatter_floor(location)
+				if(get_dist(user, src) <= 1)
+					user.add_mob_blood(src)
+		return TRUE

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -16,7 +16,7 @@
 	speech_span = SPAN_ROBOT
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 | HEAR_1 | RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 
-	// Set during initialization. If initially a list, then the resulting armor will gain the listed armor values.
+	/// Set during initialization. If initially a list, then the resulting armor will gain the listed armor values.
 	var/datum/armor/armor
 
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -16,7 +16,7 @@
 			if(prob(8))
 				flash_act(affect_silicon = 1)
 			log_combat(M, src, "attacked")
-			adjustBruteLoss(damage)
+			adjustBruteLoss(run_armor(damage, BRUTE, MELEE))
 			updatehealth()
 		else
 			playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
@@ -26,7 +26,7 @@
 /mob/living/silicon/attack_animal(mob/living/simple_animal/M)
 	. = ..()
 	if(.)
-		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
+		var/damage = run_armor(rand(M.melee_damage_lower, M.melee_damage_upper), M.melee_damage_type, MELEE, M.armour_penetration)
 		if(prob(damage))
 			for(var/mob/living/N in buckled_mobs)
 				N.Paralyze(20)
@@ -48,7 +48,7 @@
 /mob/living/silicon/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	if(user.a_intent == INTENT_HARM)
 		..(user, 1)
-		adjustBruteLoss(rand(10, 15))
+		adjustBruteLoss(run_armor(rand(10, 15), BRUTE, MELEE))
 		playsound(loc, "punch", 25, 1, -1)
 		visible_message(span_danger("[user] has punched [src]!"), \
 				span_userdanger("[user] has punched [src]!"))
@@ -106,8 +106,9 @@
 /mob/living/silicon/bullet_act(obj/item/projectile/Proj, def_zone)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, Proj, def_zone)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-		adjustBruteLoss(Proj.damage)
-		if(prob(Proj.damage*1.5))
+		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.flag, Proj.armour_penetration)
+		adjustBruteLoss(damage)
+		if(prob(damage*1.5))
 			for(var/mob/living/M in buckled_mobs)
 				M.visible_message(span_boldwarning("[M] is knocked off of [src]!"))
 				unbuckle_mob(M)
@@ -124,4 +125,4 @@
 		return ..()
 
 /mob/living/silicon/rust_heretic_act()
-	adjustBruteLoss(500)
+	adjustBruteLoss(run_armor(500, BRUTE, MELEE)) // Not gonna survive this, but it was worth the try.


### PR DESCRIPTION
# Document the changes in your pull request
Partial port of ParadiseSS13/Paradise/pull/19986. 

Silicons now can have armor. By default, they have zero armor in all categories. 
The only cyborg module that will have armor will be mining which will get 20% melee armor.

Mining cyborgs can be upgraded up three times with goliath hide plates which increases melee armor by 10% each. 
Highest reachable melee armor they can reach is 50%.

Rationale from ported PR:
> Considering we are on lavaland, and mining borgs kinda don't have armor when everything hits like a truck, and while miners get meds and legion cores, and all mining cyborgs get is the worlds slowest self repair system, maybe they should have melee armor. So this pr does it. Yes, this makes mining cyborgs _slightly_ more robust for melee attacks for say, malf AI. However, they usually die by lasers or flash into baton, which is perma stun, so this will not be an issue.

# Wiki Documentation
Mining module gives 20% melee armor. 
They can get upgraded goliath hide plates up to 3 times. Each time increases melee armor by 10%.
<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog
:cl:  
rscadd: Mining Cyborgs start with 20% melee armor.
rscadd: Mining Cyborgs can be upgraded with goliath hide plates up to 3 times. Each time increases melee armor by 10%.
/:cl:
