### PR TITLE
fixes a missing 'the' in the nukie 'code not available' fluff(?) text

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -91,7 +91,7 @@
 		antag_memory += "<B>[nuke_team.tracked_nuke] Code</B>: [nuke_team.memorized_code]<br>"
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
 	else
-		to_chat(owner, "Unfortunately the syndicate was unable to provide you with nuclear authorization code.")
+		to_chat(owner, "Unfortunately the Syndicate was unable to provide you with the nuclear authorization code.")
 
 /datum/antagonist/nukeop/proc/move_to_spawnpoint()
 	var/team_number = 1


### PR DESCRIPTION
FUCK

title says it all

"Unfortunately, the syndicate was unable to provide you nuclear authentication code"

is now

"Unfortunately, the Syndicate was unable to provide you with the nuclear authentication code."

:cl:  
spellcheck: added one 'the' to the text you get when something fucks up and nukies dont get their code
/:cl:
