### PR TITLE
Radiation storm now deal less EMP to tcomms machines

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -50,7 +50,7 @@
 		return
 	priority_announce("The station has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt.", "Anomaly Alert")
 	for(var/obj/machinery/telecomms/T in GLOB.telecomms_list)
-		T.emp_act(EMP_HEAVY)
+		T.emp_act(EMP_LIGHT)
 
 /datum/weather/rad_storm/end()
 	if(..())


### PR DESCRIPTION
radiation storm is already a pain and coms blackout all together is just really too much for the crew

# Document the changes in your pull request
Radiation storm now deal less EMP to tcomms machines

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Radiation storm now deal less EMP to tcomms machines
/:cl:
