### PR TITLE
You Can Now Alt-Click to Toggle Lock Robots

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -540,18 +540,7 @@
 			to_chat(user, span_warning("Unable to locate a radio!"))
 
 	else if(W.GetID())			// trying to unlock the interface with an ID card
-		if(opened)
-			to_chat(user, span_warning("You must close the cover to swipe an ID card!"))
-		else
-			if(allowed(usr))
-				locked = !locked
-				to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] [src]'s cover."))
-				to_chat(src, span_notice("[usr] [locked ? "locks" : "unlocks"] your cover."))
-				update_icons()
-				if(emagged)
-					to_chat(user, span_notice("The cover interface glitches out for a split second."))
-			else
-				to_chat(user, span_danger("Access denied."))
+		togglelock(user)
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
@@ -604,6 +593,23 @@
 			to_chat(user, span_notice("You replace the headlamp bulb.")) //yogs end
 	else
 		return ..()
+
+/mob/living/silicon/robot/proc/togglelock(mob/user)
+	if(opened)
+		to_chat(user, span_warning("You must close the cover to swipe an ID card!"))
+	else
+		if(allowed(user))
+			locked = !locked
+			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] [src]'s cover."))
+			to_chat(src, span_notice("[user] [locked ? "locks" : "unlocks"] your cover."))
+			update_icons()
+			if(emagged)
+				to_chat(user, span_notice("The cover interface glitches out for a split second."))
+		else
+			to_chat(user, span_danger("Access denied."))
+
+/mob/living/silicon/robot/AltClick(mob/user)
+	togglelock(user)
 
 /mob/living/silicon/robot/verb/unlock_own_cover()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -298,16 +298,7 @@
 		else
 			to_chat(user, span_warning("The maintenance panel is locked."))
 	else if(W.GetID())
-		if(bot_core.allowed(user) && !open && !emagged)
-			locked = !locked
-			to_chat(user, "Controls are now [locked ? "locked." : "unlocked."]")
-		else
-			if(emagged)
-				to_chat(user, span_danger("ERROR"))
-			if(open)
-				to_chat(user, span_warning("Please close the access panel before locking it."))
-			else
-				to_chat(user, span_warning("Access denied."))
+		togglelock(user)
 	else if(istype(W, /obj/item/paicard))
 		insertpai(user, W)
 	else if(istype(W, /obj/item/hemostat) && paicard)
@@ -336,6 +327,21 @@
 			if(W.force) //if force is non-zero
 				do_sparks(5, TRUE, src)
 			..()
+
+/mob/living/simple_animal/bot/proc/togglelock(mob/user)
+	if(bot_core.allowed(user) && !open && !emagged)
+		locked = !locked
+		to_chat(user, "Controls are now [locked ? "locked." : "unlocked."]")
+	else
+		if(emagged)
+			to_chat(user, span_danger("ERROR"))
+		if(open)
+			to_chat(user, span_warning("Please close the access panel before locking it."))
+		else
+			to_chat(user, span_warning("Access denied."))
+
+/mob/living/simple_animal/bot/AltClick(mob/user)
+	togglelock(user)
 
 /mob/living/simple_animal/bot/bullet_act(obj/item/projectile/Proj)
 	if(Proj && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))


### PR DESCRIPTION
# Document the changes in your pull request
Port of BeeStation/BeeStation-Hornet/pull/1313
Assuming you have the required access, you can alt-click to toggle lock covers belonging to robots (simple bots & cyborgs).

Quality of Life.

# Changelog
:cl:  
tweak: You can now alt-click robots to toggle their lock.
/:cl:
