### PR TITLE
Fixes ballistic gun overlays

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -150,15 +150,17 @@
 	if(!type || !frames)
 		return
 	update_appearance(UPDATE_OVERLAYS)
+	var/list/added_overlays = list()
 	if(type == "fire")
-		feedback_fire_slide ? add_overlay(feedback_firing_icon) : add_overlay(feedback_original_icon)
+		added_overlays += feedback_fire_slide ? add_overlay(feedback_firing_icon) : add_overlay(feedback_original_icon)
 		DabAnimation(speed = feedback_recoil_speed, angle = ((rand(25,50)) * feedback_recoil_amount), direction = (feedback_recoil_reverse ? 2 : 3), hold_seconds = feedback_recoil_hold)
 	else if(bolt_type == BOLT_TYPE_LOCKING)
 		if(type == "slide_close") // cause the gun to move clockwise if slide is closed
 			DabAnimation(speed = feedback_recoil_speed, angle = ((rand(20,25)) * feedback_recoil_amount), direction = 2)
 	if(type != "fire")
-		add_overlay("[feedback_original_icon_base]_[type]") // actual animation
+		added_overlays += add_overlay("[feedback_original_icon_base]_[type]") // actual animation
 	sleep(frames)
+	cut_overlays(added_overlays)
 	update_appearance(UPDATE_OVERLAYS)
 
 /obj/item/gun/ballistic/update_icon_state()


### PR DESCRIPTION
# Document the changes in your pull request


# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Ballistic guns no longer get error sprites after shooting them too many times. They also don't have the cocked back overlay when they aren't.
/:cl:
