### PR TITLE
Fixes typo in toy mballoon description

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -129,7 +129,7 @@
 
 /obj/item/toy/mballoon
 	name = "toy mballoon"
-	desc = "A blue baloon, it looks.. mentory?"
+	desc = "A blue balloon, it looks.. mentory?"
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7


### PR DESCRIPTION
# Document the changes in your pull request
Toy mballoon no longer has a typo of "baloon".

# Changelog
:cl:  
spellcheck: The toy mballoon is properly described as a balloon and not a "baloon".
/:cl:
