### PR TITLE
[PORT] Adds Baldium, the opposite of Barber's Aid

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -46,6 +46,7 @@
 		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,
 		/datum/reagent/concentrated_barbers_aid,
+		/datum/reagent/baldium,
 		/datum/reagent/colorful_reagent,
 		/datum/reagent/peaceborg/confuse,
 		/datum/reagent/peaceborg/tire,

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1864,6 +1864,26 @@
 			H.facial_hair_style = "Beard (Very Long)"
 			H.update_hair()
 
+/datum/reagent/baldium
+	name = "Baldium"
+	description = "A major cause of hair loss across the world."
+	reagent_state = LIQUID
+	color = "#ecb2cf"
+	taste_description = "bitterness"
+
+/datum/reagent/baldium/reaction_mob(mob/living/M, methods, reac_volume, show_message, permeability)
+	. = ..()
+	if(!(methods & (TOUCH|VAPOR)))
+		return
+	if(!permeability)
+		return
+	if(M && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		to_chat(H, span_danger("Your hair starts to fall out in clumps!"))
+		H.hair_style = "Bald"
+		H.facial_hair_style = "Shaved"
+		H.update_hair()
+
 /datum/reagent/saltpetre
 	name = "Saltpetre"
 	description = "Volatile. Controversial. Third Thing."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -709,7 +709,7 @@
 /datum/chemical_reaction/baldium
 	name = /datum/reagent/baldium
 	id = /datum/reagent/baldium
-	results = list(/datum/reagent/baldium = 1)
+	results = list(/datum/reagent/baldium = 3)
 	required_reagents = list(/datum/reagent/uranium/radium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/lye = 1)
 	required_temp = 374
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -706,6 +706,13 @@
 	results = list(/datum/reagent/concentrated_barbers_aid = 2)
 	required_reagents = list(/datum/reagent/barbers_aid = 1, /datum/reagent/toxin/mutagen = 1)
 
+/datum/chemical_reaction/baldium
+	name = /datum/reagent/baldium
+	id = /datum/reagent/baldium
+	results = list(/datum/reagent/baldium = 1)
+	required_reagents = list(/datum/reagent/uranium/radium = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/lye = 1)
+	required_temp = 374
+
 /datum/chemical_reaction/saltpetre
 	name = /datum/reagent/saltpetre
 	id = /datum/reagent/saltpetre


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new chem called Baldium. It makes you bald.

To make it, mix equal parts radium, lye, and sulfuric acid and heat to 374 kelvin.

From tgstation/tgstation#48409

# Why it's good for the game

I think it's funny, and has the potential for chemists to do funny gimmicks with it.

# Wiki Documentation

Add Baldium to the guide to chemistry in the "other recipes" section:
- Recipe: 1 radium + 1 lye + 1 sulfuric acid -> 3 baldium
- Required temperature: >= 374 kelvin
- Reagent color: #ecb2cf
- Description: Causes baldness.
- No OD/addiction effects

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: adds baldium, the opposite of barber's aid
/:cl:
