### PR TITLE
Makes ion carbines actually shoot the weaker ion projectiles like was stated in a PR 6 months ago

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -22,6 +22,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	pin = null
+	ammo_type = list(/obj/item/ammo_casing/energy/ion/hos)
 	ammo_x_offset = 2
 	flight_x_offset = 18
 	flight_y_offset = 11

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -22,7 +22,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 	pin = null
-	ammo_type = list(/obj/item/ammo_casing/energy/ion/hos)
+	ammo_type = list(/obj/item/ammo_casing/energy/ion/weak)
 	ammo_x_offset = 2
 	flight_x_offset = 18
 	flight_y_offset = 11


### PR DESCRIPTION
#17707

Pretty sure other changes from that PR weren't actually made, but this is the only one that actually seems to matter right now

:cl:  
bugfix: ion carbines now ACTUALLY shoot weaker bullets like was intended in a PR 6 months ago
/:cl:
