### PR TITLE
Slight nitrous oxide (reagent) nerf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1370,13 +1370,14 @@
 		exposed_mob.adjust_drowsiness(drowsiness_to_apply)
 
 /datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/M)
-	M.adjust_drowsiness(4 SECONDS * REM)
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		H.blood_volume = max(H.blood_volume - 5, 0)
+	if(current_cycle >= 8)
+		M.adjust_drowsiness(4 SECONDS * REM)
 	if(prob(20))
 		M.losebreath += 2
 		M.adjust_confusion_up_to(2 SECONDS, 5 SECONDS)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.blood_volume = max(H.blood_volume - 2, 0)
 	..()
 
 /datum/reagent/nitrium_low_metabolization

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1377,7 +1377,7 @@
 			M.adjust_confusion_up_to(2 SECONDS, 5 SECONDS)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.blood_volume = max(H.blood_volume - 2, 0)
+		H.blood_volume = max(H.blood_volume - 5, 0)
 	..()
 
 /datum/reagent/nitrium_low_metabolization

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1370,7 +1370,7 @@
 		exposed_mob.adjust_drowsiness(drowsiness_to_apply)
 
 /datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/M)
-	if(current_cycle >= 8)
+	if(current_cycle >= 4)
 		M.adjust_drowsiness(4 SECONDS * REM)
 		if(prob(20))
 			M.losebreath += 2

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1372,9 +1372,9 @@
 /datum/reagent/nitrous_oxide/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 8)
 		M.adjust_drowsiness(4 SECONDS * REM)
-	if(prob(20))
-		M.losebreath += 2
-		M.adjust_confusion_up_to(2 SECONDS, 5 SECONDS)
+		if(prob(20))
+			M.losebreath += 2
+			M.adjust_confusion_up_to(2 SECONDS, 5 SECONDS)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.blood_volume = max(H.blood_volume - 2, 0)


### PR DESCRIPTION
# Document the changes in your pull request

Knockout/lethal reagent that triggers effectively instantly, easy to make by chemistry, also works as a gas production chemical
Slightly delayed effects of reagent to reduce effectivity as a weapon, reduced bloodloss because bloodloss is a mess

Nitrous oxide now only starts stacking drowsiness after 4 cycles (still faster than morphine, but slow enough to get some distance)
effect from vapor application untouched
Losebreath stacks and confusion also only start occuring after 8 cycles


# Wiki Documentation

Nitrous oxide reagent
after 4 cycles, applies 4 seconds of drowsiness with a 20% chance for +2 failed breaths and 2 to 5 seconds of confusion

# Changelog
:cl:  
tweak: Nitrous oxide reagent now has to metabolize 4 times before causing drowsines and confusion
/:cl:
