### PR TITLE
Makes illegal tech less illegal

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1129,7 +1129,7 @@
 
 /datum/techweb_node/syndicate_basic
 	id = "syndicate_basic"
-	display_name = "Illegal Technology"
+	display_name = "Foreign Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
 	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "donksofttoyvendor", "donksoft_refill", "thermal_goggles")


### PR DESCRIPTION
# Document the changes in your pull request

Under current rules security technically 🤓 isnt supposed to be using debatably illegal technology even though most of it is useful to them and made for their use specifically

This renames it to "Foreign Technology" but if anyone thinks of any cooler names like espionage or something I'm cool with that

# Changelog

:cl:  
tweak: Illegal tech is no longer illegal
/:cl:
