### PR TITLE
Mining Cyborg Proto-Kinetic Crusher Upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -947,3 +947,33 @@
 		var/obj/item/borg_snack_dispenser/medical/lollipopshooter = new(R.module)
 		R.module.basic_modules += lollipopshooter
 		R.module.add_module(lollipopshooter, FALSE, TRUE)
+
+/obj/item/borg/upgrade/crusher
+	name = "cyborg proto-kinetic crusher"
+	desc = "A proto-kinetic crusher adapted to be mounted on mining cyborgs. "
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "mining_hammer0"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/miner
+	module_flags = BORG_MODULE_MINER
+
+/obj/item/borg/upgrade/crusher/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/item/kinetic_crusher/crusher = locate() in R.module.modules
+	if(crusher)
+		to_chat(user, span_warning("This cyborg is already equipped with a proto-kinetic crusher!"))
+		return FALSE
+	crusher = new(R.module)
+	R.module.basic_modules += crusher
+	R.module.add_module(crusher, FALSE, TRUE)
+
+/obj/item/borg/upgrade/crusher/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/obj/item/kinetic_crusher/crusher = locate() in R.module.modules
+	if(crusher)
+		R.module.remove_module(crusher, TRUE)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -956,7 +956,7 @@
 	id = "borg_upgrade_protocrusher"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/crusher
-	// The iron and glass price here is 3x of the deconstruction materials for a crusher. The extra materials are the standard modkit price.
+	// Roughly 2x of deconstruction materials for a crusher plus the cost of a standard modkit. 
 	materials = list(/datum/material/iron = 6000, /datum/material/glass = 6000, /datum/material/gold = 1500, /datum/material/uranium = 1000)
 	construction_time = 4 SECONDS
 	category = list("Cyborg Upgrade Modules")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -951,6 +951,16 @@
 	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_protocrusher
+	name = "Cyborg Upgrade (Proto-kinetic Crusher)"
+	id = "borg_upgrade_protocrusher"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/crusher
+	// The iron and glass price here is 3x of the deconstruction materials for a crusher. The extra materials are the standard modkit price.
+	materials = list(/datum/material/iron = 6000, /datum/material/glass = 6000, /datum/material/gold = 1500, /datum/material/uranium = 1000)
+	construction_time = 4 SECONDS
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/boris_ai_controller
 	name = "B.O.R.I.S. AI-Cyborg Remote Control Module"
 	id = "borg_ai_control"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -554,7 +554,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter","miningcharge","borg_upgrade_protocrusher")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter", "miningcharge", "borg_upgrade_protocrusher")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/magmite_mining

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -554,7 +554,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter","miningcharge")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter","miningcharge","borg_upgrade_protocrusher")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/magmite_mining


### PR DESCRIPTION
# Document the changes in your pull request
There is a new upgrade that can be given to mining cyborgs that gives them a proto-kinetic crusher.

Costs 6000 metal, 6000 glass, 1500 gold, and 1000 uranium. (2x price of deconstruction of a crusher + modkit price)
Locked behind Advanced Mining Technology.

# Wiki Documentation
New upgrade to add to the [list of cyborg upgrades](https://wiki.yogstation.net/wiki/Guide_to_robotics#Cyborg_Upgrades).

# Changelog
:cl:  
rscadd: A new cyborg upgrade is available for mining cyborgs that gives them a proto-kinetic crusher.
/:cl:
