### PR TITLE
New Traitor Objective - Break shit!!!

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1356,7 +1356,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /**
   * Sets up the achievement, returns TRUE if it was set up successfully and can be used, FALSE otherwise
   */
-/datum/objective/minor/proc/finalize()
+/datum/objective/proc/finalize()
 	return FALSE
 
 
@@ -1608,3 +1608,97 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/area/target_area = get_area(target)
 
 	return (istype(user_area, dropoff) && istype(target_area, dropoff))
+
+/**
+  * Break shit - the objective
+  *
+  * Areas are stored, not references to the machines and not checking the machines globally
+  * This solves the following issues:
+  * * Problem 1 - Engineers rebuild and then the sabotage is immediately undone, the traitor having no reason to stop them
+  * * Problem 2 - Engineers build a random machine in maint where no one would look to fuck over the traitor
+  * The idea is that the traitor must commit to breaking the machines
+  */
+/datum/objective/break_machinery
+	name = "Destroy some machines"
+	explanation_text = "Destroy all of something in the areas it spawns in."
+	var/obj/machinery/target_obj_type
+	var/list/potential_target_types
+	var/list/area/target_areas
+
+/datum/objective/break_machinery/finalize()
+	var/station_z = SSmapping.levels_by_trait(ZTRAIT_STATION)[1]
+	if(!target_obj_type) // Select our target machine if there is none pre-set
+		potential_target_types = list(
+			// SCIENCE
+			/obj/machinery/rnd/server,
+			/obj/machinery/mecha_part_fabricator,
+			// ENGINEERING
+			/obj/machinery/power/smes,
+			/obj/machinery/power/supermatter_crystal,
+			/obj/machinery/telecomms, // hard-mode
+			// MEDICAL
+			/obj/machinery/stasis,
+			/obj/machinery/sleeper,
+			/obj/machinery/atmospherics/components/unary/cryo_cell,
+			/obj/machinery/clonepod,
+			// OTHER
+			/obj/machinery/autolathe,
+			/obj/machinery/ore_silo,
+			/obj/machinery/teleport/hub,
+			/obj/machinery/rnd/production/protolathe, // hard-mode 2.0
+		)
+		potential_target_types = shuffle(potential_target_types)
+		var/targets_len = potential_target_types.len
+		var/iteration = 1
+		while(!target_obj_type && targets_len >= iteration)
+			for(var/obj/machinery/machine as anything in GLOB.machines)
+				if(machine.z == station_z && istype(machine, potential_target_types[iteration]))
+					target_obj_type = potential_target_types[iteration]
+					break
+			iteration++
+
+	if(!target_obj_type)
+		return FALSE
+
+	var/machine_name = initial(target_obj_type.name)
+	name = "Destroy [machine_name][machine_name[length(machine_name)] == "s" ? "es" : "s"]"
+	// Find and store areas
+	for(var/obj/machinery/machine as anything in GLOB.machines)
+		if(!istype(machine, target_obj_type))
+			continue
+		if(machine.z != station_z)
+			continue
+		if(!istype(get_area(machine), /area))
+			continue
+		target_areas |= get_area(machine)
+		if(target_areas.len >= 4)
+			break
+
+	// Format explanation text
+	explanation_text = "Ensure no functioning [machine_name][machine_name[length(machine_name)] == "s" ? "es" : "s"] exist in "
+	switch(target_areas.len)
+		if(0)
+			return FALSE
+		if(1)
+			explanation_text += "[target_areas[1].name]."
+		if(2)
+			explanation_text += "[target_areas[1].name] and [target_areas[2].name]."
+		else
+			var/iteration = 1
+			for(var/area/target_area in target_areas)
+				if(iteration == target_areas.len)
+					explanation_text += "and [target_area.name]."
+					break
+				explanation_text += "[target_area.name], "
+				iteration++
+	return TRUE
+
+/datum/objective/break_machinery/check_completion()
+	if(!target_obj_type)
+		return TRUE
+	if(target_areas.len == 0)
+		return TRUE
+	for(var/area/target_area in target_areas)
+		if(locate(target_obj_type) in target_area)
+			return FALSE
+	return TRUE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1661,7 +1661,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 	var/machine_name = initial(target_obj_type.name)
 	name = "Destroy [machine_name][machine_name[length(machine_name)] == "s" ? "es" : "s"]"
-	// Find and store areas
+	// Find and shuffle machines for random area selection
+	var/list/eligible_machines = list()
 	for(var/obj/machinery/machine as anything in GLOB.machines)
 		if(!istype(machine, target_obj_type))
 			continue
@@ -1669,6 +1670,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			continue
 		if(!istype(get_area(machine), /area))
 			continue
+		eligible_machines |= machine
+
+	eligible_machines = shuffle(eligible_machines)
+	// Store areas
+	for(var/obj/machinery/machine as anything in eligible_machines)
 		target_areas |= get_area(machine)
 		if(target_areas.len >= 4)
 			break

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1626,12 +1626,12 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/list/area/target_areas
 
 /datum/objective/break_machinery/finalize()
+	target_areas = list()
 	var/station_z = SSmapping.levels_by_trait(ZTRAIT_STATION)[1]
 	if(!target_obj_type) // Select our target machine if there is none pre-set
 		potential_target_types = list(
 			// SCIENCE
 			/obj/machinery/rnd/server,
-			/obj/machinery/mecha_part_fabricator,
 			// ENGINEERING
 			/obj/machinery/power/smes,
 			/obj/machinery/power/supermatter_crystal,
@@ -1639,7 +1639,6 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			// MEDICAL
 			/obj/machinery/stasis,
 			/obj/machinery/sleeper,
-			/obj/machinery/atmospherics/components/unary/cryo_cell,
 			/obj/machinery/clonepod,
 			// OTHER
 			/obj/machinery/autolathe,

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -15,6 +15,7 @@
 GLOBAL_LIST_EMPTY(telecomms_list)
 
 /obj/machinery/telecomms
+	name = "telecommunications machine"
 	icon = 'icons/obj/machines/telecomms.dmi'
 	critical_machine = TRUE
 	var/list/links = list() // list of machines this machine is linked to

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -216,8 +216,13 @@
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
-		else // Objectives that involve destroying items in areas
-			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
+		else
+			var/datum/objective/break_machinery/break_objective = new
+			break_objective.owner = owner
+			if(break_objective.finalize())
+				add_objective(break_objective)
+			else
+				forge_single_human_objective()
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -211,11 +211,13 @@
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()
 			add_objective(download_objective)
-		else
+		else if(prob(50))
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
 			steal_objective.find_target()
 			add_objective(steal_objective)
+		else // Objectives that involve destroying items in areas
+			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 
 /datum/antagonist/traitor/proc/forge_single_AI_objective()
 	.=1


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new traitor objective that selects a random machine from the list below and tasks the traitor with ensuring there are no more of them in their spawn area.

![image](https://github.com/yogstation13/Yogstation/assets/28408322/45f88c65-b4de-4400-b294-8511342e1d84)

Up to four areas can be selected.

The idea behind choosing *areas* instead of the machines themselves is that
- If references to the machines are stored, they can be broken once and then immediately repaired, which is boring, cheesable, and short-lived
- If ALL machines count, someone could cheese the traitor by building a machine in some fuck-off location that the traitor does not know to check
- By using areas, the traitor has to commit to preventing those structures from existing in that area, but they can still be built elsewhere - as long as the original spawn location is disrupted, it is a success

# Wiki Documentation

```go
// SCIENCE
/obj/machinery/rnd/server,
// ENGINEERING
/obj/machinery/power/smes,
/obj/machinery/power/supermatter_crystal,
/obj/machinery/telecomms, // hard-mode
// MEDICAL
/obj/machinery/stasis,
/obj/machinery/sleeper,
/obj/machinery/clonepod,
// OTHER
/obj/machinery/autolathe,
/obj/machinery/ore_silo,
/obj/machinery/teleport/hub,
/obj/machinery/rnd/production/protolathe, // hard-mode 2.0
```

# Changelog

:cl:  
rscadd: Added a new sabotage-focused objective that has the traitor destroy and prevent the reconstruction of machines in certain areas. (i.e. sleepers or SMES)
/:cl:
