### PR TITLE
Map rotations and player votes no longer offer maps that were played >=70% of the time in the last 10 rounds

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -644,6 +644,6 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			var/next_map = query_previous_maps.NextRow()
 			if(!next_map)
 				continue
-			previous_maps[next_map.item[1]] += 1 / (11 - i) //this lessens the influence of rounds that were longer ago
+			previous_maps[next_map[1]] += 1 / (11 - i) //this lessens the influence of rounds that were longer ago
 		qdel(query_previous_maps)
 	return previous_maps

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -375,17 +375,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	else
 		for(var/M in global.config.maplist)
 			mapvotes[M] = 1
-			
-	var/list/previous_maps = list()
-	if(SSdbcore.Connect())
-		var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
-			SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
-		"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
-		if(!query_previous_maps.Execute())
-			qdel(query_previous_maps)
-		while(query_previous_maps.NextRow())
-			previous_maps[query_previous_maps.item[1]] += 1
-		qdel(query_previous_maps)
+	var/previous_maps = get_map_weights()
 
 	//filter votes
 	for (var/map in mapvotes)
@@ -407,7 +397,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		if (VM.config_max_users > 0 && players > VM.config_max_users)
 			mapvotes.Remove(map)
 			continue
-		if(previous_maps && previous_maps[VM.map_name] > 7)
+		if(previous_maps[VM.map_name] > 7)
 			mapvotes.Remove(map)
 			continue
 
@@ -639,3 +629,21 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	for(var/turf/to_contain as anything in Z_TURFS(z_level))
 		var/area/our_area = to_contain.loc
 		our_area.contained_turfs += to_contain
+
+
+
+/datum/controller/subsystem/mapping/proc/get_map_weights()
+	var/list/previous_maps = list()
+	if(SSdbcore.Connect())
+		var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
+			SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
+		"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
+		if(!query_previous_maps.Execute())
+			qdel(query_previous_maps)
+		for(var/i = 1 to 10)
+			var/next_map = query_previous_maps.NextRow()
+			if(!next_map)
+				continue
+			previous_maps[next_map.item[1]] += 1 / (11 - i) //this lessens the influence of rounds that were longer ago
+		qdel(query_previous_maps)
+	return previous_maps

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -375,6 +375,17 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	else
 		for(var/M in global.config.maplist)
 			mapvotes[M] = 1
+			
+	var/list/previous_maps = list()
+	if(SSdbcore.Connect())
+		var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
+			SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
+		"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
+		if(!query_previous_maps.Execute())
+			qdel(query_previous_maps)
+		while(query_previous_maps.NextRow())
+			previous_maps[query_previous_maps.item[1]] += 1
+		qdel(query_previous_maps)
 
 	//filter votes
 	for (var/map in mapvotes)
@@ -394,6 +405,9 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			mapvotes.Remove(map)
 			continue
 		if (VM.config_max_users > 0 && players > VM.config_max_users)
+			mapvotes.Remove(map)
+			continue
+		if(previous_maps && previous_maps[VM.map_name] > 7)
 			mapvotes.Remove(map)
 			continue
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -637,7 +637,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
 			SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
-		"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
+		"}, list("lower" = "[text2num(GLOB.round_id) - 9]", "upper" = GLOB.round_id))
 		if(!query_previous_maps.Execute())
 			qdel(query_previous_maps)
 		for(var/i = 1 to 10)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -647,3 +647,10 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			previous_maps[next_map[1]] += 1 / (11 - i) //this lessens the influence of rounds that were longer ago
 		qdel(query_previous_maps)
 	return previous_maps
+
+/client/proc/DebugMapWeights()
+	set name = "See Map Weights"
+	set category = "Misc.Server Debug"
+	var/weights = SSmapping.get_map_weights()
+	for(var/key in weights)
+		to_chat(src, "[key]: weights[key]")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -190,18 +190,7 @@ SUBSYSTEM_DEF(vote)
 				if(!lower_admin && SSmapping.map_voted)
 					to_chat(usr, span_warning("The next map has already been selected."))
 					return FALSE
-				var/list/previous_maps = list()
-				if(SSdbcore.Connect())
-					var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
-						SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
-					"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
-					if(!query_previous_maps.Execute())
-						qdel(query_previous_maps)
-					while(query_previous_maps.NextRow())
-						previous_maps[query_previous_maps.item[1]] += 1
-					qdel(query_previous_maps)
-
-
+				var/list/previous_maps = SSmapping.get_map_weights()
 				// Randomizes the list so it isn't always METASTATION
 				var/list/maps = list()
 				for(var/map in global.config.maplist)
@@ -212,7 +201,7 @@ SUBSYSTEM_DEF(vote)
 						continue
 					if(VM.config_max_users > 0 && GLOB.clients.len > VM.config_max_users)
 						continue
-					if(previous_maps && previous_maps[VM.map_name] > 7)
+					if(previous_maps[VM.map_name] > 7)
 						continue
 					maps += VM.map_name
 					shuffle_inplace(maps)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -190,6 +190,18 @@ SUBSYSTEM_DEF(vote)
 				if(!lower_admin && SSmapping.map_voted)
 					to_chat(usr, span_warning("The next map has already been selected."))
 					return FALSE
+				var/list/previous_maps = list()
+				if(SSdbcore.Connect())
+					var/datum/DBQuery/query_previous_maps = SSdbcore.NewQuery({"
+						SELECT map_name FROM [format_table_name("round")] WHERE id BETWEEN lower = :lower AND upper = :upper
+					"}, list("lower" = GLOB.round_id - 9, "upper" = GLOB.round_id))
+					if(!query_previous_maps.Execute())
+						qdel(query_previous_maps)
+					while(query_previous_maps.NextRow())
+						previous_maps[query_previous_maps.item[1]] += 1
+					qdel(query_previous_maps)
+
+
 				// Randomizes the list so it isn't always METASTATION
 				var/list/maps = list()
 				for(var/map in global.config.maplist)
@@ -199,6 +211,8 @@ SUBSYSTEM_DEF(vote)
 					if(VM.config_min_users > 0 && GLOB.clients.len < VM.config_min_users)
 						continue
 					if(VM.config_max_users > 0 && GLOB.clients.len > VM.config_max_users)
+						continue
+					if(previous_maps && previous_maps[VM.map_name] > 7)
 						continue
 					maps += VM.map_name
 					shuffle_inplace(maps)


### PR DESCRIPTION
# Document the changes in your pull request

So a problem we have with retaining impressive mappers is that they feel that working on anything other than BoxStation is a waste of time because we nearly always play BoxStation. Many solutions were presented like "turning off map votes", "turning off map vote after map rotations" and "killing all people who like box" However I do not believe the community to be very approving of this decision. I have created an infinitely worse solution that still gives BoxStation lovers the upper hand while FORCING players to experience these new maps, eventually with the opportunity to lower this even more. Remember that BoxStation is only 25% of our map pool.

Simply put, if we played BoxStation 7 times in a row, it won't even be an option. This still gives you an impressive SEVENTY PERCENT box chance, but that forces it to an upper range where no-lifers still have to experience new and different maps (which will in turn get issues fixed on them). If you play 5 rounds of Box, a Gax, and then 2 rounds of box, looks like we're going to Meta/Gax/Asteroid. PLAY THE OTHER MAPS!!!!!!!!!!!!!!!

Of course, this is generic. If we somehow played 7 rounds on the NVS Gax, it also wouldn't be offered.

Not a config option, not parameterized, not anything. This is going up for a draft and making sure I actually am calling the database correctly (I have no clue how it works)

# Changelog

:cl:  
rscadd: Map rotations and player votes no longer offer maps if they were played the last 70% of rounds
/:cl:
