### PR TITLE
Resonance Cascade

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -554,6 +554,15 @@
 					id.critter_money = FALSE
 			message_admins("[key_name_admin(mob_user)] has deactivated critter money (pets generated on money withdrawl)!")
 			log_admin("[key_name(mob_user)] has deactivated critter money.")
+		if("halflife")
+			if(!check_rights_for(rights, R_FUN))
+				return
+			for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
+				if(!isturf(S.loc) || !is_station_level(S.z))
+					continue
+				S.antinoblium_attached = TRUE
+			message_admins("[key_name_admin(mob_user)] has started a resonance cascade!")
+			log_admin("[key_name(mob_user)] has started a resonance cascade.")
 
 	if(E)
 		E.processing = FALSE

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -145,7 +145,8 @@
 	for(var/obj/machinery/power/apc/A in GLOB.apcs_list)
 		if(!is_station_level(A.z))
 			continue
-		A.overload_lighting()
+		if(prob(75))
+			A.overload_lighting()
 		A.emp_act(EMP_HEAVY) // stationwide blackout
 		if(prob(25)) // chance of some fun effects
 			if(prob(20))

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -135,7 +135,7 @@
 		/mob/living/simple_animal/hostile/asteroid/marrowweaver = 12
 	)
 	hostile_types = list(
-		/mob/living/simple_animal/hostile/asteroid/hivelord/legion = 24,
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril = 24,
 		/mob/living/simple_animal/hostile/asteroid/basilisk/watcher = 24,
 	)
 	endWhen = INFINITY // keep going until it's done

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -159,6 +159,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/support_integrity = 100			// Current support integrity. Provides *fun* effects
 	var/antinoblium_attached = FALSE	// The thing that makes it explode more
 	var/corruptor_attached = FALSE		// The thing that reduces support integrity
+	var/resonance_cascading = FALSE		// IT'S NOT SHUTTING DOWN!!!!!!!
 
 	// Radio related variables
 	var/obj/item/radio/radio
@@ -284,13 +285,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/proc/alarm()
 	switch(get_status())
 		if(SUPERMATTER_DELAMINATING)
-			playsound(src, 'sound/misc/bloblarm.ogg', 100)
+			playsound(src, 'sound/misc/bloblarm.ogg', 100, FALSE, 100, pressure_affected=FALSE)
 		if(SUPERMATTER_EMERGENCY)
-			playsound(src, 'sound/machines/engine_alert1.ogg', 100)
+			playsound(src, 'sound/machines/engine_alert1.ogg', 100, FALSE, 100, pressure_affected=FALSE)
 		if(SUPERMATTER_DANGER)
-			playsound(src, 'sound/machines/engine_alert2.ogg', 100)
+			playsound(src, 'sound/machines/engine_alert2.ogg', 100, FALSE, 10, pressure_affected=FALSE)
 		if(SUPERMATTER_WARNING)
-			playsound(src, 'sound/machines/supermatter_alert.ogg', 75)
+			playsound(src, 'sound/machines/supermatter_alert.ogg', 75, FALSE, pressure_affected=FALSE)
 
 /obj/machinery/power/supermatter_crystal/proc/get_integrity()
 	var/integrity = damage / explosion_point
@@ -318,30 +319,33 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		speaking = "[emergency_alert] The supermatter has reached critical integrity failure. Emergency causality destabilization field has been activated."
 	radio.talk_into(src, speaking, common_channel, language = get_selected_language())
-	for(var/i in SUPERMATTER_COUNTDOWN_TIME to 0 step -10)
-		if(damage < explosion_point) // Cutting it a bit close there engineers
+	for(var/i in SUPERMATTER_COUNTDOWN_TIME to 0 step (-1 SECONDS))
+		if(damage < explosion_point && !resonance_cascading) // Cutting it a bit close there engineers
 			radio.talk_into(src, "[safe_alert] Failsafe has been disengaged.", common_channel)
 			log_game("The supermatter crystal:[safe_alert] Failsafe has been disengaged.") // yogs start - Logs SM chatter
 			investigate_log("The supermatter crystal:[safe_alert] Failsafe has been disengaged.", INVESTIGATE_SUPERMATTER) // yogs end
 			cut_overlay(causality_field, TRUE)
 			final_countdown = FALSE
 			return
-		else if((i % 50) != 0 && i > 50) // A message once every 5 seconds until the final 5 seconds which count down individualy
+		else if((i % (5 SECONDS)) != 0 && i > (5 SECONDS)) // A message once every 5 seconds until the final 5 seconds which count down individualy
 			sleep(1 SECONDS)
 			continue
-		else if(i > 50)
+		else if(i > 5 SECONDS)
 			if(corruptor_attached)
 				speaking = "[DisplayTimeText(round(rand()*5*i,1), TRUE)] remain before causality stabilization."
 			else
 				speaking = "[DisplayTimeText(i, TRUE)] remain before causality stabilization."
 			log_game("The supermatter crystal: [DisplayTimeText(i, TRUE)] remain before causality stabilization.") // yogs start - Logs SM chatter
 			investigate_log("The supermatter crystal: [DisplayTimeText(i, TRUE)] remain before causality stabilization.", INVESTIGATE_SUPERMATTER)
-			if(i == 300)	//Yogs- also adds audio when SM hits countdown
-				playsound(src, 'yogstation/sound/voice/sm/fcitadel_30sectosingularity.ogg', 100)
-			if(i == 150)
-				playsound(src, 'yogstation/sound/voice/sm/fcitadel_15sectosingularity.ogg', 100)
-			if(i == 100)
-				playsound(src, 'yogstation/sound/voice/sm/fcitadel_10sectosingularity.ogg', 100)	// yogs end
+			if(i == 30 SECONDS)	//Yogs- also adds audio when SM hits countdown
+				playsound(src, 'yogstation/sound/voice/sm/fcitadel_30sectosingularity.ogg', 100, FALSE, 100, pressure_affected=FALSE)
+			if(i == 15 SECONDS)
+				playsound(src, 'yogstation/sound/voice/sm/fcitadel_15sectosingularity.ogg', 100, FALSE, 100, pressure_affected=FALSE)
+			if(i == 10 SECONDS)
+				playsound(src, 'yogstation/sound/voice/sm/fcitadel_10sectosingularity.ogg', 100, FALSE, 100, pressure_affected=FALSE)
+				if(antinoblium_attached && !resonance_cascading) // yogs- resonance cascade!
+					resonance_cascading = TRUE
+					sound_to_playing_players('sound/magic/lightning_chargeup.ogg', 50, FALSE) // yogs end
 		else
 			if(corruptor_attached)
 				speaking = "[round(i*0.1*rand(),1)]..."
@@ -378,7 +382,15 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, span_boldannounce("You feel reality distort for a moment..."))
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-	if(combined_gas > MOLE_PENALTY_THRESHOLD)
+
+	if(resonance_cascading)
+		sound_to_playing_players('sound/magic/lightningbolt.ogg', volume = 50)
+		var/datum/round_event_control/resonance_cascade/xen = new
+		xen.runEvent()
+		message_admins("[src] has caused a resonance cascade.")
+		investigate_log("has caused a resonance cascade.", INVESTIGATE_SUPERMATTER)
+
+	if(combined_gas > MOLE_PENALTY_THRESHOLD && !resonance_cascading)
 		message_admins("[src] has collapsed into a singularity. [ADMIN_JMP(src)].")
 		investigate_log("has collapsed into a singularity.", INVESTIGATE_SUPERMATTER)
 		if(T)
@@ -400,12 +412,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		else
 			message_admins("[src] has exploded")
 			investigate_log("has exploded.", INVESTIGATE_SUPERMATTER)
-		if(antinoblium_attached)
-			explosion_mod += 1
 		INVOKE_ASYNC(GLOBAL_PROC, /proc/empulse, T, explosion_power * explosion_mod, (explosion_power * explosion_mod * 2) + (explosion_power/4), TRUE, FALSE, FALSE, TRUE)
-		explosion(T, explosion_power * explosion_mod * 0.5 , explosion_power * explosion_mod + 2, explosion_power * explosion_mod + 4 , explosion_power * explosion_mod + 6, 1, 1)
-		radiation_pulse(src, (last_rads + 2400) * explosion_power)
-		if(power > POWER_PENALTY_THRESHOLD)
+		explosion(T, explosion_power * explosion_mod * 0.5, explosion_power * explosion_mod + 2, explosion_power * explosion_mod + 4, explosion_power * explosion_mod + 6, 1, 1)
+		radiation_pulse(T, (last_rads + 2400) * explosion_power)
+		if(power > POWER_PENALTY_THRESHOLD && !resonance_cascading)
 			investigate_log("has spawned additional energy balls.", INVESTIGATE_SUPERMATTER)
 			var/obj/singularity/energy_ball/E = new(T)
 			E.energy = power
@@ -520,9 +530,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		// Mole releated calculations
 		var/bzmol = max(removed.get_moles(/datum/gas/bz), 0)
 		var/nitriummol = max(removed.get_moles(/datum/gas/nitrium), 0)
+		var/antinobmol = max(removed.get_moles(/datum/gas/antinoblium), 0)
 
 		// Power of the gas. Scale of 0 to 1
-		gasmix_power_ratio = clamp(plasmacomp + o2comp + co2comp + tritiumcomp + bzcomp + nitriumcomp - pluoxiumcomp - n2comp, 0, 1)
+		gasmix_power_ratio = clamp(plasmacomp + o2comp + co2comp + tritiumcomp + bzcomp + nitriumcomp + antinobliumcomp - pluoxiumcomp - n2comp, 0, 1)
 
 		// How much heat to emit/resist
 		dynamic_heat_modifier = max((plasmacomp * PLASMA_HEAT_PENALTY) + (o2comp * OXYGEN_HEAT_PENALTY) + (co2comp * CO2_HEAT_PENALTY) + (tritiumcomp * TRITIUM_HEAT_PENALTY) + (pluoxiumcomp * PLUOXIUM_HEAT_PENALTY) + (n2comp * NITROGEN_HEAT_PENALTY) + (bzcomp * BZ_HEAT_PENALTY) + (h2ocomp * H2O_HEAT_PENALTY) + (haloncomp * HALON_HEAT_PENALTY) + (antinobliumcomp * ANTINOB_HEAT_PENALTY), 0.5)
@@ -577,6 +588,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				if(prob(80))
 					src.fire_nuclear_particle()	// Spawn more radballs at 80% chance each
 
+		if(antinobliumcomp >= 0.5 && antinobmol > 100 && !antinoblium_attached) // don't put this stuff in the SM
+			investigate_log("[src] has reached criticial antinoblium concentration and started a resonance cascade.", INVESTIGATE_SUPERMATTER)
+			message_admins("[src] has reached criticial antinoblium concentration and started a resonance cascade.")
+			antinoblium_attached = TRUE // oh god oh fuck
+
 		var/device_energy = power * REACTION_POWER_MODIFIER
 
 		//To figure out how much temperature to add each tick, consider that at one atmosphere's worth
@@ -630,7 +646,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			playsound(src.loc, 'sound/weapons/emitter2.ogg', 100, 1, extrarange = 10)
 			supermatter_zap(src, 5, clamp(power*2, 4000, 20000))
 
-		if(prob(15) && power > POWER_PENALTY_THRESHOLD)
+		if(prob(15) && (power > POWER_PENALTY_THRESHOLD || combined_gas > MOLE_PENALTY_THRESHOLD || antinoblium_attached))
 			supermatter_pull(src, power/750)
 		if(prob(5))
 			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
@@ -689,6 +705,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				radio.talk_into(src, "Warning: Critical coolant mass reached.", engineering_channel)
 				log_game("The supermatter crystal: Warning: Critical coolant mass reached.") // yogs start - Logs SM chatter
 				investigate_log("The supermatter crystal: Warning: Critical coolant mass reached.", INVESTIGATE_SUPERMATTER) // yogs end
+			
+			if(antinoblium_attached && support_integrity <= 0)
+				radio.talk_into(src, "DANGER: RESONANCE CASCADE IMMINENT.", engineering_channel)
+				log_game("The supermatter crystal: DANGER: RESONANCE CASCADE IMMINENT.") // yogs start - Logs SM chatter
+				investigate_log("The supermatter crystal: DANGER: RESONANCE CASCADE IMMINENT.", INVESTIGATE_SUPERMATTER) // yogs end
 
 		if(damage > explosion_point)
 			countdown()
@@ -716,7 +737,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				if(20)
 					radio.talk_into(src, "CRYSTAL WELL DESTABILIZED, ELECTROMAGNETIC PULSES INBOUND, PARANOBLIUM INTERFACE OPERATING AT [round(15+ rand()*10,0.01)]% CAPACITY", common_channel)
 				if(10)
-					radio.talk_into(src, "ELECTROMAGNETIC PULSE CONTAINMENT FAILED, PARANOBLIUM INTERFACE NONFUNCTIONAL, DELAMINATION IMMINENT", common_channel)
+					radio.talk_into(src, "ELECTROMAGNETIC FIELD CONTAINMENT FAILED, PARANOBLIUM INTERFACE NONFUNCTIONAL, RESONANCE CASCADE IMMINENT", common_channel)
 				if(6)
 					radio.talk_into(src, "ELECTROMAGNETIC PULSES IMMINENT, CONTAINMENT AND COOLING FAILURE IMMINENT", common_channel)
 				if(1) //after those emps, anyone who can hear this must be lucky.
@@ -730,6 +751,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			power += round((100-support_integrity)/2,1)
 		if(support_integrity<70)
 			if(prob(30+round((100-support_integrity)/2,1)))
+				playsound(src.loc, 'sound/weapons/emitter2.ogg', 100, 1, extrarange = 10)
 				supermatter_zap(src, 5, min(power*2, 20000))
 		if(support_integrity<40)
 			if(prob(10))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1834,7 +1834,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/supermatter_delaminator
 	name = "Antinoblium Shard"
 	desc = "A special variant of supermatter crystal reverse engineered by syndicate scientists using samples retrieved by agents. \
-			Attaching this to an active supermatter crystal will destabilize the internal crystal well, causing an energy cascade. \
+			Attaching this to an active supermatter crystal will destabilize the internal crystal well, causing a resonance cascade. \
 			Ensures a storm of EMP waves that blacks out the entire station and eventually the full delamination of the crystal. \
 			Comes with a secure radiation shielded containment box, special tweezers and usage instructions."
 	item = /obj/item/storage/box/syndie_kit/supermatter_delaminator

--- a/tgui/packages/tgui/interfaces/SecretsPanel.js
+++ b/tgui/packages/tgui/interfaces/SecretsPanel.js
@@ -69,6 +69,7 @@ export const SecretsPanel = (props, context) => {
           <Button color={'bad'} content={'Change bomb cap'} onClick={() => act('changebombcap')} disabled={!funRights} /><br />
           <Button.Confirm color={'bad'} content={'Mass Purrbation'} onClick={() => act('masspurrbation')} disabled={!funRights} /><br />
           <Button.Confirm color={'bad'} content={'Mass Remove Purrbation'} onClick={() => act('massremovepurrbation')} disabled={!funRights} /><br />
+          <Button.Confirm color={'bad'} content={'Resonance Cascade'} onClick={() => act('halflife')} disabled={!funRights} /><br />
         </Section>
         <Section title={'Debug Secrets'}>
           <Button.Confirm color={'bad'} content={'Change all maintenance doors to engie/brig access only'} onClick={() => act('maint_access_engiebrig')} disabled={!debugRights} /><br />


### PR DESCRIPTION
# Document the changes in your pull request

This PR introduces a new SM delamination type, caused by the traitor delaminator kit or large amounts of antinoblium gas. If antinoblium gas is the cause, it can be reversed by adding hypernoblium gas, but only if the traitor kit wasn't used and it hasn't been too long since the process began.

Before the explosion, it has the same effects as the delaminator already did (see #9037 for details), with the addition of a gravitational pull and the explosion power lowered a bit to compensate for what's about to happen. The alarm sounds will be audible across the station once it reaches 25% or lower integrity.

Immediately after the explosion, every APC on the station will be EMP'd causing a station-wide blackout, and some will cause tesla arcs or small explosions. Most of the lights will also break. After this, portals will appear and dangerous lavaland fauna will invade the station. The shuttle will be automatically called if it hasn't been already.

# Wiki Documentation

On the guide to the supermatter, add antinoblium to the list of gas effects with this description:
"Adding this gas to the supermatter will cause a resonance cascade that will destroy a lot of the station, unless you add lots of hypernoblium quickly enough to reverse the process. Do not use this gas unless you want to kill people."

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: adds resonance cascade, a new delamination type
bugfix: fixed portal storms spawning visual effects in the wrong place
/:cl:
