### PR TITLE
fixes antinob crystal description

### DIFF
--- a/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
+++ b/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
@@ -34,7 +34,7 @@
 
 /obj/item/stack/antinoblium_crystal
 	name = "Antinoblium Crystal"
-	desc = "Crystalized antinoblium, nitrium, and zauker. An incredibly volatile material."
+	desc = "Crystalized antinoblium, bz, and nitrogen. An incredibly volatile material."
 	icon_state = "antinoblium_crystal"
 	resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | UNACIDABLE
 	grind_results = list(/datum/reagent/antinoblium = 20)


### PR DESCRIPTION

# Document the changes in your pull request

updates the description of the item cause I forgot to when I made the crystallizer PR

# Spriting

no

# Wiki Documentation

no

# Changelog

:cl:  
spellcheck: fixed antinoblium crystal description
/:cl:
