### PR TITLE
Throwing weapons box holds the items it spawns with

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -734,6 +734,18 @@
 	new /obj/item/restraints/legcuffs/bola/tactical(src)
 	new /obj/item/restraints/legcuffs/bola/tactical(src)
 
+/obj/item/storage/box/syndie_kit/throwing_weapons/Initialize(mapload)
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 9 // 5 + 2 + 2
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = 18 // 5*2 + 2*1 + 3*2
+	STR.set_holdable(list(
+		/obj/item/restraints/legcuffs/bola/tactical,
+		/obj/item/paperplane/syndicate,
+		/obj/item/throwing_star
+	))
+
 /obj/item/storage/box/syndie_kit/cutouts/PopulateContents()
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/76482

Just makes sense, it's a box for throwing weapons and it can't hold the bolas it spawns with.

Makes throwing weapons box only hold syndicate paper plane, bola and throwing stars.

:cl:  Helg2
tweak: Box with throwing weapons now can hold the items it spawns with.
/:cl: