### PR TITLE
Gluttony demon is now unaffected by sugar OD

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -181,11 +181,15 @@
 	taste_description = "sweetness"
 
 /datum/reagent/consumable/sugar/overdose_start(mob/living/M)
+	if(HAS_TRAIT(M, TRAIT_BOTTOMLESS_STOMACH))
+		return
 	to_chat(M, span_userdanger("You go into hyperglycaemic shock! Lay off the twinkies!"))
 	M.AdjustSleeping(600, FALSE)
 	. = 1
 
 /datum/reagent/consumable/sugar/overdose_process(mob/living/M)
+	if(HAS_TRAIT(M, TRAIT_BOTTOMLESS_STOMACH))
+		return
 	M.AdjustSleeping(40, FALSE)
 	..()
 	. = 1


### PR DESCRIPTION
# Document the changes in your pull request

I'm surprised I've never heard of this until it happened to me, which it happened *a lot*

# Changelog

:cl:  
tweak: Gluttony demon is no longer affected by sugar OD
/:cl:
