### PR TITLE
Revert "Readds druid as a roundstart lawset (#19496)"

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -455,8 +455,6 @@ LAW_WEIGHT robocop,0
 ION_LAW_WEIGHT robocop,2
 LAW_WEIGHT ceo,3
 ION_LAW_WEIGHT ceo,1
-LAW_WEIGHT druid,2
-ION_LAW_WEIGHT druid,3
 LAW_WEIGHT reporter,2
 ION_LAW_WEIGHT reporter,1
 
@@ -489,6 +487,8 @@ LAW_WEIGHT researcher,0
 ION_LAW_WEIGHT researcher,2
 LAW_WEIGHT clown,0
 ION_LAW_WEIGHT clown,2
+LAW_WEIGHT druid,0
+ION_LAW_WEIGHT druid,3
 LAW_WEIGHT detective,0
 ION_LAW_WEIGHT detective,2
 LAW_WEIGHT hulkamania,0


### PR DESCRIPTION
This reverts commit e02a063d8941126a36e20dd37b47a51c3f2ad99c.


# Document the changes in your pull request

Druid causes many problems and should not have been reenabled as a roundstart. For starters, you are literally an IPC murderboning machine. Secondly, have you seen the kitchen? Whats that, killing animals? Thats a big nono, Slimes killing monkeys? 100% not!!!!!!!!! Then finally to top it all off, the laws conflict so easily, which is just a nightmare for players and rules wise.


# Changelog

:cl:  
tweak: Druid is now disabled again
/:cl:
