### PR TITLE
[DRAFT] New drink: Syndicate Screwdriver

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -932,3 +932,10 @@
 	results = list(/datum/reagent/consumable/ethanol/triumphal_arch = 10)
 	required_reagents = list(/datum/reagent/consumable/ethanol/mushi_kombucha = 5, /datum/reagent/consumable/ethanol/grappa = 2, /datum/reagent/consumable/lemonjuice = 2, /datum/reagent/gold = 1)
 	mix_message = "The mixture turns a deep golden hue."
+
+/datum/chemical_reaction/syndicate_screwdriver
+	name = "Syndicate Screwdriver"
+	id = /datum/reagent/consumable/ethanol/syndicate_screwdriver
+	results = list(datum/reagent/ethanol/syndicate_screwdriver = 2)
+	required_reagents = list (/datum/reagent/consumable/ethanol/screwdriver = 2, /datum/reagent/consumable/ethanol/syndicatebomb = 2)
+	mix_message = "The drink sparkles red with syndicate power"


### PR DESCRIPTION
# Document the changes in your pull request

A suggestion from @YashinHak about making a new Syndicate drink which is called the Syndicate Screwdriver, a combination of Syndicate bomb + Screwdriver to make a traitor based drink that gives you temp fast hands. 

I am currently working on the last part which is coding in the temp hands but any suggestions or tweaks will be appreciated.
Name: Syndicate Screwdriver
Boozepwr: 90 (subjected to change)
Effect: People that are part of the syndicate gain temp fast-hands (acts like a lesser version of tacti-gloves)

# Spriting
[https://imgur.com/a/Gm6Uirp](url)
Sprite done by @zer0tactics

# Wiki Documentation

Syndicate Screwdriver - A special drink that invigorates members of the Syndicate to preform tasks fasters, however due to its high alcohol content it was determined to be "unsafe"

# Changelog
:cl:  
rscadd: New drink, Syndicate Screwdriver  
wip: Finishing up code
imageadd: Syndicate Screwdriver sprite
/:cl:
