### PR TITLE
Worldbreaker balance PR (again)

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -467,8 +467,10 @@
 	for(var/obj/item/I in range(1, get_turf(target)))
 		push_away(user, I)
 	for(var/obj/structure/S in range(1, get_turf(target)))
-		S.take_damage(25)
-		
+		S.take_damage(30)
+	for(var/obj/machinery/M in range(1, get_turf(target)))
+		S.take_damage(20) //machinery is still important so it does less
+
 /*---------------------------------------------------------------
 	end of pummel section
 ---------------------------------------------------------------*/
@@ -542,6 +544,8 @@
 		linked_martial.push_away(owner, I, 2)
 	for(var/obj/structure/S in range(actual_range/2, owner))
 		S.take_damage(25 + (plates * 3))
+	for(var/obj/machinery/M in range(actual_range/2, owner))
+		S.take_damage(10) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
 
 	if(get_turf(owner))//fuck that tile up
 		var/turf/open/floor/target = get_turf(owner)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -469,7 +469,7 @@
 	for(var/obj/structure/S in range(1, get_turf(target)))
 		S.take_damage(30)
 	for(var/obj/machinery/M in range(1, get_turf(target)))
-		S.take_damage(20) //machinery is still important so it does less
+		M.take_damage(20) //machinery is still important so it does less
 
 /*---------------------------------------------------------------
 	end of pummel section
@@ -545,7 +545,7 @@
 	for(var/obj/structure/S in range(actual_range/2, owner))
 		S.take_damage(25 + (plates * 3))
 	for(var/obj/machinery/M in range(actual_range/2, owner))
-		S.take_damage(10) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
+		M.take_damage(10) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
 
 	if(get_turf(owner))//fuck that tile up
 		var/turf/open/floor/target = get_turf(owner)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -58,8 +58,10 @@
 	if(!can_use(H) || (modifiers["shift"] || modifiers["alt"] || modifiers["ctrl"]))
 		return
 
-	if(isobj(target) && target.loc == H) //no using abilities on your own items
-		return
+	if(isitem(target))//don't attack if we're clicking on our inventory
+		var/obj/item/thing = target
+		if(target.item_flags & IN_INVENTORY)
+			return
 
 	if(H.a_intent == INTENT_DISARM)
 		leap(H, target)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -60,7 +60,7 @@
 
 	if(isitem(target))//don't attack if we're clicking on our inventory
 		var/obj/item/thing = target
-		if(target.item_flags & IN_INVENTORY)
+		if(thing.item_flags & IN_INVENTORY)
 			return
 
 	if(H.a_intent == INTENT_DISARM)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -296,9 +296,10 @@
 		push_away(user, L)
 		if(L.loc == user.loc && isanimal(L) && L.stat == DEAD)
 			L.gib()
-	for(var/obj/item/I in range(range, user))
-		push_away(user, I)
 	for(var/obj/obstruction in range(range, user))
+		if(isitem(obstruction))
+			push_away(user, obstruction)
+			continue
 		if(!isstructure(obstruction) && !ismachinery(obstruction))
 			continue
 		var/damage = 5
@@ -478,9 +479,10 @@
 			L.anchored = FALSE
 		push_away(user, L)
 		hurt(user, L, damage)
-	for(var/obj/item/I in range(1, get_turf(target)))
-		push_away(user, I)
 	for(var/obj/obstruction in range(1, get_turf(target)))
+		if(isitem(obstruction))
+			push_away(user, obstruction)
+			continue
 		if(!isstructure(obstruction) && !ismachinery(obstruction))
 			continue
 		var/damage = 10

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -305,7 +305,7 @@
 		var/damage = 5
 		if(obstruction.loc == user.loc)
 			damage *= 3
-		obstruction.take_damage(damage, sound_effect = prob(50)) //reduced sound from hitting LOTS of things
+		obstruction.take_damage(damage, sound_effect = FALSE) //reduced sound from hitting LOTS of things
 
 	animate(user, time = 0.1 SECONDS, pixel_y = 0)
 	playsound(user, 'sound/effects/gravhit.ogg', 20, TRUE)
@@ -569,7 +569,7 @@
 		var/damage = 10
 		if(isstructure(obstruction)) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
 			damage += 15 + (plates * 3)
-		obstruction.take_damage(damage)
+		obstruction.take_damage(damage) //we WANT this one to be loud
 
 	if(get_turf(owner))//fuck that tile up
 		var/turf/open/floor/target = get_turf(owner)

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -22,6 +22,7 @@
 #define THROW_TOSSDMG 10 //the damage dealt by the initial throw
 #define THROW_SLAMDMG 5 //the damage dealt per object impacted during a throw
 #define THROW_OBJDMG 500 //Total amount of structure damage that can be done
+#define COOLDOWN_GRAB 0.8 SECONDS //basically just to prevent infinite stunlock spam
 
 /datum/martial_art/worldbreaker
 	name = "Worldbreaker"
@@ -31,6 +32,7 @@
 	var/recalibration = /mob/living/carbon/human/proc/worldbreaker_recalibration
 	var/list/thrown = list()
 	COOLDOWN_DECLARE(next_leap)
+	COOLDOWN_DECLARE(next_grab)
 	COOLDOWN_DECLARE(next_balloon)
 	COOLDOWN_DECLARE(next_pummel)
 	var/datum/action/cooldown/worldstomp/linked_stomp
@@ -339,6 +341,11 @@
 	target.add_fingerprint(user, FALSE)
 
 	if(isliving(target) && target != user)
+		if(!COOLDOWN_FINISHED(src, next_grab))
+			return
+		COOLDOWN_START(src, next_grab, COOLDOWN_GRAB)
+		user.changeNext_move(COOLDOWN_GRAB + 1)
+
 		playsound(user, 'sound/weapons/thudswoosh.ogg', 65, FALSE, -1) //play sound here incase some ungrabbable object was clicked
 		var/mob/living/victim = target
 		var/obj/structure/bed/grip/F = new(Z, user) // Buckles them to an invisible bed
@@ -703,3 +710,4 @@
 #undef THROW_TOSSDMG
 #undef THROW_SLAMDMG
 #undef THROW_OBJDMG
+#undef COOLDOWN_GRAB

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -192,7 +192,8 @@
 
 	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
 	if(plate_change)
-		user.physiology.armor = user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
+		var/final = plate_change * PLATE_REDUCTION
+		user.physiology.armor = user.physiology.armor.modifyRating(final, final, final, final, final, 0, final, final, final, final, final)//literally everything EXCEPT for bio, because otherwise we become immune to water
 
 	plates = clamp(plates + amount, 0, PLATE_CAP)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -146,7 +146,7 @@
 		return
 
 	if(damagetype != BRUTE && damagetype != BURN)
-		damage /= 4 //brute and burn are most effective
+		damage /= 3 //brute and burn are most effective
 
 	currentplate += damage
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -201,8 +201,7 @@
 
 	var/plate_change = clamp(amount + plates, 0, MAX_PLATES) - min(plates, MAX_PLATES)
 	if(plate_change)
-		var/final = plate_change * PLATE_REDUCTION
-		user.physiology.armor = user.physiology.armor.modifyRating(final, final, final, final, final, 0, final, final, final, final, final)//literally everything EXCEPT for bio, because otherwise we become immune to water
+		user.physiology.armor = user.physiology.armor.modifyAllRatings(plate_change * PLATE_REDUCTION)
 
 	plates = clamp(plates + amount, 0, PLATE_CAP)
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -71,6 +71,9 @@
 	if(!H.Adjacent(target) || H==target)
 		return
 
+	if(isobj(target) && target.loc == H) //no punching your own items
+		return
+
 	if(H.a_intent == INTENT_HARM)
 		pummel(H,target)
 	if(H.a_intent == INTENT_GRAB && isliving(target))
@@ -291,6 +294,10 @@
 			L.gib()
 	for(var/obj/item/I in range(range, user))
 		push_away(user, I)
+	for(var/obj/structure/S in range(range, user))
+		S.take_damage(5, sound_effect = FALSE)//reduced sound from hitting LOTS of things
+	for(var/obj/machinery/M in range(range, user))
+		M.take_damage(5, sound_effect = FALSE)
 
 	animate(user, time = 0.1 SECONDS, pixel_y = 0)
 	playsound(user, 'sound/effects/gravhit.ogg', 20, TRUE)
@@ -374,7 +381,7 @@
 
 	var/dir_to_target = get_dir(get_turf(tossed), target) //vars that let the thing be thrown while moving similar to things thrown normally
 	var/turf/T = get_step(get_turf(tossed), dir_to_target)
-	if(T.density) // crash into a wall and damage everything flying towards it before stopping 
+	if(T?.density) // crash into a wall and damage everything flying towards it before stopping 
 		for(var/mob/living/victim in thrown)
 			hurt(user, victim, THROW_SLAMDMG) 
 			victim.Knockdown(1 SECONDS)
@@ -450,7 +457,7 @@
 	shockwave.pixel_x = -240
 	shockwave.pixel_y = -240
 	shockwave.alpha = 100 //slightly weaker looking
-	animate(shockwave, alpha = 0, transform = matrix().Scale(0.2), time = 3)
+	animate(shockwave, alpha = 0, transform = matrix().Scale(0.25), time = 3)
 	QDEL_IN(shockwave, 4)
 
 	for(var/mob/living/L in range(1, get_turf(target)))
@@ -467,9 +474,9 @@
 	for(var/obj/item/I in range(1, get_turf(target)))
 		push_away(user, I)
 	for(var/obj/structure/S in range(1, get_turf(target)))
-		S.take_damage(30)
+		S.take_damage(30, sound_effect = FALSE) //reduced sound from hitting LOTS of things
 	for(var/obj/machinery/M in range(1, get_turf(target)))
-		M.take_damage(20) //machinery is still important so it does less
+		M.take_damage(20, sound_effect = FALSE) //machinery is important so it does less
 
 /*---------------------------------------------------------------
 	end of pummel section


### PR DESCRIPTION
Sure this increases max amount of armour to 100, however with the reduction to the maximum amount of plates it will be
138 total damage reduction before
120 total damage reduction after

The main thing is it'll reduce the downtime of waiting for plates to stack up from 0 without actually making plates grow faster
as well as removing chip damage while heavy

Plates not getting affected at all by other damage types made stamina weapons completely useless and forced the armoury to be opened immediately
Now other types of weapons weapons DO work, but less effectively at 1/3 their original damage
Technically a baton will be better at breaking plates than a vibro blade, but meleeing someone with a martial art is a dumb idea in the first place

being heavy no longer increases damage as durability, speed, and knockback scaling with heavy was enough of a distinction
as well, damage being inconsistent between weights felt worse than it needed to
The damage was averaged, so being heavy will do less damage and being light will do more damage than before
grab never scaled damage with heavy so it's untouched

Removes AP because the martial art already does enough, it doesn't need to almost entirely ignore armour too
Still does 50/50 melee/bomb though, so it'll 'effectively' have some AP as not many melee armours also have bomb armour

:cl:  
tweak: Worldbreaker tweaks
tweak: plates give 20 armour instead of 10
tweak: max plates that can give armour is 5 down from 8
tweak: max plates is 10 down from 15
tweak: worldstomp base radius increased to 8
tweak: all AP removed
tweak: all damage also does 2x that as stamina damage
tweak: damage types other than brute and burn are now able to break plates, but at 1/3 effect
tweak: plates only knock back and stagger if thrown by the worldbreaker
tweak: being heavy no longer increases damage
tweak: leap does 20 instead of 15/25
tweak: worldstomp does 15 base instead of 20/10
tweak: pummel does 15 instead of 18/12
tweak: pummel targets a tile instead of mob
tweak: pummel and leap can damage structures
tweak: pummel, leap, and worldstomp can now damage machinery, but significantly less damage than structures
bugfix: grab has a cooldown
/:cl:
