### PR TITLE
Buffs backstab switchblade into damage slowdown and gives 100 AP on backstabs

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -442,7 +442,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/switchblade/backstab/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/backstabs, 2) // 40 damage
+	AddComponent(/datum/component/backstabs, 2, 2 SECONDS) // 40 damage, 2s CD
 
 /obj/item/phone
 	name = "red phone"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -442,7 +442,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/switchblade/backstab/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/backstabs, 1.75) // 35 damage
+	AddComponent(/datum/component/backstabs, 2) // 40 damage
 
 /obj/item/phone
 	name = "red phone"

--- a/yogstation/code/datums/components/backstabs.dm
+++ b/yogstation/code/datums/components/backstabs.dm
@@ -1,24 +1,46 @@
 /datum/component/backstabs
 	var/backstab_multiplier = 2 // 2x damage by default
+	var/stored_ap = 0
 
 /datum/component/backstabs/Initialize(mult)
 	backstab_multiplier = mult
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ITEM_PRE_ATTACK, PROC_REF(pre_attack))
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(on_attack))
 
-/datum/component/backstabs/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
+/datum/component/backstabs/proc/can_backstab(obj/item/source, atom/target, mob/living/user)
+	if(!isliving(target))
+		return FALSE
+	var/mob/living/living_target = target
 	// No bypassing pacifism nerd
 	if(source.force > 0 && HAS_TRAIT(user, TRAIT_PACIFISM) && (source.damtype != STAMINA))
-		return
+		return FALSE
 	// Same calculation that kinetic crusher uses
-	var/backstab_dir = get_dir(user, target)
+	var/backstab_dir = get_dir(user, living_target)
 	// No backstabbing people if they're already in crit
-	if(!target.stat && (user.dir & backstab_dir) && (target.dir & backstab_dir))
-		var/multi = backstab_multiplier - 1
-		var/dmg = source.force * multi
-		if(dmg) // Truthy because backstabs can heal lol
-			target.apply_damage(dmg, source.damtype, BODY_ZONE_CHEST, 0, source.wound_bonus*multi, source.bare_wound_bonus*multi, source.sharpness*multi)
-			log_combat(user, target, "scored a backstab", source.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(source.damtype)])")
-			if(iscarbon(target))
-				target.emote("scream") // SPY AROUND HERE
+	if(living_target.stat || !(user.dir & backstab_dir) || !(living_target.dir & backstab_dir))
+		return FALSE
+	return TRUE
+
+/datum/component/backstabs/proc/pre_attack(obj/item/source, atom/target, mob/living/user)
+	SIGNAL_HANDLER
+	if(!can_backstab(source, target, user))
+		return
+	stored_ap = source.armour_penetration
+	source.armour_penetration = 100
+
+/datum/component/backstabs/proc/on_attack(obj/item/source, mob/living/target, mob/living/user)
+	// SIGNAL_HANDLER // screaming doesn't sleep!!
+	if(!can_backstab(source, target, user))
+		return
+	source.armour_penetration = stored_ap
+	var/multi = backstab_multiplier - 1
+	var/dmg = source.force * multi
+	if(dmg) // Truthy because backstabs can heal lol
+		target.apply_damage(dmg, source.damtype, BODY_ZONE_CHEST, 0, source.wound_bonus*multi, source.bare_wound_bonus*multi, source.sharpness*multi)
+		log_combat(user, target, "scored a backstab", source.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(source.damtype)])")
+		if(iscarbon(target))
+			// extra safe to ensure no sleeping
+			var/datum/emote/living/scream/scream_emote = new
+			scream_emote.run_emote(scream_emote) // SPY AROUND HERE

--- a/yogstation/code/datums/components/backstabs.dm
+++ b/yogstation/code/datums/components/backstabs.dm
@@ -34,7 +34,6 @@
 	// SIGNAL_HANDLER // screaming doesn't sleep!!
 	if(!can_backstab(source, target, user))
 		return
-	source.armour_penetration = stored_ap
 	var/multi = backstab_multiplier - 1
 	var/dmg = source.force * multi
 	if(dmg) // Truthy because backstabs can heal lol
@@ -44,3 +43,4 @@
 			// extra safe to ensure no sleeping
 			var/datum/emote/living/scream/scream_emote = new
 			scream_emote.run_emote(scream_emote) // SPY AROUND HERE
+	source.armour_penetration = stored_ap


### PR DESCRIPTION
# Document the changes in your pull request

The switchblade is woefully underused, hopefully damage slowdown will see it more useful alongside items like the energy dagger

# Changelog

:cl:  
tweak: Backstabbing switchblade now deals 40 total damage with 100 AP on backstabs
/:cl:
