### PR TITLE
Makes cogscarab slightly less tedious to play

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -112,11 +112,9 @@
 	icon_dead = "drone_clock_dead"
 	picked = TRUE
 	pass_flags = PASSTABLE
-	health = 50
-	maxHealth = 50
 	harm_intent_damage = 5
 	density = TRUE
-	speed = 1
+	speed = 0
 	ventcrawler = VENTCRAWLER_NONE
 	faction = list("neutral", "ratvar")
 	speak_emote = list("clanks", "clinks", "clunks", "clangs")


### PR DESCRIPTION
They're expected to run all over reebe upgrading and building things, but they're slower than players
Wasn't wanting to risk giving them -1 speed like regular drones, as that makes them notably faster than players and they don't have pacifism like regular drones
But at a speed of 0, it should at least be less painful to play as a glorified drone

:cl:  
tweak: Cogscarabs are slightly faster but have less health
/:cl:
