### PR TITLE
Changelings may no longer purchase Adrenaline Sacs & Strained Muscles together.

### DIFF
--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -24,9 +24,9 @@
 	var/list/abilities = list()
 
 	for(var/path in changeling.all_powers)
-		var/datum/action/changeling/ability = path
+		var/datum/action/changeling/ability = new path
 
-		var/dna_cost = initial(ability.dna_cost)
+		var/dna_cost = ability.dna_cost
 		if(dna_cost <= 0)
 			continue
 
@@ -35,18 +35,18 @@
 			continue //yogs end - removing combat abilities from xenolings
 
 		var/list/abilitydata = list()
-		abilitydata["name"] = initial(ability.name)
-		abilitydata["desc"] = initial(ability.desc)
-		abilitydata["helptext"] = initial(ability.helptext)
+		abilitydata["name"] = ability.name
+		abilitydata["desc"] = ability.desc
+		abilitydata["helptext"] = ability.helptext
 		abilitydata["owned"] = changeling.has_sting(ability)
-		var/req_dna = initial(ability.req_dna)
-		var/req_absorbs = initial(ability.req_absorbs)
+		var/req_dna = ability.req_dna
+		var/req_absorbs = ability.req_absorbs
 		abilitydata["dna_cost"] = dna_cost
 		abilitydata["can_purchase"] = ((req_absorbs <= true_absorbs) && (req_dna <= absorbed_dna_count) && (dna_cost <= genetic_points_remaining))
 		abilitydata["conflicting_powers"] = list()
-		for(var/conflicts in ability.conflicts) 
-			var/datum/action/changeling/conflcting_ability = conflicts
-			abilitydata["conflicting_powers"] += initial(conflcting_ability.name)
+		for(var/conflict in ability.conflicts)
+			var/datum/action/changeling/conflcting_ability = new conflict
+			abilitydata["conflicting_powers"] += conflcting_ability.name
 		
 		abilities += list(abilitydata)
 

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -34,17 +34,21 @@
 		if(istype(changeling, /datum/antagonist/changeling/xenobio) && !xenoling_available)
 			continue //yogs end - removing combat abilities from xenolings
 
-		var/list/AL = list()
-		AL["name"] = initial(ability.name)
-		AL["desc"] = initial(ability.desc)
-		AL["helptext"] = initial(ability.helptext)
-		AL["owned"] = changeling.has_sting(ability)
+		var/list/abilitydata = list()
+		abilitydata["name"] = initial(ability.name)
+		abilitydata["desc"] = initial(ability.desc)
+		abilitydata["helptext"] = initial(ability.helptext)
+		abilitydata["owned"] = changeling.has_sting(ability)
 		var/req_dna = initial(ability.req_dna)
 		var/req_absorbs = initial(ability.req_absorbs)
-		AL["dna_cost"] = dna_cost
-		AL["can_purchase"] = ((req_absorbs <= true_absorbs) && (req_dna <= absorbed_dna_count) && (dna_cost <= genetic_points_remaining))
-
-		abilities += list(AL)
+		abilitydata["dna_cost"] = dna_cost
+		abilitydata["can_purchase"] = ((req_absorbs <= true_absorbs) && (req_dna <= absorbed_dna_count) && (dna_cost <= genetic_points_remaining))
+		abilitydata["conflicting_powers"] = list()
+		for(var/conflicts in ability.conflicts) 
+			var/datum/action/changeling/conflcting_ability = conflicts
+			abilitydata["conflicting_powers"] += initial(conflcting_ability.name)
+		
+		abilities += list(abilitydata)
 
 	data["abilities"] = abilities
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -225,6 +225,11 @@
 	if(HAS_TRAIT(owner.current, TRAIT_DEATHCOMA))//To avoid potential exploits by buying new powers while in stasis, which clears your verblist.
 		to_chat(owner.current, "We lack the energy to evolve new abilities right now.")
 		return
+	//this checks for conflicting abilities that you dont want players to have at the same time (movement speed abilities for example)
+	for(var/conflictingpower in thepower.conflicts) 
+		if(has_sting(conflictingpower))
+			to_chat(owner.current, "This power conflicts with another power we currently have!")
+			return
 
 	geneticpoints -= thepower.dna_cost
 	purchasedpowers += thepower

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -18,6 +18,8 @@
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
 	var/active = FALSE //used by a few powers that toggle
 	var/xenoling_available = TRUE // Avaliable to xenolings
+	///list of power you cannot purchase together
+	var/list/conflicts = list()
 
 /*
 changeling code now relies on on_purchase to grant powers.

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -7,6 +7,7 @@
 	dna_cost = 2
 	req_human = 1
 	req_stat = UNCONSCIOUS
+	conflicts = list(/datum/action/changeling/strained_muscles)
 
 //Recover from stuns.
 /datum/action/changeling/adrenaline/sting_action(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -11,6 +11,8 @@
 	req_human = 1
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
 	active = FALSE //Whether or not you are a hedgehog
+	conflicts = list(/datum/action/changeling/adrenaline)
+
 
 /datum/action/changeling/strained_muscles/sting_action(mob/living/carbon/user)
 	..()

--- a/tgui/packages/tgui/interfaces/CellularEmporium.js
+++ b/tgui/packages/tgui/interfaces/CellularEmporium.js
@@ -49,6 +49,13 @@ export const CellularEmporium = (props, context) => {
                 <Box color="good">
                   {ability.helptext}
                 </Box>
+                {!!ability.conflicting_powers && (
+                  <Box color="bad">
+                    {ability.conflicting_powers.forEach(power => {
+                    power;
+                    })}
+                  </Box>
+                )}
               </LabeledList.Item>
             ))}
           </LabeledList>

--- a/tgui/packages/tgui/interfaces/CellularEmporium.js
+++ b/tgui/packages/tgui/interfaces/CellularEmporium.js
@@ -49,11 +49,12 @@ export const CellularEmporium = (props, context) => {
                 <Box color="good">
                   {ability.helptext}
                 </Box>
-                {!!ability.conflicting_powers && (
+                {!!ability.conflicting_powers.length && (
                   <Box color="bad">
-                    {ability.conflicting_powers.forEach(power => {
-                    power;
-                    })}
+
+                    {"This ability conflicts with: "
+                    + ability.conflicting_powers.join(", ")}
+
                   </Box>
                 )}
               </LabeledList.Item>


### PR DESCRIPTION
# Document the changes in your pull request

I made this PR to make it so changelings cannot run away or chase you at super omega unfair speeds whenever they feel like it. When used alone, both abilities are fair with their own drawbacks, but when used together they give you an impossibly fast escape tool, or an impossible to outrun monster. The changes were tested and worked pretty well.

# Spriting

No new sprites.

# Wiki Documentation

<!-- Under the abilities "Adrenaline Sacs" and "Strained Muscles" please add this to their description "Cannot be purchased with "Strained Muscles" and "Cannot be purchased with Adrenaline Sacs."

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
ChubbyGummyBear

rscadd: Added the inability to purchase both movement speed changeling abilities at the same time.

/:cl:
