### PR TITLE
Adjust failure chance for surgery on improvised surfaces

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -25,7 +25,7 @@
 /obj/structure/bed/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/surgery_bed, \
-		success_chance = 0.8, \
+		success_chance = 0.85, \
 	)
 
 /obj/structure/bed/examine(mob/user)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -217,7 +217,7 @@
 /obj/structure/holobed/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/surgery_bed, \
-		success_chance = 0.8, \
+		success_chance = 0.95, \
 	)
 
 /obj/structure/holobed/examine(mob/user)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -482,7 +482,7 @@
 /obj/structure/bed/surgical_mat/Initialize(mapload)
 	..()
 	var/datum/component/surgery_bed/SB = GetComponent(/datum/component/surgery_bed)
-	SB.success_chance = 0.8
+	SB.success_chance = 0.95
 
 /obj/structure/bed/surgical_mat/MouseDrop(over_object, src_location, over_location)
 	. = ..()
@@ -541,7 +541,7 @@
 /obj/structure/bed/surgical_mat/goliath/Initialize(mapload)
 	..()
 	var/datum/component/surgery_bed/SB = GetComponent(/datum/component/surgery_bed)
-	SB.success_chance = 0.85
+	SB.success_chance = 0.97
 
 /obj/item/surgical_mat/goliath
 	name = "goliath hide surgical mat"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request
Makes ghetto surgery not impossible. Increases success chance on actual medical equipment to a 1/20 chance instead of a 1/5 chance of failure that it used to be.
Goliath medical bed (which is apparently a thing) now has a 1/33 failure chance.
Tables are still a 1/5. Beds are slightly improved to a 1/6.7 chance of failure.

I find it stupid that there's no difference between doing surgery on some random table, and a medical roller bed or holobed. I do, however understand that the stasis bed and operating table should not just be surpassed completely.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: buffs surgery success chance on medical field equipment
/:cl:
