### PR TITLE
egg-based food is vegetarian friendly

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_egg.dm
+++ b/code/modules/food_and_drinks/food/snacks_egg.dm
@@ -18,7 +18,7 @@
 	list_reagents = list(/datum/reagent/consumable/eggyolk = 5, /datum/reagent/growthserum = 1)
 	cooked_type = /obj/item/reagent_containers/food/snacks/boiledegg
 	filling_color = "#F0E68C"
-	foodtype = MEAT | EGG
+	foodtype = EGG
 	grind_results = list()
 	var/mob/living/egg_rper
 
@@ -105,7 +105,7 @@
 	filling_color = "#FFFFF0"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 3)
 	tastes = list("egg" = 4, "salt" = 1, "pepper" = 1)
-	foodtype = MEAT | FRIED | BREAKFAST | EGG
+	foodtype = FRIED | BREAKFAST | EGG
 
 /obj/item/reagent_containers/food/snacks/boiledegg
 	name = "boiled egg"
@@ -115,7 +115,7 @@
 	filling_color = "#FFFFF0"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("egg" = 1)
-	foodtype = MEAT | BREAKFAST | EGG
+	foodtype = BREAKFAST | EGG
 
 /obj/item/reagent_containers/food/snacks/omelette
 	name = "omelette du fromage"
@@ -126,7 +126,7 @@
 	bitesize = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	tastes = list("egg" = 1, "cheese" = 1)
-	foodtype = MEAT | BREAKFAST | EGG
+	foodtype = BREAKFAST | EGG
 
 /obj/item/reagent_containers/food/snacks/omelette/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/fork))
@@ -176,4 +176,4 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5)
 	filling_color = "#F0E68C"
 	tastes = list("egg" = 1)
-	foodtype = MEAT | GRAIN | EGG
+	foodtype = GRAIN | EGG

--- a/code/modules/food_and_drinks/food/snacks_salad.dm
+++ b/code/modules/food_and_drinks/food/snacks_salad.dm
@@ -115,7 +115,7 @@
 	icon_state = "eggbowl"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("rice" = 1, "egg" = 1)
-	foodtype = GRAIN | MEAT | EGG // rip NinjaNomnom
+	foodtype = GRAIN | EGG // rip NinjaNomnom
 
 /obj/item/reagent_containers/food/snacks/salad/edensalad
 	name = "\improper Salad of Eden"


### PR DESCRIPTION
Removes meat tag from egg-based foods containing no meat, since they're not meat.

# Wiki Documentation

food type on guide to food i'll do this

:cl:  Ktlwjec
tweak: Egg-based foods are no longer meat by default.
/:cl: