### PR TITLE
Doubles Round Start SMES Power

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -18931,15 +18931,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"fgM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 6e+007
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "fgP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "barshutters";
@@ -38839,6 +38830,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lIj" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "lIp" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -63484,6 +63482,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"tgV" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
 "tgW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -78176,15 +78181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xWo" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 6e+007
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "xWp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -125540,9 +125536,9 @@ fcv
 aYa
 aAy
 rWB
-xWo
+lIj
 bDY
-xWo
+lIj
 nYv
 aAy
 aVM
@@ -126054,9 +126050,9 @@ coR
 kej
 aAy
 lSj
-fgM
+tgV
 atj
-fgM
+tgV
 eRU
 aAy
 xfS

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -422,7 +422,7 @@
 	log_smes()
 
 /obj/machinery/power/smes/engineering
-	charge = 5e7 // Engineering starts with some charge for singulo
+	charge = 1e8 // Engineering starts with some charge for singulo
 
 /obj/machinery/power/smes/fullycharged
 	charge = 5e8 // A fully charged SMES


### PR DESCRIPTION
# Document the changes in your pull request

With engineering now usually building more robust engines at round start, they take longer to set up. Cargo and Brig regularly start running low on power when this happens. Additionally, with new things added or expanded, initial power draw at round start is just higher than it used to be. This allows for extra time to get shit set up the way engineers want to do it, but doesn't make it trivial.

# Changelog

:cl:  
tweak: Changed round start engine SMES from 50000000 to 100000000 (5e7 -> 1e8)
mapping: Made Asteroid station engine SMES match the other stations
/:cl:
