### PR TITLE
You can no longer set off a maxcap in your hand and survive

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -445,7 +445,7 @@
 				gib()
 				return
 			else
-				brute_loss = 200*(2 - round(bomb_armor/60, 0.05))	//0-83% damage reduction
+				brute_loss = 200*(2 - round(bomb_armor/100, 0.05))	//0-50% damage reduction because this should still kill you
 				burn_loss = brute_loss/2 //don't wanna husk people	
 				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(throw_target, 200, 4)


### PR DESCRIPTION
Instead of the STRONGEST EXPLOSION POSSIBLE being reduced to a mere 99 damage if you're wearing a bomb suit, now they will deal a total of 300 (200 brute 100 burn) even with 100 bomb armor. No hugging maxcaps, you die. No amount of protection that you can reasonably wear will save you from that kind of blast. Also this means you can't face tank the BSA.


# Wiki Documentation

Bomb armor is 83% effective, but only 50% for especially strong blasts.

# Changelog

:cl:  

tweak: Devastation-tier explosions will now game end you more effectively

/:cl:
