### PR TITLE
Condenses syndi attachments into one kit - for 1TC or 10TC for nukies

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -844,3 +844,11 @@
 	var/obj/item/bodybag/environmental/prisoner/syndicate/pbag = new(src)
 	var/obj/item/syndicate_prisoner_remote/remote = new(src)
 	remote.bag = pbag
+
+/obj/item/storage/box/syndie_kit/attachments
+	real_name = "attachments kit"
+
+/obj/item/storage/box/syndie_kit/attachments/PopulateContents()
+	new /obj/item/attachment/scope/holo(src)
+	new /obj/item/attachment/grip/vertical(src)
+	new /obj/item/attachment/laser_sight(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1978,23 +1978,17 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/prisonerbag
 	cost = 2
 
-/datum/uplink_item/device_tools/holo_sight
-	name = "Holographic Sight"
-	desc = "A high-tech holographic sight that improves the aim of the weapon it's attached to."
-	item = /obj/item/attachment/scope/holo
-	cost = 2
+/datum/uplink_item/device_tools/attachments
+	name = "Weapon Attachments"
+	desc = "A set of attachments that will make your gun more accurate and stable. \
+			Comes with a laser sight as well, for that extra tactical feel."
+	item = /obj/item/storage/box/syndie_kit/attachments
+	cost = 1
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
-/datum/uplink_item/device_tools/vert_grip
-	name = "Vertical Grip"
-	desc = "A vertical foregrip that reduces the shock of firing a weapon. Extra handy for higher recoil guns like the sniper rifle."
-	item = /obj/item/attachment/grip/vertical
-	cost = 2
-
-/datum/uplink_item/device_tools/laser_sight
-	name = "Laser Sight"
-	desc = "An aesthetic laser sight that improves your accuracy and shows you where you're aiming."
-	item = /obj/item/attachment/laser_sight
-	cost = 2
+/datum/uplink_item/device_tools/attachments/nukie
+	cost = 10
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/device_tools/mechpilotguide
 	name = "Mech Piloting for Dummies"


### PR DESCRIPTION
# Document the changes in your pull request

It's clear to me that nukies get way more out of this than tots do, so instead of making it mega expensive for both, it will just be expensive for nukies who can afford it, while making the regular kit super affordable- Having attachments is not exactly game-winning for traitors, but there is value in the lack of camera shake and the laser sight is very cool to use.

# Changelog

:cl:  
tweak: Condensed all purchasable syndicate attachments into one kit, which is more expensive for nukies than it is for traitors.
/:cl:
