### PR TITLE
Ion Carbines are now bulky.

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -19,7 +19,7 @@
 	name = "ion carbine"
 	desc = "The MK.II Prototype Ion Projector is a lightweight carbine version of the larger ion rifle, built to be ergonomic and efficient."
 	icon_state = "ioncarbine"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BELT
 	pin = null
 	ammo_x_offset = 2


### PR DESCRIPTION
Ion Carbines are no longer normal sized. WTs got similar treatment, being able to load up on cheap, easily producible ion weapons is silly. 

# Changelog

:cl:  
tweak: Ion Carbines weight moved from NORMAL to BULKY
/:cl:
