### PR TITLE
Modular PDAs Now Work On Mechs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -296,7 +296,6 @@
 		update_part_values()
 		return
 	capacitor = new /obj/item/stock_parts/capacitor(src)
-	
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -244,7 +244,7 @@
 /// Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
 /obj/mecha/proc/update_part_values()
 	if(scanmod)
-		// Starting at 20 energy per step (tier 0), each tier reduces this value down by 5 until it reaches 0.
+		// Starting at 20 energy per step (at tier 0), each tier reduces this value down by 5 until it reaches 0.
 		normal_step_energy_drain = max(20 - (5 * scanmod.rating), 0)
 		if(!leg_overload_mode)
 			step_energy_drain = normal_step_energy_drain

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -244,7 +244,7 @@
 /// Updates the values given by scanning module and capacitor tier, called when a part is removed or inserted.
 /obj/mecha/proc/update_part_values()
 	if(scanmod)
-		// Starting at 20 energy per drain (tier 0), each tier reduces this value down by 5 until it reaches 0.
+		// Starting at 20 energy per step (tier 0), each tier reduces this value down by 5 until it reaches 0.
 		normal_step_energy_drain = max(20 - (5 * scanmod.rating), 0)
 		if(!leg_overload_mode)
 			step_energy_drain = normal_step_energy_drain

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -296,7 +296,8 @@
 		update_part_values()
 		return
 	capacitor = new /obj/item/stock_parts/capacitor(src)
-
+	update_part_values()
+	
 /obj/mecha/proc/add_cabin()
 	cabin_air = new
 	cabin_air.set_temperature(T20C)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -283,9 +283,8 @@
 	if(sm)
 		sm.forceMove(src)
 		scanmod = sm
-		update_part_values()
-		return
-	scanmod = new /obj/item/stock_parts/scanning_module(src)
+	else
+		scanmod = new /obj/item/stock_parts/scanning_module(src)
 	update_part_values()
 
 /obj/mecha/proc/add_capacitor(obj/item/stock_parts/capacitor/cap=null) ///Adds a capacitor, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
@@ -293,11 +292,10 @@
 	if(cap)
 		cap.forceMove(src)
 		capacitor = cap
-		update_part_values()
-		return
-	capacitor = new /obj/item/stock_parts/capacitor(src)
+	else
+		capacitor = new /obj/item/stock_parts/capacitor(src)
 	update_part_values()
-	
+
 /obj/mecha/proc/add_cabin()
 	cabin_air = new
 	cabin_air.set_temperature(T20C)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -140,9 +140,6 @@
 	var/occupant_sight_flags = 0 //sight flags to give to the occupant (e.g. mech mining scanner gives meson-like vision)
 	var/mouse_pointer
 
-	/// The energy armor value given by the last known capacitor (if any). Used to determine if energy armor should be given/removed and how much more.
-	var/last_cap_energy_armor = 0
-
 	hud_possible = list (DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_TRACK_HUD)
 
 /obj/item/radio/mech //this has to go somewhere
@@ -255,13 +252,6 @@
 		normal_step_energy_drain = 500 // If they somehow move, a massive energy drain per step.
 		step_energy_drain = normal_step_energy_drain
 
-	// Capacitors:
-	var/new_armor = capacitor ? capacitor.rating*5 : 0 // Each rating increases energy armor by 5.
-	var/difference_armor = new_armor - last_cap_energy_armor
-	if(difference_armor != 0)
-		armor = armor.modifyRating(energy = difference_armor)
-	last_cap_energy_armor = new_armor
-
 ////////////////////////
 ////// Helpers /////////
 ////////////////////////
@@ -283,18 +273,16 @@
 	if(sm)
 		sm.forceMove(src)
 		scanmod = sm
-	else
-		scanmod = new /obj/item/stock_parts/scanning_module(src)
-	update_part_values()
+		return
+	scanmod = new /obj/item/stock_parts/scanning_module(src)
 
 /obj/mecha/proc/add_capacitor(obj/item/stock_parts/capacitor/cap=null) ///Adds a capacitor, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
 	QDEL_NULL(capacitor)
 	if(cap)
 		cap.forceMove(src)
 		capacitor = cap
-	else
-		capacitor = new /obj/item/stock_parts/capacitor(src)
-	update_part_values()
+		return
+	capacitor = new /obj/item/stock_parts/capacitor(src)
 
 /obj/mecha/proc/add_cabin()
 	cabin_air = new
@@ -1142,11 +1130,9 @@
 		return
 	if(scanmod && scanmod == M)
 		scanmod = null
-		update_part_values()
 		return
 	if(capacitor && capacitor == M)
 		capacitor = null
-		update_part_values()
 		return
 
 /obj/mecha/proc/go_out(forced, atom/newloc = loc)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1130,9 +1130,11 @@
 		return
 	if(scanmod && scanmod == M)
 		scanmod = null
+		update_part_values()
 		return
 	if(capacitor && capacitor == M)
 		capacitor = null
+		update_part_values()
 		return
 
 /obj/mecha/proc/go_out(forced, atom/newloc = loc)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -196,11 +196,17 @@
 		if(add_req_access || maint_access)
 			if(internals_access_allowed(user))
 				var/obj/item/card/id/id_card
-				if(istype(W, /obj/item/card/id))
+				if(isidcard(W))
 					id_card = W
-				else
+				else if(istype(W, /obj/item/pda))
 					var/obj/item/pda/pda = W
 					id_card = pda.id
+				else if(istype(W, /obj/item/modular_computer/tablet/pda))
+					var/obj/item/modular_computer/tablet/pda/tablet_pda = W
+					id_card = tablet_pda.GetID()
+				else // In the case in which the ID can't be found:
+					to_chat(user, span_notice("The interface doesn't seem to be up-to-date with how you're handling your ID. Try a different way."))
+					return
 				output_maintenance_dialog(id_card, user)
 				return
 			else

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -195,19 +195,7 @@
 	if(W.GetID())
 		if(add_req_access || maint_access)
 			if(internals_access_allowed(user))
-				var/obj/item/card/id/id_card
-				if(isidcard(W))
-					id_card = W
-				else if(istype(W, /obj/item/pda))
-					var/obj/item/pda/pda = W
-					id_card = pda.id
-				else if(istype(W, /obj/item/modular_computer/tablet/pda))
-					var/obj/item/modular_computer/tablet/pda/tablet_pda = W
-					id_card = tablet_pda.GetID()
-				else // In the case in which the ID can't be found:
-					to_chat(user, span_notice("The interface doesn't seem to be up-to-date with how you're handling your ID. Try a different way."))
-					return
-				output_maintenance_dialog(id_card, user)
+				output_maintenance_dialog(W.GetID(), user)
 				return
 			else
 				to_chat(user, span_warning("Invalid ID: Access denied."))


### PR DESCRIPTION
# Document the changes in your pull request
Fixes a runtime where it was assumed that every non-ID is a PDA (old); in practice, this means you can now use your modular PDA (new) instead of having to take the ID out each time.

Also removes a snippet of code that #15121 didn't remove regarding removing armor based on the capacitor.

# Changelog
:cl:  
bugfix: Modular PDAs now can be properly used for accessing a mech's panel (keycodes/maint/etc).
/:cl:
