### PR TITLE
Fixes "You can no longer use camera consoles with the Bluespace Rapid Part Exchange Device"

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -19,11 +19,7 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		return ..()
 	if(user.Adjacent(T)) // no TK upgrading.
 		if(works_from_distance)
-			if(in_view_range(user, T))
-				user.Beam(T, icon_state = "rped_upgrade", time = 5)
-			else
-				to_chat(user, span_warning("Out of range!"))
-				return
+			user.Beam(T, icon_state = "rped_upgrade", time = 5)
 		T.exchange_parts(user, src)
 		return FALSE
 	return ..()
@@ -32,8 +28,11 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 	if(adjacent || !istype(T) || (!T.component_parts && !T.works_with_rped_anyways))
 		return ..()
 	if(works_from_distance)
-		user.Beam(T, icon_state = "rped_upgrade", time = 5)
-		T.exchange_parts(user, src)
+		if(in_view_range(user, T))
+			user.Beam(T, icon_state = "rped_upgrade", time = 5)
+			T.exchange_parts(user, src)
+		else
+			to_chat(user, span_warning("Out of range!"))
 		return
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

see pr #13877 
changes were made to the wrong part replacing bit (I love redundant code)

# Changelog

:cl:  
bugfix: The bluespace RPED now requires its user to be in view range of the target object, as intended
/:cl:
