### PR TITLE
Fixes some Ultra Violence stuff

### DIFF
--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -125,10 +125,10 @@
 ---------------------------------------------------------------*/
 /datum/martial_art/ultra_violence/proc/pocket_pistol(mob/living/carbon/human/A)
 	var/obj/item/gun/ballistic/revolver/ipcmartial/gun = locate() in A // check if they already had one
-	if(gun && style < 8) // can't dual wield unless you're at the max style level
+	if(gun)
 		to_chat(A, span_notice("You reload your revolver."))
 		gun.magazine.top_off()
-	else
+	if(style >= 8 || !gun) // can dual wield at the max style level
 		gun = new(A)   ///I don't check does the user have an item in a hand, because it is a martial art action, and to use it... you need to have a empty hand
 		to_chat(A, span_notice("You whip out your revolver."))
 		gun.gun_owner = A

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -67,7 +67,8 @@
 /datum/martial_art/ultra_violence/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("H",D)
 	check_streak(A,D)
-	handle_style(A, 0.1, STYLE_PUNCH)
+	if(A != D) // why are you hitting yourself
+		handle_style(A, 0.1, STYLE_PUNCH)
 	return FALSE
 
 /datum/martial_art/ultra_violence/proc/InterceptClickOn(mob/living/carbon/human/H, params, atom/A) //moved this here because it's not just for dashing anymore
@@ -123,10 +124,15 @@
 
 ---------------------------------------------------------------*/
 /datum/martial_art/ultra_violence/proc/pocket_pistol(mob/living/carbon/human/A)
-	var/obj/item/gun/ballistic/revolver/ipcmartial/gun = new /obj/item/gun/ballistic/revolver/ipcmartial (A)   ///I don't check does the user have an item in a hand, because it is a martial art action, and to use it... you need to have a empty hand
-	gun.gun_owner = A
+	var/obj/item/gun/ballistic/revolver/ipcmartial/gun = locate() in A // check if they already had one
+	if(gun && style < 8) // can't dual wield unless you're at the max style level
+		to_chat(A, span_notice("You reload your revolver."))
+		gun.magazine.top_off()
+	else
+		gun = new(A)   ///I don't check does the user have an item in a hand, because it is a martial art action, and to use it... you need to have a empty hand
+		to_chat(A, span_notice("You whip out your revolver."))
+		gun.gun_owner = A
 	A.put_in_hands(gun)
-	to_chat(A, span_notice("You whip out your revolver."))
 	streak = ""
 
 /obj/item/gun/ballistic/revolver/ipcmartial
@@ -168,7 +174,7 @@
 	var/mob/living/L = target
 	if(L.stat == DEAD)
 		return . // no using dead bodies to gain style, that's boring and uncool KILL SOME REAL THINGS
-	if(ishuman(firer))
+	if(ishuman(firer) && firer != target) // WHY ARE YOU SHOOTING YOURSELF
 		var/mob/living/carbon/human/H = firer
 		if(H.mind?.has_martialart(MARTIALART_ULTRAVIOLENCE))
 			var/datum/martial_art/ultra_violence/UV = H.mind.martial_art


### PR DESCRIPTION
# Document the changes in your pull request

Dual wielding the pistol was never intended, but it feels really cool to do, so it's now only possible to do at the maximum style level which you'd only be able to get to if you're already decimating the station and lasts only a few seconds. Trying to dual wield otherwise will just reload it instead of giving you another one.

Also, you can't hit yourself to gain style anymore.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:    
tweak: ultra violence revolver can only be dual-wielded at the max style level
bugfix: ultra violence no longer gains style from hitting yourself
/:cl:
