### PR TITLE
Allows traitors to buy an unstackable version of the microbomb implant

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -83,6 +83,14 @@
 		imp_in.gib(1)
 	qdel(src)
 
+/// Unstackable microbomb - Can only fit the one.
+/obj/item/implant/explosive/unstackable/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	for(var/X in target.implants)
+		if(istype(X, type))
+			return FALSE
+
+	return ..()
+
 /obj/item/implant/explosive/macro
 	name = "macrobomb implant"
 	desc = "And boom goes the weasel. And everything else nearby."
@@ -118,6 +126,15 @@
 	name = "implant case - 'Explosive'"
 	desc = "A glass case containing an explosive implant."
 	imp_type = /obj/item/implant/explosive
+
+/obj/item/implanter/explosive/unstackable
+	name = "implanter (weak microbomb)"
+	imp_type = /obj/item/implant/explosive/unstackable
+
+/obj/item/implantcase/explosive/unstackable
+	name = "implant case - 'Weak Explosive'"
+	desc = "A glass case containing a weak explosive implant."
+	imp_type = /obj/item/implant/explosive/unstackable
 
 /obj/item/implanter/explosive_macro
 	name = "implanter (macrobomb)"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -523,6 +523,12 @@
 /obj/item/storage/box/syndie_kit/imp_microbomb/PopulateContents()
 	new /obj/item/implanter/explosive(src)
 
+/obj/item/storage/box/syndie_kit/imp_microbomb_tot
+	real_name = "weak microbomb implant box"
+
+/obj/item/storage/box/syndie_kit/imp_microbomb_tot/PopulateContents()
+	new /obj/item/implanter/explosive/unstackable(src)
+
 /obj/item/storage/box/syndie_kit/imp_macrobomb
 	real_name = "macrobomb implant box"
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2062,6 +2062,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
 
+/// For traitors, microbomb that can't be stacked
+/datum/uplink_item/implants/traitor_microbomb
+	name = "Weak Microbomb Implant"
+	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \
+			This implant, unlike its nuclear counterpart, cannot be stacked. \
+			This will permanently destroy your body, however."
+	item = /obj/item/storage/box/syndie_kit/imp_microbomb_tot
+	cost = 1
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
+
 /datum/uplink_item/implants/macrobomb
 	name = "Macrobomb Implant"
 	desc = "An implant injected into the body, and later activated either manually or automatically upon death. \


### PR DESCRIPTION
# Document the changes in your pull request

Costs 1TC and cannot stack unlike nuclear microbomb implants.

I figure a C4 costs 1TC and achieves basically the same goal with a health/voice sensors, why not let them have it.

# Changelog

:cl:  
rscadd: Added an unstackable "weak" microbomb implant available for purchase by traitors for 1TC
/:cl:
