### PR TITLE
Makes the all terrain vehicle actually all terrain

### DIFF
--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -5,6 +5,7 @@
 	icon_state = "atv"
 	key_type = /obj/item/key
 	var/static/mutable_appearance/atvcover
+	resistance_flags = LAVA_PROOF
 
 /obj/vehicle/ridden/atv/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/atv.dm
+++ b/code/modules/vehicles/atv.dm
@@ -10,7 +10,7 @@
 /obj/vehicle/ridden/atv/Initialize(mapload)
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 1
+	D.vehicle_move_delay = 0
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)


### PR DESCRIPTION
Why give mining medics a clunky ATV when it can't even drive over the only terrain that matters, lava
Also, it's a vehicle, why is it slower than just walking?

:cl:  
tweak: ATVs can drive over lava
tweak: ATV is now faster than walking (on lavaland)
/:cl:
