### PR TITLE
[Port] Space heaters heat up a wider area

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -112,8 +112,10 @@
 	if(mode == HEATER_MODE_COOL)
 		deltaTemperature *= -1
 	if(deltaTemperature)
-		env.set_temperature(env.return_temperature() + deltaTemperature)
-		air_update_turf()
+		for (var/turf/open/turf in ((L.atmos_adjacent_turfs || list()) + L))
+			var/datum/gas_mixture/turf_gasmix = turf.return_air()
+			turf_gasmix.set_temperature(turf_gasmix.return_temperature() + deltaTemperature)
+			air_update_turf(FALSE, FALSE)
 
 	var/working = TRUE
 


### PR DESCRIPTION
* port this https://github.com/tgstation/tgstation/pull/71793

Buff space heaters to make temperature changes further so to stabilize area more efficient when too hot or too cold

Should work but still require tm because my private server atmos doesnt work anymore and idk why and not because of this pr

# Document the changes in your pull request
Space heaters now make temperature changes at further range


# Wiki Documentation
Space heaters now make temperature changes at further range

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Space heaters now make temperature changes at further range
/:cl:
