### PR TITLE
Darkspawn Buffing

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -15,7 +15,7 @@
 	//Psi variables
 	var/psi = 100 //Psi is the resource used for darkspawn powers
 	var/psi_cap = 150 //Max Psi by default
-	var/psi_regen = 25 //How much Psi will regenerate after using an ability
+	var/psi_regen = 20 //How much Psi will regenerate after using an ability
 	var/psi_regen_delay = 5 //How many ticks need to pass before Psi regenerates
 	var/psi_regen_ticks = 0 //When this hits 0, regenerate Psi and return to psi_regen_delay
 	var/psi_used_since_regen = 0 //How much Psi has been used since we last regenerated

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -14,8 +14,8 @@
 
 	//Psi variables
 	var/psi = 100 //Psi is the resource used for darkspawn powers
-	var/psi_cap = 100 //Max Psi by default
-	var/psi_regen = 20 //How much Psi will regenerate after using an ability
+	var/psi_cap = 150 //Max Psi by default
+	var/psi_regen = 25 //How much Psi will regenerate after using an ability
 	var/psi_regen_delay = 5 //How many ticks need to pass before Psi regenerates
 	var/psi_regen_ticks = 0 //When this hits 0, regenerate Psi and return to psi_regen_delay
 	var/psi_used_since_regen = 0 //How much Psi has been used since we last regenerated

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/crawling_shadows.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/crawling_shadows.dm
@@ -5,7 +5,7 @@
 	desc = "Assumes a shadowy form for a minute that can crawl through vents and squeeze through the cracks in doors. You can also knock people out by attacking them."
 	button_icon_state = "crawling_shadows"
 	check_flags =  AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
-	psi_cost = 60
+	psi_cost = 50
 	lucidity_price = 2 //probably going to replace creep with this
 
 /datum/action/innate/darkspawn/crawling_shadows/IsAvailable(feedback = FALSE)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/tagalong.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/tagalong.dm
@@ -2,10 +2,10 @@
 /datum/action/innate/darkspawn/tagalong
 	name = "Tagalong"
 	id = "tagalong"
-	desc = "Melds with a target's shadow, causing you to invisibly follow them. Only works in lit areas, and you will be forced out if you hold any items. Costs 30 Psi."
+	desc = "Melds with a target's shadow, causing you to invisibly follow them. Only works in lit areas, and you will be forced out if you hold any items. Costs 20 Psi."
 	button_icon_state = "tagalong"
 	check_flags = AB_CHECK_CONSCIOUS
-	psi_cost = 30
+	psi_cost = 20
 	psi_addendum = ", but is free to cancel"
 	lucidity_price = 2
 	var/datum/status_effect/tagalong/tagalong

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/time_dilation.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/time_dilation.dm
@@ -2,10 +2,10 @@
 /datum/action/innate/darkspawn/time_dilation
 	name = "Time Dilation"
 	id = "time_dilation"
-	desc = "Greatly increases reaction times and action speed, and provides immunity to slowdown. This lasts for 1 minute. Costs 75 Psi."
+	desc = "Greatly increases reaction times and action speed, and provides immunity to slowdown. This lasts for 1 minute. Costs 50 Psi."
 	button_icon_state = "time_dilation"
 	check_flags = AB_CHECK_CONSCIOUS
-	psi_cost = 75
+	psi_cost = 50
 	lucidity_price = 3
 
 /datum/action/innate/darkspawn/time_dilation/IsAvailable(feedback = FALSE)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	if(isobserver(user) || isdarkspawn(user))
 		to_chat(user, "<span class='velvet bold'>Functions:<span>")
-		to_chat(user, span_velvet("<b>Help intent:</b> Click on an open tile within seven tiles to jump to it for 10 Psi."))
+		to_chat(user, span_velvet("<b>Help intent:</b> Click on an open tile within seven tiles to jump to it for 5 Psi."))
 		to_chat(user, span_velvet("<b>Disarm intent:</b> Click on an airlock to force it open for 15 Psi (or 30 if it's bolted.)"))
 		to_chat(user, span_velvet("<b>Harm intent:</b> Fire a projectile that travels up to five tiles, knocking down[twin ? " and pulling forwards" : ""] the first creature struck."))
 		to_chat(user, span_velvet("The tendrils will break any lights hit in melee,"))
@@ -99,7 +99,7 @@
 	to_chat(user, span_velvet("You pull yourself towards [target]."))
 	playsound(user, 'sound/magic/tail_swing.ogg', 10, TRUE)
 	user.throw_at(target, 5, 3)
-	darkspawn.use_psi(10)
+	darkspawn.use_psi(5)
 
 /obj/item/umbral_tendrils/proc/tendril_swing(mob/living/user, mob/living/target) //swing the tendrils to knock someone down
 	if(isliving(target) && target.lying)


### PR DESCRIPTION
# Document the changes in your pull request

Made a few buffs to Darkspawn, as they're in a...not great spot having been removed for as long as they have. I've gone ahead and made a few modifications, in order to try and make more than two or three abilities worth taking (currently the only useful spells are crawling shadows, veil mind and creep), and to make the abilities which are pretty much necessary actually usable. (Crawling shadows and creep being a borderline necessity, yet extremely expensive considering the max pool of Psi available, and the recharge) 

# Spriting

# Wiki Documentation

Crawling shadows Psi cost decreased to 50
Time dilation Psi cost decreased to 50
Tagalong Psi cost decreased to 20
Tendrils leap Psi cost decreased to 5
Increased Psi cap to 150

# Changelog


:cl:  
tweak: Crawling shadows Psi cost decreased to 50
tweak: Time dilation Psi cost decreased to 50
tweak: Tagalong Psi cost decreased to 20
tweak: Tendrils leap Psi cost decreased to 5
tweak: Increased Psi cap to 150
/:cl:
