### PR TITLE
fix true devil attack_ghost runtime

### DIFF
--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -142,7 +142,7 @@
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /mob/living/carbon/true_devil/attack_ghost(mob/dead/observer/user as mob)
-	if(ascended || user.mind.soulOwner == src.mind)
+	if(ascended || user.mind?.soulOwner == src.mind)
 		var/mob/living/simple_animal/imp/S = new(get_turf(loc))
 		S.key = user.key
 		var/datum/antagonist/imp/A = new()


### PR DESCRIPTION
# Document the changes in your pull request

this is (i assume) inconsequential but it prevented ghosts from inquisitively clicking the devil to examine (had to shift click)

# Changelog

:cl:  
bugfix: fixed not being able to examine true devil with ghost inquisitive click
/:cl:
