### PR TITLE
You can now build HFR instead of buying from cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1216,24 +1216,6 @@
 	crate_type = /obj/structure/closet/crate/secure/engineering
 	dangerous = TRUE
 
-/datum/supply_pack/engine/hypertorus_fusion_reactor
-	name = "HFR Crate"
-	desc = "The new and improved fusion reactor. Requires CE access to open."
-	cost = 10000
-	access = ACCESS_CE
-	contains = list(/obj/item/hfr_box/corner,
-					/obj/item/hfr_box/corner,
-					/obj/item/hfr_box/corner,
-					/obj/item/hfr_box/corner,
-					/obj/item/hfr_box/body/fuel_input,
-					/obj/item/hfr_box/body/moderator_input,
-					/obj/item/hfr_box/body/waste_output,
-					/obj/item/hfr_box/body/interface,
-					/obj/item/hfr_box/core)
-	crate_name = "HFR crate"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-	dangerous = TRUE
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////// Canisters & Materials ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -19,6 +19,7 @@
 								"Spacepod Designs", // yoggers
 								"Service",
 								"Assemblies"
+								"HFR Designs"
 								)
 	production_animation = "protolathe_n"
 	allowed_buildtypes = PROTOLATHE

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -18,7 +18,7 @@
 								"Computer Parts",
 								"Spacepod Designs", // yoggers
 								"Service",
-								"Assemblies"
+								"Assemblies",
 								"HFR Designs"
 								)
 	production_animation = "protolathe_n"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -163,7 +163,7 @@
 	display_name = "Advanced Engineering"
 	description = "Pushing the boundaries of physics, one chainsaw-fist at a time."
 	prereq_ids = list("engineering", "emp_basic")
-	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "decontamination_unit", "particle_emitter", "tricorder")
+	design_ids = list("engine_goggles", "magboots", "forcefield_projector", "weldingmask", "decontamination_unit", "particle_emitter", "tricorder", "hfr_corner", "hfr_interface", "hfr_waste", "hfr_moderator", "hfr_fuel", "hfr_core")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/anomaly

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -4184,6 +4184,7 @@
 #include "yogstation\code\modules\research\rdconsole.dm"
 #include "yogstation\code\modules\research\designs\bluespace_designs.dm"
 #include "yogstation\code\modules\research\designs\comp_board_designs.dm"
+#include "yogstation\code\modules\research\designs\HFR_designs.dm"
 #include "yogstation\code\modules\research\designs\medical_designs.dm"
 #include "yogstation\code\modules\research\designs\misc_designs.dm"
 #include "yogstation\code\modules\research\designs\spacepod_designs.dm"

--- a/yogstation/code/modules/research/designs/HFR_designs.dm
+++ b/yogstation/code/modules/research/designs/HFR_designs.dm
@@ -1,0 +1,59 @@
+/datum/design/hfr_corner
+	name = "Circuit Design (HFR Corner Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_corner"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/corner
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 4000, /datum/material/plasma = 4000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/hfr_waste
+	name = "Circuit Design (HFR Waste Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_waste"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/body/waste_output
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 4000, /datum/material/plasma = 4000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/hfr_fuel
+	name = "Circuit Design (HFR Fuel Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_fuel"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/body/fuel_input
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 4000, /datum/material/plasma = 4000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/hfr_moderator
+	name = "Circuit Design (HFR Moderator Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_moderator"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/body/moderator_input
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 4000, /datum/material/plasma = 4000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/hfr_interface
+	name = "Circuit Design (HFR Interface Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_interface"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/body/interface
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 4000, /datum/material/plasma = 4000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/hfr_core
+	name = "Circuit Design (HFR Core Box)"
+	desc = "Allows for the construction of the HFR."
+	id = "hfr_core"
+	build_type = PROTOLATHE
+	build_path = /obj/item/hfr_box/core
+	category = list("HFR Designs")
+	materials = list(/datum/material/iron = 6000, /datum/material/plasma = 6000, /datum/material/glass = 6000)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING


### PR DESCRIPTION
Allows atmos techs to make HFR for atmos shenanigans. HFR is very costly in cargo and i havent seen one ordered it because there is one free already. 

# Document the changes in your pull request
HFR designs are now in advanced engineering tech node
You can no longer buy HFR from cargo


# Wiki Documentation
HFR designs are now in advanced engineering tech node
You can no longer buy HFR from cargo

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: HFR designs are now in advanced engineering tech node
rscdel: You can no longer buy HFR from cargo
/:cl:
