### PR TITLE
Missing capitalisation, punctuation etc in some protolathe designs

### DIFF
--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -185,7 +185,7 @@
 
 /datum/design/board/researcher_module
 	name = "Core Module Design (Ethical Researcher)"
-	desc = "Allows for the construction of a Ethical Researcher AI Core Module."
+	desc = "Allows for the construction of an Ethical Researcher AI Core Module."
 	id = "researcher_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000)
 	build_path = /obj/item/aiModule/core/full/researcher

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -3,7 +3,7 @@
 ///////////////////////////////////
 
 /datum/design/airlock_scanner
-	name = "Airlock scanner"
+	name = "Airlock Scanner"
 	id = "airlock_scanner"
 	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -75,7 +75,7 @@
 	category = list("initial","Food")
 
 /datum/design/meat
-	name = "Synthetic meat"
+	name = "Synthetic Meat"
 	id = "meat"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 150)
@@ -83,7 +83,7 @@
 	category = list("initial","Food")
 
 /datum/design/egg
-	name = "Synthetic egg"
+	name = "Synthetic Egg"
 	id = "egg"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 100)

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -288,7 +288,7 @@
 
 /datum/design/board/shuttle/flight_control
 	name = "Computer Design (Shuttle Flight Controller)"
-	desc = "Allows for the construction of circuit boards used to build a console that enables shuttle flight"
+	desc = "Allows for the construction of circuit boards used to build a console that enables shuttle flight."
 	id = "shuttle_control"
 	build_path = /obj/item/circuitboard/computer/shuttle/flight_control
 	category = list("Computer Boards", "Shuttle Machinery")
@@ -296,12 +296,11 @@
 
 /datum/design/board/shuttle/shuttle_docker
 	name = "Computer Design (Shuttle Zoning Designator)"
-	desc = "Allows for the construction of circuit boards used to build a console that enables the targetting of custom flight locations"
+	desc = "Allows for the construction of circuit boards used to build a console that enables the targetting of custom flight locations."
 	id = "shuttle_docker"
 	build_path = /obj/item/circuitboard/computer/shuttle/docker
 	category = list("Computer Boards", "Shuttle Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
-
 
 /datum/design/board/ai_server_overview
 	name = "Computer Design (AI Server Overview Console)"

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -287,7 +287,7 @@
 
 /datum/design/limb_disk/lizard
 	name = "Lizard Limb Design Disk"
-	desc = "Contains designs for lizard bodyparts for the limbgrower - Lizard tongue, and tail"
+	desc = "Contains designs for lizard bodyparts for the limbgrower - Lizard tongue, and tail."
 	id = "limbdesign_lizard"
 	build_path = /obj/item/disk/design_disk/limbs/lizard
 

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -41,7 +41,7 @@
 	build_path = /obj/item/circuitboard/machine/shuttle/capacitor_bank
 	category = list ("Shuttle Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
-	
+
 /datum/design/board/spaceship_navigation_beacon
 	name = "Machine Design (Bluespace Navigation Gigabeacon)"
 	desc = "The circuit board for a Bluespace Navigation Gigabeacon."
@@ -605,7 +605,7 @@
 
 /datum/design/board/oven
 	name = "Machine Design (Oven)"
-	desc = "The circuit board for a Oven."
+	desc = "The circuit board for an Oven."
 	id = "oven"
 	build_path = /obj/item/circuitboard/machine/oven
 	category = list ("Misc. Machinery")
@@ -637,7 +637,7 @@
 
 /datum/design/board/ticket_machine
 	name = "Machine Design (Ticket Machine)"
-	desc = "The circuit board for a dish drive."
+	desc = "The circuit board for a ticket machine."
 	id = "ticket_machine"
 	build_path = /obj/item/circuitboard/machine/ticketmachine
 	category = list ("Misc. Machinery")
@@ -746,7 +746,6 @@
 	build_path = /obj/item/circuitboard/machine/ai_data_core
 	category = list("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-
 
 /datum/design/board/ai_core_display
 	name = "Machine Design (AI Core Display Board)"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -104,7 +104,7 @@
 
 /datum/design/dartsyringe
 	name = "Reagent Dart"
-	desc = "A specialized syringe that quickly inject reagent. It can hold up to 15 units."
+	desc = "A specialized syringe that quickly injects reagents. It can hold up to 15 units."
 	id = "dartsyringe"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/glass = 2500)
@@ -280,7 +280,7 @@
 	materials = list(/datum/material/glass = 2000, /datum/material/diamond = 1000)
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-	
+
 /datum/design/hyposprayspeedupg
 	name = "Hypospray Speed Upgrade"
 	desc = "An upgrade for hyposprays that installs a springloaded mechanism, allowing it to inject with reduced delay."
@@ -396,7 +396,7 @@
 
 /datum/design/cyberimp_meson
 	name = "Meson Eyes"
-	desc = "These cybernetic eyes will give you meson-vision. Looks like it could withstand seeing a supermatter crystal!."
+	desc = "These cybernetic eyes will give you meson-vision. Looks like it could withstand seeing a supermatter crystal!"
 	id = "ci-meson"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
@@ -525,7 +525,7 @@
 	build_path = /obj/item/organ/cyberimp/leg/magboot
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-		
+
 /////////////////////////////////////////
 ////////////Regular Implants/////////////
 /////////////////////////////////////////
@@ -650,7 +650,7 @@
 
 /datum/design/cybernetic_ears
 	name = "Cybernetic Ears"
-	desc = "A pair of cybernetic ears"
+	desc = "A pair of cybernetic ears."
 	id = "cybernetic_ears"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 40
@@ -661,7 +661,7 @@
 
 /datum/design/cybernetic_stomach
 	name = "Cybernetic Stomach"
-	desc = "A cybernetic stomach"
+	desc = "A cybernetic stomach."
 	id = "cybernetic_stomach"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 40
@@ -672,7 +672,7 @@
 
 /datum/design/cybernetic_stomach_u
 	name = "Upgraded Cybernetic Stomach"
-	desc = "An upgraded cybernetic stomach"
+	desc = "An upgraded cybernetic stomach."
 	id = "cybernetic_stomach_u"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 50
@@ -683,7 +683,7 @@
 
 /datum/design/cybernetic_appendix
 	name = "Cybernetic Appendix"
-	desc = "A replacement for those who lost a part of themselfs."
+	desc = "A replacement for those who lost a part of themselves."
 	id = "cybernetic_appendix"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 50
@@ -694,7 +694,7 @@
 
 /datum/design/synthetic_plasmavessel
 	name = "Synthetic Plasma Vessel"
-	desc = "A complex synthetic construct meant to replicate the effects of a plasma vessel"
+	desc = "A complex synthetic construct meant to replicate the effects of a plasma vessel."
 	id = "synthetic_plasmavessel"
 	build_type = PROTOLATHE
 	construction_time = 50

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -159,7 +159,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/clownshoesimplant
-	name = "Clownshoes implant"
+	name = "Clownshoes Implant"
 	desc = "Advanced clown technology has allowed the implanting of bananium to allow for heightened prankage."
 	id = "clownshoesimplant"
 	build_type = PROTOLATHE | MECHFAB
@@ -199,8 +199,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/atmos_thermal
-	name = "Atmospheric thermal imaging goggles"
-	desc = "Used by Atmospheric Technician to determine the temperature of the air"
+	name = "Atmospheric Thermal Imaging Goggles"
+	desc = "Used by Atmospheric Technicians to determine the temperature of the air."
 	id = "atmos_thermal"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/plasma = 100)
@@ -359,7 +359,7 @@
 
 /datum/design/ticket_remote
 	name = "Ticket Machine Remote"
-	desc = "A remote for operating a ticket machine (sold seperately)"
+	desc = "A remote for operating a ticket machine (sold seperately)."
 	id = "ticket_remote"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
@@ -445,8 +445,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/holosignclown
-	name = "HONK holobanana projector"
-	desc = "A holographic projector that creates hardlight bananas"
+	name = "HONK Holobanana Projector"
+	desc = "A holographic projector that creates hardlight bananas."
 	id = "holosignclown"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/plastic = 500, /datum/material/bananium = 1000)
@@ -529,7 +529,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/platingmki
-	name = "MK.I bluespace plating"
+	name = "MK.I Bluespace Plating"
 	desc = "Plating fitted for a plated vest or helmet. Makes you faster, but gives less armor."
 	id = "platingmki"
 	build_type = PROTOLATHE
@@ -539,7 +539,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/platingmkii
-	name = "MK.II ceramic plating"
+	name = "MK.II Ceramic Plating"
 	desc = "Plating fitted for a plated vest or helmet. Better than what you get at the start of the shift."
 	id = "platingmkii"
 	build_type = PROTOLATHE
@@ -549,7 +549,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/platingmkiii
-	name = "MK.III plasteel plating"
+	name = "MK.III Plasteel Plating"
 	desc = "Plating fitted for a plated vest or helmet. Makes you slower, but gives more armor."
 	id = "platingmkiii"
 	build_type = PROTOLATHE
@@ -559,7 +559,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/platingmkiv
-	name = "MK.IV titanium plating"
+	name = "MK.IV Titanium Plating"
 	desc = "Plating fitted for a plated vest or helmet. Turns you into a walking tank."
 	id = "platingmkiv"
 	build_type = PROTOLATHE

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -5,7 +5,7 @@
 
 /datum/design/handdrill
 	name = "Hand Drill"
-	desc = "A small electric hand drill with an interchangeable screwdriver and bolt bit"
+	desc = "A small electric hand drill with an interchangeable screwdriver and bolt bit."
 	id = "handdrill"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 3500, /datum/material/silver = 1500, /datum/material/titanium = 2500)
@@ -15,7 +15,7 @@
 
 /datum/design/jawsoflife
 	name = "Jaws of Life"
-	desc = "A small, compact Jaws of Life with an interchangeable pry jaws and cutting jaws"
+	desc = "A small, compact Jaws of Life with an interchangeable pry jaws and cutting jaws."
 	id = "jawsoflife" // added one more requirment since the Jaws of Life are a bit OP
 	build_path = /obj/item/jawsoflife
 	build_type = PROTOLATHE
@@ -25,7 +25,7 @@
 
 /datum/design/shuttlecreator
 	name = "Rapid Shuttle Designator"
-	desc = "An advanced device capable of defining areas for use in the creation of shuttles"
+	desc = "An advanced device capable of defining areas for use in the creation of shuttles."
 	id = "shuttle_creator"
 	build_path = /obj/item/shuttle_creator
 	build_type = PROTOLATHE
@@ -44,7 +44,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/frames
-	name = "RCD frames designs upgrade"
+	name = "RCD Frames Designs Upgrade"
 	desc = "Adds computer and machine frame designs to the RCD."
 	id = "rcd_upgrade_frames"
 	build_type = PROTOLATHE
@@ -54,7 +54,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/simple_circuits
-	name = "RCD simple circuits designs upgrade"
+	name = "RCD Simple Circuits Designs Upgrade"
 	desc = "Adds simple circuits to the RCD."
 	id = "rcd_upgrade_simple_circuits"
 	build_type = PROTOLATHE
@@ -64,7 +64,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/furnishing
-	name = "RCD furnishing upgrade"
+	name = "RCD Furnishing Upgrade"
 	desc = "Adds the ability to furnish areas using the RCD."
 	id = "rcd_upgrade_furnishing"
 	build_type = PROTOLATHE
@@ -74,7 +74,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/conveyor
-	name = "RCD Conveyor upgrade"
+	name = "RCD Conveyor Upgrade"
 	desc = "Adds the ability to dispense conveyors and switches using the RCD."
 	id = "rcd_upgrade_conveyor"
 	build_type = PROTOLATHE
@@ -84,7 +84,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/silo_link
-	name = "Advanced RCD silo link upgrade"
+	name = "Advanced RCD Silo Link Upgrade"
 	desc = "Adds the silo direct link to the RCD."
 	id = "rcd_upgrade_silo_link"
 	build_type = PROTOLATHE


### PR DESCRIPTION
Check changes, as title says + limgrower and biogen. Names are capitalised as standard but some weren't, some punctuation/grammar errors fixed too. Changed ticket machine description (funny copy paste moment).

:cl:  Ktlwjec
spellcheck: Fixes missing capitalisation, punctuation etc in some protolathe designs
/:cl: