### PR TITLE
Makes martial arts faster to learn after a round ends

### DIFF
--- a/code/game/objects/items/granters/martial_arts/_martial_arts.dm
+++ b/code/game/objects/items/granters/martial_arts/_martial_arts.dm
@@ -16,6 +16,8 @@
 
 /obj/item/book/granter/martial/on_reading_start(mob/user)
 	to_chat(user, span_notice("You start reading about [martial_name]..."))
+	if(SSticker.current_state == GAME_STATE_FINISHED)//faster after the round ends
+		pages_to_mastery = 0
 
 /obj/item/book/granter/martial/on_reading_finished(mob/user)
 	to_chat(user, "[greet]")

--- a/code/game/objects/items/granters/martial_arts/_martial_arts.dm
+++ b/code/game/objects/items/granters/martial_arts/_martial_arts.dm
@@ -12,12 +12,13 @@
 	if(user.mind.has_martialart(initial(martial.id)))
 		to_chat(user, span_warning("You already know [martial_name]!"))
 		return FALSE
+	if(SSticker.current_state == GAME_STATE_FINISHED)//instant after the round ends
+		on_reading_finished(user)
+		return FALSE
 	return TRUE
 
 /obj/item/book/granter/martial/on_reading_start(mob/user)
 	to_chat(user, span_notice("You start reading about [martial_name]..."))
-	if(SSticker.current_state == GAME_STATE_FINISHED)//faster after the round ends
-		pages_to_mastery = 0
 
 /obj/item/book/granter/martial/on_reading_finished(mob/user)
 	to_chat(user, "[greet]")


### PR DESCRIPTION
With the donator perk of getting one free uplink item for the end of the round, it's pretty useless to select a martial art as they take so long to read that you'll be dead before you get time to finish reading it

This cuts out all except for 1 instance of reading

:cl:  
tweak: Makes martial arts faster to learn after a round ends
/:cl:
