### PR TITLE
reduces hfr cost from cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1219,7 +1219,7 @@
 /datum/supply_pack/engine/hypertorus_fusion_reactor
 	name = "HFR Crate"
 	desc = "The new and improved fusion reactor. Requires CE access to open."
-	cost = 10000
+	cost = 4600
 	access = ACCESS_CE
 	contains = list(/obj/item/hfr_box/corner,
 					/obj/item/hfr_box/corner,


### PR DESCRIPTION
Maybe a bit too high just for a gas maker, changed price to tg's price

# Document the changes in your pull request
HFR crate now costs 4600cr



# Wiki Documentation
HFR crate now costs 4600cr

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: HFR crate now costs 4600cr
/:cl:
