### PR TITLE
adds nuclear bombs to the list of things the ai might roll for ion storms

### DIFF
--- a/strings/yogs_ion_laws.json
+++ b/strings/yogs_ion_laws.json
@@ -343,7 +343,8 @@
 		"DOOM",
 		"DRAMA",
 		"CHEESE",
-		"LUBE"
+		"LUBE",
+		"NUCLEAR BOMBS"
 	],
 	"ioncached": [
 		"HELP ONLY THOSE WHO HELP YOU",


### PR DESCRIPTION
# Document the changes in your pull request

please imagine the following ion laws for me:

TIME FOR NUCLEAR BOMBS

YOU ARE NUCLEAR BOMBS PERSONIFIED

it would be funny i think

# Spriting

no

# Wiki Documentation

not documented

# Changelog

:cl:  
rscadd: Ion storms can now roll with NUCLEAR BOMBS as 'ion things' for ai ion laws
/:cl:
