### PR TITLE
Makes stargazer less terrible but also less good

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -123,68 +123,49 @@
 
 /obj/structure/destructible/clockwork/stargazer/proc/upgrade_weapon(obj/item/I, mob/living/user)
 	ADD_TRAIT(I, TRAIT_STARGAZED, STARGAZER_TRAIT)
-	switch(rand(1, 10))
+	switch(rand(1, 8))
 		if(1)
-			to_chat(user, "<span class='neovgre'>You feel [I] tighten to your hand.</span>")
-			ADD_TRAIT(I, TRAIT_NODROP, STARGAZER_TRAIT)
+			to_chat(user, "<span class='neovgre'>[I] looks as if it could pierce reality.</span>")
+			I.force += 1
+			I.armour_penetration += 10
+			I.sharpness = SHARP_POINTY
 			return
 		if(2)
 			to_chat(user, "<span class='neovgre'>[I] looks as if it could cut through anything.</span>")
-			I.force += 6
+			I.force += 2
+			I.sharpness = SHARP_EDGED
 			return
 		if(3)
-			I.w_class = WEIGHT_CLASS_TINY
-			to_chat(user, "<span class='neovgre'>[I] suddenly shrinks!</span>")
+			to_chat(user, "<span class='neovgre'>[I] looks as if it could shatter bones in a single strike.</span>")
+			I.force += 2
+			I.sharpness = SHARP_NONE
 			return
 		if(4)
-			I.light_power = 3
-			I.light_range = 2
-			I.light_color = LIGHT_COLOR_CLOCKWORK
-			to_chat(user, "<span class='neovgre'>[I] shines with a brilliant light!</span>")
-			return
-		if(5)
 			I.damtype = BURN
 			I.force += 2
 			I.light_power = 1.5
 			I.light_range = 2
 			I.light_color = LIGHT_COLOR_FIRE
-			to_chat(user, "<span class='neovgre'>[I] emits off an intense heat!</span>")
+			to_chat(user, "<span class='neovgre'>[I] begins to emit an intense heat!</span>")
+			return
+		if(5)
+			I.light_power = 3
+			I.light_range = 2
+			I.light_color = LIGHT_COLOR_CLOCKWORK
+			I.block_chance += 15
+			to_chat(user, "<span class='neovgre'>[I] shines with a brilliant protecting light!</span>")
 			return
 		if(6)
-			I.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
-			to_chat(user, "<span class='neovgre'>[I] becomes unbreakable!</span>")
+			I.w_class = WEIGHT_CLASS_TINY
+			I.slot_flags |= ITEM_SLOT_POCKETS
+			to_chat(user, "<span class='neovgre'>[I] suddenly shrinks small enough to fit in one's pockets!</span>")
 			return
 		if(7)
-			to_chat(user, "<span class='neovgre'>You feel [I] attempting to communicate with you.</span>")
-			var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s [I]?", ROLE_PAI, null, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
-			if(LAZYLEN(candidates))
-				var/mob/dead/observer/C = pick(candidates)
-				var/mob/living/simple_animal/shade/S = new(src)
-				S.ckey = C.ckey
-				S.fully_replace_character_name(null, "The spirit of [name]")
-				S.status_flags |= GODMODE
-				S.copy_languages(user, LANGUAGE_MASTER)	//Make sure the sword can understand and communicate with the user.
-				S.update_atom_languages()
-				S.grant_all_languages(FALSE, FALSE, TRUE)	//Grants omnitongue
-				var/input = sanitize_name(stripped_input(S,"What are you named?", ,"", MAX_NAME_LEN))
-
-				if(src && input)
-					name = input
-					S.fully_replace_character_name(null, "The spirit of [input]")
-			else
-				to_chat(user, "<span class='neovgre'>The [I] stops talking to you...</span>")
-				REMOVE_TRAIT(I, TRAIT_STARGAZED, STARGAZER_TRAIT)
-			return
-		if(8)
-			to_chat(user, "<span class='neovgre'>[I] goes blunt.</span>")
-			I.force = max(I.force - 4, 0)
-			return
-		if(9)
 			to_chat(user, "<span class='neovgre'>You feel bloodlust starting to emanate from [I]!</span>")
 			I.AddComponent(/datum/component/lifesteal, 4)
 			return
-		if(10)
-			to_chat(user, "<span class='neovgre'>[I] suddenly transforms, gaining the magical properties of shungite, it will protect your from EMPs!</span>")
-			I.AddComponent(/datum/component/empprotection)
-			I.color = COLOR_ALMOST_BLACK
+		if(8)
+			I.block_chance += 10
+			I.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+			to_chat(user, "<span class='neovgre'>[I] becomes unbreakable!</span>")
 			return

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -143,14 +143,14 @@
 		if(4)
 			I.damtype = BURN
 			I.force += 2
-			I.light_power = 1.5
+			I.light_power = 1
 			I.light_range = 2
 			I.light_color = LIGHT_COLOR_FIRE
 			to_chat(user, "<span class='neovgre'>[I] begins to emit an intense heat!</span>")
 			return
 		if(5)
 			I.light_power = 3
-			I.light_range = 2
+			I.light_range = 3
 			I.light_color = LIGHT_COLOR_CLOCKWORK
 			I.block_chance += 15
 			to_chat(user, "<span class='neovgre'>[I] shines with a brilliant protecting light!</span>")


### PR DESCRIPTION
the clockwork stargazer can both make ridiculously strong items, as well as make them terrible
this sort of normalizes the result

the results are now

- +1 force / +10 ap / sharpness is pointy
- +2 force / sharpness is edged
- +2 force / sharpness is blunt
- +2 force / damage type is burn / gives weak glow
- +15 block / gives strong glow
- weight class to tiny / can go into pockets
- lifesteal 4 health per hit
- +10 block / indestructible weapon

:cl:  
tweak: Stargazer can no longer make items worse
/:cl:
