### PR TITLE
Fix rapid cable layer runtime caused by not containing its own cable stack

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -284,7 +284,7 @@
 
 /obj/item/twohanded/rcl/pre_loaded/Initialize(mapload) //Comes preloaded with cable, for testing stuff
 	. = ..()
-	loaded = new()
+	loaded = new(src)
 	loaded.max_amount = max_amount
 	loaded.amount = max_amount
 	update_appearance(UPDATE_ICON)


### PR DESCRIPTION
# Document the changes in your pull request

Caused by cable stack having a `null` loc when placing wires

code/modules/power/cable.dm L717-719
```
//create a new powernet with the cable, if needed it will be merged later
var/datum/powernet/newPN = new(loc.z)
newPN.add_cable(NC)
```

Probably caused terrible powernet errors

# Changelog

No user-facing bugs that I am aware of