### PR TITLE
antinoblium recipe changes

### DIFF
--- a/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
+++ b/code/game/objects/items/stacks/sheets/hypernob_crystal.dm
@@ -34,7 +34,7 @@
 
 /obj/item/stack/antinoblium_crystal
 	name = "Antinoblium Crystal"
-	desc = "Crystalized antinoblium, nitrium, and zauker. An incredibly volatile material."
+	desc = "Crystalized antinoblium, bz, and plasma. An incredibly volatile material."
 	icon_state = "antinoblium_crystal"
 	resistance_flags = FIRE_PROOF | ACID_PROOF | FREEZE_PROOF | UNACIDABLE
 	grind_results = list(/datum/reagent/antinoblium = 20)

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	min_temp = TCMB
 	max_temp = TCMB + 20
 	energy_release = 2800000
-	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/bz = 30, /datum/gas/nitrogen = 100)
+	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/bz = 100, /datum/gas/nitrogen = 100)
 	products = list(/obj/item/stack/antinoblium_crystal = 1)
 
 /datum/gas_recipe/crystallizer/crystallized_nitrium

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	min_temp = TCMB
 	max_temp = TCMB + 20
 	energy_release = 2800000
-	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/hypernoblium = 100, /datum/gas/nitrogen = 100)
+	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/bz = 30, /datum/gas/plasma = 100)
 	products = list(/obj/item/stack/antinoblium_crystal = 1)
 
 /datum/gas_recipe/crystallizer/crystallized_nitrium

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/atmos_machines_recipes.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(gas_recipe_meta, gas_recipes_list())
 	min_temp = TCMB
 	max_temp = TCMB + 20
 	energy_release = 2800000
-	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/bz = 100, /datum/gas/nitrogen = 100)
+	requirements = list(/datum/gas/antinoblium = 100, /datum/gas/hypernoblium = 100, /datum/gas/nitrogen = 100)
 	products = list(/obj/item/stack/antinoblium_crystal = 1)
 
 /datum/gas_recipe/crystallizer/crystallized_nitrium


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

replaces the nitrogen with plasma on the antinoblium recipe, this makes it possible to keep the gases inside the crystallizer cold enough to get it to be masterwork quality

# Wiki Documentation

wiki doesn't have crystallizer recipes

# Changelog

:cl:  
tweak: antinoblium recipe in the crystallizer now uses plasma instead of nitrogen
spellcheck: fixed antinoblium item having the wrong description
/:cl:
