### PR TITLE
Removes the ability for players to start a map vote

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -153,7 +153,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 #ALLOW_VOTE_MODE
 
 ## allow players to initiate a map-change vote
-ALLOW_VOTE_MAP
+#ALLOW_VOTE_MAP
 
 ## min delay (deciseconds) between voting sessions (default 10 minutes)
 VOTE_DELAY 6000


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Disables the ability for players to start a map vote. This is good for the game because map votes force box 90% of the time, and map variety is objectively good from a game design perspective.

# Changelog

:cl:  
rscdel: Removed player map votes
/:cl:
