### PR TITLE
Liver failure stops metabolism correctly

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -46,8 +46,8 @@
 			if(provide_pain_message && damage > 10 && prob(damage/3))//the higher the damage the higher the probability
 				to_chat(C, span_warning("You feel a dull pain in your abdomen."))
 		else	//for when our liver's failing
-			reagents.end_metabolization(C, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
-			reagents.metabolize(C, can_overdose=FALSE, liverless = TRUE)
+			C.reagents.end_metabolization(C, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
+			C.reagents.metabolize(C, can_overdose=FALSE, liverless = TRUE)
 			if(HAS_TRAIT(C, TRAIT_STABLELIVER))
 				return
 			C.adjustToxLoss(4, TRUE,  TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

Fixed an error that caused reagents to never stop metabolizing when your liver fails

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed liver failure not stopping metabolism
/:cl:
