### PR TITLE
Give engi borg construction bag roundstart

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -349,6 +349,7 @@
 		/obj/item/wirecutters/cyborg,
 		/obj/item/multitool/cyborg,
 		/obj/item/t_scanner,
+		/obj/item/storage/bag/construction,
 		/obj/item/analyzer,
 		/obj/item/gripper/engineering,
 		/obj/item/geiger_counter/cyborg,


### PR DESCRIPTION
no more having to refill boards/cables everytime 

# Document the changes in your pull request

Give engi borg construction bag roundstart


# Wiki Documentation
construction bag for borg roundstart
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Give engi borg construction bag roundstart
/:cl:
