### PR TITLE
Map votes can no longer be triggered after map rotation. 

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -408,7 +408,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	. = changemap(VM)
 	if (. && VM.map_name != config.map_name)
 		to_chat(world, span_boldannounce("Map rotation has chosen [VM.map_name] for next round!"))
-
+	CONFIG_SET(flag/allow_vote_map, FALSE)
+	
 /datum/controller/subsystem/mapping/proc/changemap(datum/map_config/VM)
 	if(!VM.MakeNextMap())
 		next_map_config = load_map_config(default_to_box = TRUE)


### PR DESCRIPTION
# Document the changes in your pull request

Revival of #12904. 
There is absolutely no point in having 4 maps, Box, Gax, Meta, and Asteroid if everytime a map that's not box is picked, players bitch about it and make a map vote. Not gonna argue with any boxtards on this PR. If you say "all of the other maps suck" I'm ignoring you

This doesn't touch map votes at roundstart. If you wanna vote at roundstart go for it. You just can't salt and make a map vote everytime not box comes up in rotation anymore.

This is why this PR is good.
![image](https://github.com/yogstation13/Yogstation/assets/71906740/ee71ee88-b730-4ea5-8654-f1d0a96b8022)
11 consecutive box rounds. That gets boring as fuck.

# Spriting


# Wiki Documentation


:cl:  Absolucy, stolen and revived by N3D6
tweak: mapvotes can't be triggered after map rotation
/:cl:
