### PR TITLE
Fixes the canister UI

### DIFF
--- a/tgui/packages/tgui/interfaces/Canister.js
+++ b/tgui/packages/tgui/interfaces/Canister.js
@@ -20,7 +20,7 @@ export const Canister = (props, context) => {
     restricted,
   } = data;
   return (
-    <Window width={300} height={232} resizable>
+    <Window width={300} height={254} resizable>
       <Window.Content>
         <Section
           title="Canister"

--- a/tgui/packages/tgui/interfaces/Canister.js
+++ b/tgui/packages/tgui/interfaces/Canister.js
@@ -42,7 +42,7 @@ export const Canister = (props, context) => {
                 onClick={() => act('relabel')} />
             </>
           )}>
-          <LabeledControls>
+          <LabeledControls justify="center">
             <LabeledControls.Item
               minWidth="66px"
               label="Pressure">
@@ -66,7 +66,7 @@ export const Canister = (props, context) => {
                   maxValue={maxReleasePressure}
                   step={5}
                   stepPixelSize={0.75}
-                  width={10}
+                  width={8}
                   format={value => value + "kPa"}
                   onDrag={(e, value) => act('pressure', {
                     pressure: value,
@@ -93,18 +93,8 @@ export const Canister = (props, context) => {
                   })} />
               </Box>
             </LabeledControls.Item>
-            <LabeledControls.Item label="Valve">
-              <Button
-                my={0.5}
-                width="75px"
-                lineHeight={2}
-                fontSize="11px"
-                color={valveOpen
-                  ? (hasHoldingTank ? 'caution' : 'danger')
-                  : null}
-                content={valveOpen ? 'Open' : 'Closed'}
-                onClick={() => act('valve')} />
-            </LabeledControls.Item>
+          </LabeledControls>
+          <LabeledControls justify="center">
             <LabeledControls.Item
               mr={1}
               label="Port">
@@ -119,6 +109,18 @@ export const Canister = (props, context) => {
                     : 'Disconnected'}
                   position="top" />
               </Box>
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Valve">
+              <Button
+                my={0.5}
+                width="75px"
+                lineHeight={2}
+                fontSize="11px"
+                color={valveOpen
+                  ? (hasHoldingTank ? 'caution' : 'danger')
+                  : null}
+                content={valveOpen ? 'Open' : 'Closed'}
+                onClick={() => act('valve')} />
             </LabeledControls.Item>
           </LabeledControls>
         </Section>


### PR DESCRIPTION
# Document the changes in your pull request

New UI

![image](https://github.com/yogstation13/Yogstation/assets/53777086/3bb69045-7cb1-49c7-b4cf-0065f91e7e62)
![image](https://github.com/yogstation13/Yogstation/assets/53777086/d1349bb4-30d8-44b1-a05a-0b0f6928bfc6)

There has always had a port button on canister UIs but it was always hidden because of the pressure/Regulator/valve button, and you'd have to resize the window horizontally to find it.
This makes it actually visible to players in-game.

# Changelog

:cl:  
bugfix: Canister UIs no longer have their port hidden.
/:cl:
