### PR TITLE
Fixes bigspoon icons

### DIFF
--- a/code/game/objects/items/two_handed/dualsaber.dm
+++ b/code/game/objects/items/two_handed/dualsaber.dm
@@ -49,7 +49,7 @@
 		set_light_color(new_color)
 
 	AddComponent(/datum/component/two_handed, \
-		force_unwielded = 3, \
+		force_unwielded = force, \
 		force_wielded = force_wielded, \
 		icon_wielded = "[base_icon_state][saber_color]1", \
 		wieldsound = 'sound/weapons/saberon.ogg', \

--- a/yogstation/code/game/objects/items/wielded/big_spoon.dm
+++ b/yogstation/code/game/objects/items/wielded/big_spoon.dm
@@ -26,7 +26,6 @@
 	AddComponent(/datum/component/two_handed, \
 		force_unwielded = 2, \
 		force_wielded = 16, \
-		icon_wielded = "[base_icon_state]1", \
 		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
 		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
 	)
@@ -37,6 +36,6 @@
 /obj/item/bigspoon/proc/on_unwield(atom/source, mob/living/user)
 	hitsound = initial(hitsound)
 
-/obj/item/bigspoon/update_icon_state()
+/obj/item/bigspoon/update_icon_state() //i don't know why it's item_state rather than icon_state like every other wielded weapon //because you're changing in-hand icons not the inventory icon
 	. = ..()
-	item_state = "[base_icon_state]0" //i don't know why it's item_state rather than icon_state like every other wielded weapon //because you're changing in-hand icons not the inventory icon
+	item_state = "[base_icon_state][HAS_TRAIT(src, TRAIT_WIELDED)]"


### PR DESCRIPTION
# Document the changes in your pull request

Another merge conflict I didn't notice from the two handed component/update apperance PR
This fixes big spoon icons
Also fixes toy deswords cuz i can.

# Changelog

:cl:  
bugfix: Big spoons now have proper icons.
bugfix: Toy deswords don't deal damage anymore.
/:cl:
