### PR TITLE
Splits UNIQUE_RENAME into itself and UNIQUE_REDESC, removes UNIQUE_REDESC from guns

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -7,9 +7,10 @@
 #define BEING_SHOCKED			(1<<3) // Whether this thing is currently (already) being shocked by a tesla
 #define DANGEROUS_POSSESSION	(1<<4) //Admin possession yes/no
 #define ON_BLUEPRINTS			(1<<5)  //Are we visible on the station blueprints at roundstart?
-#define UNIQUE_RENAME			(1<<6) // can you customize the description/name of the thing?
+#define UNIQUE_RENAME			(1<<6) // can you customize the name of the thing?
 #define USES_TGUI				(1<<7)	//put on things that use tgui on ui_interact instead of custom/old UI.
 #define FROZEN					(1<<8)
+#define UNIQUE_REDESC			(1<<9) // can you customize the description of the thing?
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_INIT(bitfields, list(
 		"UNIQUE_RENAME" = UNIQUE_RENAME,
 		"USES_TGUI" = USES_TGUI,
 		"FROZEN" = FROZEN,
+		"UNIQUE_REDESC" = UNIQUE_REDESC,
 		),
 	"datum_flags" = list(
 		"DF_USE_TAG" = DF_USE_TAG,

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -227,7 +227,7 @@
 	name = "holorecord disk"
 	desc = "Stores recorder holocalls."
 	icon_state = "holodisk"
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	var/datum/holorecord/record
 	//Preset variables
 	var/preset_image_type

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -6,7 +6,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 200
 	active_power_usage = 5000
-	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME | UNIQUE_REDESC
 	circuit = /obj/item/circuitboard/machine/quantumpad
 	var/teleport_cooldown = 400 //30 seconds base due to base parts
 	var/teleport_speed = 50

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -27,7 +27,7 @@
 	name = "data card"
 	desc = "A plastic magstripe card for simple and speedy data storage and transfer. This one has a stripe running down the middle."
 	icon_state = "data_1"
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	var/function = "storage"
 	var/data = "null"
 	var/special = null

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	icon_state = "gps-c"
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	var/gpstag = "COM0"
 	var/emped = FALSE
 	var/tracking = TRUE

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -18,7 +18,7 @@
 	throwforce = 10
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	wound_bonus = -10
 	cryo_preserve = TRUE
 	var/reskinned = FALSE
@@ -27,7 +27,7 @@
 
 	var/selected_category = MENU_ALL
 	var/list/show_categories = list(MENU_ALL, MENU_WEAPON, MENU_ARM, MENU_CLOTHING, MENU_MISC)
-	/// this text will show on the tgui menu when picking the nullrod form they want. should give a better idea of the nullrod's gimmick or quirks without giving away numbers 
+	/// this text will show on the tgui menu when picking the nullrod form they want. should give a better idea of the nullrod's gimmick or quirks without giving away numbers
 	var/additional_desc = "How are you seeing this? This is the default Nullrod bonus description. I makey a mistakey."
 
 /obj/item/nullrod/Initialize(mapload)
@@ -49,7 +49,7 @@
 		var/mob/living/carbon/human/H = user
 		H.dropItemToGround(src, TRUE, TRUE)
 	qdel(user, TRUE)
-	
+
 /obj/item/nullrod/attack_self(mob/user)
 	if(user?.mind?.holy_role && check_menu(user))
 		ui_interact(user)
@@ -62,13 +62,13 @@
 	if(user.incapacitated() || !user.is_holding(src))
 		return FALSE
 	return TRUE
-	
+
 /obj/item/nullrod/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NullRodMenu", name)
 		ui.open()
-	
+
 /obj/item/nullrod/ui_static_data(mob/user)
 	var/list/data = list()
 	data["categories"] = list()
@@ -76,9 +76,9 @@
 	for(var/category in show_categories)
 		var/list/category_data = list()
 		category_data["name"] = category
-		
+
 		var/list/nullrods = list()
-		
+
 		for(var/shaft in subtypesof(/obj/item/nullrod))
 			var/obj/item/nullrod/rod = new shaft
 			if(!rod?.chaplain_spawnable)
@@ -89,19 +89,19 @@
 			details["menu_tab"] = rod.menutab
 			details["type_path"] = rod.type
 			details["additional_description"] = rod.additional_desc
-			
+
 			var/icon/rod_pic = getFlatIcon(rod)
 			var/md5 = md5(fcopy_rsc(rod_pic))
 			if(!SSassets.cache["photo_[md5]_[rod.name]_icon.png"])
 				SSassets.transport.register_asset("photo_[md5]_[rod.name]_icon.png", rod_pic)
 			SSassets.transport.send_assets(user, list("photo_[md5]_[rod.name]_icon.png" = rod_pic))
 			details["rod_pic"] = SSassets.transport.get_asset_url("photo_[md5]_[rod.name]_icon.png")
-			
+
 			if(category == MENU_ALL || category == rod.menutab)
 				nullrods += list(details)
-				
+
 			qdel(rod)
-		
+
 		category_data["nullrods"] = nullrods
 		data["categories"] += list(category_data)
 
@@ -336,7 +336,7 @@
 	hitsound = 'sound/weapons/chainhit.ogg'
 	menutab = MENU_WEAPON
 	additional_desc = "A holy weapon, capable at meting out righteousness from a distance."
-	
+
 /obj/item/nullrod/whip/Initialize(mapload)
 	. = ..()
 	weapon_stats[REACH] = 4 //closest to a ranged weapon chaplain should ever get (that or maybe a throwing weapon)
@@ -497,7 +497,7 @@
 		user.balloon_alert(user, "You sheathe \the [src].")
 		playsound(user, 'sound/items/sheath.ogg', 25, TRUE)
 		update_appearance(UPDATE_ICON)
-		
+
 /obj/item/nullrod/dualsword/update_icon_state()
 	. = ..()
 	item_state = swords ? "fulldual" : "emptydual"
@@ -554,7 +554,7 @@
 			sheath.update_appearance(UPDATE_ICON)
 			playsound(user, 'sound/items/sheath.ogg', 25, TRUE)
 		sheath.swords = TRUE
-	
+
 
 /*---------------------------------------------------------------------------
 |
@@ -584,7 +584,7 @@
 
 /obj/item/nullrod/godhand/ignition_effect(atom/A, mob/user)
 	. = span_notice("[user] grasps [A] with [user.p_their()] flaming hand, igniting it in a burst of holy flame. Holy hot damn, that is badass. ")
-	
+
 /obj/item/nullrod/chainsaw
 	name = "chainsaw hand"
 	desc = "Good? Bad? You're the guy with the chainsaw hand."
@@ -721,7 +721,7 @@
 	var/hud_type2 = DATA_HUD_MEDICAL_ADVANCED
 	menutab = MENU_CLOTHING
 	additional_desc = "This mysterious floating skull can communicate diagnostic reports to you regarding both mechanical and organic disciples around you."
-	
+
 /obj/item/nullrod/servoskull/equipped(mob/living/carbon/human/user, slot)
 	..()
 	if(hud_type && slot == ITEM_SLOT_NECK)
@@ -739,7 +739,7 @@
 		var/datum/atom_hud/H2 = GLOB.huds[hud_type2]
 		H2.hide_from(user)
 
-/obj/item/nullrod/hermes 
+/obj/item/nullrod/hermes
 	name = "fairy boots"
 	desc = "Boots blessed by the god Hermes. Some say that they were discarded after being tainted by fae magic."
 	gender = PLURAL //Carn: for grammarically correct text-parsing, but over here too
@@ -913,7 +913,7 @@
 		return PROCESS_KILL // something has gone terribly wrong
 	if(!isliving(loc))
 		return PROCESS_KILL // something has gone terribly wrong
-	
+
 	var/notify = FALSE
 	if(COOLDOWN_FINISHED(src, holy_notification))
 		COOLDOWN_START(src, holy_notification, 0.8 SECONDS)
@@ -960,7 +960,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	menutab = MENU_MISC
 	additional_desc = "This banana is comedically sharp."
-	
+
 /obj/item/nullrod/clown/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/slippery, 40)
@@ -1103,7 +1103,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 		walking = TRUE
 	else
 		. = ..()
-	
+
 /datum/action/cooldown/spell/recall_nullrod
 	name = "Sword Recall"
 	desc = "Pulls your possessed sword back to you."

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -50,7 +50,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	force = 15
 	throwforce = 10
 	wound_bonus = 10

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -294,7 +294,9 @@
 /obj/examine(mob/user)
 	. = ..()
 	if(obj_flags & UNIQUE_RENAME)
-		. += span_notice("Use a pen on it to rename it or change its description.")
+		. += span_notice("Use a pen on it to rename it [obj_flags & UNIQUE_REDESC ? "or change its description" : ""].")
+	else if(obj_flags & UNIQUE_REDESC)
+		. += span_notice("Use a pen on it to change its description.")
 	if(unique_reskin && !current_skin)
 		. += span_notice("Alt-click it to reskin it.")
 

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -555,7 +555,7 @@
 	name = "air shoes"
 	desc = "Footwear that uses propulsion technology to keep you above the ground and let you move faster."
 	icon_state = "airshoes"
-	obj_flags = UNIQUE_RENAME //im not fucking naming them 'sonic 11's you can do that yourself ffm
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC //im not fucking naming them 'sonic 11's you can do that yourself ffm
 	actions_types = list(/datum/action/item_action/airshoes, /datum/action/item_action/dash)
 	var/airToggle = FALSE
 	///Secret vehicle that helps us move around at mach speeds

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -10,7 +10,7 @@
 	materials = list(/datum/material/glass=500)
 	max_integrity = 20
 	resistance_flags = ACID_PROOF
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	drop_sound = 'sound/items/handling/drinkglass_drop.ogg'
 	pickup_sound =  'sound/items/handling/drinkglass_pickup.ogg'
 

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -35,7 +35,7 @@ All foods are distributed among various categories. Use common sense.
 	icon_state = null
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	grind_results = list() //To let them be ground up to transfer their reagents
 	var/bitesize = 2
 	var/bitecount = 0

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -433,7 +433,7 @@
 	materials = list(/datum/material/iron=30, /datum/material/glass=10)
 	var/datum/plant_gene/gene
 	var/read_only = 0 //Well, it's still a floppy disk
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 
 /obj/item/disk/plantgene/Initialize(mapload)
 	. = ..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -4,7 +4,7 @@
 	icon_state = "hydrotray"
 	density = TRUE
 	pixel_z = 8
-	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME | UNIQUE_REDESC
 	circuit = /obj/item/circuitboard/machine/hydroponics
 	var/waterlevel = 100	//The amount of water in the tray (max 100)
 	var/maxwater = 100		//The maximum amount of water in the tray
@@ -657,7 +657,7 @@
 	// FEED ME SEYMOUR
 	if(S.has_reagent(/datum/reagent/medicine/strange_reagent, 1))
 		spawnplant()
-	
+
 	// Honey, Pests are dieing of sugar, so is the plant
 	if(S.has_reagent(/datum/reagent/consumable/honey, 1))
 		adjustPests(-rand(2,5))
@@ -798,7 +798,7 @@
 		var/list/combined_msg = list()
 		playsound(src, 'sound/effects/fastbeep.ogg', 30)
 		if(myseed)
-			combined_msg += "*** <B>[myseed.plantname]</B> ***" 
+			combined_msg += "*** <B>[myseed.plantname]</B> ***"
 			combined_msg += "- Plant Age: [span_notice("[age]")]"
 			var/list/text_string = myseed.get_analyzer_text()
 			if(text_string)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -10,7 +10,7 @@
 	While it is an effective mining tool, it did little to aid any but the most skilled and/or suicidal miners against local fauna."
 	force = 0 //Can't be used if not wielded
 	w_class = WEIGHT_CLASS_BULKY
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 5
 	throw_speed = 4
@@ -67,7 +67,7 @@
 /obj/item/kinetic_crusher/attack(mob/living/target, mob/living/carbon/user)
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
 		to_chat(user, span_warning("[src] is too heavy to use with one hand!"))
-		return	
+		return
 	var/datum/status_effect/crusher_damage/C = target.has_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)
 	if(!C)
 		C = target.apply_status_effect(STATUS_EFFECT_CRUSHERDAMAGETRACKING)

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -8,7 +8,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure."
 	w_class = WEIGHT_CLASS_NORMAL
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	force = 15
 	throwforce = 10
 	var/burst_time = 30

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -125,8 +125,15 @@
 /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
 	//Changing Name/Description of items. Only works if they have the 'unique_rename' flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
-		var/penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
+	if(isobj(O) && proximity && ((O.obj_flags & UNIQUE_RENAME) || (O.obj_flags & UNIQUE_REDESC)))
+		var/penchoice
+		if((O.obj_flags & UNIQUE_RENAME) && (O.obj_flags & UNIQUE_REDESC))
+			penchoice = input(user, "What would you like to edit?", "Rename or change description?") as null|anything in list("Rename","Change description")
+		else if(O.obj_flags & UNIQUE_RENAME)
+			penchoice = "Rename"
+		else
+			penchoice = "Change description"
+
 		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 			return
 		if(penchoice == "Rename")
@@ -162,13 +169,13 @@
 		return
 	if(!reagents.total_volume || !M.reagents)
 		return
-		
+
 	to_chat(user, span_warning("You begin to inject [src]'s contents into [M]"))
 	if(!do_after(user, 0.5 SECONDS, M))
 		return
 	reagents.reaction(M, INJECT, reagents.total_volume)
 	reagents.trans_to(M, reagents.total_volume, transfered_by = user)
-				
+
 
 
 /obj/item/pen/sleepy/Initialize(mapload)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -444,7 +444,7 @@
 /obj/item/reagent_containers/glass/urn
 	name = "urn"
 	desc = "A tall vase used for storing cremated remains."
-	obj_flags = UNIQUE_RENAME // Rename it to whoever you cremated
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC // Rename it to whoever you cremated
 	icon_state = "urn_open"
 	w_class = WEIGHT_CLASS_NORMAL // This is important! Don't just keep it in your box or something!
 	resistance_flags = NONE // Shatters easily

--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	item_flags = NOBLUDGEON
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	reagent_flags = OPENCONTAINER_NOSPILL
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0


### PR DESCRIPTION
# Document the changes in your pull request

You could use this to rename certain guns like the practice laser guns into laser guns and make them indistinguishable from a normal gun until fired. Now you can still do that, but the description can't be changed, so someone looking closely won't be fooled.

# Changelog

:cl:  
tweak: You can no longer change the description of guns.
/:cl:
