### PR TITLE
Rebalances syndicate bounties.

### DIFF
--- a/code/modules/cargo/bounties/syndicate.dm
+++ b/code/modules/cargo/bounties/syndicate.dm
@@ -25,7 +25,7 @@
 	name = "!&@#AI CONTROL CONSOLE BOARD!#@*$"
 	description = "!&@#A CONSOLE TO REMOTELY DISABLE AI UNITS WOULD BE QUITE HELPFUL FOR US, SO GET US ONE!#@*$"
 	wanted_types = list(/obj/item/circuitboard/computer/ai_upload_download)
-	reward = 6
+	reward = 2
 /datum/bounty/item/syndicate/rdsuit
 	name = "!&@#PROTOTYPE HARDSUIT!#@*$"
 	description = "!&@#WE'RE INTERESTED IN DEVELOPING ARMOR THAT CAN RESIST EXPLOSIVES BETTER. THE PROTOTYPE HARDSUIT WOULD BE HELPFUL FOR THIS GOAL!#@*$"
@@ -35,13 +35,13 @@
 	name = "!&@#BAG OF HOLDING!#@*$"
 	description = "!&@#EXPERIMENTAL BLUESPACE TECHNOLOGY LIKE A BAG OF HOLDING WOULD BE APPRECIATED BY THE LAB BOYS. THEY'RE WILLING TO PAY HANDSOMELY, TOO#@*$"
 	wanted_types = list(/obj/item/storage/backpack/holding,/obj/item/storage/backpack/holding/rd)
-	reward = 7
+	reward = 4
 /datum/bounty/item/syndicate/aeg
 	name = "!&@#ADVANCED ENERGY GUN!#@*$"
 	description = "!&@#WE'RE LOOKING FOR FLAWS IN NANOTRASEN WEAPONS TECHNOLOGY TO EXPLOIT. SEND US SOME EXAMPLES OF THEIR TECHNOLOGY, AND WE'LL REWARD YOU#@*$"
 	wanted_types = list(/obj/item/gun/energy/e_gun/nuclear)
 	required_count = 3
-	reward = 4
+	reward = 5
 /datum/bounty/item/syndicate/aiupload
 	name = "!&@#AI UPLOAD CONSOLE BOARD!#@*$"
 	description = "!&@#WE'RE PROBING NANOTRASEN AIS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOAL#@*$"
@@ -51,12 +51,12 @@
 	name = "!&@#CYBORG UPLOAD CONSOLE BOARD!#@*$"
 	description = "!&@#WE'RE PROBING NANOTRASEN CYBORGS FOR SECURITY FLAWS. A CONSOLE LIKE THIS COULD ACCOMPLISH OUR GOAL#@*$"
 	wanted_types = list(/obj/item/circuitboard/computer/borgupload)
-	reward = 3
+	reward = 2
 /datum/bounty/item/syndicate/wardenshotgun
 	name = "!&@#COMPACT COMBAT SHOTGUN!#@*$"
 	description = "!&@#WHILE INFERIOR TO OUR BULLDOG SHOTGUNS, COMPACT COMBAT SHOTGUNS CONTAIN AN EXPENSIVE PART THAT'S REQUIRED TO MANUFACTURE BULLDOG SHOTGUNS. YOU'LL SAVE US A PRETTY PENNY BY GIVING US ONE, AND WE'LL PAY YOU IN RETURN#@*$"
 	wanted_types = list(/obj/item/gun/ballistic/shotgun/automatic/combat/compact)
-	reward = 8 //you gotta kill the warden
+	reward = 5 //you gotta kill the warden //not harder than killing a captain
 /datum/bounty/item/syndicate/advancedhardsuit
 	name = "!&@#ADVANCED HARDSUIT!#@*$"
 	description = "!&@#THE RADIATION SHIELDING BUILT INTO THE ADVANCED HARDSUIT IS SERIOUSLY HIGH-TECH, AND WE WANT A GOOD LOOK AT IT. BRING IT TO US AND WE'LL GIVE YOU A REWARD.#@*$"
@@ -66,4 +66,4 @@
 	name = "!&@#PHAZON EXOSUIT!#@*$"
 	description = "!&@#WE'D LOVE TO GET OUR HANDS ON ONE OF THESE. IT MAY BE HARD TO SOURCE, BUT WE WILL REWARD YOU GENEROUSLY IF YOU SUCCEED.#@*$"
 	wanted_types = list(/obj/mecha/combat/phazon)
-	reward = 12 //you need an anomaly core and robotics for this one broski, it's gotta be worth a lot
+	reward = 10 //you need an anomaly core and robotics for this one broski, it's gotta be worth a lot


### PR DESCRIPTION
# Document the changes in your pull request
IDK where most of these numbers came from, you could get 16tc for killing the rd and raiding his shit, insanely overpriced.
Killing an rd was more valuable than killing the captain, which it shouldn't be.

AI Control Board reduced from 6 to 3 TC reward
BoH reduced from 7 to 4, you don't even need to kill an rd for this, literally just wait for an anomaly
AEG raised from 4 to 5
Cyborg upload console changed from 3 to 2, youre already getting an ai upload board by getting this one
Warden shotgun reduced from 8 to 5, not harder than killing a captain
Phazon reduced from 12 to 10, still valuable but not that valuable.


# Wiki Documentation
Probably mention these new reward prices on the wiki

# Changelog
:cl:  
tweak: Rebalanced syndicate bounties
/:cl:
