### PR TITLE
Makes C4 overlay appear overtop of mobs rather than under

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -23,7 +23,7 @@
 
 /obj/item/grenade/plastic/Initialize(mapload)
 	. = ..()
-	plastic_overlay = mutable_appearance(icon, "[item_state]2", HIGH_OBJ_LAYER)
+	plastic_overlay = mutable_appearance(icon, "[item_state]2", ABOVE_ALL_MOB_LAYER)
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/grenade/plastic/Destroy()


### PR DESCRIPTION
I just ran around an entire round with a party plastic explosive on myself and no one reacted because no one saw it

:cl:  
tweak: Makes C4 overlay appear overtop of mobs rather than under
/:cl:
