### PR TITLE
Stops heirophant club from attacking if you click an item in your inventory

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1473,7 +1473,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 		return
 	if(isitem(target))//don't attack if we're clicking on our inventory
 		var/obj/item/thing = target
-		if(target.item_flags & IN_INVENTORY)
+		if(thing.item_flags & IN_INVENTORY)
 			return
 	if(!is_mining_level(T.z) && z_level_check)
 		to_chat(user, span_warning("The club fizzles weakly, it seem its power doesn't reach this area.") )

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1471,6 +1471,8 @@ GLOBAL_LIST_EMPTY(aide_list)
 	var/turf/T = get_turf(target)
 	if(!T || timer > world.time)
 		return
+	if(isobj(target) && target.loc == user)//don't attack if we're clicking on our inventory
+		return
 	if(!is_mining_level(T.z) && z_level_check)
 		to_chat(user, span_warning("The club fizzles weakly, it seem its power doesn't reach this area.") )
 		return

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1471,8 +1471,10 @@ GLOBAL_LIST_EMPTY(aide_list)
 	var/turf/T = get_turf(target)
 	if(!T || timer > world.time)
 		return
-	if(isobj(target) && target.loc == user)//don't attack if we're clicking on our inventory
-		return
+	if(isitem(target))//don't attack if we're clicking on our inventory
+		var/obj/item/thing = target
+		if(target.item_flags & IN_INVENTORY)
+			return
 	if(!is_mining_level(T.z) && z_level_check)
 		to_chat(user, span_warning("The club fizzles weakly, it seem its power doesn't reach this area.") )
 		return


### PR DESCRIPTION
no real reason it needs to attack if you're trying to shift things around in your inventory and you misclick

:cl:  
bugfix: Stops heirophant club from attacking if you click an item in your inventory
/:cl:
