### PR TITLE
Open containers can now interact with syringes again

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -14,10 +14,10 @@
 #define SPILLABLE		(1<<7)  // Can be spilled or splashed onto an atom
 
 // Is an open container for all intents and purposes.
-#define OPENCONTAINER 	(REFILLABLE | DRAINABLE | TRANSPARENT | SPILLABLE)
+#define OPENCONTAINER 	(INJECTABLE | DRAWABLE | REFILLABLE | DRAINABLE | TRANSPARENT | SPILLABLE)
 
 // Is an open container for all intents and purposes, but can't spill for whatever reason.
-#define OPENCONTAINER_NOSPILL 	(REFILLABLE | DRAINABLE | TRANSPARENT)
+#define OPENCONTAINER_NOSPILL 	(INJECTABLE | DRAWABLE | REFILLABLE | DRAINABLE | TRANSPARENT)
 
 
 #define TOUCH			(1<<0)	// splashing, foam


### PR DESCRIPTION
You're telling me that a vial or beaker which literally has an open top, can't interact with a syringe in any way?

:cl:  
bugfix: Syringes can draw from and inject into vials and beakers again (among other things)
/:cl:
