### PR TITLE
Fixed a minor issue with bloodsuckers

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsuckers.dm
@@ -562,10 +562,10 @@
 		newheart.beating = initial(newheart.beating)
 	var/obj/item/organ/eyes/user_eyes = user.getorganslot(ORGAN_SLOT_EYES)
 	if(user_eyes)
-		user_eyes.flash_protect += 1
-		user_eyes.sight_flags = 0
-		user_eyes.see_in_dark = 2
-		user_eyes.lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
+		user_eyes.flash_protect = initial(user_eyes.flash_protect)
+		user_eyes.sight_flags = initial(user_eyes.sight_flags)
+		user_eyes.see_in_dark = initial(user_eyes.see_in_dark)
+		user_eyes.lighting_alpha = initial(user_eyes.lighting_alpha)
 	user.update_sight()
 
 /datum/antagonist/bloodsucker/proc/give_masquerade_infraction()


### PR DESCRIPTION
# Document the changes in your pull request

Losing bloodsucker antag datum sets your eyes to the default values of human eyes, but not everyone has human eyes. This changes it to set them to their initial values instead.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed eyes not being set back to normal correctly when losing bloodsucker antag datum
/:cl:
