### PR TITLE
Fixed some cloning bugs

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -627,6 +627,9 @@
 	if(!istype(dna))
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		return FALSE
+	if(TRAIT_NOCLONE in dna.species?.inherent_traits) // YOU CAN'T ESCAPE
+		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
+		return FALSE
 	if(!body_only && (mob_occupant.suiciding || mob_occupant.hellbound))
 		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
 		return FALSE

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -577,7 +577,7 @@
 
 	R.fields["bank_account"] = has_bank_account
 	R.fields["mindref"] = "[REF(mob_occupant.mind)]"
-	R.fields["last_death"] = mob_occupant.stat == DEAD ? mob_occupant.mind.last_death : -1
+	R.fields["last_death"] = mob_occupant.stat == DEAD ? mob_occupant.mind?.last_death : -1
 	R.fields["body_only"] = body_only
 
 	if(!body_only)
@@ -625,9 +625,6 @@
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		return FALSE
 	if(!istype(dna))
-		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
-		return FALSE
-	if(TRAIT_NOCLONE in dna.species?.inherent_traits) // YOU CAN'T ESCAPE
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		return FALSE
 	if(!body_only && (mob_occupant.suiciding || mob_occupant.hellbound))

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -107,6 +107,8 @@
 		C.dna.copy_dna(brainmob.stored_dna)
 		if(HAS_TRAIT(L, TRAIT_BADDNA))
 			brainmob.status_traits[TRAIT_BADDNA] = L.status_traits[TRAIT_BADDNA]
+		if(HAS_TRAIT(L, TRAIT_NOCLONE)) // YOU CAN'T ESCAPE
+			brainmob.status_traits[TRAIT_NOCLONE] = L.status_traits[TRAIT_NOCLONE]
 		var/obj/item/organ/zombie_infection/ZI = L.getorganslot(ORGAN_SLOT_ZOMBIE)
 		if(ZI)
 			brainmob.set_species(ZI.old_species)	//For if the brain is cloned


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a runtime error when cloning someone that never died, and TRAIT_NOCLONE now applies itself to brainmobs on brain removal so that you can't just clone a brain to get around it.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed being able to clone mobs with TRAIT_NOCLONE (like IPCs) by just cloning their brain
bugfix: fixed runtime error when cloning someone that never died
/:cl:
