### PR TITLE
[Fix] Terminated ID still appear original assignment icon on sechud

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -175,6 +175,7 @@
 
 			target_id_card.access -= get_all_centcom_access() + get_all_accesses()
 			target_id_card.assignment = "Unassigned"
+			target_id_card.originalassignment = null
 			target_id_card.update_label()
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE

--- a/yogstation/code/game/objects/items/cards_ids.dm
+++ b/yogstation/code/game/objects/items/cards_ids.dm
@@ -50,6 +50,8 @@
 	)
 	if(job in idfluff)
 		has_fluff = TRUE
+	else if(job == null)
+		return
 	else
 		if(has_fluff)
 			return

--- a/yogstation/code/game/objects/items/cards_ids.dm
+++ b/yogstation/code/game/objects/items/cards_ids.dm
@@ -50,7 +50,7 @@
 	)
 	if(job in idfluff)
 		has_fluff = TRUE
-	else if(job == null)
+	else if(!job)
 		return
 	else
 		if(has_fluff)


### PR DESCRIPTION
An assistant got ID terminated but when they wear the ID it still appear as an assistant on sechud same for other jobs

# Document the changes in your pull request
Fix terminated ID still appear original assignment icon on sechud now it will appear as unknown instead
# Spriting


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix terminated ID still appear original assignment icon on sechud now it will appear as unknown instead

/:cl:
