### PR TITLE
Engineering Cyborg Advanced Tools and ATMOS Holofan Upgrades

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -947,3 +947,131 @@
 		var/obj/item/borg_snack_dispenser/medical/lollipopshooter = new(R.module)
 		R.module.basic_modules += lollipopshooter
 		R.module.add_module(lollipopshooter, FALSE, TRUE)
+
+
+/obj/item/borg/upgrade/engi_advancedtools
+	name = "engineering cyborg advanced tool kit"
+	desc = "An upgrade for engineering cyborgs which replaces their basic tools with an advanced verison of them."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/engineering
+	module_flags = BORG_MODULE_ENGINEERING
+
+/obj/item/borg/upgrade/engi_advancedtools/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	for(var/obj/item/screwdriver/cyborg/SC in R.module.modules) 
+		R.module.remove_module(SC, TRUE)
+
+	for(var/obj/item/wrench/cyborg/W in R.module.modules) 
+		R.module.remove_module(W, TRUE)
+
+	for(var/obj/item/crowbar/cyborg/CB in R.module.modules) 
+		R.module.remove_module(CB, TRUE)
+
+	for(var/obj/item/wirecutters/cyborg/WC in R.module.modules) 
+		R.module.remove_module(WC, TRUE)
+
+	for(var/obj/item/multitool/cyborg/MT in R.module.modules) 
+		R.module.remove_module(MT, TRUE)
+	
+	for(var/obj/item/analyzer/AL in R.module.modules) 
+		R.module.remove_module(AL, TRUE)
+
+	var/obj/item/jawsoflife/JL = locate() in R.module.modules
+	var/obj/item/handdrill/HD = locate() in R.module.modules
+	var/obj/item/multitool/tricorder/TC = locate() in R.module.modules
+	if(JL || HD || TC)
+		to_chat(user, span_warning("This cyborg is already equipped with an advanced engineering tool kit."))
+		return FALSE
+
+	JL = new(R.module)
+	R.module.basic_modules += JL
+	R.module.add_module(JL, FALSE, TRUE)
+
+	HD = new(R.module)
+	R.module.basic_modules += HD
+	R.module.add_module(HD, FALSE, TRUE)
+
+	TC = new(R.module)
+	R.module.basic_modules += TC
+	R.module.add_module(TC, FALSE, TRUE)
+
+/obj/item/borg/upgrade/engi_advancedtools/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	for(var/obj/item/jawsoflife/JL in R.module.modules)
+		R.module.remove_module(JL, TRUE)
+
+	for(var/obj/item/handdrill/HD in R.module.modules)
+		R.module.remove_module(HD, TRUE)
+
+	for(var/obj/item/multitool/tricorder/TC in R.module.modules)
+		R.module.remove_module(TC, TRUE)
+
+	var/obj/item/screwdriver/cyborg/SC = locate() in R.module.modules
+	SC = new(R.module)
+	R.module.basic_modules += SC
+	R.module.add_module(SC, FALSE, TRUE)
+
+	var/obj/item/wrench/cyborg/W = locate() in R.module.modules
+	W = new(R.module)
+	R.module.basic_modules += W
+	R.module.add_module(W, FALSE, TRUE)
+
+	var/obj/item/crowbar/cyborg/CB = locate() in R.module.modules
+	CB = new(R.module)
+	R.module.basic_modules += CB
+	R.module.add_module(CB, FALSE, TRUE)
+
+	var/obj/item/wirecutters/cyborg/WC = locate() in R.module.modules
+	WC = new(R.module)
+	R.module.basic_modules += WC
+	R.module.add_module(WC, FALSE, TRUE)
+
+	var/obj/item/multitool/cyborg/MT = locate() in R.module.modules
+	MT = new(R.module)
+	R.module.basic_modules += MT
+	R.module.add_module(MT, FALSE, TRUE)
+
+	var/obj/item/analyzer/AL = locate() in R.module.modules
+	AL = new(R.module)
+	R.module.basic_modules += AL
+	R.module.add_module(AL, FALSE, TRUE)
+
+/obj/item/borg/upgrade/holofan
+	name = "engineering cyborg ATMOS holofan projector"
+	desc = "An upgrade that gives engineering cyborgs their own ATMOS holofan projector."
+	icon_state = "cyborg_upgrade2"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/engineering
+	module_flags = BORG_MODULE_ENGINEERING
+
+/obj/item/borg/upgrade/holofan/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/item/holosign_creator/atmos/holofan = locate() in R.module.modules
+	if(holofan)
+		to_chat(user, span_warning("This unit is already equipped with a holofan module."))
+		return FALSE
+
+	holofan = new(R.module)
+	R.module.basic_modules += holofan
+	R.module.add_module(holofan, FALSE, TRUE)
+
+/obj/item/borg/upgrade/holofan/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+	
+	for(var/obj/item/holosign_creator/atmos/holofan in R.module.modules)
+		if(holofan.signs.len)
+			for(var/obj/structure/holosign/holosign_firelock in holofan.signs)
+				qdel(holosign_firelock)
+		R.module.remove_module(holofan, TRUE)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -988,10 +988,12 @@
 		return FALSE
 
 	JL = new(R.module)
+	JL.toolspeed = 0.5 // Same toolspeed as the cyborg crowbar/cutters.
 	R.module.basic_modules += JL
 	R.module.add_module(JL, FALSE, TRUE)
 
 	HD = new(R.module)
+	HD.toolspeed = 0.5 // Same toolspeed as the cyborg screwdriver/wrench.
 	R.module.basic_modules += HD
 	R.module.add_module(HD, FALSE, TRUE)
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -980,20 +980,18 @@
 	for(var/obj/item/analyzer/AL in R.module.modules) 
 		R.module.remove_module(AL, TRUE)
 
-	var/obj/item/jawsoflife/JL = locate() in R.module.modules
-	var/obj/item/handdrill/HD = locate() in R.module.modules
-	var/obj/item/multitool/tricorder/TC = locate() in R.module.modules
+	var/obj/item/jawsoflife/cyborg/JL = locate() in R.module.modules // Carries over the toolspeed (0.5) instead of using 0.7.
+	var/obj/item/handdrill/cyborg/HD = locate() in R.module.modules // Carries over the toolspeed (0.5) instead of using 0.7.
+	var/obj/item/multitool/tricorder/TC = locate() in R.module.modules // Toolspeed improvement (0.2) from 0.5.
 	if(JL || HD || TC)
 		to_chat(user, span_warning("This cyborg is already equipped with an advanced engineering tool kit."))
 		return FALSE
 
 	JL = new(R.module)
-	JL.toolspeed = 0.5 // Same toolspeed as the cyborg crowbar/cutters.
 	R.module.basic_modules += JL
 	R.module.add_module(JL, FALSE, TRUE)
 
 	HD = new(R.module)
-	HD.toolspeed = 0.5 // Same toolspeed as the cyborg screwdriver/wrench.
 	R.module.basic_modules += HD
 	R.module.add_module(HD, FALSE, TRUE)
 
@@ -1006,10 +1004,10 @@
 	if(!.)
 		return FALSE
 
-	for(var/obj/item/jawsoflife/JL in R.module.modules)
+	for(var/obj/item/jawsoflife/cyborg/JL in R.module.modules)
 		R.module.remove_module(JL, TRUE)
 
-	for(var/obj/item/handdrill/HD in R.module.modules)
+	for(var/obj/item/handdrill/cyborg/HD in R.module.modules)
 		R.module.remove_module(HD, TRUE)
 
 	for(var/obj/item/multitool/tricorder/TC in R.module.modules)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -979,6 +979,26 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_engi_advancedtools
+	name = "Cyborg Upgrade (Advanced Engineering Tools)"
+	id = "borg_upgrade_engi_advancedtools"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/engi_advancedtools
+	/// Combined materials of all 3 experimentals tools.
+	materials = list(/datum/material/iron = 8500, /datum/material/silver = 4300, /datum/material/gold=300, /datum/material/titanium = 6000)
+	construction_time = 12 SECONDS
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_holosign
+	name = "Cyborg Upgrade (ATMOS Holofan Projector)"
+	id = "borg_upgrade_holofan"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/holofan
+	/// Same cost of the ATMOS holofan projector.
+	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/gold = 1000, /datum/material/silver = 1000, /datum/material/plastic = 500)
+	construction_time = 12 SECONDS
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracker (Exosuit Tracking Beacon)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -338,6 +338,14 @@
 	design_ids = list("borg_upgrade_holding", "borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_rped", "borg_upgrade_language", "borg_upgrade_broomer", "borg_upgrade_snacks")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
+/datum/techweb_node/adv_cyborg_upg_util
+	id = "adv_cyborg_upg_util"
+	display_name = "Cyborg Upgrades: Advanced Utility"
+	description = "Advanced utility upgrades for cyborgs."
+	prereq_ids = list("cyborg_upg_util", "exp_tools") // Experimental tools should cover everything with all of its prereqs.
+	design_ids = list("borg_upgrade_engi_advancedtools", "borg_upgrade_holofan")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+
 /datum/techweb_node/cyborg_upg_med
 	id = "cyborg_upg_med"
 	display_name = "Cyborg Upgrades: Medical"

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -155,6 +155,10 @@
 	ui_x = -96
 	ui_y = 160
 
+/datum/techweb_node/adv_cyborg_upg_util
+	ui_x = -32
+	ui_y = 160
+
 /datum/techweb_node/basic_mining
 	ui_x = 96
 	ui_y = -384

--- a/yogstation/code/game/objects/items/tools.dm
+++ b/yogstation/code/game/objects/items/tools.dm
@@ -82,6 +82,10 @@
 		to_chat(user, span_notice("You attach the cutting jaws to [src]."))
 	update_appearance(UPDATE_ICON)
 
+/obj/item/jawsoflife/cyborg
+	name = "cyborg jaws of life"
+	toolspeed = 0.5 // Same toolspeed as cyborg screwdriver/wrench.
+
 //better handdrill
 /obj/item/handdrill
 	name = "hand drill"
@@ -151,6 +155,10 @@
 	else
 		to_chat(user, span_notice("You attach the screw driver bit to [src]."))
 	update_appearance(UPDATE_ICON)
+
+/obj/item/handdrill/cyborg
+	name = "cyborg hand drill"
+	toolspeed = 0.5 // Same toolspeed as cyborg crowbar/wirecutters.
 
 /obj/item/jawsoflife/jimmy
 	name = "airlock jimmy"


### PR DESCRIPTION
# Document the changes in your pull request
Redo of #12120, except not doing the BSRPD.

Two new upgrades for engineering cyborgs.

The first replaces six basic tools with their three advanced version (jaws of life, hand drill, and tricorder). They keep their (better) tool speed from their old tools.
It costs 8500 metal, 4300 silver, 300 gold, and 6000 titanium.

The second gives an ATMOS holofan projector.
It costs 5000 metal, 1000 glass, 1000 silver, 1000 gold, and 500 plastic.

They are locked behind a new tech node called "Cyborg Upgrades: Advanced Utility" which is unlocked behind "Cyborg Upgrades: Utility" and "Experimental Tools" costing 5,000 points.

# Wiki Documentation
New upgrades to add to the [list of cyborg upgrades](https://wiki.yogstation.net/wiki/Guide_to_robotics#Cyborg_Upgrades).

# Changelog
:cl:  
rscadd: A new tech node called "Cyborg Upgrades: Advanced Utility" costing 5000 points.
rscadd: A new cyborg upgrade is available for engineering cyborgs to replace most of their basic tools with an advanced version of them.
rscadd: A new cyborg upgrade is available for engineering cyborgs to gain an ATMOS holofan projector.
/:cl:
