### PR TITLE
Fixes some issues with turf fire spreading

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -228,10 +228,21 @@
 	slippery_foam = FALSE
 	/// The amount of plasma gas this foam has absorbed. To be deposited when the foam dissipates.
 	var/absorbed_plasma = 0
+	/// The turf this foam is affecting. Its flammability is set to -10 and later reset to its initial value.
+	var/turf/open/affecting_turf
 
 /obj/effect/particle_effect/fluid/foam/firefighting/Initialize(mapload)
 	. = ..()
+	var/turf/open/T = get_turf(src)
+	if(istype(T))
+		affecting_turf = T
+		affecting_turf.flammability = -10 // set the turf to be non-flammable while the foam is covering it
 	//Remove_element(/datum/element/atmos_sensitive)
+
+/obj/effect/particle_effect/fluid/foam/firefighting/Destroy()
+	if(affecting_turf && !QDELETED(affecting_turf))
+		affecting_turf.flammability = initial(affecting_turf.flammability)
+	return ..()
 
 /obj/effect/particle_effect/fluid/foam/firefighting/process()
 	..()
@@ -240,11 +251,16 @@
 	if(!istype(location))
 		return
 
-	var/obj/effect/hotspot/hotspot = locate() in location
-	if(!(hotspot && location.air))
+	var/obj/effect/hotspot/hotspot = location.active_hotspot
+	var/obj/effect/abstract/turf_fire/turf_fire = location.turf_fire
+	if(!((hotspot||turf_fire) && location.air))
 		return
 
-	QDEL_NULL(hotspot)
+	if(hotspot)
+		QDEL_NULL(hotspot)
+	if(turf_fire)
+		QDEL_NULL(turf_fire)
+
 	var/datum/gas_mixture/air = location.air
 	var/scrub_amt = min(30, air.get_moles(/datum/gas/plasma)) //Absorb some plasma
 	air.adjust_moles(/datum/gas/plasma, -scrub_amt)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -15,9 +15,10 @@
 	var/barefootstep = null
 	var/clawfootstep = null
 	var/heavyfootstep = null
-	/// How much fuel this open turf provides to turf fires
-	var/flammability = 0.2
+	/// How much fuel this open turf provides to turf fires, and how easily they can be ignited in the first place. Can be negative to make fires die out faster.
+	var/flammability = 0.3
 	var/obj/effect/abstract/turf_fire/turf_fire
+	var/obj/effect/hotspot/hotspot
 
 //direction is direction of travel of A
 /turf/open/zPassIn(atom/movable/A, direction, turf/source)
@@ -611,3 +612,9 @@
 		return
 	if(!isgroundlessturf(src))
 		new /obj/effect/abstract/turf_fire(src, power, fire_color)
+
+/turf/open/proc/set_flammability(new_flammability)
+	if(isnull(new_flammability))
+		flammability = initial(flammability)
+		return
+	flammability = new_flammability

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -225,6 +225,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	flammability = 0
 
 /turf/open/floor/grass/snow/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -225,7 +225,7 @@
 	barefootstep = FOOTSTEP_SAND
 	clawfootstep = FOOTSTEP_SAND
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	flammability = 0
+	flammability = -5 // negative flammability, makes fires deplete much faster
 
 /turf/open/floor/grass/snow/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -151,6 +151,7 @@
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
 	digResult = /obj/item/stack/sheet/mineral/snow
+	flammability = 0
 
 /turf/open/floor/plating/asteroid/snow/getDug()
 	..()

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -151,7 +151,7 @@
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
 	digResult = /obj/item/stack/sheet/mineral/snow
-	flammability = 0
+	flammability = -5
 
 /turf/open/floor/plating/asteroid/snow/getDug()
 	..()

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -182,6 +182,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	flammability = 0
 
 /turf/open/floor/plating/ice/Initialize(mapload)
 	. = ..()

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -182,7 +182,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
-	flammability = 0
+	flammability = -5
 
 /turf/open/floor/plating/ice/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -1,4 +1,3 @@
-#define IGNITE_TURF_CHANCE 30
 #define IGNITE_TURF_LOW_POWER 8
 #define IGNITE_TURF_HIGH_POWER 22
 
@@ -6,7 +5,7 @@
 	return null
 
 /turf/open/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(prob(IGNITE_TURF_CHANCE))
+	if(prob(flammability * 100))
 		IgniteTurf(rand(IGNITE_TURF_LOW_POWER,IGNITE_TURF_HIGH_POWER))
 	return ..()
 
@@ -71,14 +70,18 @@
 		volume = starting_volume
 	if(!isnull(starting_temperature))
 		temperature = starting_temperature
-	perform_exposure()
+	if(!perform_exposure())
+		return INITIALIZE_HINT_QDEL
 	setDir(pick(GLOB.cardinals))
 	air_update_turf()
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/open/location = loc
 	if(!istype(location) || !(location.air))
-		return
+		return FALSE
+
+	if(location.active_hotspot != src)
+		qdel(location.active_hotspot)
 
 	location.active_hotspot = src
 
@@ -100,7 +103,7 @@
 		var/atom/AT = A
 		if(!QDELETED(AT) && AT != src) // It's possible that the item is deleted in temperature_expose
 			AT.fire_act(temperature, volume)
-	return
+	return TRUE
 
 /obj/effect/hotspot/proc/gauss_lerp(x, x1, x2)
 	var/b = (x1 + x2) * 0.5
@@ -250,6 +253,5 @@
 	light_range = LIGHT_RANGE_FIRE
 
 #undef INSUFFICIENT
-#undef IGNITE_TURF_CHANCE
 #undef IGNITE_TURF_LOW_POWER
 #undef IGNITE_TURF_HIGH_POWER

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -280,13 +280,18 @@
 		else if(istype(foam))
 			foam.lifetime = initial(foam.lifetime) //reduce object churn a little bit when using smoke by keeping existing foam alive a bit longer
 
-	var/obj/effect/hotspot/hotspot = (locate(/obj/effect/hotspot) in exposed_turf)
-	if(hotspot && !isspaceturf(exposed_turf) && exposed_turf.air)
+	// If there's a hotspot or turf fire, get rid of them and make the air colder
+	var/obj/effect/hotspot/hotspot = exposed_turf.active_hotspot
+	var/obj/effect/abstract/turf_fire/turf_fire = exposed_turf.turf_fire
+	if((hotspot || turf_fire) && !isspaceturf(exposed_turf) && exposed_turf.air)
 		var/datum/gas_mixture/air = exposed_turf.air
 		if(air.return_temperature() > T20C)
 			air.set_temperature(max(air.return_temperature()/2, T20C))
 		air.react(src)
-		qdel(hotspot)
+		if(hotspot)
+			qdel(hotspot)
+		if(turf_fire)
+			qdel(turf_fire)
 
 /datum/reagent/firefighting_foam/reaction_obj(obj/O, reac_volume)
 	O.extinguish()


### PR DESCRIPTION
# Document the changes in your pull request

Turf fires can no longer spread onto ice and snow, or turfs with firefighting foam on them.

Also minor performance improvement.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed turf fires being able to spread on snow/ice turfs
bugfix: fixed firefighting foam not stopping turf fires
/:cl:
