### PR TITLE
Syringe gun hugbox

### DIFF
--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -24,8 +24,10 @@
 
 /obj/item/gun/syringe/emag_act()
 	. = ..()
-	obj_flags ^= EMAGGED
 	playsound(src.loc, "sparks", 100, 1)
+	if(initial(hacked))
+		return
+	obj_flags ^= EMAGGED
 	if(obj_flags & EMAGGED)
 		to_chat(user, span_notice("\The [src] can now intake illegal reagents!"))
 		hacked = TRUE

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/syringe
 	name = "syringe gun"
-	desc = "A spring loaded rifle designed to fit syringes, used to incapacitate unruly patients from a distance."
+	desc = "A spring loaded rifle designed to fire syringes, used to incapacitate or heal unruly patients from a distance."
 	icon_state = "syringegun"
 	item_state = "syringegun"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -15,6 +15,7 @@
 	var/max_syringes = 1
 	var/has_syringe_overlay = TRUE ///If it has an overlay for inserted syringes. If true, the overlay is determined by the number of syringes inserted into it.
 	var/allow_piercing = FALSE // whether it can hold piercing syringes
+	var/hacked = FALSE /// whether it can bypass syringe content checking
 
 /obj/item/gun/syringe/Initialize(mapload)
 	. = ..()
@@ -62,6 +63,11 @@
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/syringe = A
+		if(!hacked)
+			for(var/datum/reagent/chem in syringe.reagents?.reagent_list)
+				if(!istype(chem, /datum/reagent/medicine))
+					to_chat(user, span_warning("\The [src] rejects \the [A] as it contains non-medicinal reagents!"))
+					return FALSE
 		if(syringe.proj_piercing && !allow_piercing)
 			to_chat(user, span_warning("[syringe] won't fit into [src]!"))
 			return FALSE
@@ -92,6 +98,9 @@
 	max_syringes = 6
 	allow_piercing = TRUE
 
+/obj/item/gun/syringe/rapidsyringe/syndicate
+	hacked = TRUE
+
 /obj/item/gun/syringe/syndicate
 	name = "dart pistol"
 	desc = "A small spring-loaded sidearm that functions identically to a syringe gun."
@@ -102,11 +111,13 @@
 	suppressed = TRUE //Softer fire sound
 	can_unsuppress = FALSE //Permanently silenced
 	allow_piercing = TRUE
+	hacked = TRUE
 
 /obj/item/gun/syringe/dna
 	name = "modified syringe gun"
 	desc = "A syringe gun that has been modified to fit DNA injectors instead of normal syringes."
 	allow_piercing = TRUE
+	hacked = TRUE // evil
 
 /obj/item/gun/syringe/dna/Initialize(mapload)
 	. = ..()
@@ -139,6 +150,7 @@
 	fire_sound = 'sound/items/syringeproj.ogg'
 	no_pin_required = TRUE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL //it's a fucking blowgun it shouldn't even have a triggerguard
+	hacked = TRUE // not sophisticated enough to say no
 
 /obj/item/gun/syringe/blowgun/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -22,7 +22,7 @@
 	update_appearance(UPDATE_ICON)
 	chambered = new /obj/item/ammo_casing/syringegun(src)
 
-/obj/item/gun/syringe/emag_act()
+/obj/item/gun/syringe/emag_act(mob/user)
 	. = ..()
 	playsound(src.loc, "sparks", 100, 1)
 	if(initial(hacked))

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -22,6 +22,17 @@
 	update_appearance(UPDATE_ICON)
 	chambered = new /obj/item/ammo_casing/syringegun(src)
 
+/obj/item/gun/syringe/emag_act()
+	. = ..()
+	obj_flags ^= EMAGGED
+	playsound(src.loc, "sparks", 100, 1)
+	if(obj_flags & EMAGGED)
+		to_chat(user, span_notice("\The [src] can now intake illegal reagents!"))
+		hacked = TRUE
+	else
+		to_chat(user, span_notice("\The [src] can no longer intake illegal reagents!"))
+		hacked = FALSE
+
 /obj/item/gun/syringe/handle_atom_del(atom/A)
 	. = ..()
 	if(A in syringes)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2533,7 +2533,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/chemical_gun
 	name = "Rapid Syringe Gun"
 	desc = "A modified syringe gun with a rotating drum, capable of holding and quickly firing six syringes."
-	item = /obj/item/gun/syringe/rapidsyringe
+	item = /obj/item/gun/syringe/rapidsyringe/syndicate
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 8
 	restricted_roles = list("Chemist", "Chief Medical Officer", "Virologist")


### PR DESCRIPTION
# Document the changes in your pull request

Syringe guns can no longer intake non-medicinal reagents unless emagged or purchased from an uplink.

For information on what is classified as a medicine, refer to the wiki https://wiki.yogstation.net/wiki/Guide_to_Chemistry#Medicines

Should lighten up the offensive chem meta outside of traitors who spec into it.

Odysseus syringe gun unaffected

# Changelog

:cl:  
tweak: Syringe guns can no longer intake non-medicinal reagents unless emagged or purchased from an uplink
/:cl:
