### PR TITLE
fatal revival combat log runtime

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -121,7 +121,7 @@
 		podman.dna.species.exotic_blood = max(reagents_add) || /datum/reagent/water
 		log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 		to_chat(podman, span_userdanger("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>.")) //yogs
-		log_combat(podman, "was revived with memory loss")
+		log_combat(user, podman, "was revived with memory loss", src)
 
 	else //else, one packet of seeds. maybe two
 		var/seed_count = 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -578,7 +578,7 @@
 				to_chat(src, span_danger("As life pours back through your body, you struggle to recall what last happened to you; every memory before your death is hazy. You feel like you've been dead for too long"))
 				to_chat(src, span_userdanger("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
 				src.visible_message(span_danger("[src] stares ahead blankly, blinking a few times, as if they are trying to remember something."))
-				log_combat(src, "was revived with memory loss")
+				log_combat(src, src, "was revived with memory loss")
 			B.decay_progress = 0
 		if(IS_BLOODSUCKER(src))
 			var/datum/antagonist/bloodsucker/bloodsuckerdatum = src.mind.has_antag_datum(/datum/antagonist/bloodsucker)

--- a/code/modules/surgery/ipc_revival.dm
+++ b/code/modules/surgery/ipc_revival.dm
@@ -65,9 +65,9 @@
 		"[user] completes [target]'s reactivation.")
 	to_chat(target, span_danger("ERROR: Due to sudden system shutdown, this units Random Access Memory has been corrupted."))
 	to_chat(target, span_userdanger("You do not remember your death, how you died, or who killed you. <a href='https://forums.yogstation.net/help/rules/#rule-1_6'>See rule 1.6</a>."))
-	log_combat(target, "was revived with memory loss")
+	log_combat(user, target, "was revived with memory loss", tool)
 	return TRUE
-	
+
 /datum/surgery_step/revive_ipc/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
 		display_results(user, target, span_warning("You screw up, causing more damage!"),


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a runtime caused by incorrect usage of log_combat when reviving with memory loss

Probably caused some bugs

# Changelog

No user facing bugs that I am aware of