### PR TITLE
Engineering Cyborg's Gripper Can Now Hold Internal Tanks

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -854,5 +854,6 @@
 		/obj/item/circuitboard,
 		/obj/item/electronics,
 		/obj/item/wallframe,
-		/obj/item/stock_parts
+		/obj/item/stock_parts,
+		/obj/item/tank/internals
 	)


### PR DESCRIPTION
# Document the changes in your pull request
Engineering gripper can now hold tanks. No more dragging n' dropping 303 kpa plasma tanks into the radiation collectors (and then coming back to do it again in 20 minutes). Now it can be 2533 kpa from the start.

# Wiki Documentation
Engineering cyborg's engineering gripper can hold tanks. 

# Changelog
:cl:  
tweak: The engineering gripper that Engineering Cyborgs use can now hold internal tanks. 
/:cl:
